### PR TITLE
fix(plasma-ui, plasma-web): fix carousel context

### DIFF
--- a/packages/plasma-ui/src/components/Carousel/Carousel.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.tsx
@@ -8,6 +8,7 @@ import {
     CarouselProps as BaseProps,
     applyNoSelect,
 } from '@salutejs/plasma-core';
+import { CarouselState } from '@salutejs/plasma-core/components/Carousel/CarouselContext';
 
 import { useForkRef } from '../../hooks';
 
@@ -73,8 +74,12 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(function
     });
     const handleRef = useForkRef(scrollRef, ref);
 
+    const context = React.useMemo<CarouselState>(() => {
+        return { axis, refs };
+    }, [axis, refs]);
+
     return (
-        <CarouselContext.Provider value={{ axis, refs }}>
+        <CarouselContext.Provider value={context}>
             <StyledCarousel
                 ref={handleRef}
                 axis={axis}

--- a/packages/plasma-web/src/components/Carousel/Carousel.tsx
+++ b/packages/plasma-web/src/components/Carousel/Carousel.tsx
@@ -6,6 +6,7 @@ import {
     CarouselTrack as StyledCarouselTrack,
 } from '@salutejs/plasma-core';
 import type { CarouselProps as BaseProps } from '@salutejs/plasma-core';
+import { CarouselState } from '@salutejs/plasma-core/components/Carousel/CarouselContext';
 
 import { useForkRef } from '../../hooks';
 
@@ -53,8 +54,12 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(function
     });
     const handleRef = useForkRef(scrollRef, ref);
 
+    const context = React.useMemo<CarouselState>(() => {
+        return { axis, refs };
+    }, [axis, refs]);
+
     return (
-        <CarouselContext.Provider value={{ axis, refs }}>
+        <CarouselContext.Provider value={context}>
             <StyledCarousel
                 ref={handleRef}
                 axis={axis}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.66.1-canary.20.2336920085.0
  npm install @salutejs/plasma-core@1.58.1-canary.20.2336920085.0
  npm install @salutejs/plasma-temple@1.67.2-canary.20.2336920085.0
  npm install @salutejs/plasma-typo@0.5.1-canary.20.2336920085.0
  npm install @salutejs/plasma-ui@1.103.2-canary.20.2336920085.0
  npm install @salutejs/plasma-web@1.101.1-canary.20.2336920085.0
  npm install @salutejs/plasma-cy-utils@0.11.1-canary.20.2336920085.0
  # or 
  yarn add @salutejs/plasma-b2c@1.66.1-canary.20.2336920085.0
  yarn add @salutejs/plasma-core@1.58.1-canary.20.2336920085.0
  yarn add @salutejs/plasma-temple@1.67.2-canary.20.2336920085.0
  yarn add @salutejs/plasma-typo@0.5.1-canary.20.2336920085.0
  yarn add @salutejs/plasma-ui@1.103.2-canary.20.2336920085.0
  yarn add @salutejs/plasma-web@1.101.1-canary.20.2336920085.0
  yarn add @salutejs/plasma-cy-utils@0.11.1-canary.20.2336920085.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
