### PR TITLE
docs(plasma-web,plasma-ui): fix old versions url

### DIFF
--- a/website/plasma-ui-docs/versionsArchived.json
+++ b/website/plasma-ui-docs/versionsArchived.json
@@ -1,7 +1,7 @@
 {
     "1.103.1": "https://plasma.sberdevices.ru/ui-1.103.1/",
-    "1.92.0": "https://bit.ly/3xQvdgF-1.92.0/",
-    "1.82.3": "https://bit.ly/3xQvdgF-1.82.3/",
-    "1.81.4": "https://bit.ly/3xQvdgF-1.81.4/",
-    "1.81.1": "https://bit.ly/3xQvdgF-1.81.1/"
+    "1.92.0": "https://plasma.sberdevices.ru/ui-1.92.0/",
+    "1.82.3": "https://plasma.sberdevices.ru/ui-1.82.3/",
+    "1.81.4": "https://plasma.sberdevices.ru/ui-1.81.4/",
+    "1.81.1": "https://plasma.sberdevices.ru/ui-1.81.1/"
 }

--- a/website/plasma-web-docs/versionsArchived.json
+++ b/website/plasma-web-docs/versionsArchived.json
@@ -1,5 +1,5 @@
 {
-    "1.89.0": "https://bit.ly/3OtwX5v-1.89.0/",
-    "1.88.0": "https://bit.ly/3OtwX5v-1.88.0/",
-    "1.75.7": "https://bit.ly/3OtwX5v-1.75.7/"
+    "1.89.0": "https://plasma.sberdevices.ru/web-1.89.0/",
+    "1.88.0": "https://plasma.sberdevices.ru/web-1.88.0/",
+    "1.75.7": "https://plasma.sberdevices.ru/web-1.75.7/"
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.67.1-canary.23.2351610100.0
  npm install @salutejs/plasma-icons@1.83.1-canary.23.2351610100.0
  npm install @salutejs/plasma-temple@1.68.1-canary.23.2351610100.0
  npm install @salutejs/plasma-ui@1.104.1-canary.23.2351610100.0
  npm install @salutejs/plasma-web@1.102.1-canary.23.2351610100.0
  # or 
  yarn add @salutejs/plasma-b2c@1.67.1-canary.23.2351610100.0
  yarn add @salutejs/plasma-icons@1.83.1-canary.23.2351610100.0
  yarn add @salutejs/plasma-temple@1.68.1-canary.23.2351610100.0
  yarn add @salutejs/plasma-ui@1.104.1-canary.23.2351610100.0
  yarn add @salutejs/plasma-web@1.102.1-canary.23.2351610100.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
