### PR TITLE
ci(plasma-icons): fix deps

### DIFF
--- a/packages/plasma-icons/package-lock.json
+++ b/packages/plasma-icons/package-lock.json
@@ -3267,9 +3267,9 @@
             }
         },
         "@salutejs/plasma-core": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@salutejs/plasma-core/-/plasma-core-1.58.0.tgz",
-            "integrity": "sha512-tp7deoT37qhJqz2TvYrF+qkvlhG0IIYclgaCFowEazyfefkXlvLXTFj4Li0QTZ+BPVH05insGqHt3YU9uDTGLQ==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@salutejs/plasma-core/-/plasma-core-1.59.0.tgz",
+            "integrity": "sha512-dIidkNzsF6Zl0l9xGp0KfGLMgaaAyWOwDrM6033iachbFKjUQ//uXxAbpiuMw8ZHHPXJiQKbaqYwUvWL41TYkA==",
             "dev": true,
             "requires": {
                 "focus-visible": "5.2.0",

--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -22,7 +22,7 @@
         "@babel/preset-env": "^7.15.4",
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.15.0",
-        "@salutejs/plasma-core": "1.58.0",
+        "@salutejs/plasma-core": "1.59.0",
         "@types/node": "^16.7.13",
         "@types/react": "16.9.38",
         "@types/react-dom": "16.9.8",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.67.1-canary.24.2351066338.0
  npm install @salutejs/plasma-icons@1.83.1-canary.24.2351066338.0
  npm install @salutejs/plasma-temple@1.68.1-canary.24.2351066338.0
  npm install @salutejs/plasma-ui@1.104.1-canary.24.2351066338.0
  npm install @salutejs/plasma-web@1.102.1-canary.24.2351066338.0
  # or 
  yarn add @salutejs/plasma-b2c@1.67.1-canary.24.2351066338.0
  yarn add @salutejs/plasma-icons@1.83.1-canary.24.2351066338.0
  yarn add @salutejs/plasma-temple@1.68.1-canary.24.2351066338.0
  yarn add @salutejs/plasma-ui@1.104.1-canary.24.2351066338.0
  yarn add @salutejs/plasma-web@1.102.1-canary.24.2351066338.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
