### PR TITLE
fix(plasma-core): unnecessary Price export

### DIFF
--- a/packages/plasma-core/src/index.ts
+++ b/packages/plasma-core/src/index.ts
@@ -18,7 +18,6 @@ export * from './components/Tabs';
 export * from './components/TextArea';
 export * from './components/TextField';
 export * from './components/Badge';
-export * from './components/Price';
 export * from './components/Image';
 export * from './components/Toast';
 export * from './components/Typography';


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.67.1-canary.25.2351958186.0
  npm install @salutejs/plasma-core@1.59.1-canary.25.2351958186.0
  npm install @salutejs/plasma-icons@1.83.1-canary.25.2351958186.0
  npm install @salutejs/plasma-temple@1.68.1-canary.25.2351958186.0
  npm install @salutejs/plasma-typo@0.6.1-canary.25.2351958186.0
  npm install @salutejs/plasma-ui@1.104.1-canary.25.2351958186.0
  npm install @salutejs/plasma-web@1.102.1-canary.25.2351958186.0
  npm install @salutejs/plasma-cy-utils@0.12.1-canary.25.2351958186.0
  npm install @salutejs/plasma-sb-utils@0.58.1-canary.25.2351958186.0
  # or 
  yarn add @salutejs/plasma-b2c@1.67.1-canary.25.2351958186.0
  yarn add @salutejs/plasma-core@1.59.1-canary.25.2351958186.0
  yarn add @salutejs/plasma-icons@1.83.1-canary.25.2351958186.0
  yarn add @salutejs/plasma-temple@1.68.1-canary.25.2351958186.0
  yarn add @salutejs/plasma-typo@0.6.1-canary.25.2351958186.0
  yarn add @salutejs/plasma-ui@1.104.1-canary.25.2351958186.0
  yarn add @salutejs/plasma-web@1.102.1-canary.25.2351958186.0
  yarn add @salutejs/plasma-cy-utils@0.12.1-canary.25.2351958186.0
  yarn add @salutejs/plasma-sb-utils@0.58.1-canary.25.2351958186.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
