### PR TITLE
fix(plasma-b2c): fix scroll handle position passed to callbacks

### DIFF
--- a/packages/plasma-b2c/src/components/Slider/Handle.tsx
+++ b/packages/plasma-b2c/src/components/Slider/Handle.tsx
@@ -79,10 +79,8 @@ export const Handle = React.forwardRef<HTMLDivElement, HandleProps>(
 
         const onDrag = React.useCallback(
             (_, data) => {
-                const newHandleXPosition = data.lastX;
-
                 if (onChange) {
-                    const newValue = getValue(newHandleXPosition, stepSize, min, max);
+                    const newValue = getValue(data.x, stepSize, min, max);
                     if (lastOnChangeValue.current !== newValue) {
                         onChange(newValue, data);
                         lastOnChangeValue.current = newValue;
@@ -94,8 +92,7 @@ export const Handle = React.forwardRef<HTMLDivElement, HandleProps>(
 
         const onStop = React.useCallback(
             (_, data) => {
-                const newHandleXPosition = data.lastX;
-                const newValue = getValue(newHandleXPosition, stepSize, min, max);
+                const newValue = getValue(data.x, stepSize, min, max);
                 onChangeCommitted(newValue, data);
             },
             [onChangeCommitted, stepSize, min, max],

--- a/packages/plasma-ui/src/components/Slider/Handle.tsx
+++ b/packages/plasma-ui/src/components/Slider/Handle.tsx
@@ -65,10 +65,8 @@ export const Handle = React.forwardRef<HTMLDivElement, HandleProps>(
 
         const onDrag = React.useCallback(
             (_, data) => {
-                const newHandleXPosition = data.lastX;
-
                 if (onChange) {
-                    const newValue = getValue(newHandleXPosition, stepSize, min, max);
+                    const newValue = getValue(data.x, stepSize, min, max);
                     if (lastOnChangeValue.current !== newValue) {
                         onChange(newValue, data);
                         lastOnChangeValue.current = newValue;
@@ -80,8 +78,7 @@ export const Handle = React.forwardRef<HTMLDivElement, HandleProps>(
 
         const onStop = React.useCallback(
             (_, data) => {
-                const newHandleXPosition = data.lastX;
-                const newValue = getValue(newHandleXPosition, stepSize, min, max);
+                const newValue = getValue(data.x, stepSize, min, max);
                 onChangeCommitted(newValue, data);
             },
             [onChangeCommitted, stepSize, min, max],


### PR DESCRIPTION
Поправил отставание ползунка от мышки при изменении `value` в `onChange`

```ts
const [value, setValue] = useState(0);

const onChangeHandler = (values) => {
  setValue(values);
}

return (
  <Slider value={value} onChange={onChangeHandler} />
);
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.70.2-canary.48.2452775690.0
  npm install @salutejs/plasma-core@1.60.2-canary.48.2452775690.0
  npm install @salutejs/plasma-icons@1.84.2-canary.48.2452775690.0
  npm install @salutejs/plasma-temple@1.70.2-canary.48.2452775690.0
  npm install @salutejs/plasma-typo@0.7.2-canary.48.2452775690.0
  npm install @salutejs/plasma-ui@1.106.2-canary.48.2452775690.0
  npm install @salutejs/plasma-web@1.105.2-canary.48.2452775690.0
  npm install @salutejs/plasma-cy-utils@0.13.2-canary.48.2452775690.0
  npm install @salutejs/plasma-sb-utils@0.59.2-canary.48.2452775690.0
  # or 
  yarn add @salutejs/plasma-b2c@1.70.2-canary.48.2452775690.0
  yarn add @salutejs/plasma-core@1.60.2-canary.48.2452775690.0
  yarn add @salutejs/plasma-icons@1.84.2-canary.48.2452775690.0
  yarn add @salutejs/plasma-temple@1.70.2-canary.48.2452775690.0
  yarn add @salutejs/plasma-typo@0.7.2-canary.48.2452775690.0
  yarn add @salutejs/plasma-ui@1.106.2-canary.48.2452775690.0
  yarn add @salutejs/plasma-web@1.105.2-canary.48.2452775690.0
  yarn add @salutejs/plasma-cy-utils@0.13.2-canary.48.2452775690.0
  yarn add @salutejs/plasma-sb-utils@0.59.2-canary.48.2452775690.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
