### PR TITLE
feat(plasma-ui): Stepper render optimization

### DIFF
--- a/packages/plasma-ui/src/components/Stepper/Stepper.hooks.ts
+++ b/packages/plasma-ui/src/components/Stepper/Stepper.hooks.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 
 export interface UseStepperProps {
     /**
@@ -24,8 +24,15 @@ export interface UseStepperProps {
 }
 
 export const useStepper = ({ value, step = 1, min = 0, max = Infinity, onChange }: UseStepperProps) => {
-    const onLessClick = useCallback((event) => onChange?.(value - step, event), [value, step, onChange]);
-    const onMoreClick = useCallback((event) => onChange?.(value + step, event), [value, step, onChange]);
+    const curValue = useRef(value);
+
+    useEffect(() => {
+        curValue.current = value;
+    }, [value]);
+
+    const onLessClick = useCallback((event) => onChange?.(curValue.current - step, event), [step, onChange]);
+    const onMoreClick = useCallback((event) => onChange?.(curValue.current + step, event), [step, onChange]);
+
     const isMin = value <= min;
     const isMax = value >= max;
     const isLessDisabled = isMin || value - step < min;

--- a/packages/plasma-ui/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/plasma-ui/src/components/Stepper/Stepper.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Story, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { IconMinus, IconPlus, IconClose } from '@salutejs/plasma-icons';
@@ -75,29 +75,37 @@ interface CustomAssemblyProps {
     showFormat: boolean;
 }
 
+const icoMinus = <IconMinus color="inherit" size="xs" />;
+const icoPlus = <IconPlus color="inherit" size="xs" />;
+const icoClose = <IconClose color="inherit" size="xs" />;
+
 export const CustomAssembly: Story<CustomAssemblyProps> = ({ step, min, max, disabled, showWarning, showFormat }) => {
     const [value, setValue] = useState(5);
     const formatter = (val: number) => `${val}$`;
+
+    const onMinClick = useCallback(() => setValue((value) => Math.max(value - step, min)), [min, step]);
+    const onPlusClick = useCallback(() => setValue((value) => Math.min(value + step, max)), [max, step]);
+
     return (
         <StepperRoot aria-label="Счётчик">
             <StepperButton
                 aria-label="Уменьшить значение"
                 view={value > min ? 'secondary' : 'critical'}
-                icon={value > min ? <IconMinus color="inherit" size="xs" /> : <IconClose color="inherit" size="xs" />}
-                onClick={() => setValue(Math.max(value - step, min))}
+                icon={value > min ? icoMinus : icoClose}
+                onClick={onMinClick}
             />
             <StepperValue
                 value={value}
                 disabled={disabled}
                 showWarning={showWarning}
-                formatter={showFormat && formatter}
+                formatter={showFormat ? formatter : undefined}
             />
             <StepperButton
                 aria-label="Увеличить значение"
                 view="secondary"
-                icon={<IconPlus color="inherit" size="xs" />}
+                icon={icoPlus}
                 disabled={value >= max}
-                onClick={() => setValue(Math.min(value + step, max))}
+                onClick={onPlusClick}
             />
         </StepperRoot>
     );

--- a/packages/plasma-ui/src/components/Stepper/StepperButton.tsx
+++ b/packages/plasma-ui/src/components/Stepper/StepperButton.tsx
@@ -13,21 +13,23 @@ export interface StepperButtonProps
 /**
  * Стилизованная кнопка, применяемая для контроля над значением степпера.
  */
-export const StepperButton = React.forwardRef<HTMLButtonElement, StepperButtonProps>(
-    // eslint-disable-next-line prefer-arrow-callback
-    function StepperButton({ pin = 'circle-circle', view = 'secondary', icon, disabled, ...rest }, ref) {
-        return (
-            <ActionButton
-                aria-disabled={disabled}
-                disabled={disabled}
-                size="m"
-                ref={ref}
-                pin={pin}
-                view={view}
-                {...rest}
-            >
-                {icon}
-            </ActionButton>
-        );
-    },
+export const StepperButton = React.memo(
+    React.forwardRef<HTMLButtonElement, StepperButtonProps>(
+        // eslint-disable-next-line prefer-arrow-callback
+        function StepperButton({ pin = 'circle-circle', view = 'secondary', icon, disabled, ...rest }, ref) {
+            return (
+                <ActionButton
+                    aria-disabled={disabled}
+                    disabled={disabled}
+                    size="m"
+                    ref={ref}
+                    pin={pin}
+                    view={view}
+                    {...rest}
+                >
+                    {icon}
+                </ActionButton>
+            );
+        },
+    ),
 );


### PR DESCRIPTION
Переоткрыл: https://github.com/salute-developers/plasma/pull/43

Добавил мемоизацию в кнопки.
И убрал зависимость мемоизации функций, обработчиков нажатий, от значения степера.

До: 1ms
<img width="1465" alt="Screenshot 2022-06-01 at 22 42 02" src="https://user-images.githubusercontent.com/1077074/171496574-cff65536-2e52-4b44-9dea-52953101b722.png">

После: 0.5ms
<img width="1459" alt="Screenshot 2022-06-01 at 22 35 22" src="https://user-images.githubusercontent.com/1077074/171496579-c2391790-dc97-4dcd-b0b0-3686884e19ab.png">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.74.0-canary.50.2516594509.0
  npm install @salutejs/plasma-ui@1.110.0-canary.50.2516594509.0
  # or 
  yarn add @salutejs/plasma-temple@1.74.0-canary.50.2516594509.0
  yarn add @salutejs/plasma-ui@1.110.0-canary.50.2516594509.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
