### PR TITLE
feat(plasma-ui): ProductCard render optimization

### DIFF
--- a/packages/plasma-ui/src/components/ProductCard/ProductCard.tsx
+++ b/packages/plasma-ui/src/components/ProductCard/ProductCard.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ReactNode } from 'react';
+import React, { forwardRef, ReactNode, memo } from 'react';
 import styled, { css } from 'styled-components';
 import { body1, black, blackSecondary, success, mediaQuery } from '@salutejs/plasma-core';
 import type { DisabledProps } from '@salutejs/plasma-core';
@@ -85,14 +85,14 @@ const StyledCard = styled(Card)<{ $backgroundColor?: string }>`
     background-color: ${({ $backgroundColor }) => $backgroundColor};
     color: ${blackSecondary};
 `;
-const StyledMediaSlot = styled.div`
+const StyledMediaSlot = memo(styled.div`
     height: 100%;
 
     & img {
         display: block;
         height: 100%;
     }
-`;
+`);
 
 const getGradient = (backgroundColor: string) => {
     const color = Color(backgroundColor);
@@ -145,13 +145,13 @@ const StyledCardContent = styled(CardContent)<{ $backgroundColor?: string; $isVa
             margin-top: -3rem;
         `}
 `;
-const StyledBadgeSlot = styled.div`
+const StyledBadgeSlot = memo(styled.div`
     position: absolute;
     top: 0.5rem;
     left: 0.5rem;
     z-index: 1;
-`;
-const StyledText = styled(Footnote1)`
+`);
+const StyledText = memo(styled(Footnote1)`
     max-height: 3.38rem;
     overflow: hidden;
     display: -webkit-box;
@@ -168,9 +168,9 @@ const StyledText = styled(Footnote1)`
                 ${body1}
             `,
         )}
-`;
+`);
 
-const StyledAdditionalInfo = styled(Footnote1)`
+const StyledAdditionalInfo = memo(styled(Footnote1)`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -184,13 +184,13 @@ const StyledAdditionalInfo = styled(Footnote1)`
                 ${body1}
             `,
         )}
-`;
-const StyledBottom = styled.div`
+`);
+const StyledBottom = memo(styled.div`
     display: flex;
     align-items: center;
     flex-direction: column;
     margin-top: 0.25rem;
-`;
+`);
 const StyledPrices = styled.div`
     display: flex;
     flex-direction: column;
@@ -214,7 +214,8 @@ const StyledPrice = styled(Price)<{ $type?: 'new' | 'old' }>`
             opacity: 0.56;
         `}
 `;
-const StyledStepper = styled(ProductCardStepper)<{ $onTop?: boolean }>`
+
+const StyledStepper = memo(styled(ProductCardStepper)<{ $onTop?: boolean }>`
     width: 100%;
     transition: ${({ theme }) => (theme.lowPerformance ? 'unset' : 'all 0.15s ease-in-out')};
 
@@ -226,7 +227,22 @@ const StyledStepper = styled(ProductCardStepper)<{ $onTop?: boolean }>`
             : css`
                   margin-top: 0.5rem;
               `}
-`;
+`);
+
+const Prices = memo<{ price: number; oldPrice?: number }>(({ price, oldPrice }) => {
+    return (
+        <StyledPrices>
+            <StyledPrice $type={oldPrice !== undefined ? 'new' : undefined} forwardedAs={Body2}>
+                {price}
+            </StyledPrice>
+            {oldPrice && (
+                <StyledPrice $type="old" stroke forwardedAs={Caption}>
+                    {oldPrice}
+                </StyledPrice>
+            )}
+        </StyledPrices>
+    );
+});
 
 /**
  * Карточка продукта с возможностью указания картинки, текста, цены и выбора количества.
@@ -267,21 +283,7 @@ export const ProductCard = forwardRef<HTMLDivElement, ProductCardProps>(function
                         {additionalInfo && <StyledAdditionalInfo>{additionalInfo}</StyledAdditionalInfo>}
                         {(price !== undefined || quantity !== undefined) && (
                             <StyledBottom>
-                                {price !== undefined && (
-                                    <StyledPrices>
-                                        <StyledPrice
-                                            $type={oldPrice !== undefined ? 'new' : undefined}
-                                            forwardedAs={Body2}
-                                        >
-                                            {price}
-                                        </StyledPrice>
-                                        {oldPrice && (
-                                            <StyledPrice $type="old" stroke forwardedAs={Caption}>
-                                                {oldPrice}
-                                            </StyledPrice>
-                                        )}
-                                    </StyledPrices>
-                                )}
+                                {price !== undefined && <Prices price={price} oldPrice={oldPrice} />}
                                 {!disabled && quantity !== undefined && (
                                     <StyledStepper
                                         readonly={readonly}

--- a/packages/plasma-ui/src/components/ProductCard/ProductCardStepper.tsx
+++ b/packages/plasma-ui/src/components/ProductCard/ProductCardStepper.tsx
@@ -46,7 +46,9 @@ const StyledInfoButton = styled(Button).attrs(() => ({ size: 's', square: true }
         `}
 `;
 
-const StyledStepperButton = styled(Button).attrs(() => ({ size: 's', square: true }))<{ $isHidden?: boolean }>`
+const StyledStepperButton = React.memo(styled(Button).attrs(() => ({ size: 's', square: true }))<{
+    $isHidden?: boolean;
+}>`
     color: ${black};
     background-color: rgba(8, 8, 8, 0.12); /* TODO: Перенести в tokens */
     align-self: flex-end;
@@ -59,7 +61,10 @@ const StyledStepperButton = styled(Button).attrs(() => ({ size: 's', square: tru
             opacity: 0;
             visibility: hidden;
         `}
-`;
+`);
+
+const iconMinus = <IconMinus color="inherit" size="s" />;
+const iconPlus = <IconPlus color="inherit" size="s" />;
 
 /**
  * Степпер карточки продукта.
@@ -90,11 +95,11 @@ export const ProductCardStepper: FC<ProductCardStepperProps> = ({
             ) : (
                 <>
                     <StyledStepperButton disabled={disabled} $isHidden={!isValuePositive} onClick={onLessClick}>
-                        <IconMinus color="inherit" size="s" />
+                        {iconMinus}
                     </StyledStepperButton>
                     <StyledStepperValue $isHidden={!isValuePositive} value={value} showWarning={isMax} />
                     <StyledStepperButton disabled={disabled || isMoreDisabled} onClick={onMoreClick}>
-                        <IconPlus color="inherit" size="s" />
+                        {iconPlus}
                     </StyledStepperButton>
                 </>
             )}


### PR DESCRIPTION
Переоткрыл https://github.com/salute-developers/plasma/pull/40

Вынес constant elements в переменные.
Добавил мемоизацию к styled component.
Использовал оптимизированный Stepper (он в отдельном PR).

До 3.8 ms
<img width="1586" alt="Screenshot 2022-06-01 at 10 22 41" src="https://user-images.githubusercontent.com/1077074/171351818-8eba1713-fd43-41f6-b14c-d926e69f1739.png">
После 1.8 ms
<img width="1585" alt="Screenshot 2022-06-01 at 10 25 26" src="https://user-images.githubusercontent.com/1077074/171351878-e0af5064-7241-4d7a-8c73-ca2900587cea.png">
 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.74.0-canary.53.2517224761.0
  npm install @salutejs/plasma-ui@1.110.0-canary.53.2517224761.0
  # or 
  yarn add @salutejs/plasma-temple@1.74.0-canary.53.2517224761.0
  yarn add @salutejs/plasma-ui@1.110.0-canary.53.2517224761.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
