### PR TITLE
feat(plasma-ui): DatePicker render optimization

### DIFF
--- a/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
@@ -125,9 +125,17 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         return [1, maxDayInMonth];
     }, [minMonth, maxMonth, minDay, maxDay, year, month, minYear, maxYear]);
 
-    const [yearRange, monthsRange, daysRange] = React.useMemo(() => {
-        return [getRange(minYear, maxYear), getRange(monthsFrom, monthsTo), getRange(daysFrom, daysTo)];
-    }, [minYear, maxYear, monthsFrom, monthsTo, daysFrom, daysTo]);
+    const [daysRange] = React.useMemo(() => {
+        return [getRange(daysFrom, daysTo)];
+    }, [daysFrom, daysTo]);
+
+    const [monthsRange] = React.useMemo(() => {
+        return [getRange(monthsFrom, monthsTo)];
+    }, [monthsFrom, monthsTo]);
+
+    const [yearRange] = React.useMemo(() => {
+        return [getRange(minYear, maxYear)];
+    }, [minYear, maxYear]);
 
     const getNextMonth = React.useCallback(
         (currentMonth: number, currentYear: number): number => {


### PR DESCRIPTION
Переоткрыл https://github.com/salute-developers/plasma/pull/36
cc @SeanSilke 

Убрал зависимость пропса range SimpleDatePicker от лишних переменных.

## Измерения

Проверил на сбербоксе и макбуке. Сборка реакта продовая. Измерения получал через Profiler компонент.

macbook
| DatePicker  | initial render |  rerender |
| ------------- | ------------- |--------|
| optimized  | 26 ms | 10 ms |
| non optimized | 27 ms  |  30 ms|

sberbox

| DatePicker  | initial render |  rerender |
| ------------- | ------------- |--------|
| optimized  | 344 ms  |  121 ms|
| non optimized | 322ms |  308 ms|


## flame chart

До 34 ms
<img width="1436" alt="Screenshot 2022-05-26 at 10 26 33" src="https://user-images.githubusercontent.com/1077074/170439484-47c49a39-110a-408a-904b-b05805ee1e38.png">


После 27 ms
<img width="1443" alt="Screenshot 2022-05-26 at 10 17 47" src="https://user-images.githubusercontent.com/1077074/170438110-a1557903-abee-44fd-9275-5f6e029c8aa0.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.74.0-canary.56.2517300946.0
  npm install @salutejs/plasma-ui@1.110.0-canary.56.2517300946.0
  # or 
  yarn add @salutejs/plasma-temple@1.74.0-canary.56.2517300946.0
  yarn add @salutejs/plasma-ui@1.110.0-canary.56.2517300946.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
