### PR TITLE
fix(plasma-ui): Fix overflow issue in `ProductCard` with media component

### DIFF
--- a/packages/plasma-ui/src/components/ProductCard/ProductCard.tsx
+++ b/packages/plasma-ui/src/components/ProductCard/ProductCard.tsx
@@ -87,6 +87,7 @@ const StyledCard = styled(Card)<{ $backgroundColor?: string }>`
 `;
 const StyledMediaSlot = styled.div`
     height: 100%;
+    min-height: 0;
 
     & img {
         display: block;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.72.2-canary.61.2461820009.0
  npm install @salutejs/plasma-ui@1.108.2-canary.61.2461820009.0
  # or 
  yarn add @salutejs/plasma-temple@1.72.2-canary.61.2461820009.0
  yarn add @salutejs/plasma-ui@1.108.2-canary.61.2461820009.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
