### PR TITLE
feat(plasma-ui): Tabs render optimization

### DIFF
--- a/packages/plasma-ui/src/components/Tabs/TabItem.tsx
+++ b/packages/plasma-ui/src/components/Tabs/TabItem.tsx
@@ -76,6 +76,8 @@ export const StyledTabItem = styled(BaseTabItem)<TabItemProps>`
     }
 `;
 
+export const StyledTabItemMemo = React.memo(StyledTabItem);
+
 /**
  * Элемент списка вкладок, недопустимо использовать вне компонента Tabs.
  */
@@ -88,5 +90,5 @@ export const TabItem: FC<TabItemProps> = (props) => {
         return () => refs?.unregister(ref);
     }, [refs]);
 
-    return <StyledTabItem ref={ref} {...props} />;
+    return <StyledTabItemMemo ref={ref} {...props} />;
 };

--- a/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Icon, IconClock } from '@salutejs/plasma-icons';
@@ -46,6 +46,13 @@ interface StoryProps {
     text: string;
 }
 
+const Icons = [
+    <Icon icon={icons[0] as 'clock'} size="s" />,
+    <Icon icon={icons[1] as 'clock'} size="s" />,
+    <Icon icon={icons[2] as 'clock'} size="s" />,
+    <Icon icon={icons[3] as 'clock'} size="s" />,
+];
+
 export const Default: Story<StoryProps & TabsProps> = ({
     itemsNumber,
     size,
@@ -60,8 +67,29 @@ export const Default: Story<StoryProps & TabsProps> = ({
     animated,
 }) => {
     const id = 'tabs-example';
-    const items = Array(itemsNumber).fill(0);
     const [index, setIndex] = React.useState(0);
+
+    const items = useMemo(() => {
+        type elem = {
+            label: string;
+            onClick: () => void;
+            onFocus: () => void;
+            onBlur: () => void;
+        };
+
+        const res: Array<elem> = [];
+        for (let i = 0; i < itemsNumber; i++) {
+            res.push({
+                label: `${text} ${i} `,
+                onFocus: action(`onFocus item #${i}`),
+                onBlur: action(`onBlur item #${i}`),
+                onClick: () => {
+                    !disabled && setIndex(i);
+                },
+            });
+        }
+        return res;
+    }, [itemsNumber, text]);
 
     const tabIndex = disabled ? -1 : 0;
 
@@ -79,19 +107,19 @@ export const Default: Story<StoryProps & TabsProps> = ({
             animated={animated}
             forwardedAs="ul"
         >
-            {items.map((_, i) => (
+            {items.map((elem, i) => (
                 <TabItem
                     key={`item:${i}`}
                     forwardedAs="li"
                     isActive={i === index}
                     aria-controls={id}
                     tabIndex={tabIndex}
-                    contentLeft={enableContentLeft && <Icon icon={icons[i % icons.length] as 'clock'} size="s" />}
-                    onClick={() => !disabled && setIndex(i)}
-                    onFocus={action(`onFocus item #${i}`)}
-                    onBlur={action(`onBlur item #${i}`)}
+                    contentLeft={enableContentLeft && Icons[i % icons.length]}
+                    onClick={elem.onClick}
+                    onFocus={elem.onFocus}
+                    onBlur={elem.onBlur}
                 >
-                    {text}
+                    {elem.label}
                 </TabItem>
             ))}
         </Tabs>

--- a/packages/plasma-ui/src/components/Tabs/Tabs.tsx
+++ b/packages/plasma-ui/src/components/Tabs/Tabs.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef, useMemo } from 'react';
 import type { TabsProps as BaseProps } from '@salutejs/plasma-core';
 
 import { TabsView, TabsViewProps } from './TabsView';
-import { TabItem } from './TabItem';
 import { TabItemRefs, TabsAnimationContext } from './TabsAnimationContext';
 import { TabsSlider } from './TabsSlider';
 
@@ -39,9 +38,9 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(function Tabs({ childr
 
     const { index, ...rest } = props;
     const childrenArray = React.Children.toArray(children);
-    const animatedChildren = childrenArray.map((child, i) => {
+    const animatedChildren = childrenArray.map((child) => {
         if (React.isValidElement(child)) {
-            return <TabItem animated key={i} {...child.props} disabled={rest.disabled} />;
+            return React.cloneElement(child, { disabled: rest.disabled, animated: true });
         }
         return child;
     });


### PR DESCRIPTION
Оптимизайия Tabs.
До :2.8 ms
![Screenshot 2022-06-23 at 02 48 41](https://user-images.githubusercontent.com/1077074/175179023-3a40ebe3-f30a-48c8-ad65-1af13586b370.png)
После: 1.6 ms
![Screenshot_2022-06-22_at_00 47 29](https://user-images.githubusercontent.com/1077074/175179147-17ecfbf8-1486-4d44-9488-312749bd71b3.png)

Поправлен "баг" с потерей ключей - Создание элементом заменено на клонирование.
Переписана история, так чтобы сократить количество  перерисовок.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.78.0-canary.76.2549466437.0
  npm install @salutejs/plasma-temple@1.77.0-canary.76.2549466437.0
  npm install @salutejs/plasma-ui@1.113.0-canary.76.2549466437.0
  npm install @salutejs/plasma-web@1.113.0-canary.76.2549466437.0
  # or 
  yarn add @salutejs/plasma-b2c@1.78.0-canary.76.2549466437.0
  yarn add @salutejs/plasma-temple@1.77.0-canary.76.2549466437.0
  yarn add @salutejs/plasma-ui@1.113.0-canary.76.2549466437.0
  yarn add @salutejs/plasma-web@1.113.0-canary.76.2549466437.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
