### PR TITLE
feat(plasma-ui): Performance addon for Tabs

### DIFF
--- a/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
@@ -2,6 +2,8 @@ import React, { useMemo, useState } from 'react';
 import { Story, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Icon, IconClock } from '@salutejs/plasma-icons';
+import { InteractionTaskArgs, PublicInteractionTask, withPerformance } from 'storybook-addon-performance';
+import { fireEvent, waitFor } from '@testing-library/dom';
 
 import { InContainerDecorator, disableProps } from '../../helpers';
 
@@ -139,6 +141,46 @@ Default.args = {
     enableContentLeft: true,
     text: 'Label',
 };
+
+const interactionTasks: PublicInteractionTask[] = [
+    {
+        name: 'Display Tabs',
+        description: 'Select second tab',
+        run: async ({ container, controls }: InteractionTaskArgs): Promise<void> => {
+            const [firstTab, secondTab] = container.querySelectorAll('[role="tab"]');
+
+            if (firstTab === null || secondTab === null) {
+                throw new Error('');
+            }
+
+            const isSelected = (tab: typeof secondTab) => () => {
+                const ariaSelected = tab.getAttribute('aria-selected');
+                if (ariaSelected === 'true') {
+                    return Promise.resolve();
+                }
+                return Promise.reject();
+            };
+
+            fireEvent.click(firstTab);
+            await waitFor(isSelected(firstTab));
+
+            await controls.time(async () => {
+                fireEvent.click(secondTab);
+                await waitFor(isSelected(secondTab));
+            });
+        },
+    },
+];
+
+Default.parameters = {
+    performance: {
+        interactions: interactionTasks,
+        allowedGroups: ['client'],
+        disable: false,
+    },
+};
+
+Default.decorators = [withPerformance];
 
 export const Arrows: Story<StoryProps & TabsControllerProps> = ({
     itemsNumber,

--- a/packages/plasma-ui/src/components/Tabs/performance-results/controls-tabs--default.json
+++ b/packages/plasma-ui/src/components/Tabs/performance-results/controls-tabs--default.json
@@ -1,0 +1,76 @@
+{
+    "results": [
+        {
+            "groupId": "Client",
+            "map": {
+                "Initial render": {
+                    "type": "timed",
+                    "taskName": "Initial render",
+                    "averageMs": 1.2640000021457671,
+                    "samples": 100,
+                    "variance": {
+                        "upperPercentage": 145.25316366906438,
+                        "lowerPercentage": 36.70885992382528,
+                        "standardDeviation": 0.3806625799171542
+                    }
+                },
+                "Re render": {
+                    "type": "timed",
+                    "taskName": "Re render",
+                    "averageMs": 0.2239999994635582,
+                    "samples": 100,
+                    "variance": {
+                        "upperPercentage": 391.0714270865393,
+                        "lowerPercentage": 55.35714541115247,
+                        "standardDeviation": 0.10403845329246743
+                    }
+                },
+                "Complete render (mount + layout + paint)": {
+                    "type": "timed",
+                    "taskName": "Complete render (mount + layout + paint)",
+                    "averageMs": 8.20700000077486,
+                    "samples": 100,
+                    "variance": {
+                        "upperPercentage": 176.59315237892267,
+                        "lowerPercentage": 13.488485520053706,
+                        "standardDeviation": 2.5430003942232835
+                    }
+                },
+                "DOM element count": {
+                    "type": "static",
+                    "taskName": "DOM element count",
+                    "value": "27"
+                },
+                "DOM element count (no nested inline svg elements)": {
+                    "type": "static",
+                    "taskName": "DOM element count (no nested inline svg elements)",
+                    "value": "23"
+                },
+                "React Fiber node count": {
+                    "type": "static",
+                    "taskName": "React Fiber node count",
+                    "value": "82"
+                }
+            }
+        },
+        {
+            "groupId": "Interactions",
+            "map": {
+                "Display Tabs": {
+                    "type": "timed",
+                    "taskName": "Display Tabs",
+                    "averageMs": 0.4209999993443489,
+                    "samples": 100,
+                    "variance": {
+                        "upperPercentage": 66.27078127535088,
+                        "lowerPercentage": 28.741096772965236,
+                        "standardDeviation": 0.09197282202789417
+                    }
+                }
+            }
+        }
+    ],
+    "storyName": "controls-tabs--default",
+    "samples": 100,
+    "copies": 1
+}


### PR DESCRIPTION
Добавил https://storybook.js.org/addons/storybook-addon-performance
Написал Interactions для переключения табов

Зафиксировал результаты прогона  аддона на сбилженном сторебуке.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.81.0-canary.80.2590033861.0
  npm install @salutejs/plasma-temple@1.81.0-canary.80.2590033861.0
  npm install @salutejs/plasma-ui@1.116.0-canary.80.2590033861.0
  npm install @salutejs/plasma-web@1.116.0-canary.80.2590033861.0
  # or 
  yarn add @salutejs/plasma-b2c@1.81.0-canary.80.2590033861.0
  yarn add @salutejs/plasma-temple@1.81.0-canary.80.2590033861.0
  yarn add @salutejs/plasma-ui@1.116.0-canary.80.2590033861.0
  yarn add @salutejs/plasma-web@1.116.0-canary.80.2590033861.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
