### PR TITLE
fix(plasma-b2c): missing react-draggable dep

### DIFF
--- a/packages/plasma-b2c/package-lock.json
+++ b/packages/plasma-b2c/package-lock.json
@@ -13574,6 +13574,11 @@
                 }
             }
         },
+        "classnames": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+            "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+        },
         "clean-css": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -13743,12 +13748,6 @@
                     }
                 }
             }
-        },
-        "clsx": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-            "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-            "dev": true
         },
         "co": {
             "version": "4.6.0",
@@ -27769,12 +27768,11 @@
             }
         },
         "react-draggable": {
-            "version": "4.4.4",
-            "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
-            "integrity": "sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==",
-            "dev": true,
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.3.tgz",
+            "integrity": "sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==",
             "requires": {
-                "clsx": "^1.1.1",
+                "classnames": "^2.2.5",
                 "prop-types": "^15.6.0"
             }
         },

--- a/packages/plasma-b2c/package.json
+++ b/packages/plasma-b2c/package.json
@@ -30,6 +30,7 @@
         "@salutejs/plasma-core": "1.62.0",
         "@salutejs/plasma-typo": "0.9.0",
         "@salutejs/plasma-web": "1.113.0",
+        "react-draggable": "4.4.3",
         "react-file-drop": "3.1.2",
         "react-popper": "2.2.5",
         "react-sortable-hoc": "2.0.0",
@@ -81,23 +82,7 @@
         "ts-node": "10.3.0",
         "typescript": "3.9.10"
     },
-    "keywords": [
-        "design-system",
-        "react-components",
-        "ui-kit",
-        "react"
-    ],
-    "files": [
-        "components",
-        "es",
-        "hocs",
-        "hooks",
-        "mixins",
-        "tokens",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js"
-    ],
+    "keywords": ["design-system", "react-components", "ui-kit", "react"],
+    "files": ["components", "es", "hocs", "hooks", "mixins", "tokens", "types", "utils", "index.d.ts", "index.js"],
     "sideEffects": false
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.78.1-canary.82.2571193920.0
  # or 
  yarn add @salutejs/plasma-b2c@1.78.1-canary.82.2571193920.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
