### PR TITLE
fix(plasma-web): Fix `Calendar` problems: unexpected popup close; don't updated change year and month  

### DIFF
--- a/packages/plasma-web/src/components/Calendar/CalendarBase.tsx
+++ b/packages/plasma-web/src/components/Calendar/CalendarBase.tsx
@@ -3,14 +3,7 @@ import styled from 'styled-components';
 
 import type { CalendarStateType, DateObject, Calendar } from './types';
 import { CalendarState } from './types';
-import {
-    changeEventThread,
-    getDateFromValue,
-    getNextDate,
-    getPrevDate,
-    getStartYear,
-    YEAR_RENDER_COUNT,
-} from './utils';
+import { getDateFromValue, getNextDate, getPrevDate, getStartYear, YEAR_RENDER_COUNT } from './utils';
 import { CalendarDays } from './CalendarDays';
 import { CalendarMonths } from './CalendarMonths';
 import { CalendarHeader } from './CalendarHeader';
@@ -81,7 +74,8 @@ export const CalendarBase: React.FC<CalendarBaseProps> = ({
 
     const handleOnChangeMonth = useCallback(
         (monthIndex: number) => {
-            changeEventThread(() => {
+            // TODO: https://github.com/salute-developers/plasma/issues/92
+            setTimeout(() => {
                 setCalendarState(CalendarState.Days);
                 setDate({ ...date, monthIndex });
             });
@@ -91,7 +85,8 @@ export const CalendarBase: React.FC<CalendarBaseProps> = ({
 
     const handleOnChangeYear = useCallback(
         (year: number) => {
-            changeEventThread(() => {
+            // TODO: https://github.com/salute-developers/plasma/issues/92
+            setTimeout(() => {
                 setCalendarState(CalendarState.Months);
                 setDate({ ...date, year });
             });

--- a/packages/plasma-web/src/components/Calendar/CalendarBase.tsx
+++ b/packages/plasma-web/src/components/Calendar/CalendarBase.tsx
@@ -3,7 +3,14 @@ import styled from 'styled-components';
 
 import type { CalendarStateType, DateObject, Calendar } from './types';
 import { CalendarState } from './types';
-import { getDateFromValue, getNextDate, getPrevDate, getStartYear, YEAR_RENDER_COUNT } from './utils';
+import {
+    changeEventThread,
+    getDateFromValue,
+    getNextDate,
+    getPrevDate,
+    getStartYear,
+    YEAR_RENDER_COUNT,
+} from './utils';
 import { CalendarDays } from './CalendarDays';
 import { CalendarMonths } from './CalendarMonths';
 import { CalendarHeader } from './CalendarHeader';
@@ -74,16 +81,20 @@ export const CalendarBase: React.FC<CalendarBaseProps> = ({
 
     const handleOnChangeMonth = useCallback(
         (monthIndex: number) => {
-            setCalendarState(CalendarState.Days);
-            setDate({ ...date, monthIndex });
+            changeEventThread(() => {
+                setCalendarState(CalendarState.Days);
+                setDate({ ...date, monthIndex });
+            });
         },
         [type, date],
     );
 
     const handleOnChangeYear = useCallback(
         (year: number) => {
-            setCalendarState(CalendarState.Months);
-            setDate({ ...date, year });
+            changeEventThread(() => {
+                setCalendarState(CalendarState.Months);
+                setDate({ ...date, year });
+            });
         },
         [date, type],
     );

--- a/packages/plasma-web/src/components/Calendar/CalendarMonths.tsx
+++ b/packages/plasma-web/src/components/Calendar/CalendarMonths.tsx
@@ -70,7 +70,7 @@ export const CalendarMonths: React.FC<CalendarMonthsProps> = ({ date: currentDat
                     tabIndex={0}
                     isCurrent={isCurrent}
                     isSelected={isSelected}
-                    onClickCapture={handleOnChangeMonth}
+                    onClick={handleOnChangeMonth}
                     data-month-index={i}
                     key={`StyledMonth-${i}`}
                 >


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.83.1-canary.89.2636049096.0
  npm install @salutejs/plasma-web@1.117.1-canary.89.2636049096.0
  # or 
  yarn add @salutejs/plasma-b2c@1.83.1-canary.89.2636049096.0
  yarn add @salutejs/plasma-web@1.117.1-canary.89.2636049096.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
