### PR TITLE
fix(plasma-ui): add explicit children for FC type

### DIFF
--- a/packages/plasma-core/src/components/Typography/Typography.component-test.tsx
+++ b/packages/plasma-core/src/components/Typography/Typography.component-test.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { ReactNode } from 'react';
 import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
 
 describe('plasma-core: Typography', () => {
@@ -45,7 +45,7 @@ describe('plasma-core: Typography', () => {
         cy.matchImageSnapshot();
     });
 
-    const Container: FC = ({ children }) => <div style={{ width: '50px' }}>{children}</div>;
+    const Container = ({ children }: { children: ReactNode }) => <div style={{ width: '50px' }}>{children}</div>;
 
     it('Typography with breakWord', () => {
         mount(

--- a/packages/plasma-ui/src/components/Card/Card.examples.tsx
+++ b/packages/plasma-ui/src/components/Card/Card.examples.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, PropsWithChildren } from 'react';
 import styled, { css, InterpolationFunction } from 'styled-components';
 import { primary, secondary } from '@salutejs/plasma-tokens';
 import { applyMaxLines, MaxLinesProps } from '@salutejs/plasma-core';
@@ -68,7 +68,7 @@ const StyledItemTitle = styled(Body1)<MaxLinesProps & TextAlignProps>`
     }
 `;
 
-export const ProductCard: React.FC<CardExampleProps> = ({ title, subtitle, imageSrc, ...rest }) => (
+export const ProductCard: FC<PropsWithChildren<CardExampleProps>> = ({ title, subtitle, imageSrc, ...rest }) => (
     <Card {...rest}>
         <CardBody>
             <CardContent>
@@ -80,7 +80,7 @@ export const ProductCard: React.FC<CardExampleProps> = ({ title, subtitle, image
     </Card>
 );
 
-export const MusicCard: React.FC<CardExampleProps> = ({
+export const MusicCard: FC<PropsWithChildren<CardExampleProps>> = ({
     title,
     subtitle,
     roundness = 12,
@@ -107,7 +107,7 @@ export const MusicCard: React.FC<CardExampleProps> = ({
     </>
 );
 
-export const GalleryCard: React.FC<CardExampleProps> = ({
+export const GalleryCard: React.FC<React.PropsWithChildren<CardExampleProps>> = ({
     title,
     subtitle,
     imageSrc,

--- a/packages/plasma-ui/src/components/Carousel/Carousel.component-test.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.component-test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
-import React, { FC } from 'react';
+import React, { ReactNode } from 'react';
 import { useVirtual } from '@salutejs/use-virtual';
 import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
 
@@ -33,13 +33,13 @@ describe('plasma-ui: Carousel', () => {
     const CarouselItem = getComponent('CarouselItem');
     const Body3 = getComponent('Body3');
 
-    const CarouselDecorator: FC = ({ children }) => (
+    const CarouselDecorator = ({ children }: { children: ReactNode }) => (
         <CypressTestDecorator>
             <Container>{children}</Container>
         </CypressTestDecorator>
     );
 
-    const AnimatedCarouselX: FC = () => {
+    const AnimatedCarouselX = () => {
         const [index, setIndex] = useRemoteHandlers({
             initialIndex: 0,
             axis: 'x',
@@ -72,7 +72,7 @@ describe('plasma-ui: Carousel', () => {
         );
     };
 
-    const AnimatedCarouselY: FC = () => {
+    const AnimatedCarouselY = () => {
         const [index, setIndex] = useRemoteHandlers({
             initialIndex: 0,
             axis: 'y',

--- a/packages/plasma-ui/src/components/Carousel/Carousel.examples.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.examples.tsx
@@ -59,7 +59,12 @@ export interface ScalingColCardProps extends Omit<CarouselItemProps, 'size' | 's
     };
 }
 
-export const ScalingColCard: React.FC<ScalingColCardProps> = ({ isActive, scrollSnapAlign, item, ...rest }) => (
+export const ScalingColCard: React.FC<React.PropsWithChildren<ScalingColCardProps>> = ({
+    isActive,
+    scrollSnapAlign,
+    item,
+    ...rest
+}) => (
     <CarouselCol size={2} sizeM={1.5} scrollSnapAlign={scrollSnapAlign} {...rest}>
         <StyledColInner>
             <StyledMusicCard

--- a/packages/plasma-ui/src/components/Carousel/CarouselCol.tsx
+++ b/packages/plasma-ui/src/components/Carousel/CarouselCol.tsx
@@ -14,7 +14,7 @@ export interface CarouselColProps extends ColProps, CarouselItemProps, React.HTM
  * Элемент списка. В рамках интерфейса элемент наследуется от ``Col`` и ``CarouselItem``.
  * Используется для каруселей с сеткой.
  */
-export const CarouselCol: React.FC<CarouselColProps> = ({ children, ...rest }) => {
+export const CarouselCol: React.FC<React.PropsWithChildren<CarouselColProps>> = ({ children, ...rest }) => {
     return (
         <StyledCol type="calc" role="group" aria-roledescription="slide" {...rest}>
             {children}

--- a/packages/plasma-ui/src/components/Cell/Cell.tsx
+++ b/packages/plasma-ui/src/components/Cell/Cell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, PropsWithChildren, HTMLAttributes } from 'react';
 import styled from 'styled-components';
 import { SelfPosition } from 'csstype';
 import { addFocus, FocusProps, OutlinedProps } from '@salutejs/plasma-core';
@@ -123,7 +123,7 @@ export interface CellProps extends FocusProps, OutlinedProps, AsProps {
 /**
  * Базовый компонент для отображения блоков контента в списках и карточках.
  */
-export const Cell: React.FC<CellProps & React.HTMLAttributes<HTMLDivElement>> = (props) => {
+export const Cell: FC<PropsWithChildren<CellProps & HTMLAttributes<HTMLDivElement>>> = (props) => {
     const {
         contentLeft: left,
         content,

--- a/packages/plasma-ui/src/components/Cell/CellDisclosure.tsx
+++ b/packages/plasma-ui/src/components/Cell/CellDisclosure.tsx
@@ -11,7 +11,7 @@ const DisclosureBtn = styled(Button)`
 
 export interface DisclosureProps extends Omit<ButtonProps, 'children' | 'text' | 'contentLeft' | 'contentRight'> {}
 
-export const Disclosure: React.FC<DisclosureProps> = (props) => {
+export const Disclosure: React.FC<React.PropsWithChildren<DisclosureProps>> = (props) => {
     return (
         <DisclosureBtn
             {...props}

--- a/packages/plasma-ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -11,7 +11,7 @@ export default {
     component: Checkbox,
     decorators: [
         InSpacingDecorator,
-        (Story: React.FC) => (
+        (Story) => (
             <SSRProvider>
                 <Story />
             </SSRProvider>

--- a/packages/plasma-ui/src/components/Checkbox/IconDone.tsx
+++ b/packages/plasma-ui/src/components/Checkbox/IconDone.tsx
@@ -16,7 +16,7 @@ interface IconProps {
     className?: string;
 }
 
-const Done: React.FC<IconProps> = (props) => (
+const Done: React.FC<React.PropsWithChildren<IconProps>> = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
         <path
             d="M9 16.2l-3.5-3.5a.984.984 0 00-1.4 0 .984.984 0 000 1.4l4.19 4.19c.39.39 1.02.39 1.41 0L20.3 7.7a.984.984 0 000-1.4.984.984 0 00-1.4 0L9 16.2z"
@@ -33,7 +33,7 @@ const StyledRoot = styled.div<{ w: string }>`
     `}
 `;
 
-export const IconDone: React.FC<IconProps> = ({ size = 's', color, className }) => {
+export const IconDone: React.FC<React.PropsWithChildren<IconProps>> = ({ size = 's', color, className }) => {
     return (
         <StyledRoot w={`${sizeMap[size]}rem`} className={className}>
             <Done color={color} size={size} />

--- a/packages/plasma-ui/src/components/Confirm/Confirm.tsx
+++ b/packages/plasma-ui/src/components/Confirm/Confirm.tsx
@@ -155,7 +155,7 @@ const StyledCell = styled(Cell)`
 /**
  * Сообщение подтверждения действия пользователя.
  */
-export const Confirm: React.FC<ConfirmProps> = (props) => {
+export const Confirm: React.FC<React.PropsWithChildren<ConfirmProps>> = (props) => {
     const {
         title,
         subtitle,

--- a/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
+++ b/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
@@ -61,7 +61,7 @@ export interface DeviceThemeProps {
  * с помощью пропса `detectDeviceCallback`.
  * При этом стоит помнить, что разрешены только 3 стандартных значения.
  */
-export const DeviceThemeProvider: React.FC<DeviceThemeProps> = ({
+export const DeviceThemeProvider: React.FC<React.PropsWithChildren<DeviceThemeProps>> = ({
     theme,
     children,
     detectDeviceCallback = detectDevice,

--- a/packages/plasma-ui/src/components/Grid/Container.tsx
+++ b/packages/plasma-ui/src/components/Grid/Container.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, PropsWithChildren, HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import {
     Container as BaseContainer,
@@ -40,7 +40,7 @@ const StyledContainer = styled(BaseContainer)<StyledContainerProps>`
  * Блок с полями по бокам для размещения контента по вертикали.
  * Блок нельзя вкладывать сам в себя или дальше по дереву.
  */
-export const Container: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...props }) => {
+export const Container: FC<PropsWithChildren<HTMLAttributes<HTMLDivElement>>> = ({ children, ...props }) => {
     const ref = React.useRef<HTMLDivElement | null>(null);
     const [width, setWidth] = React.useState(0);
 

--- a/packages/plasma-ui/src/components/Header/Header.stories.tsx
+++ b/packages/plasma-ui/src/components/Header/Header.stories.tsx
@@ -36,7 +36,11 @@ interface ContentComponentProps {
     enableIcons: boolean;
 }
 
-const Content: React.FC<ContentComponentProps> = ({ contentType, contentItemsNumber, enableIcons }) => {
+const Content: React.FC<React.PropsWithChildren<ContentComponentProps>> = ({
+    contentType,
+    contentItemsNumber,
+    enableIcons,
+}) => {
     const [activeTab, setActiveTab] = React.useState(0);
 
     const contentItems = Array(contentItemsNumber).fill(0);

--- a/packages/plasma-ui/src/components/Header/Header.tsx
+++ b/packages/plasma-ui/src/components/Header/Header.tsx
@@ -72,7 +72,7 @@ export type HeaderProps = React.HTMLAttributes<HTMLDivElement> &
  * Сборный компонент для отрисовки шапки страницы.
  * Уже включает в себя все составные части шапки.
  */
-export const Header: React.FC<HeaderProps> = ({ children, ...props }) => {
+export const Header: React.FC<React.PropsWithChildren<HeaderProps>> = ({ children, ...props }) => {
     const { minimize, back, logo, logoAlt, title, subtitle, onMinimizeClick, onBackClick, ...rest } = props as AllProps;
 
     return (

--- a/packages/plasma-ui/src/components/Header/HeaderArrow.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderArrow.tsx
@@ -51,7 +51,11 @@ const StyledIcon = styled(IconChevronLeft)<Pick<HeaderArrowProps, 'arrow'>>`
 /**
  * Кнопка-стрелка с возможностью отображения в двух типах - "назад" или "свернуть".
  */
-export const HeaderArrow: React.FC<HeaderArrowProps> = ({ arrow, iconSize = 's', ...rest }) => (
+export const HeaderArrow: React.FC<React.PropsWithChildren<HeaderArrowProps>> = ({
+    arrow,
+    iconSize = 's',
+    ...rest
+}) => (
     <StyledButton size="s" square view="clear" tabIndex={-1} outlined={false} forwardedAs="div" {...rest}>
         <StyledIcon size={iconSize} arrow={arrow} />
     </StyledButton>

--- a/packages/plasma-ui/src/components/Header/HeaderBack.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderBack.tsx
@@ -7,4 +7,6 @@ export interface HeaderBackProps extends Omit<HeaderArrowProps, 'arrow'> {}
 /**
  * Кнопка назад.
  */
-export const HeaderBack: React.FC<HeaderBackProps> = (props) => <HeaderArrow arrow="back" {...props} />;
+export const HeaderBack: React.FC<React.PropsWithChildren<HeaderBackProps>> = (props) => (
+    <HeaderArrow arrow="back" {...props} />
+);

--- a/packages/plasma-ui/src/components/Header/HeaderButton.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderButton.tsx
@@ -19,7 +19,11 @@ export interface HeaderButtonProps
 /**
  * Кнопка без внутренних отступов, границ и цвета фона.
  */
-export const HeaderButton: React.FC<HeaderButtonProps> = ({ size = 'm', children, ...rest }) => {
+export const HeaderButton: React.FC<React.PropsWithChildren<HeaderButtonProps>> = ({
+    size = 'm',
+    children,
+    ...rest
+}) => {
     return (
         <StyledHeaderButton size={size} view="clear" outlined={false} {...rest}>
             {children}

--- a/packages/plasma-ui/src/components/Header/HeaderContent.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { HTMLAttributes, FC, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 const StyledHeaderContent = styled.div`
@@ -12,6 +12,6 @@ const StyledHeaderContent = styled.div`
 /**
  * Контейнер для контента шапки.
  */
-export const HeaderContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...rest }) => (
+export const HeaderContent: FC<PropsWithChildren<HTMLAttributes<HTMLDivElement>>> = ({ children, ...rest }) => (
     <StyledHeaderContent {...rest}>{children}</StyledHeaderContent>
 );

--- a/packages/plasma-ui/src/components/Header/HeaderMinimize.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderMinimize.tsx
@@ -7,4 +7,6 @@ export interface HeaderBackProps extends Omit<HeaderArrowProps, 'arrow'> {}
 /**
  * Кнопка свернуть.
  */
-export const HeaderMinimize: React.FC<HeaderBackProps> = (props) => <HeaderArrow arrow="minimize" {...props} />;
+export const HeaderMinimize: React.FC<React.PropsWithChildren<HeaderBackProps>> = (props) => (
+    <HeaderArrow arrow="minimize" {...props} />
+);

--- a/packages/plasma-ui/src/components/Header/HeaderRoot.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderRoot.tsx
@@ -91,7 +91,12 @@ export interface HeaderRootProps extends React.HTMLAttributes<HTMLDivElement> {
 /**
  * Корневой узел для шапки.
  */
-export const HeaderRoot: React.FC<HeaderRootProps> = ({ children, size, gradientColor, ...rest }) => {
+export const HeaderRoot: React.FC<React.PropsWithChildren<HeaderRootProps>> = ({
+    children,
+    size,
+    gradientColor,
+    ...rest
+}) => {
     return (
         <StyledHeaderRoot {...rest} $size={size} $gradientColor={gradientColor}>
             <StyledInner>{children}</StyledInner>

--- a/packages/plasma-ui/src/components/Header/NeuHeader.tsx
+++ b/packages/plasma-ui/src/components/Header/NeuHeader.tsx
@@ -63,7 +63,7 @@ export type NeuHeaderProps = HTMLAttributes<HTMLDivElement> &
  * * Свойство `subtitle` переименовано в `subTitle`.
  * `NeuHeader` заменит собой исходный `Header` в будущих версиях.
  */
-export const NeuHeader: React.FC<NeuHeaderProps> = ({
+export const NeuHeader: React.FC<React.PropsWithChildren<NeuHeaderProps>> = ({
     arrow,
     onArrowClick,
     logo,

--- a/packages/plasma-ui/src/components/Icon/IconSet.tsx
+++ b/packages/plasma-ui/src/components/Icon/IconSet.tsx
@@ -27,7 +27,7 @@ export interface IconSetProps {
     include?: Array<IName>;
 }
 
-export const IconSet: React.FC<IconSetProps> = ({ size, color, exclude, include }) => {
+export const IconSet: React.FC<React.PropsWithChildren<IconSetProps>> = ({ size, color, exclude, include }) => {
     return (
         <StyledRow>
             {Object.entries(iconSectionsSet).map(([sectionName, section]) => {

--- a/packages/plasma-ui/src/components/Image/Image.tsx
+++ b/packages/plasma-ui/src/components/Image/Image.tsx
@@ -6,4 +6,4 @@ export type ImageProps = BaseProps;
 /**
  * Компонент для отображения картинок.
  */
-export const Image: React.FC<ImageProps> = styled(BaseImage)``;
+export const Image: React.FC<React.PropsWithChildren<ImageProps>> = styled(BaseImage)``;

--- a/packages/plasma-ui/src/components/MarkedList/MarkedList.tsx
+++ b/packages/plasma-ui/src/components/MarkedList/MarkedList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import { footnote1 } from '@salutejs/plasma-tokens';
 
@@ -32,11 +32,9 @@ export interface MarkedItemProps {
     text?: string;
 }
 
-export const MarkedItem: React.FC<MarkedItemProps & React.LiHTMLAttributes<HTMLLIElement>> = ({
-    text,
-    children,
-    ...props
-}) => (
+export const MarkedItem: React.FC<
+    MarkedItemProps & React.LiHTMLAttributes<HTMLLIElement> & { children?: ReactNode }
+> = ({ text, children, ...props }) => (
     <StyledMarkedItem {...props}>
         {children}
         {text && <StyledItemText>{text}</StyledItemText>}

--- a/packages/plasma-ui/src/components/Marquee/Marquee.tsx
+++ b/packages/plasma-ui/src/components/Marquee/Marquee.tsx
@@ -47,7 +47,7 @@ interface MarqueeProps {
 /**
  * Компонент для отображения бегущей строки
  */
-export const Marquee: FC<MarqueeProps> = ({ textAlign, children, ...rest }) => {
+export const Marquee: FC<React.PropsWithChildren<MarqueeProps>> = ({ textAlign, children, ...rest }) => {
     const animationSpeed = 70;
     const textRef = useRef<HTMLDivElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);

--- a/packages/plasma-ui/src/components/PaginationDots/SmartPaginationDots.tsx
+++ b/packages/plasma-ui/src/components/PaginationDots/SmartPaginationDots.tsx
@@ -10,7 +10,12 @@ export interface SmartPaginationDotsProps extends BaseProps, React.HTMLAttribute
  * Компонент для отображения точек пагинации
  * с возможностью ограничения количества видимых элементов.
  */
-export const SmartPaginationDots: React.FC<SmartPaginationDotsProps> = ({ items, index, visibleItems, ...rest }) => {
+export const SmartPaginationDots: React.FC<React.PropsWithChildren<SmartPaginationDotsProps>> = ({
+    items,
+    index,
+    visibleItems,
+    ...rest
+}) => {
     const { sliced, activeId } = usePaginationDots({ items, index, visibleItems });
 
     return (

--- a/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
@@ -66,7 +66,7 @@ export interface DatePickerProps extends Omit<SimpleDatePickerProps, 'type' | 'r
 /**
  * Компонент для выбора даты.
  */
-export const DatePicker: React.FC<DatePickerProps> = ({
+export const DatePicker: React.FC<React.PropsWithChildren<DatePickerProps>> = ({
     id,
     options = defaultOptions,
     size,

--- a/packages/plasma-ui/src/components/Pickers/Picker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Picker.tsx
@@ -278,7 +278,7 @@ export interface PickerProps
  * Компонент для отображения барабана-пикера,
  * позволяющего визуально проскроллить опции вверх-вниз.
  */
-export const Picker: FC<PickerProps> = ({
+export const Picker: FC<React.PropsWithChildren<PickerProps>> = ({
     id,
     size = DEFAULT_PICKER_SIZE,
     value,

--- a/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
+++ b/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
@@ -110,7 +110,7 @@ export interface PickerItemProps extends React.HTMLAttributes<HTMLDivElement>, S
     isSnapAlwaysStop?: boolean;
 }
 
-export const PickerItem: React.FC<PickerItemProps> = ({
+export const PickerItem: React.FC<React.PropsWithChildren<PickerItemProps>> = ({
     size = 's',
     item,
     index,

--- a/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
@@ -71,7 +71,7 @@ export interface TimePickerProps extends Omit<SimpleTimePickerProps, 'type' | 'r
 /**
  * Компонент для выбора времени.
  */
-export const TimePicker: React.FC<TimePickerProps> = ({
+export const TimePicker: React.FC<React.PropsWithChildren<TimePickerProps>> = ({
     id,
     options = defaultOptions,
     step,

--- a/packages/plasma-ui/src/components/ProductCard/ProductCardStepper.tsx
+++ b/packages/plasma-ui/src/components/ProductCard/ProductCardStepper.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLAttributes } from 'react';
+import React, { FC, HTMLAttributes, PropsWithChildren } from 'react';
 import styled, { css } from 'styled-components';
 import { black, warning } from '@salutejs/plasma-core';
 import { IconMinus, IconPlus } from '@salutejs/plasma-icons';
@@ -69,7 +69,7 @@ const iconPlus = <IconPlus color="inherit" size="s" />;
 /**
  * Степпер карточки продукта.
  */
-export const ProductCardStepper: FC<ProductCardStepperProps> = ({
+export const ProductCardStepper: FC<PropsWithChildren<ProductCardStepperProps>> = ({
     value,
     step,
     min,

--- a/packages/plasma-ui/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-ui/src/components/Radiobox/Radiobox.stories.tsx
@@ -11,7 +11,7 @@ export default {
     component: Radiobox,
     decorators: [
         InSpacingDecorator,
-        (Story: React.FC) => (
+        (Story: React.FC<React.PropsWithChildren<unknown>>) => (
             <SSRProvider>
                 <Story />
             </SSRProvider>

--- a/packages/plasma-ui/src/components/Slider/Double.tsx
+++ b/packages/plasma-ui/src/components/Slider/Double.tsx
@@ -37,7 +37,14 @@ function getXCenterHandle(handle: HTMLDivElement) {
     return handlePosition - containerX;
 }
 
-export const Slider: React.FC<SliderProps> = ({ min, max, value, disabled, onChangeCommitted, onChange }) => {
+export const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({
+    min,
+    max,
+    value,
+    disabled,
+    onChangeCommitted,
+    onChange,
+}) => {
     const [state, setState] = React.useState({
         stepSize: 0,
         railFillWidth: 0,

--- a/packages/plasma-ui/src/components/Slider/Single.tsx
+++ b/packages/plasma-ui/src/components/Slider/Single.tsx
@@ -30,7 +30,14 @@ export interface SliderProps {
     onChange?(value: number): void;
 }
 
-export const Slider: React.FC<SliderProps> = ({ min, max, value, disabled, onChangeCommitted, onChange }) => {
+export const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({
+    min,
+    max,
+    value,
+    disabled,
+    onChangeCommitted,
+    onChange,
+}) => {
     const [state, setState] = React.useState({
         xHandle: 0,
         stepSize: 0,

--- a/packages/plasma-ui/src/components/Slider/Slider.tsx
+++ b/packages/plasma-ui/src/components/Slider/Slider.tsx
@@ -11,7 +11,7 @@ const isSingleValueProps = (props: SliderProps): props is SingleSliderProps => t
  * Слайдер позволяет определить числовое значение в пределах указаного промежутка. Можно указать два значения.
  * Только для приложения Салют.
  */
-export const Slider: React.FC<SliderProps> = (props) => {
+export const Slider: React.FC<React.PropsWithChildren<SliderProps>> = (props) => {
     if (isSingleValueProps(props)) {
         return <SliderSingleValue {...props} />;
     }

--- a/packages/plasma-ui/src/components/Slider/SliderBase.tsx
+++ b/packages/plasma-ui/src/components/Slider/SliderBase.tsx
@@ -49,7 +49,7 @@ const Fill = styled.div`
     width: 0;
 `;
 
-export const SliderBase: React.FC<SliderProps> = ({
+export const SliderBase: React.FC<React.PropsWithChildren<SliderProps>> = ({
     max,
     min,
     setStepSize,

--- a/packages/plasma-ui/src/components/Stepper/Stepper.tsx
+++ b/packages/plasma-ui/src/components/Stepper/Stepper.tsx
@@ -51,7 +51,7 @@ export type StepperProps = UseStepperProps &
 /**
  * Готовый компонент для создания счетчика, подобного ``input[type="range"]``.
  */
-export const Stepper: React.FC<StepperProps> = ({
+export const Stepper: React.FC<React.PropsWithChildren<StepperProps>> = ({
     value,
     step,
     min,

--- a/packages/plasma-ui/src/components/Stepper/StepperValue.tsx
+++ b/packages/plasma-ui/src/components/Stepper/StepperValue.tsx
@@ -56,7 +56,13 @@ export interface StepperValueProps extends React.HTMLAttributes<HTMLDivElement>,
 /**
  * Компонент для отображения значения степпера.
  */
-export const StepperValue: React.FC<StepperValueProps> = ({ value, disabled, showWarning, formatter, ...rest }) => (
+export const StepperValue: React.FC<React.PropsWithChildren<StepperValueProps>> = ({
+    value,
+    disabled,
+    showWarning,
+    formatter,
+    ...rest
+}) => (
     <StyledValue role="status" aria-live="polite" disabled={disabled} showWarning={showWarning} {...rest}>
         {typeof formatter === 'function' ? formatter(value) : value}
     </StyledValue>

--- a/packages/plasma-ui/src/components/Tabs/TabItem.tsx
+++ b/packages/plasma-ui/src/components/Tabs/TabItem.tsx
@@ -81,7 +81,7 @@ export const StyledTabItemMemo = React.memo(StyledTabItem);
 /**
  * Элемент списка вкладок, недопустимо использовать вне компонента Tabs.
  */
-export const TabItem: FC<TabItemProps> = (props) => {
+export const TabItem: FC<React.PropsWithChildren<TabItemProps>> = (props) => {
     const ref = useRef<HTMLElement>(null);
     const { refs } = useTabsAnimationContext();
 

--- a/packages/plasma-ui/src/components/Tabs/TabsSlider.tsx
+++ b/packages/plasma-ui/src/components/Tabs/TabsSlider.tsx
@@ -32,7 +32,7 @@ export const StyledSlider = styled.div<Pick<SliderProps, 'disabled'>>`
 /**
  * Слайдер переключения табов
  */
-export const TabsSlider: React.FC<SliderProps> = ({ index, ...rest }) => {
+export const TabsSlider: React.FC<React.PropsWithChildren<SliderProps>> = ({ index, ...rest }) => {
     const [dimensions, setDimensions] = useState({ left: 0, width: 0, height: 0 });
     const { refs } = useTabsAnimationContext();
 

--- a/packages/plasma-ui/src/components/TextBox/TextBox.tsx
+++ b/packages/plasma-ui/src/components/TextBox/TextBox.tsx
@@ -56,7 +56,7 @@ export interface TextPttrnProps {
 /**
  * Компонент для отображения текста в скомпанованном блоке.
  */
-export const TextBox: React.FC<TextPttrnProps> = ({
+export const TextBox: React.FC<React.PropsWithChildren<TextPttrnProps>> = ({
     label,
     title,
     subTitle,

--- a/packages/plasma-ui/src/helpers/GridLines.tsx
+++ b/packages/plasma-ui/src/helpers/GridLines.tsx
@@ -66,7 +66,7 @@ export interface GridLinesProps extends React.HTMLAttributes<HTMLDivElement> {
 /**
  * Вспомогательный компонент для демонстрации в Storybook.
  */
-export const GridLines: React.FC<GridLinesProps> = ({ columns = 12, ...rest }) => {
+export const GridLines: React.FC<React.PropsWithChildren<GridLinesProps>> = ({ columns = 12, ...rest }) => {
     const cols = Array(columns).fill(0);
 
     return (

--- a/packages/plasma-ui/src/helpers/Palette.tsx
+++ b/packages/plasma-ui/src/helpers/Palette.tsx
@@ -88,7 +88,7 @@ export interface PaletteProps {
     heading?: string;
 }
 
-export const Palette: React.FC<PaletteProps> = ({ theme = 'darkSber', title, heading }) => {
+export const Palette: React.FC<React.PropsWithChildren<PaletteProps>> = ({ theme = 'darkSber', title, heading }) => {
     const selectedTheme = themes[theme][':root'];
     const primary = selectedTheme['--plasma-colors-primary'];
     const items = React.useMemo(() => {

--- a/packages/plasma-ui/src/helpers/StoryDecorators.tsx
+++ b/packages/plasma-ui/src/helpers/StoryDecorators.tsx
@@ -4,20 +4,20 @@ import { Container } from '../components/Grid';
 
 import { GridLines } from './GridLines';
 
-export const InSpacing = (Story: React.FC) => (
+export const InSpacing = (Story: React.FC<React.PropsWithChildren<unknown>>) => (
     <div style={{ padding: '1rem' }}>
         <Story />
     </div>
 );
 
-export const WithGridLines = (Story: React.FC, context) => (
+export const WithGridLines = (Story: React.FC<React.PropsWithChildren<unknown>>, context) => (
     <>
         {context.args.displayGrid && <GridLines />}
         <Story />
     </>
 );
 
-export const InContainer = (Story: React.FC) => (
+export const InContainer = (Story: React.FC<React.PropsWithChildren<unknown>>) => (
     <Container>
         <Story />
     </Container>

--- a/packages/plasma-ui/src/helpers/ThemeBackground.tsx
+++ b/packages/plasma-ui/src/helpers/ThemeBackground.tsx
@@ -51,6 +51,6 @@ const StyledRoot = styled.div<Props>`
         `}
 `;
 
-export const ThemeBackground: React.FC<Props> = ({ children, ...rest }) => {
+export const ThemeBackground: React.FC<React.PropsWithChildren<Props>> = ({ children, ...rest }) => {
     return <StyledRoot {...rest}>{children}</StyledRoot>;
 };

--- a/packages/plasma-ui/src/helpers/ThemeSelect.tsx
+++ b/packages/plasma-ui/src/helpers/ThemeSelect.tsx
@@ -37,7 +37,7 @@ const themes = {
     lightJoy: createGlobalStyle(lightJoy),
 };
 
-export const ThemeSelect: React.FC = () => {
+export const ThemeSelect = () => {
     const [currentTheme, setCurrentTheme] = useState('darkSber');
 
     const Theme = themes[currentTheme];
@@ -67,7 +67,7 @@ const typos = {
     mobile: createGlobalStyle(mobile),
 };
 
-export const TypoSelect: React.FC = () => {
+export const TypoSelect: React.FC<React.PropsWithChildren<unknown>> = () => {
     const [currentTypo, setCurrentTypo] = useState('sberBox');
 
     const Typo = typos[currentTypo];

--- a/packages/plasma-ui/src/mixins/mixins.stories.tsx
+++ b/packages/plasma-ui/src/mixins/mixins.stories.tsx
@@ -10,9 +10,9 @@ import type {
 
 import { InteractionProps } from '.';
 
-export const OutlinedComponent: React.FC<FocusProps & OutlinedProps> = () => undefined;
-export const BlurredComponent: React.FC<BlurProps> = () => undefined;
-export const DisabledComponent: React.FC<DisabledProps> = () => undefined;
-export const InteractionComponent: React.FC<InteractionProps> = () => undefined;
-export const RoundnessComponent: React.FC<RoundnessProps> = () => undefined;
-export const ViewComponent: React.FC<ViewProps> = () => undefined;
+export const OutlinedComponent: React.FC<React.PropsWithChildren<FocusProps & OutlinedProps>> = () => undefined;
+export const BlurredComponent: React.FC<React.PropsWithChildren<BlurProps>> = () => undefined;
+export const DisabledComponent: React.FC<React.PropsWithChildren<DisabledProps>> = () => undefined;
+export const InteractionComponent: React.FC<React.PropsWithChildren<InteractionProps>> = () => undefined;
+export const RoundnessComponent: React.FC<React.PropsWithChildren<RoundnessProps>> = () => undefined;
+export const ViewComponent: React.FC<React.PropsWithChildren<ViewProps>> = () => undefined;


### PR DESCRIPTION
Прогнал codemode "implicit-children" для react 18.
https://github.com/eps1lon/types-react-codemod
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.83.1-canary.94.2631884268.0
  npm install @salutejs/plasma-ui@1.117.1-canary.94.2631884268.0
  # or 
  yarn add @salutejs/plasma-temple@1.83.1-canary.94.2631884268.0
  yarn add @salutejs/plasma-ui@1.117.1-canary.94.2631884268.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
