### PR TITLE
fix(plasma-ui): removed FC type

### DIFF
--- a/packages/plasma-core/src/components/Typography/Typography.component-test.tsx
+++ b/packages/plasma-core/src/components/Typography/Typography.component-test.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { ReactNode } from 'react';
 import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
 
 describe('plasma-core: Typography', () => {
@@ -45,7 +45,7 @@ describe('plasma-core: Typography', () => {
         cy.matchImageSnapshot();
     });
 
-    const Container: FC = ({ children }) => <div style={{ width: '50px' }}>{children}</div>;
+    const Container = ({ children }: { children: ReactNode }) => <div style={{ width: '50px' }}>{children}</div>;
 
     it('Typography with breakWord', () => {
         mount(

--- a/packages/plasma-ui/src/components/Card/Card.examples.tsx
+++ b/packages/plasma-ui/src/components/Card/Card.examples.tsx
@@ -68,7 +68,7 @@ const StyledItemTitle = styled(Body1)<MaxLinesProps & TextAlignProps>`
     }
 `;
 
-export const ProductCard: React.FC<CardExampleProps> = ({ title, subtitle, imageSrc, ...rest }) => (
+export const ProductCard = ({ title, subtitle, imageSrc, ...rest }: CardExampleProps) => (
     <Card {...rest}>
         <CardBody>
             <CardContent>
@@ -80,7 +80,7 @@ export const ProductCard: React.FC<CardExampleProps> = ({ title, subtitle, image
     </Card>
 );
 
-export const MusicCard: React.FC<CardExampleProps> = ({
+export const MusicCard = ({
     title,
     subtitle,
     roundness = 12,
@@ -89,7 +89,7 @@ export const MusicCard: React.FC<CardExampleProps> = ({
     imageCustomRatio,
     textAlign,
     ...rest
-}) => (
+}: CardExampleProps) => (
     <>
         <Card roundness={roundness} {...rest}>
             <CardBody>
@@ -107,7 +107,7 @@ export const MusicCard: React.FC<CardExampleProps> = ({
     </>
 );
 
-export const GalleryCard: React.FC<CardExampleProps> = ({
+export const GalleryCard = ({
     title,
     subtitle,
     imageSrc,
@@ -115,7 +115,7 @@ export const GalleryCard: React.FC<CardExampleProps> = ({
     imageCustomRatio,
     textAlign,
     ...rest
-}) => (
+}: CardExampleProps) => (
     <>
         <Card {...rest}>
             <CardBody>

--- a/packages/plasma-ui/src/components/Carousel/Carousel.component-test.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.component-test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
-import React, { FC } from 'react';
+import React, { ReactNode } from 'react';
 import { useVirtual } from '@salutejs/use-virtual';
 import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
 
@@ -33,13 +33,13 @@ describe('plasma-ui: Carousel', () => {
     const CarouselItem = getComponent('CarouselItem');
     const Body3 = getComponent('Body3');
 
-    const CarouselDecorator: FC = ({ children }) => (
+    const CarouselDecorator = ({ children }: { children: ReactNode }) => (
         <CypressTestDecorator>
             <Container>{children}</Container>
         </CypressTestDecorator>
     );
 
-    const AnimatedCarouselX: FC = () => {
+    const AnimatedCarouselX = () => {
         const [index, setIndex] = useRemoteHandlers({
             initialIndex: 0,
             axis: 'x',
@@ -72,7 +72,7 @@ describe('plasma-ui: Carousel', () => {
         );
     };
 
-    const AnimatedCarouselY: FC = () => {
+    const AnimatedCarouselY = () => {
         const [index, setIndex] = useRemoteHandlers({
             initialIndex: 0,
             axis: 'y',

--- a/packages/plasma-ui/src/components/Carousel/Carousel.examples.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.examples.tsx
@@ -59,7 +59,7 @@ export interface ScalingColCardProps extends Omit<CarouselItemProps, 'size' | 's
     };
 }
 
-export const ScalingColCard: React.FC<ScalingColCardProps> = ({ isActive, scrollSnapAlign, item, ...rest }) => (
+export const ScalingColCard = ({ isActive, scrollSnapAlign, item, ...rest }: ScalingColCardProps) => (
     <CarouselCol size={2} sizeM={1.5} scrollSnapAlign={scrollSnapAlign} {...rest}>
         <StyledColInner>
             <StyledMusicCard

--- a/packages/plasma-ui/src/components/Carousel/CarouselCol.tsx
+++ b/packages/plasma-ui/src/components/Carousel/CarouselCol.tsx
@@ -14,7 +14,7 @@ export interface CarouselColProps extends ColProps, CarouselItemProps, React.HTM
  * Элемент списка. В рамках интерфейса элемент наследуется от ``Col`` и ``CarouselItem``.
  * Используется для каруселей с сеткой.
  */
-export const CarouselCol: React.FC<CarouselColProps> = ({ children, ...rest }) => {
+export const CarouselCol = ({ children, ...rest }: CarouselColProps) => {
     return (
         <StyledCol type="calc" role="group" aria-roledescription="slide" {...rest}>
             {children}

--- a/packages/plasma-ui/src/components/Cell/Cell.tsx
+++ b/packages/plasma-ui/src/components/Cell/Cell.tsx
@@ -123,7 +123,7 @@ export interface CellProps extends FocusProps, OutlinedProps, AsProps {
 /**
  * Базовый компонент для отображения блоков контента в списках и карточках.
  */
-export const Cell: React.FC<CellProps & React.HTMLAttributes<HTMLDivElement>> = (props) => {
+export const Cell = (props: CellProps & React.HTMLAttributes<HTMLDivElement>) => {
     const {
         contentLeft: left,
         content,

--- a/packages/plasma-ui/src/components/Cell/CellDisclosure.tsx
+++ b/packages/plasma-ui/src/components/Cell/CellDisclosure.tsx
@@ -11,7 +11,7 @@ const DisclosureBtn = styled(Button)`
 
 export interface DisclosureProps extends Omit<ButtonProps, 'children' | 'text' | 'contentLeft' | 'contentRight'> {}
 
-export const Disclosure: React.FC<DisclosureProps> = (props) => {
+export const Disclosure = (props: DisclosureProps) => {
     return (
         <DisclosureBtn
             {...props}

--- a/packages/plasma-ui/src/components/Checkbox/IconDone.tsx
+++ b/packages/plasma-ui/src/components/Checkbox/IconDone.tsx
@@ -16,7 +16,7 @@ interface IconProps {
     className?: string;
 }
 
-const Done: React.FC<IconProps> = (props) => (
+const Done = (props: IconProps) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
         <path
             d="M9 16.2l-3.5-3.5a.984.984 0 00-1.4 0 .984.984 0 000 1.4l4.19 4.19c.39.39 1.02.39 1.41 0L20.3 7.7a.984.984 0 000-1.4.984.984 0 00-1.4 0L9 16.2z"
@@ -33,7 +33,7 @@ const StyledRoot = styled.div<{ w: string }>`
     `}
 `;
 
-export const IconDone: React.FC<IconProps> = ({ size = 's', color, className }) => {
+export const IconDone = ({ size = 's', color, className }: IconProps) => {
     return (
         <StyledRoot w={`${sizeMap[size]}rem`} className={className}>
             <Done color={color} size={size} />

--- a/packages/plasma-ui/src/components/Confirm/Confirm.tsx
+++ b/packages/plasma-ui/src/components/Confirm/Confirm.tsx
@@ -155,7 +155,7 @@ const StyledCell = styled(Cell)`
 /**
  * Сообщение подтверждения действия пользователя.
  */
-export const Confirm: React.FC<ConfirmProps> = (props) => {
+export const Confirm = (props: ConfirmProps) => {
     const {
         title,
         subtitle,

--- a/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
+++ b/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { createGlobalStyle, ThemeProvider } from 'styled-components';
 import { sberPortal, sberBox, mobile, sberPortalScale } from '@salutejs/plasma-tokens';
 import { transformStyles } from '@salutejs/plasma-core';
@@ -44,6 +44,7 @@ export interface DeviceThemeProps {
      * Флаг для отключения анимаций и прочих твиков над UI, снижающих производительность.
      */
     lowPerformance?: boolean;
+    children?: ReactNode;
 }
 
 /**
@@ -61,13 +62,13 @@ export interface DeviceThemeProps {
  * с помощью пропса `detectDeviceCallback`.
  * При этом стоит помнить, что разрешены только 3 стандартных значения.
  */
-export const DeviceThemeProvider: React.FC<DeviceThemeProps> = ({
+export const DeviceThemeProvider = ({
     theme,
     children,
     detectDeviceCallback = detectDevice,
     responsiveTypo = false,
     lowPerformance = false,
-}) => {
+}: DeviceThemeProps) => {
     const deviceKind = detectDeviceCallback();
     const deviceScale = deviceScales[deviceKind] || sberPortalScale;
     const Typo = React.useMemo(() => typoSizes[deviceKind], [deviceKind]);

--- a/packages/plasma-ui/src/components/Grid/Container.tsx
+++ b/packages/plasma-ui/src/components/Grid/Container.tsx
@@ -40,7 +40,7 @@ const StyledContainer = styled(BaseContainer)<StyledContainerProps>`
  * Блок с полями по бокам для размещения контента по вертикали.
  * Блок нельзя вкладывать сам в себя или дальше по дереву.
  */
-export const Container: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...props }) => {
+export const Container = ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
     const ref = React.useRef<HTMLDivElement | null>(null);
     const [width, setWidth] = React.useState(0);
 

--- a/packages/plasma-ui/src/components/Header/Header.stories.tsx
+++ b/packages/plasma-ui/src/components/Header/Header.stories.tsx
@@ -36,7 +36,7 @@ interface ContentComponentProps {
     enableIcons: boolean;
 }
 
-const Content: React.FC<ContentComponentProps> = ({ contentType, contentItemsNumber, enableIcons }) => {
+const Content = ({ contentType, contentItemsNumber, enableIcons }: ContentComponentProps) => {
     const [activeTab, setActiveTab] = React.useState(0);
 
     const contentItems = Array(contentItemsNumber).fill(0);

--- a/packages/plasma-ui/src/components/Header/Header.tsx
+++ b/packages/plasma-ui/src/components/Header/Header.tsx
@@ -71,7 +71,7 @@ export type HeaderProps = React.HTMLAttributes<HTMLDivElement> &
  * Сборный компонент для отрисовки шапки страницы.
  * Уже включает в себя все составные части шапки.
  */
-export const Header: React.FC<HeaderProps> = ({ children, ...props }) => {
+export const Header = ({ children, ...props }: HeaderProps) => {
     const { minimize, back, logo, logoAlt, title, subtitle, onMinimizeClick, onBackClick, ...rest } = props as AllProps;
 
     return (

--- a/packages/plasma-ui/src/components/Header/HeaderArrow.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderArrow.tsx
@@ -51,7 +51,7 @@ const StyledIcon = styled(IconChevronLeft)<Pick<HeaderArrowProps, 'arrow'>>`
 /**
  * Кнопка-стрелка с возможностью отображения в двух типах - "назад" или "свернуть".
  */
-export const HeaderArrow: React.FC<HeaderArrowProps> = ({ arrow, iconSize = 's', ...rest }) => (
+export const HeaderArrow = ({ arrow, iconSize = 's', ...rest }: HeaderArrowProps) => (
     <StyledButton size="s" square view="clear" tabIndex={-1} outlined={false} forwardedAs="div" {...rest}>
         <StyledIcon size={iconSize} arrow={arrow} />
     </StyledButton>

--- a/packages/plasma-ui/src/components/Header/HeaderBack.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderBack.tsx
@@ -7,4 +7,4 @@ export interface HeaderBackProps extends Omit<HeaderArrowProps, 'arrow'> {}
 /**
  * Кнопка назад.
  */
-export const HeaderBack: React.FC<HeaderBackProps> = (props) => <HeaderArrow arrow="back" {...props} />;
+export const HeaderBack = (props: HeaderBackProps) => <HeaderArrow arrow="back" {...props} />;

--- a/packages/plasma-ui/src/components/Header/HeaderButton.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderButton.tsx
@@ -19,7 +19,7 @@ export interface HeaderButtonProps
 /**
  * Кнопка без внутренних отступов, границ и цвета фона.
  */
-export const HeaderButton: React.FC<HeaderButtonProps> = ({ size = 'm', children, ...rest }) => {
+export const HeaderButton = ({ size = 'm', children, ...rest }: HeaderButtonProps) => {
     return (
         <StyledHeaderButton size={size} view="clear" outlined={false} {...rest}>
             {children}

--- a/packages/plasma-ui/src/components/Header/HeaderContent.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderContent.tsx
@@ -12,6 +12,6 @@ const StyledHeaderContent = styled.div`
 /**
  * Контейнер для контента шапки.
  */
-export const HeaderContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ children, ...rest }) => (
+export const HeaderContent = ({ children, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
     <StyledHeaderContent {...rest}>{children}</StyledHeaderContent>
 );

--- a/packages/plasma-ui/src/components/Header/HeaderMinimize.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderMinimize.tsx
@@ -7,4 +7,4 @@ export interface HeaderBackProps extends Omit<HeaderArrowProps, 'arrow'> {}
 /**
  * Кнопка свернуть.
  */
-export const HeaderMinimize: React.FC<HeaderBackProps> = (props) => <HeaderArrow arrow="minimize" {...props} />;
+export const HeaderMinimize = (props: HeaderBackProps) => <HeaderArrow arrow="minimize" {...props} />;

--- a/packages/plasma-ui/src/components/Header/HeaderRoot.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderRoot.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import { mediaQuery } from '@salutejs/plasma-core';
 import Color from 'color';
@@ -86,12 +86,13 @@ export interface HeaderRootProps extends React.HTMLAttributes<HTMLDivElement> {
      * Можно использовать hex, rgb и rgba значения цвета.
      */
     gradientColor?: string;
+    children?: ReactNode;
 }
 
 /**
  * Корневой узел для шапки.
  */
-export const HeaderRoot: React.FC<HeaderRootProps> = ({ children, size, gradientColor, ...rest }) => {
+export const HeaderRoot = ({ children, size, gradientColor, ...rest }: HeaderRootProps) => {
     return (
         <StyledHeaderRoot {...rest} $size={size} $gradientColor={gradientColor}>
             <StyledInner>{children}</StyledInner>

--- a/packages/plasma-ui/src/components/Header/NeuHeader.tsx
+++ b/packages/plasma-ui/src/components/Header/NeuHeader.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, MouseEventHandler } from 'react';
+import React, { HTMLAttributes, MouseEventHandler, ReactNode } from 'react';
 
 import { HeaderRoot, HeaderRootProps } from './HeaderRoot';
 import { HeaderArrow } from './HeaderArrow';
@@ -51,7 +51,7 @@ export type NeuHeaderProps = HTMLAttributes<HTMLDivElement> &
     ArrowProps &
     (LogoProps | NoLogoProps) &
     (TitleProps | NoTitleProps) &
-    Pick<HeaderRootProps, 'gradientColor'>;
+    Pick<HeaderRootProps, 'gradientColor'> & { children?: ReactNode };
 
 /**
  * Сборный компонент для отрисовки шапки страницы.
@@ -63,7 +63,7 @@ export type NeuHeaderProps = HTMLAttributes<HTMLDivElement> &
  * * Свойство `subtitle` переименовано в `subTitle`.
  * `NeuHeader` заменит собой исходный `Header` в будущих версиях.
  */
-export const NeuHeader: React.FC<NeuHeaderProps> = ({
+export const NeuHeader = ({
     arrow,
     onArrowClick,
     logo,
@@ -72,7 +72,7 @@ export const NeuHeader: React.FC<NeuHeaderProps> = ({
     subTitle,
     children,
     ...rest
-}) => {
+}: NeuHeaderProps) => {
     return (
         <HeaderRoot {...rest}>
             <HeaderArrow onClick={onArrowClick} arrow={arrow} />

--- a/packages/plasma-ui/src/components/Icon/IconSet.tsx
+++ b/packages/plasma-ui/src/components/Icon/IconSet.tsx
@@ -27,7 +27,7 @@ export interface IconSetProps {
     include?: Array<IName>;
 }
 
-export const IconSet: React.FC<IconSetProps> = ({ size, color, exclude, include }) => {
+export const IconSet = ({ size, color, exclude, include }: IconSetProps) => {
     return (
         <StyledRow>
             {Object.entries(iconSectionsSet).map(([sectionName, section]) => {

--- a/packages/plasma-ui/src/components/Image/Image.tsx
+++ b/packages/plasma-ui/src/components/Image/Image.tsx
@@ -1,9 +1,10 @@
 import styled from 'styled-components';
 import { Image as BaseImage, ImageProps as BaseProps } from '@salutejs/plasma-core';
+import { ReactElement } from 'react';
 
 export type ImageProps = BaseProps;
 
 /**
  * Компонент для отображения картинок.
  */
-export const Image: React.FC<ImageProps> = styled(BaseImage)``;
+export const Image: (props: ImageProps) => ReactElement = styled(BaseImage)``;

--- a/packages/plasma-ui/src/components/MarkedList/MarkedList.tsx
+++ b/packages/plasma-ui/src/components/MarkedList/MarkedList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import { footnote1 } from '@salutejs/plasma-tokens';
 
@@ -30,13 +30,10 @@ export interface MarkedItemProps {
      * Текстовое значение, оборачивается в свой тег
      */
     text?: string;
+    children?: ReactNode;
 }
 
-export const MarkedItem: React.FC<MarkedItemProps & React.LiHTMLAttributes<HTMLLIElement>> = ({
-    text,
-    children,
-    ...props
-}) => (
+export const MarkedItem = ({ text, children, ...props }: MarkedItemProps & React.LiHTMLAttributes<HTMLLIElement>) => (
     <StyledMarkedItem {...props}>
         {children}
         {text && <StyledItemText>{text}</StyledItemText>}

--- a/packages/plasma-ui/src/components/Marquee/Marquee.tsx
+++ b/packages/plasma-ui/src/components/Marquee/Marquee.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useLayoutEffect, useRef, useState } from 'react';
+import React, { ReactNode, useLayoutEffect, useRef, useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
 
 const marquee = keyframes`
@@ -41,13 +41,14 @@ const StyledText = styled.div`
 `;
 
 interface MarqueeProps {
+    children?: ReactNode;
     textAlign?: 'start' | 'center' | 'end';
 }
 
 /**
  * Компонент для отображения бегущей строки
  */
-export const Marquee: FC<MarqueeProps> = ({ textAlign, children, ...rest }) => {
+export const Marquee = ({ textAlign, children, ...rest }: MarqueeProps) => {
     const animationSpeed = 70;
     const textRef = useRef<HTMLDivElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);

--- a/packages/plasma-ui/src/components/PaginationDots/SmartPaginationDots.tsx
+++ b/packages/plasma-ui/src/components/PaginationDots/SmartPaginationDots.tsx
@@ -10,7 +10,7 @@ export interface SmartPaginationDotsProps extends BaseProps, React.HTMLAttribute
  * Компонент для отображения точек пагинации
  * с возможностью ограничения количества видимых элементов.
  */
-export const SmartPaginationDots: React.FC<SmartPaginationDotsProps> = ({ items, index, visibleItems, ...rest }) => {
+export const SmartPaginationDots = ({ items, index, visibleItems, ...rest }: SmartPaginationDotsProps) => {
     const { sliced, activeId } = usePaginationDots({ items, index, visibleItems });
 
     return (

--- a/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
@@ -66,7 +66,7 @@ export interface DatePickerProps extends Omit<SimpleDatePickerProps, 'type' | 'r
 /**
  * Компонент для выбора даты.
  */
-export const DatePicker: React.FC<DatePickerProps> = ({
+export const DatePicker = ({
     id,
     options = defaultOptions,
     size,
@@ -86,7 +86,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     yearsAriaLabel: yearAriaLabel,
     infiniteScroll,
     ...rest
-}) => {
+}: DatePickerProps) => {
     const normalizeValues = React.useMemo(() => getNormalizeValues(getDateValues, getSeconds)(value, min, max), [
         value,
     ]);

--- a/packages/plasma-ui/src/components/Pickers/Picker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Picker.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useRef, useCallback, useEffect, useContext } from 'react';
-import type { FC, HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 import styled, { css, ThemeContext } from 'styled-components';
 import { primary } from '@salutejs/plasma-tokens';
 import { IconChevronUp, IconChevronDown } from '@salutejs/plasma-icons';
@@ -278,7 +278,7 @@ export interface PickerProps
  * Компонент для отображения барабана-пикера,
  * позволяющего визуально проскроллить опции вверх-вниз.
  */
-export const Picker: FC<PickerProps> = ({
+export const Picker = ({
     id,
     size = DEFAULT_PICKER_SIZE,
     value,
@@ -290,7 +290,7 @@ export const Picker: FC<PickerProps> = ({
     'aria-label': ariaLabel,
     onChange,
     ...rest
-}) => {
+}: PickerProps) => {
     const isSingleItem = items.length === 1;
     const disabled = rest.disabled || isSingleItem;
 

--- a/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
+++ b/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
@@ -110,7 +110,7 @@ export interface PickerItemProps extends React.HTMLAttributes<HTMLDivElement>, S
     isSnapAlwaysStop?: boolean;
 }
 
-export const PickerItem: React.FC<PickerItemProps> = ({
+export const PickerItem = ({
     size = 's',
     item,
     index,
@@ -120,7 +120,7 @@ export const PickerItem: React.FC<PickerItemProps> = ({
     autofocus,
     disabled,
     ...rest
-}) => {
+}: PickerItemProps) => {
     const itemRef = React.useRef<HTMLDivElement | null>(null);
     /*
      * Выведем стили еще до того, как отработает коллбек стилей.

--- a/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
@@ -71,7 +71,7 @@ export interface TimePickerProps extends Omit<SimpleTimePickerProps, 'type' | 'r
 /**
  * Компонент для выбора времени.
  */
-export const TimePicker: React.FC<TimePickerProps> = ({
+export const TimePicker = ({
     id,
     options = defaultOptions,
     step,
@@ -92,7 +92,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
     hoursAriaLabel,
     infiniteScroll,
     ...rest
-}) => {
+}: TimePickerProps) => {
     const normalizeValues = React.useMemo(() => getNormalizeValues(getTimeValues, getSeconds)(value, min, max), [
         value,
     ]);

--- a/packages/plasma-ui/src/components/ProductCard/ProductCardStepper.tsx
+++ b/packages/plasma-ui/src/components/ProductCard/ProductCardStepper.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLAttributes } from 'react';
+import React, { HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import { black, warning } from '@salutejs/plasma-core';
 import { IconMinus, IconPlus } from '@salutejs/plasma-icons';
@@ -69,7 +69,7 @@ const iconPlus = <IconPlus color="inherit" size="s" />;
 /**
  * Степпер карточки продукта.
  */
-export const ProductCardStepper: FC<ProductCardStepperProps> = ({
+export const ProductCardStepper = ({
     value,
     step,
     min,
@@ -78,7 +78,7 @@ export const ProductCardStepper: FC<ProductCardStepperProps> = ({
     readonly,
     onChange,
     ...rest
-}) => {
+}: ProductCardStepperProps) => {
     const { onLessClick, onMoreClick, isMax, isMoreDisabled } = useStepper({
         value,
         step,

--- a/packages/plasma-ui/src/components/Sheet/Sheet.tsx
+++ b/packages/plasma-ui/src/components/Sheet/Sheet.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import { overlay, primary, backgroundPrimary } from '@salutejs/plasma-tokens';
 
@@ -20,6 +20,7 @@ export interface SheetProps extends React.HTMLAttributes<HTMLDivElement> {
      * который шторка закрывается.
      */
     withOverlay?: boolean;
+    children?: ReactNode;
 }
 
 const StyledWrapper = styled.div<{ isOpen: boolean }>`
@@ -103,13 +104,7 @@ const StyledSheetHandle = styled.div`
  * Открывает окно-шторку поверх основного экрана.
  * Только для приложения Салют.
  */
-export const Sheet: React.FC<React.PropsWithChildren<SheetProps>> = ({
-    isOpen,
-    children,
-    onClose,
-    withOverlay = true,
-    ...restProps
-}) => {
+export const Sheet = ({ isOpen, children, onClose, withOverlay = true, ...restProps }: SheetProps) => {
     const contentWrapperRef = React.useRef<HTMLDivElement>(null);
     const handleRef = React.useRef<HTMLDivElement>(null);
 

--- a/packages/plasma-ui/src/components/Slider/Double.tsx
+++ b/packages/plasma-ui/src/components/Slider/Double.tsx
@@ -37,7 +37,7 @@ function getXCenterHandle(handle: HTMLDivElement) {
     return handlePosition - containerX;
 }
 
-export const Slider: React.FC<SliderProps> = ({ min, max, value, disabled, onChangeCommitted, onChange }) => {
+export const Slider = ({ min, max, value, disabled, onChangeCommitted, onChange }: SliderProps) => {
     const [state, setState] = React.useState({
         stepSize: 0,
         railFillWidth: 0,

--- a/packages/plasma-ui/src/components/Slider/Single.tsx
+++ b/packages/plasma-ui/src/components/Slider/Single.tsx
@@ -30,7 +30,7 @@ export interface SliderProps {
     onChange?(value: number): void;
 }
 
-export const Slider: React.FC<SliderProps> = ({ min, max, value, disabled, onChangeCommitted, onChange }) => {
+export const Slider = ({ min, max, value, disabled, onChangeCommitted, onChange }: SliderProps) => {
     const [state, setState] = React.useState({
         xHandle: 0,
         stepSize: 0,

--- a/packages/plasma-ui/src/components/Slider/Slider.tsx
+++ b/packages/plasma-ui/src/components/Slider/Slider.tsx
@@ -11,7 +11,7 @@ const isSingleValueProps = (props: SliderProps): props is SingleSliderProps => t
  * Слайдер позволяет определить числовое значение в пределах указаного промежутка. Можно указать два значения.
  * Только для приложения Салют.
  */
-export const Slider: React.FC<SliderProps> = (props) => {
+export const Slider = (props: SliderProps) => {
     if (isSingleValueProps(props)) {
         return <SliderSingleValue {...props} />;
     }

--- a/packages/plasma-ui/src/components/Slider/SliderBase.tsx
+++ b/packages/plasma-ui/src/components/Slider/SliderBase.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled, { css, ThemeContext } from 'styled-components';
 import { surfaceLiquid03, buttonAccent, scalingPixelBasis, sberPortalScale } from '@salutejs/plasma-tokens';
 
@@ -12,6 +12,7 @@ interface SliderProps {
     min: number;
     max: number;
     railFillWidth: number;
+    children?: ReactNode;
     railFillXPosition?: number;
     disabled?: boolean;
     setStepSize(stepSize: number): void;
@@ -49,7 +50,7 @@ const Fill = styled.div`
     width: 0;
 `;
 
-export const SliderBase: React.FC<SliderProps> = ({
+export const SliderBase = ({
     max,
     min,
     setStepSize,
@@ -57,7 +58,7 @@ export const SliderBase: React.FC<SliderProps> = ({
     children,
     railFillXPosition = 0,
     disabled,
-}) => {
+}: SliderProps) => {
     const ref = React.useRef<HTMLDivElement | null>(null);
     const theme = React.useContext(ThemeContext);
 

--- a/packages/plasma-ui/src/components/Stepper/Stepper.tsx
+++ b/packages/plasma-ui/src/components/Stepper/Stepper.tsx
@@ -51,7 +51,7 @@ export type StepperProps = UseStepperProps &
 /**
  * Готовый компонент для создания счетчика, подобного ``input[type="range"]``.
  */
-export const Stepper: React.FC<StepperProps> = ({
+export const Stepper = ({
     value,
     step,
     min,
@@ -66,7 +66,7 @@ export const Stepper: React.FC<StepperProps> = ({
     ariaLabelIncrement,
     ariaLabelRemove,
     ...props
-}) => {
+}: StepperProps) => {
     const { onLessClick, onMoreClick, isMin, isMax, isLessDisabled, isMoreDisabled } = useStepper({
         value,
         step,

--- a/packages/plasma-ui/src/components/Stepper/StepperValue.tsx
+++ b/packages/plasma-ui/src/components/Stepper/StepperValue.tsx
@@ -56,7 +56,7 @@ export interface StepperValueProps extends React.HTMLAttributes<HTMLDivElement>,
 /**
  * Компонент для отображения значения степпера.
  */
-export const StepperValue: React.FC<StepperValueProps> = ({ value, disabled, showWarning, formatter, ...rest }) => (
+export const StepperValue = ({ value, disabled, showWarning, formatter, ...rest }: StepperValueProps) => (
     <StyledValue role="status" aria-live="polite" disabled={disabled} showWarning={showWarning} {...rest}>
         {typeof formatter === 'function' ? formatter(value) : value}
     </StyledValue>

--- a/packages/plasma-ui/src/components/Tabs/TabItem.tsx
+++ b/packages/plasma-ui/src/components/Tabs/TabItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import styled, { css } from 'styled-components';
 import { TabItem as BaseTabItem, button2, buttonFocused } from '@salutejs/plasma-core';
 import type { TabItemProps as BaseTabItemProps, AsProps } from '@salutejs/plasma-core';
@@ -81,7 +81,7 @@ export const StyledTabItemMemo = React.memo(StyledTabItem);
 /**
  * Элемент списка вкладок, недопустимо использовать вне компонента Tabs.
  */
-export const TabItem: FC<TabItemProps> = (props) => {
+export const TabItem = (props: TabItemProps) => {
     const ref = useRef<HTMLElement>(null);
     const { refs } = useTabsAnimationContext();
 

--- a/packages/plasma-ui/src/components/Tabs/TabsSlider.tsx
+++ b/packages/plasma-ui/src/components/Tabs/TabsSlider.tsx
@@ -32,7 +32,7 @@ export const StyledSlider = styled.div<Pick<SliderProps, 'disabled'>>`
 /**
  * Слайдер переключения табов
  */
-export const TabsSlider: React.FC<SliderProps> = ({ index, ...rest }) => {
+export const TabsSlider = ({ index, ...rest }: SliderProps) => {
     const [dimensions, setDimensions] = useState({ left: 0, width: 0, height: 0 });
     const { refs } = useTabsAnimationContext();
 

--- a/packages/plasma-ui/src/components/TextBox/TextBox.tsx
+++ b/packages/plasma-ui/src/components/TextBox/TextBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import { primary, secondary } from '@salutejs/plasma-tokens';
 
@@ -49,22 +49,14 @@ export interface TextPttrnProps {
     title?: string;
     subTitle?: string;
     caption?: string;
-
+    children?: ReactNode;
     size?: 'm' | 'l';
 }
 
 /**
  * Компонент для отображения текста в скомпанованном блоке.
  */
-export const TextBox: React.FC<TextPttrnProps> = ({
-    label,
-    title,
-    subTitle,
-    caption,
-    size = 'm',
-    children,
-    ...rest
-}) => {
+export const TextBox = ({ label, title, subTitle, caption, size = 'm', children, ...rest }: TextPttrnProps) => {
     if (children) {
         return <TextBoxRoot {...rest}>{children}</TextBoxRoot>;
     }

--- a/packages/plasma-ui/src/helpers/GridLines.tsx
+++ b/packages/plasma-ui/src/helpers/GridLines.tsx
@@ -66,7 +66,7 @@ export interface GridLinesProps extends React.HTMLAttributes<HTMLDivElement> {
 /**
  * Вспомогательный компонент для демонстрации в Storybook.
  */
-export const GridLines: React.FC<GridLinesProps> = ({ columns = 12, ...rest }) => {
+export const GridLines = ({ columns = 12, ...rest }: GridLinesProps) => {
     const cols = Array(columns).fill(0);
 
     return (

--- a/packages/plasma-ui/src/helpers/Palette.tsx
+++ b/packages/plasma-ui/src/helpers/Palette.tsx
@@ -88,7 +88,7 @@ export interface PaletteProps {
     heading?: string;
 }
 
-export const Palette: React.FC<PaletteProps> = ({ theme = 'darkSber', title, heading }) => {
+export const Palette = ({ theme = 'darkSber', title, heading }: PaletteProps) => {
     const selectedTheme = themes[theme][':root'];
     const primary = selectedTheme['--plasma-colors-primary'];
     const items = React.useMemo(() => {

--- a/packages/plasma-ui/src/helpers/ThemeBackground.tsx
+++ b/packages/plasma-ui/src/helpers/ThemeBackground.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import { text, background, gradient } from '@salutejs/plasma-tokens';
 
@@ -6,6 +6,7 @@ interface Props {
     showcase?: boolean;
     spaced?: boolean;
     vertical?: boolean;
+    children?: ReactNode;
 }
 
 const StyledRoot = styled.div<Props>`
@@ -51,6 +52,6 @@ const StyledRoot = styled.div<Props>`
         `}
 `;
 
-export const ThemeBackground: React.FC<Props> = ({ children, ...rest }) => {
+export const ThemeBackground = ({ children, ...rest }: Props) => {
     return <StyledRoot {...rest}>{children}</StyledRoot>;
 };

--- a/packages/plasma-ui/src/helpers/ThemeSelect.tsx
+++ b/packages/plasma-ui/src/helpers/ThemeSelect.tsx
@@ -37,7 +37,7 @@ const themes = {
     lightJoy: createGlobalStyle(lightJoy),
 };
 
-export const ThemeSelect: React.FC = () => {
+export const ThemeSelect = () => {
     const [currentTheme, setCurrentTheme] = useState('darkSber');
 
     const Theme = themes[currentTheme];
@@ -67,7 +67,7 @@ const typos = {
     mobile: createGlobalStyle(mobile),
 };
 
-export const TypoSelect: React.FC = () => {
+export const TypoSelect = () => {
     const [currentTypo, setCurrentTypo] = useState('sberBox');
 
     const Typo = typos[currentTypo];


### PR DESCRIPTION
Попробовал полностью убрать FC.
Получилось даже лучше, чем явно добавлять детей к FC.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/cra-template-plasma-basic-template@2.2.2-canary.97.2732738307.0
  npm install @salutejs/cra-template-plasma-shop-template@2.2.2-canary.97.2732738307.0
  npm install @salutejs/plasma-temple@1.84.4-canary.97.2732738307.0
  npm install @salutejs/plasma-ui@1.118.4-canary.97.2732738307.0
  # or 
  yarn add @salutejs/cra-template-plasma-basic-template@2.2.2-canary.97.2732738307.0
  yarn add @salutejs/cra-template-plasma-shop-template@2.2.2-canary.97.2732738307.0
  yarn add @salutejs/plasma-temple@1.84.4-canary.97.2732738307.0
  yarn add @salutejs/plasma-ui@1.118.4-canary.97.2732738307.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
