### PR TITLE
fix(plasma-web): Fix border visible for `TextField` and `TextArea`

### DIFF
--- a/packages/plasma-web/src/components/Input/Input.tsx
+++ b/packages/plasma-web/src/components/Input/Input.tsx
@@ -160,6 +160,8 @@ const StyledInput = styled.input<StyledInputProps>`
     ${applySizes}
     ${inputTypo}
 
+    -webkit-appearance: none; /* для отображение рамок на iOS */
+
     box-sizing: border-box;
     width: 100%;
 

--- a/packages/plasma-web/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-web/src/components/TextArea/TextArea.tsx
@@ -13,6 +13,8 @@ export interface TextAreaProps extends BaseProps {
 }
 
 const StyledTextArea = styled(BaseArea)`
+    -webkit-appearance: none; /* для отображение рамок на iOS */
+
     ${applyInputStyles}
 `;
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.84.1-canary.103.2702507967.0
  npm install @salutejs/plasma-web@1.118.1-canary.103.2702507967.0
  # or 
  yarn add @salutejs/plasma-b2c@1.84.1-canary.103.2702507967.0
  yarn add @salutejs/plasma-web@1.118.1-canary.103.2702507967.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
