### PR TITLE
fix(plasma-core): Fix `Tab` control behavior for Safari

### DIFF
--- a/packages/plasma-core/src/components/Tabs/TabItem.tsx
+++ b/packages/plasma-core/src/components/Tabs/TabItem.tsx
@@ -11,6 +11,7 @@ interface StyledTabItemProps {
     isActive?: boolean;
     isChildren?: boolean;
     isContentLeft?: boolean;
+    disabled?: boolean;
 }
 
 export interface TabItemProps extends AsProps, React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -54,7 +55,7 @@ const StyledTabItemText = styled.span`
     }
 `;
 
-export const StyledTabItem = styled.button<StyledTabItemProps>`
+export const StyledTabItem = styled.div<StyledTabItemProps>`
     align-items: center;
     box-sizing: border-box;
     display: flex;

--- a/packages/plasma-core/src/components/Tabs/Tabs.component-test.tsx
+++ b/packages/plasma-core/src/components/Tabs/Tabs.component-test.tsx
@@ -75,7 +75,7 @@ describe('plasma-core: Tabs', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('div > button:nth-child(2)').click();
+        cy.get('div > div:nth-child(2)').click();
         cy.matchImageSnapshot();
     });
 
@@ -87,19 +87,19 @@ describe('plasma-core: Tabs', () => {
         );
 
         cy.root().get('[role="tablist"]').trigger('keydown', { keyCode: 13 });
-        cy.get('div > button:nth-child(1)').should('have.attr', 'tabindex', '0');
+        cy.get('div:nth-child(1)').last().should('have.attr', 'tabindex', '0');
 
         cy.root().get('[role="tablist"]').trigger('keydown', { keyCode: 39 });
-        cy.get('div > button:nth-child(2)').should('have.attr', 'tabindex', '0');
+        cy.get('div:nth-child(2)').last().should('have.attr', 'tabindex', '0');
 
         cy.root().get('[role="tablist"]').trigger('keydown', { keyCode: 37 });
-        cy.get('div > button:nth-child(1)').should('have.attr', 'tabindex', '0');
+        cy.get('div:nth-child(1)').last().should('have.attr', 'tabindex', '0');
 
         cy.root().get('[role="tablist"]').trigger('keydown', { keyCode: 35 });
-        cy.get('div > button:nth-child(3)').should('have.attr', 'tabindex', '0');
+        cy.get('div:nth-child(3)').last().should('have.attr', 'tabindex', '0');
 
         cy.root().get('[role="tablist"]').trigger('keydown', { keyCode: 36 });
-        cy.get('div > button:nth-child(1)').should('have.attr', 'tabindex', '0');
+        cy.get('div:nth-child(1)').last().should('have.attr', 'tabindex', '0');
     });
 
     it('scrollable', () => {
@@ -147,7 +147,7 @@ describe('plasma-core: Tabs', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('div > button:nth-child(2)')
+        cy.get('div > div:nth-child(2)')
             .click({ force: true })
             .then(() => {
                 expect(onIndexChange).not.called;
@@ -174,7 +174,7 @@ describe('plasma-core: Tabs', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('div > button:nth-child(2)').click();
+        cy.get('div > div:nth-child(2)').click();
         cy.matchImageSnapshot();
     });
 });

--- a/packages/plasma-ui/src/components/Tabs/Tabs.component-test.tsx
+++ b/packages/plasma-ui/src/components/Tabs/Tabs.component-test.tsx
@@ -124,7 +124,7 @@ describe('plasma-ui: Tabs', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('div > button:nth-child(2)').focus();
+        cy.get('div > div:nth-child(2)').focus();
         cy.matchImageSnapshot();
     });
 
@@ -141,7 +141,7 @@ describe('plasma-ui: Tabs', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('div > button:nth-child(2)').focus();
+        cy.get('div > div:nth-child(2)').focus();
         cy.matchImageSnapshot();
     });
 
@@ -154,7 +154,7 @@ describe('plasma-ui: Tabs', () => {
             return (
                 <Tabs>
                     {items.map((item, i) => (
-                        <StyledTabItem key={i} isActive={i === index} onClick={() => setIndex(i)}>
+                        <StyledTabItem key={i} tabIndex={0} isActive={i === index} onClick={() => setIndex(i)}>
                             {item.label}
                         </StyledTabItem>
                     ))}
@@ -168,8 +168,8 @@ describe('plasma-ui: Tabs', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('div > button:nth-child(2)').focus();
-        cy.get('div > button:nth-child(1)').focus().click({ force: true });
+        cy.get('div > div:nth-child(2)').focus();
+        cy.get('div > div:nth-child(1)').last().focus().click({ force: true });
 
         cy.matchImageSnapshot();
     });

--- a/packages/plasma-web/src/components/Tabs/Tabs.component-test.tsx
+++ b/packages/plasma-web/src/components/Tabs/Tabs.component-test.tsx
@@ -22,7 +22,7 @@ describe('plasma-web: Tabs', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('div > button:nth-child(2)').focus();
+        cy.get('div > div:nth-child(2)').focus();
         cy.matchImageSnapshot();
     });
 });


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.85.1-canary.106.2718047501.0
  npm install @salutejs/plasma-core@1.64.3-canary.106.2718047501.0
  npm install @salutejs/plasma-icons@1.90.2-canary.106.2718047501.0
  npm install @salutejs/plasma-temple@1.84.3-canary.106.2718047501.0
  npm install @salutejs/plasma-typo@0.11.3-canary.106.2718047501.0
  npm install @salutejs/plasma-ui@1.118.3-canary.106.2718047501.0
  npm install @salutejs/plasma-web@1.118.3-canary.106.2718047501.0
  npm install @salutejs/plasma-cy-utils@0.17.3-canary.106.2718047501.0
  npm install @salutejs/plasma-sb-utils@0.63.3-canary.106.2718047501.0
  # or 
  yarn add @salutejs/plasma-b2c@1.85.1-canary.106.2718047501.0
  yarn add @salutejs/plasma-core@1.64.3-canary.106.2718047501.0
  yarn add @salutejs/plasma-icons@1.90.2-canary.106.2718047501.0
  yarn add @salutejs/plasma-temple@1.84.3-canary.106.2718047501.0
  yarn add @salutejs/plasma-typo@0.11.3-canary.106.2718047501.0
  yarn add @salutejs/plasma-ui@1.118.3-canary.106.2718047501.0
  yarn add @salutejs/plasma-web@1.118.3-canary.106.2718047501.0
  yarn add @salutejs/plasma-cy-utils@0.17.3-canary.106.2718047501.0
  yarn add @salutejs/plasma-sb-utils@0.63.3-canary.106.2718047501.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
