### PR TITLE
ci(plasma-b2c): fix storybook build

### DIFF
--- a/packages/plasma-b2c/src/components/Modal/Modal.stories.mdx
+++ b/packages/plasma-b2c/src/components/Modal/Modal.stories.mdx
@@ -63,9 +63,3 @@ export default function() {
     );
 }
 ```
-
-## Live demo
-
-<Canvas>
-    <Story name="LiveDemo" story={stories.LiveDemo} />
-</Canvas>


### PR DESCRIPTION
```
WARN Module build failed (from ./node_modules/babel-loader/lib/index.js):
WARN SyntaxError: Projects/plasma/packages/plasma-b2c/src/components/Modal/Modal.stories.mdx: Identifier '_LiveDemo_' has already been declared. (98:13)
WARN 
WARN    96 | _LiveDemo_.storyName = 'LiveDemo';
WARN    97 |
WARN >  98 | export const _LiveDemo_ = stories.LiveDemo;
WARN       |              ^
WARN    99 | _LiveDemo_.storyName = 'LiveDemo';
WARN   100 |
WARN   101 | const componentMeta = { title: 'Controls/Modal', decorators: [InSpacingDecorator], component: Modal, includeStories: ["_LiveDemo_","_LiveDemo_"],  };

```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.87.1-canary.125.2833055576.0
  # or 
  yarn add @salutejs/plasma-b2c@1.87.1-canary.125.2833055576.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
