### PR TITLE
fix(plasma-ui): Fix gap issue between buttons in `Confirm` component

### DIFF
--- a/packages/plasma-ui/src/components/Confirm/Confirm.tsx
+++ b/packages/plasma-ui/src/components/Confirm/Confirm.tsx
@@ -97,6 +97,8 @@ const tvLayout = css`
     align-items: center;
 `;
 
+const StyledButton = styled(Button)``;
+
 const ConfirmRoot = styled.div<{ visible: boolean }>`
     position: absolute;
     left: 0;
@@ -124,7 +126,10 @@ const ConfirmRoot = styled.div<{ visible: boolean }>`
 const BtnWrap = styled.div<{ reverse: boolean }>`
     flex: 1;
     display: flex;
-    gap: 0.75rem;
+
+    ${StyledButton}:not(:last-child) {
+        ${({ reverse }) => (reverse ? { marginLeft: '0.75rem' } : { marginRight: '0.75rem' })}
+    }
 
     ${({ reverse }) =>
         reverse && {
@@ -181,10 +186,18 @@ export const Confirm = (props: ConfirmProps) => {
     useAutoFocus(btnRef, { trigger: visible });
 
     const approve = (
-        <Button size="s" ref={btnRef} tabIndex={0} stretch view={view} text={approveText} onClick={onApproveClick} />
+        <StyledButton
+            size="s"
+            ref={btnRef}
+            tabIndex={0}
+            stretch
+            view={view}
+            text={approveText}
+            onClick={onApproveClick}
+        />
     );
     const dismiss = dismissText ? (
-        <Button size="s" stretch view="secondary" text={dismissText} onClick={onDismissClick} />
+        <StyledButton size="s" stretch view="secondary" text={dismissText} onClick={onDismissClick} />
     ) : null;
     const buttons = (
         <BtnWrap reverse={reverseButtons}>


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.87.1-canary.131.2861368107.0
  npm install @salutejs/plasma-core@1.65.1-canary.131.2861368107.0
  npm install @salutejs/plasma-icons@1.91.1-canary.131.2861368107.0
  npm install @salutejs/plasma-temple@1.86.1-canary.131.2861368107.0
  npm install @salutejs/plasma-typo@0.12.1-canary.131.2861368107.0
  npm install @salutejs/plasma-ui@1.120.1-canary.131.2861368107.0
  npm install @salutejs/plasma-web@1.120.1-canary.131.2861368107.0
  npm install @salutejs/plasma-cy-utils@0.18.1-canary.131.2861368107.0
  npm install @salutejs/plasma-sb-utils@0.64.1-canary.131.2861368107.0
  # or 
  yarn add @salutejs/plasma-b2c@1.87.1-canary.131.2861368107.0
  yarn add @salutejs/plasma-core@1.65.1-canary.131.2861368107.0
  yarn add @salutejs/plasma-icons@1.91.1-canary.131.2861368107.0
  yarn add @salutejs/plasma-temple@1.86.1-canary.131.2861368107.0
  yarn add @salutejs/plasma-typo@0.12.1-canary.131.2861368107.0
  yarn add @salutejs/plasma-ui@1.120.1-canary.131.2861368107.0
  yarn add @salutejs/plasma-web@1.120.1-canary.131.2861368107.0
  yarn add @salutejs/plasma-cy-utils@0.18.1-canary.131.2861368107.0
  yarn add @salutejs/plasma-sb-utils@0.64.1-canary.131.2861368107.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
