### PR TITLE
fix(plasma-ui): Replace useLayoutEffect to useIsomorphicLayoutEffect for `Slider` and `Marquee`

### DIFF
--- a/packages/plasma-ui/src/components/Marquee/Marquee.tsx
+++ b/packages/plasma-ui/src/components/Marquee/Marquee.tsx
@@ -1,5 +1,6 @@
-import React, { ReactNode, useLayoutEffect, useRef, useState } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
 import styled, { css, keyframes } from 'styled-components';
+import { useIsomorphicLayoutEffect } from '@salutejs/plasma-core';
 
 const marquee = keyframes`
     0% { transform: translateX(0%) }
@@ -58,7 +59,7 @@ export const Marquee = ({ textAlign, children, ...rest }: MarqueeProps) => {
         animationDuration: 0,
     });
 
-    useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         const wrapperWidth = wrapperRef.current?.getBoundingClientRect().width || 0;
         const textWidth = textRef.current?.getBoundingClientRect().width || 0;
         setState({

--- a/packages/plasma-ui/src/components/Slider/SliderBase.tsx
+++ b/packages/plasma-ui/src/components/Slider/SliderBase.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import styled, { css, ThemeContext } from 'styled-components';
 import { surfaceLiquid03, buttonAccent, scalingPixelBasis, sberPortalScale } from '@salutejs/plasma-tokens';
+import { useIsomorphicLayoutEffect } from '@salutejs/plasma-core';
 
 export const handleDiameter = 1.5;
 export const handleBorderWidth = 0.0625;
@@ -62,7 +63,7 @@ export const SliderBase = ({
     const ref = React.useRef<HTMLDivElement | null>(null);
     const theme = React.useContext(ThemeContext);
 
-    React.useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         const resizeHandler = () => {
             if (ref.current) {
                 const rootElementFontSize = (theme?.deviceScale ?? sberPortalScale) * scalingPixelBasis;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.87.1-canary.132.2865600299.0
  npm install @salutejs/plasma-core@1.65.1-canary.132.2865600299.0
  npm install @salutejs/plasma-icons@1.91.1-canary.132.2865600299.0
  npm install @salutejs/plasma-temple@1.86.1-canary.132.2865600299.0
  npm install @salutejs/plasma-typo@0.12.1-canary.132.2865600299.0
  npm install @salutejs/plasma-ui@1.120.1-canary.132.2865600299.0
  npm install @salutejs/plasma-web@1.120.1-canary.132.2865600299.0
  npm install @salutejs/plasma-cy-utils@0.18.1-canary.132.2865600299.0
  npm install @salutejs/plasma-sb-utils@0.64.1-canary.132.2865600299.0
  # or 
  yarn add @salutejs/plasma-b2c@1.87.1-canary.132.2865600299.0
  yarn add @salutejs/plasma-core@1.65.1-canary.132.2865600299.0
  yarn add @salutejs/plasma-icons@1.91.1-canary.132.2865600299.0
  yarn add @salutejs/plasma-temple@1.86.1-canary.132.2865600299.0
  yarn add @salutejs/plasma-typo@0.12.1-canary.132.2865600299.0
  yarn add @salutejs/plasma-ui@1.120.1-canary.132.2865600299.0
  yarn add @salutejs/plasma-web@1.120.1-canary.132.2865600299.0
  yarn add @salutejs/plasma-cy-utils@0.18.1-canary.132.2865600299.0
  yarn add @salutejs/plasma-sb-utils@0.64.1-canary.132.2865600299.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
