### PR TITLE
feat(plasma-ui): Add forwardRef for `Header`,`NeuHeader` and `Cell` components

### DIFF
--- a/packages/plasma-ui/src/components/Cell/Cell.tsx
+++ b/packages/plasma-ui/src/components/Cell/Cell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import { SelfPosition } from 'csstype';
 import { addFocus, FocusProps, OutlinedProps } from '@salutejs/plasma-core';
@@ -123,7 +123,7 @@ export interface CellProps extends FocusProps, OutlinedProps, AsProps {
 /**
  * Базовый компонент для отображения блоков контента в списках и карточках.
  */
-export const Cell = (props: CellProps & React.HTMLAttributes<HTMLDivElement>) => {
+export const Cell = forwardRef<HTMLDivElement, CellProps & React.HTMLAttributes<HTMLDivElement>>((props, ref) => {
     const {
         contentLeft: left,
         content,
@@ -134,7 +134,7 @@ export const Cell = (props: CellProps & React.HTMLAttributes<HTMLDivElement>) =>
     } = props;
 
     return (
-        <CellRoot {...rest}>
+        <CellRoot ref={ref} {...rest}>
             {left && <CellLeft align={alignLeft}>{left}</CellLeft>}
             <CellContentWrapper>
                 <CellContent>{content}</CellContent>
@@ -142,4 +142,4 @@ export const Cell = (props: CellProps & React.HTMLAttributes<HTMLDivElement>) =>
             </CellContentWrapper>
         </CellRoot>
     );
-};
+});

--- a/packages/plasma-ui/src/components/Header/Header.tsx
+++ b/packages/plasma-ui/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { PickOptional } from '../../types';
 
@@ -71,11 +71,11 @@ export type HeaderProps = React.HTMLAttributes<HTMLDivElement> &
  * Сборный компонент для отрисовки шапки страницы.
  * Уже включает в себя все составные части шапки.
  */
-export const Header = ({ children, ...props }: HeaderProps) => {
+export const Header = forwardRef<HTMLHeadElement, HeaderProps>(({ children, ...props }, ref) => {
     const { minimize, back, logo, logoAlt, title, subtitle, onMinimizeClick, onBackClick, ...rest } = props as AllProps;
 
     return (
-        <HeaderRoot {...rest}>
+        <HeaderRoot ref={ref} {...rest}>
             {(minimize || back) && (
                 <HeaderArrow onClick={back ? onBackClick : onMinimizeClick} arrow={back ? 'back' : 'minimize'} />
             )}
@@ -89,4 +89,4 @@ export const Header = ({ children, ...props }: HeaderProps) => {
             {children && <HeaderContent>{children}</HeaderContent>}
         </HeaderRoot>
     );
-};
+});

--- a/packages/plasma-ui/src/components/Header/HeaderRoot.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderRoot.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import Color from 'color';
 
@@ -93,10 +93,12 @@ export interface HeaderRootProps extends React.HTMLAttributes<HTMLDivElement> {
 /**
  * Корневой узел для шапки.
  */
-export const HeaderRoot = ({ children, size, gradientColor, ...rest }: HeaderRootProps) => {
-    return (
-        <StyledHeaderRoot {...rest} $size={size} $gradientColor={gradientColor}>
-            <StyledInner>{children}</StyledInner>
-        </StyledHeaderRoot>
-    );
-};
+export const HeaderRoot = forwardRef<HTMLHeadElement, HeaderRootProps>(
+    ({ children, size, gradientColor, ...rest }, ref) => {
+        return (
+            <StyledHeaderRoot ref={ref} {...rest} $size={size} $gradientColor={gradientColor}>
+                <StyledInner>{children}</StyledInner>
+            </StyledHeaderRoot>
+        );
+    },
+);

--- a/packages/plasma-ui/src/components/Header/NeuHeader.tsx
+++ b/packages/plasma-ui/src/components/Header/NeuHeader.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, MouseEventHandler, ReactNode } from 'react';
+import React, { HTMLAttributes, MouseEventHandler, ReactNode, forwardRef } from 'react';
 
 import { HeaderRoot, HeaderRootProps } from './HeaderRoot';
 import { HeaderArrow } from './HeaderArrow';
@@ -63,27 +63,20 @@ export type NeuHeaderProps = HTMLAttributes<HTMLDivElement> &
  * * Свойство `subtitle` переименовано в `subTitle`.
  * `NeuHeader` заменит собой исходный `Header` в будущих версиях.
  */
-export const NeuHeader = ({
-    arrow,
-    onArrowClick,
-    logo,
-    logoAlt,
-    title,
-    subTitle,
-    children,
-    ...rest
-}: NeuHeaderProps) => {
-    return (
-        <HeaderRoot {...rest}>
-            <HeaderArrow onClick={onArrowClick} arrow={arrow} />
-            {logo && <HeaderLogo src={logo} alt={logoAlt} />}
-            {title && (
-                <HeaderTitleWrapper>
-                    <HeaderTitle>{title}</HeaderTitle>
-                    {subTitle && <HeaderSubtitle>{subTitle}</HeaderSubtitle>}
-                </HeaderTitleWrapper>
-            )}
-            {children && <HeaderContent>{children}</HeaderContent>}
-        </HeaderRoot>
-    );
-};
+export const NeuHeader = forwardRef<HTMLHeadElement, NeuHeaderProps>(
+    ({ arrow, onArrowClick, logo, logoAlt, title, subTitle, children, ...rest }, ref) => {
+        return (
+            <HeaderRoot ref={ref} {...rest}>
+                <HeaderArrow onClick={onArrowClick} arrow={arrow} />
+                {logo && <HeaderLogo src={logo} alt={logoAlt} />}
+                {title && (
+                    <HeaderTitleWrapper>
+                        <HeaderTitle>{title}</HeaderTitle>
+                        {subTitle && <HeaderSubtitle>{subTitle}</HeaderSubtitle>}
+                    </HeaderTitleWrapper>
+                )}
+                {children && <HeaderContent>{children}</HeaderContent>}
+            </HeaderRoot>
+        );
+    },
+);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.88.0-canary.143.2925472697.0
  npm install @salutejs/plasma-ui@1.122.0-canary.143.2925472697.0
  # or 
  yarn add @salutejs/plasma-temple@1.88.0-canary.143.2925472697.0
  yarn add @salutejs/plasma-ui@1.122.0-canary.143.2925472697.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
