### PR TITLE
feat(plasma-ui): Add options for eventListeners in useRemoteListener hook

### DIFF
--- a/packages/plasma-ui/src/hooks/useRemoteListener.ts
+++ b/packages/plasma-ui/src/hooks/useRemoteListener.ts
@@ -37,9 +37,14 @@ const getRemoteKey = (key: string, isLong: boolean): RemoteKey | undefined => {
  * который вызывает коллбек при нажатии кнопок навигации.
  * @param {Function} cb
  * @param {number} keypressTimeMs
+ * @param {AddEventListenerOptions} eventListenerOptions
  * @return {void}
  */
-export const useRemoteListener = (cb: (key: RemoteKey, event: KeyboardEvent) => void, keypressTimeMs = 150) => {
+export const useRemoteListener = (
+    cb: (key: RemoteKey, event: KeyboardEvent) => void,
+    keypressTimeMs = 150,
+    eventListenerOptions?: AddEventListenerOptions,
+) => {
     const keydown = useRef<number | null>(null);
 
     useEffect(() => {
@@ -61,12 +66,12 @@ export const useRemoteListener = (cb: (key: RemoteKey, event: KeyboardEvent) => 
             keydown.current = null;
         };
 
-        window.addEventListener('keydown', handleKeydown);
-        window.addEventListener('keyup', handleKeyup);
+        window.addEventListener('keydown', handleKeydown, eventListenerOptions);
+        window.addEventListener('keyup', handleKeyup, eventListenerOptions);
 
         return () => {
-            window.removeEventListener('keydown', handleKeydown);
-            window.removeEventListener('keyup', handleKeyup);
+            window.removeEventListener('keydown', handleKeydown, eventListenerOptions);
+            window.removeEventListener('keyup', handleKeyup, eventListenerOptions);
         };
     }, [cb]);
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.90.0-canary.146.2948397596.0
  npm install @salutejs/plasma-ui@1.124.0-canary.146.2948397596.0
  # or 
  yarn add @salutejs/plasma-temple@1.90.0-canary.146.2948397596.0
  yarn add @salutejs/plasma-ui@1.124.0-canary.146.2948397596.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
