### PR TITLE
fix(plasma-ui): Add sizes style for responsive typo in `DeviceThemeProvider`

### DIFF
--- a/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
+++ b/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { createGlobalStyle, ThemeProvider } from 'styled-components';
-import { sberPortal, sberBox, mobile, sberPortalScale } from '@salutejs/plasma-tokens';
+import { sberPortal, sberBox, mobile, sberPortalScale, sizes } from '@salutejs/plasma-tokens';
 import { transformStyles } from '@salutejs/plasma-core';
 import { standard, compatible } from '@salutejs/plasma-typo';
 
@@ -20,6 +20,7 @@ const typoSizes = {
 
 const StandardTypo = createGlobalStyle(standard);
 const CompatibleTypo = createGlobalStyle(compatible);
+const Size = createGlobalStyle(sizes);
 
 export interface DeviceThemeProps {
     /**
@@ -79,6 +80,7 @@ export const DeviceThemeProvider = ({
                 <>
                     <StandardTypo deviceScale={deviceScale} />
                     <CompatibleTypo />
+                    <Size />
                 </>
             ) : (
                 <Typo />


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.90.2-canary.153.2969385840.0
  npm install @salutejs/plasma-ui@1.124.2-canary.153.2969385840.0
  # or 
  yarn add @salutejs/plasma-temple@1.90.2-canary.153.2969385840.0
  yarn add @salutejs/plasma-ui@1.124.2-canary.153.2969385840.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
