### PR TITLE
fix(plasma-ui): restore scroll in translateToIndex

### DIFF
--- a/packages/plasma-core/src/components/Carousel/utils.ts
+++ b/packages/plasma-core/src/components/Carousel/utils.ts
@@ -209,6 +209,11 @@ const axisToSizeKeyMap: Record<UseCarouselLiteOptions['axis'], 'offsetWidth' | '
     y: 'offsetHeight',
 };
 
+const axisToScrollKeyMap: Record<UseCarouselLiteOptions['axis'], 'scrollLeft' | 'scrollTop'> = {
+    x: 'scrollLeft',
+    y: 'scrollTop',
+};
+
 function getCenterPosition(itemSize: number, itemStart: number, carouselSize: number, trackOffset: number) {
     const relativeMiddle = itemStart + trackOffset + itemSize / 2;
 
@@ -268,6 +273,8 @@ function translateToPosition(element: HTMLElement, axis: UseCarouselLiteOptions[
     element.style.transform = translate(position);
 }
 
+const scrollOptions: ScrollToOptions = { behavior: 'auto', left: 0, top: 0 };
+
 /**
  * Делает расчет следующей позиции карусели исходя из параметров
  * index, align и размеров элементов track и carousel.
@@ -293,6 +300,12 @@ export function translateToIndex(
 ): void {
     if (track === null || carousel === null) {
         return;
+    }
+
+    const scrollKey = axisToScrollKeyMap[axis];
+
+    if (disableAnimation === false && carousel[scrollKey] !== 0) {
+        carousel.scrollTo(scrollOptions);
     }
 
     const itemToTranslateTo = track.children.item(index) as HTMLElement | null;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.162.3045568868.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.162.3045568868.xml)  
[PlasmaTokensColor--canary.162.3045568868.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.162.3045568868.swift)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.93.1-canary.162.3045568868.0
  npm install @salutejs/plasma-core@1.70.1-canary.162.3045568868.0
  npm install @salutejs/plasma-icons@1.96.1-canary.162.3045568868.0
  npm install @salutejs/plasma-temple@1.93.1-canary.162.3045568868.0
  npm install @salutejs/plasma-typo@0.17.1-canary.162.3045568868.0
  npm install @salutejs/plasma-ui@1.127.1-canary.162.3045568868.0
  npm install @salutejs/plasma-web@1.126.1-canary.162.3045568868.0
  npm install @salutejs/plasma-cy-utils@0.23.1-canary.162.3045568868.0
  npm install @salutejs/plasma-sb-utils@0.69.1-canary.162.3045568868.0
  # or 
  yarn add @salutejs/plasma-b2c@1.93.1-canary.162.3045568868.0
  yarn add @salutejs/plasma-core@1.70.1-canary.162.3045568868.0
  yarn add @salutejs/plasma-icons@1.96.1-canary.162.3045568868.0
  yarn add @salutejs/plasma-temple@1.93.1-canary.162.3045568868.0
  yarn add @salutejs/plasma-typo@0.17.1-canary.162.3045568868.0
  yarn add @salutejs/plasma-ui@1.127.1-canary.162.3045568868.0
  yarn add @salutejs/plasma-web@1.126.1-canary.162.3045568868.0
  yarn add @salutejs/plasma-cy-utils@0.23.1-canary.162.3045568868.0
  yarn add @salutejs/plasma-sb-utils@0.69.1-canary.162.3045568868.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
