### PR TITLE
fix(plasma-web): Headline5 tag h5

### DIFF
--- a/packages/plasma-web/src/components/Typography/Headline/index.ts
+++ b/packages/plasma-web/src/components/Typography/Headline/index.ts
@@ -6,4 +6,4 @@ export { Headline1, Headline2, Headline3, Headline4 } from '@salutejs/plasma-cor
 
 export const Headline5 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...headline5 });
 
-export const H5 = styled.h3({ margin: 0, ...headline5 });
+export const H5 = styled.h5({ margin: 0, ...headline5 });


### PR DESCRIPTION
fixes #140 
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.164.3051066417.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.164.3051066417.xml)  
[PlasmaTokensColor--canary.164.3051066417.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.164.3051066417.swift)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.93.1-canary.164.3051066417.0
  npm install @salutejs/plasma-web@1.126.1-canary.164.3051066417.0
  # or 
  yarn add @salutejs/plasma-b2c@1.93.1-canary.164.3051066417.0
  yarn add @salutejs/plasma-web@1.126.1-canary.164.3051066417.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
