### PR TITLE
feat(plasma-ui): device kind processing

### DIFF
--- a/packages/plasma-ui/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.stories.tsx
@@ -1,14 +1,14 @@
-import React, { useRef, useContext, useCallback } from 'react';
+import React, { useRef, useCallback } from 'react';
 import { Story, Meta, addDecorator } from '@storybook/react';
 import type { SnapType, SnapAlign, CarouselLiteProps } from '@salutejs/plasma-core';
 import { CarouselItemVirtual } from '@salutejs/plasma-core';
-import * as tokens from '@salutejs/plasma-tokens';
 import { useVirtual } from '@salutejs/use-virtual';
-import styled, { ThemeContext } from 'styled-components';
+import styled from 'styled-components';
 import { withPerformance, InteractionTaskArgs, PublicInteractionTask } from 'storybook-addon-performance';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { IconChevronLeft, IconChevronRight } from '@salutejs/plasma-icons';
 
+import { useThemeContext } from '../../hooks';
 import { isSberBox } from '../../utils';
 import { ProductCard, MusicCard, GalleryCard } from '../Card/Card.examples';
 import { DeviceThemeProvider } from '../Device';
@@ -222,8 +222,8 @@ Basic.argTypes = {
 };
 
 const CarouselVirtualBasicComponent = () => {
-    // deviceScale = 1 (Mobile), deviceScale = 2 (Sberbox, TV, Portal)
-    const { deviceScale } = useContext(ThemeContext);
+    // INFO: deviceScale = 1 (Mobile), deviceScale = 2 (Sberbox, TV, Portal)
+    const { deviceScale } = useThemeContext();
     const parentRef = useRef(null);
     const axis = 'x';
 

--- a/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
+++ b/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
@@ -75,7 +75,7 @@ export const DeviceThemeProvider = ({
     const Typo = React.useMemo(() => typoSizes[deviceKind], [deviceKind]);
 
     return (
-        <ThemeProvider theme={{ ...theme, deviceScale, lowPerformance }}>
+        <ThemeProvider theme={{ ...theme, deviceScale, lowPerformance, deviceKind }}>
             {responsiveTypo ? (
                 <>
                     <StandardTypo deviceScale={deviceScale} />

--- a/packages/plasma-ui/src/components/Pickers/Picker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Picker.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo, useState, useRef, useCallback, useEffect, useContext } from 'react';
+import React, { useMemo, useState, useRef, useCallback, useEffect } from 'react';
 import type { HTMLAttributes } from 'react';
-import styled, { css, ThemeContext } from 'styled-components';
+import styled, { css } from 'styled-components';
 import { primary } from '@salutejs/plasma-tokens';
 import { IconChevronUp, IconChevronDown } from '@salutejs/plasma-icons';
 import { applyDisabled, DisabledProps, useIsomorphicLayoutEffect } from '@salutejs/plasma-core';
 
-import { useRemoteListener } from '../../hooks';
+import { useRemoteListener, useThemeContext } from '../../hooks';
 import { Button } from '../Button';
 import { Carousel, CarouselProps } from '../Carousel';
 
@@ -297,7 +297,7 @@ export const Picker = ({
     const min = 0;
     const max = items.length - 1;
 
-    const theme = useContext(ThemeContext);
+    const theme = useThemeContext();
     // by default 'true' on high perfomance devices
     const infiniteScroll = rest.infiniteScroll ?? !theme?.lowPerformance;
 

--- a/packages/plasma-ui/src/components/ProductCard/ProductCard.tsx
+++ b/packages/plasma-ui/src/components/ProductCard/ProductCard.tsx
@@ -11,6 +11,7 @@ import { Card } from '../Card/Card';
 import type { CardProps } from '../Card/Card';
 import { CardBody } from '../Card/CardBody';
 import { CardContent } from '../Card/CardContent';
+import { useDeviceKind } from '../../hooks';
 
 import { ProductCardStepper } from './ProductCardStepper';
 import type { ProductCardStepperProps } from './ProductCardStepper';
@@ -271,6 +272,10 @@ export const ProductCard = forwardRef<HTMLDivElement, ProductCardProps>(function
     },
     ref,
 ) {
+    const { isSberBox } = useDeviceKind();
+
+    const isReadonly = isSberBox || readonly;
+
     return (
         <StyledRoot>
             {badge && <StyledBadgeSlot>{badge}</StyledBadgeSlot>}
@@ -278,7 +283,7 @@ export const ProductCard = forwardRef<HTMLDivElement, ProductCardProps>(function
                 <StyledCardBody>
                     {media && <StyledMediaSlot>{media}</StyledMediaSlot>}
                     <StyledCardContent
-                        $isValuePositive={!readonly && !!quantity && quantity > 0}
+                        $isValuePositive={!isReadonly && !!quantity && quantity > 0}
                         $backgroundColor={backgroundColor}
                     >
                         {text && <StyledText>{text}</StyledText>}
@@ -288,13 +293,13 @@ export const ProductCard = forwardRef<HTMLDivElement, ProductCardProps>(function
                                 {price !== undefined && <Prices price={price} oldPrice={oldPrice} />}
                                 {!disabled && quantity !== undefined && (
                                     <StyledStepper
-                                        readonly={readonly}
+                                        readonly={isReadonly}
                                         value={quantity}
                                         step={quantityStep}
                                         min={quantityMin}
                                         max={quantityMax}
                                         onChange={onQuantityChange}
-                                        $onTop={readonly || (price !== undefined && quantity === 0)}
+                                        $onTop={isReadonly || (price !== undefined && quantity === 0)}
                                         disabled={disabledAction || disabled}
                                     />
                                 )}

--- a/packages/plasma-ui/src/components/ProductCard/ProductCard.tsx
+++ b/packages/plasma-ui/src/components/ProductCard/ProductCard.tsx
@@ -276,10 +276,19 @@ export const ProductCard = forwardRef<HTMLDivElement, ProductCardProps>(function
 
     const isReadonly = isSberBox || readonly;
 
+    const tabIndex = isSberBox ? 0 : -1;
+
     return (
         <StyledRoot>
             {badge && <StyledBadgeSlot>{badge}</StyledBadgeSlot>}
-            <StyledCard {...rest} ref={ref} disabled={disabled} $backgroundColor={backgroundColor}>
+            <StyledCard
+                {...rest}
+                ref={ref}
+                tabIndex={tabIndex}
+                outlined={isSberBox}
+                disabled={disabled}
+                $backgroundColor={backgroundColor}
+            >
                 <StyledCardBody>
                     {media && <StyledMediaSlot>{media}</StyledMediaSlot>}
                     <StyledCardContent

--- a/packages/plasma-ui/src/components/Slider/SliderBase.tsx
+++ b/packages/plasma-ui/src/components/Slider/SliderBase.tsx
@@ -1,7 +1,9 @@
 import React, { ReactNode } from 'react';
-import styled, { css, ThemeContext } from 'styled-components';
+import styled, { css } from 'styled-components';
 import { surfaceLiquid03, buttonAccent, scalingPixelBasis, sberPortalScale } from '@salutejs/plasma-tokens';
 import { useIsomorphicLayoutEffect } from '@salutejs/plasma-core';
+
+import { useThemeContext } from '../../hooks';
 
 export const handleDiameter = 1.5;
 export const handleBorderWidth = 0.0625;
@@ -61,7 +63,7 @@ export const SliderBase = ({
     disabled,
 }: SliderProps) => {
     const ref = React.useRef<HTMLDivElement | null>(null);
-    const theme = React.useContext(ThemeContext);
+    const theme = useThemeContext();
 
     useIsomorphicLayoutEffect(() => {
         const resizeHandler = () => {

--- a/packages/plasma-ui/src/hooks/index.ts
+++ b/packages/plasma-ui/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useDebouncedFunction, useForkRef } from '@salutejs/plasma-core';
 
 export { useRemoteListener } from './useRemoteListener';
 export { useThemeContext } from './useThemeContext';
+export { useDeviceKind } from './useDeviceKind';

--- a/packages/plasma-ui/src/hooks/index.ts
+++ b/packages/plasma-ui/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useDebouncedFunction, useForkRef } from '@salutejs/plasma-core';
 
 export { useRemoteListener } from './useRemoteListener';
+export { useThemeContext } from './useThemeContext';

--- a/packages/plasma-ui/src/hooks/useDeviceKind.ts
+++ b/packages/plasma-ui/src/hooks/useDeviceKind.ts
@@ -1,0 +1,19 @@
+import { DeviceKindList } from '../utils';
+
+import { useThemeContext } from './useThemeContext';
+
+type DeviceKind = Record<'isSberBox' | 'isSberPortal' | 'isMobile', boolean>;
+
+/**
+ * Возвращает тип устройства, в булевом выражение, на котором было запущено приложение.
+ * @return {DeviceKind}
+ */
+export const useDeviceKind = (): DeviceKind => {
+    const { deviceKind } = useThemeContext();
+
+    return {
+        isSberBox: deviceKind === DeviceKindList.sberBox,
+        isSberPortal: deviceKind === DeviceKindList.sberPortal,
+        isMobile: deviceKind === DeviceKindList.mobile,
+    };
+};

--- a/packages/plasma-ui/src/hooks/useThemeContext.ts
+++ b/packages/plasma-ui/src/hooks/useThemeContext.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react';
+import { ThemeContext } from 'styled-components';
+
+import { DeviceKind } from '../utils';
+
+interface ThemeProviderContext {
+    deviceKind: DeviceKind;
+    deviceScale: number;
+    lowPerformance: boolean;
+    [key: string]: unknown;
+}
+
+/**
+ * Возвращает контекст темы.
+ * @return {ThemeProviderContext}
+ */
+export const useThemeContext = (): ThemeProviderContext => {
+    return useContext<ThemeProviderContext>(ThemeContext);
+};

--- a/packages/plasma-ui/src/utils/deviceDetection.ts
+++ b/packages/plasma-ui/src/utils/deviceDetection.ts
@@ -6,6 +6,12 @@ export const deviceScales = {
 
 export type DeviceKind = keyof typeof deviceScales;
 
+export enum DeviceKindList {
+    sberBox = 'sberBox',
+    mobile = 'mobile',
+    sberPortal = 'sberPortal',
+}
+
 /**
  * Проверка в браузере на устройство "SberPortal".
  * @return {boolean}
@@ -74,16 +80,16 @@ export const isTV = (): boolean => {
  */
 export const detectDevice = (): DeviceKind => {
     if (typeof navigator === 'undefined') {
-        return 'sberBox';
+        return DeviceKindList.sberBox;
     }
     switch (true) {
         case isSberPortal():
-            return 'sberPortal';
+            return DeviceKindList.sberPortal;
         case isSberBoxTop():
         case isSberBox():
         case isTV():
-            return 'sberBox';
+            return DeviceKindList.sberBox;
         default:
-            return 'mobile';
+            return DeviceKindList.mobile;
     }
 };

--- a/packages/plasma-ui/src/utils/index.ts
+++ b/packages/plasma-ui/src/utils/index.ts
@@ -22,5 +22,5 @@ export type { Breakpoint, MediaQueryFunction } from './mediaQuery';
 
 export type { PinProps } from '@salutejs/plasma-core';
 
-export { detectDevice, deviceScales, isSberBox, isSberPortal } from './deviceDetection';
+export { detectDevice, deviceScales, isSberBox, isSberPortal, DeviceKindList } from './deviceDetection';
 export type { DeviceKind } from './deviceDetection';


### PR DESCRIPTION
В **storybook** методы типа `isSberBox` не реагировали на изменения типа устройства.

Теперь у нас есть централизованный способ получения типа устройства на основе контекста темы.
               
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[sbermarket_ios-swift--canary.177.3187477830.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/sbermarket_ios-swift--canary.177.3187477830.swift)  
[sbermarket_kotlin--canary.177.3187477830.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/sbermarket_kotlin--canary.177.3187477830.kt)  
[sbermarket_react-native--canary.177.3187477830.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/sbermarket_react-native--canary.177.3187477830.ts)  
[colors--canary.177.3187477830.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.177.3187477830.xml)  
[PlasmaTokensColor--canary.177.3187477830.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.177.3187477830.swift)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.98.0-canary.177.3187477830.0
  npm install @salutejs/plasma-ui@1.132.0-canary.177.3187477830.0
  # or 
  yarn add @salutejs/plasma-temple@1.98.0-canary.177.3187477830.0
  yarn add @salutejs/plasma-ui@1.132.0-canary.177.3187477830.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
