### PR TITLE
fix(plasma-ui): fix using sb-addon-performance usages for future storybook versions

### DIFF
--- a/packages/plasma-ui/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useCallback } from 'react';
-import { Story, Meta, addDecorator } from '@storybook/react';
+import { Story, Meta } from '@storybook/react';
 import type { SnapType, SnapAlign, CarouselLiteProps } from '@salutejs/plasma-core';
 import { CarouselItemVirtual } from '@salutejs/plasma-core';
 import { useVirtual } from '@salutejs/use-virtual';
@@ -65,8 +65,6 @@ const ChevronLeft: React.FC = React.memo(() => {
 const ChevronRight: React.FC = React.memo(() => {
     return <IconChevronRight size="s" color="#fff" />;
 });
-
-addDecorator(withPerformance);
 
 function isSelected(element: HTMLElement) {
     return () => {
@@ -180,6 +178,8 @@ export const Basic: Story<CarouselProps & CarouselColProps & { displayGrid: bool
     );
 };
 
+Basic.decorators = [withPerformance];
+
 Basic.story = {
     name: 'Basic',
     parameters: {
@@ -285,6 +285,8 @@ export const CarouselVirtualBasic = () => {
     );
 };
 
+CarouselVirtualBasic.decorators = [withPerformance];
+
 CarouselVirtualBasic.args = {
     displayGrid: true,
 };
@@ -356,6 +358,8 @@ export const Vertical: Story<CarouselProps & CarouselColProps & { displayGrid: b
         </DeviceThemeProvider>
     );
 };
+
+Vertical.decorators = [withPerformance];
 
 Vertical.args = {
     ...Basic.args,
@@ -616,6 +620,8 @@ export const CarouselLiteBasic: Story<CarouselLiteProps & CarouselColProps & { d
         </DeviceThemeProvider>
     );
 };
+
+CarouselLiteBasic.decorators = [withPerformance];
 
 CarouselLiteBasic.args = {
     displayGrid: true,

--- a/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Story, Meta, addDecorator } from '@storybook/react';
+import { Story, Meta } from '@storybook/react';
 import { withPerformance, PublicInteractionTask, InteractionTaskArgs } from 'storybook-addon-performance';
 import type { SnapType } from '@salutejs/plasma-core';
 import { waitFor } from '@testing-library/dom';
@@ -9,8 +9,6 @@ import { isSberBox } from '../../utils';
 import { disableProps } from '../../helpers';
 
 import { DatePicker, TimePicker, DatePickerProps, TimePickerProps } from '.';
-
-addDecorator(withPerformance);
 
 const StyledWrapper = styled.div`
     display: grid;
@@ -212,6 +210,8 @@ export const Default: Story<DefaultStoryProps> = (args) => {
     );
 };
 
+Default.decorators = [withPerformance];
+
 Default.args = {
     initialValue: '01.09.1980 00:28:59',
     minDate: '01.01.1975 01:15:29',
@@ -326,6 +326,9 @@ export const Date_Picker: Story<DatePickerStoryProps> = ({
 };
 
 // eslint-disable-next-line @typescript-eslint/camelcase
+Date_Picker.decorators = [withPerformance];
+
+// eslint-disable-next-line @typescript-eslint/camelcase
 Date_Picker.parameters = {
     performance: {
         interactions: interactionTasksDatePicker,
@@ -425,6 +428,9 @@ export const Time_Picker: Story<TimePickerStoryProps> = ({
         />
     );
 };
+
+// eslint-disable-next-line @typescript-eslint/camelcase
+Time_Picker.decorators = [withPerformance];
 
 // eslint-disable-next-line @typescript-eslint/camelcase
 Time_Picker.parameters = {


### PR DESCRIPTION
addDecorator в новых версиях (см https://github.com/salute-developers/plasma/pull/194) добавляет декораторы строго глобально, и при текущем использовании будет навешиваться на стори несколько раз. Это вызывает выполнение сразу нескольких бенчмарков одновременно для текущей стори, что аффектит измерения. Не меняет поведение на текущей версии
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.248.3564455048.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.248.3564455048.xml)  
[color_sbermarket_ios-swift--canary.248.3564455048.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.248.3564455048.swift)  
[color_sbermarket_kotlin--canary.248.3564455048.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.248.3564455048.kt)  
[color_sbermarket_react-native--canary.248.3564455048.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.248.3564455048.ts)  
[color_sberprime_ios-swift--canary.248.3564455048.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.248.3564455048.swift)  
[color_sberprime_kotlin--canary.248.3564455048.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.248.3564455048.kt)  
[color_sberprime_react-native--canary.248.3564455048.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.248.3564455048.ts)  
[PlasmaTokensColor--canary.248.3564455048.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.248.3564455048.swift)  
[typo_mage_kotlin--canary.248.3564455048.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.248.3564455048.kt)  
[typo_mage_react-native--canary.248.3564455048.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.248.3564455048.ts)  
[typo_plasma_kotlin--canary.248.3564455048.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.248.3564455048.kt)  
[typo_plasma_react-native--canary.248.3564455048.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.248.3564455048.ts)  
[typo_ruler_kotlin--canary.248.3564455048.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.248.3564455048.kt)  
[typo_ruler_react-native--canary.248.3564455048.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.248.3564455048.ts)  
[typo_sage_kotlin--canary.248.3564455048.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.248.3564455048.kt)  
[typo_sage_react-native--canary.248.3564455048.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.248.3564455048.ts)  
[typo_sbermarket_kotlin--canary.248.3564455048.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.248.3564455048.kt)  
[typo_sbermarket_react-native--canary.248.3564455048.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.248.3564455048.ts)  
[typo_soulmate_kotlin--canary.248.3564455048.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.248.3564455048.kt)  
[typo_soulmate_react-native--canary.248.3564455048.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.248.3564455048.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.114.4-canary.248.3564455048.0
  npm install @salutejs/plasma-ui@1.147.3-canary.248.3564455048.0
  # or 
  yarn add @salutejs/plasma-temple@1.114.4-canary.248.3564455048.0
  yarn add @salutejs/plasma-ui@1.147.3-canary.248.3564455048.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
