### PR TITLE
feat(plasma-tokens-web/b2b/b2c/ui): Add overlay tokens

### DIFF
--- a/packages/plasma-tokens-b2b/data/ds.ts
+++ b/packages/plasma-tokens-b2b/data/ds.ts
@@ -14,6 +14,7 @@ import {
     normalizeLetterSpace,
     FullColorsList,
 } from '@salutejs/plasma-tokens-utils';
+import { general } from '@salutejs/plasma-colors';
 
 import { DesignLanguage } from '../design-language/build/diez-plasma-tokens-b2b-web';
 import type {
@@ -39,8 +40,51 @@ const baseColors = mapDesignToBaseColors(ds);
 /* =                THEMES                = */
 /* ======================================== */
 
+const overlayTokens = {
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.72),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.72),
+    },
+};
+
 const light: FullColors & WebColors = {
     ...baseColors,
+    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.light_primary.color),
@@ -270,8 +314,10 @@ const light: FullColors & WebColors = {
         value: '',
     },
 };
+
 const dark: FullColors & WebColors = {
     ...baseColors,
+    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.dark_primary.color),

--- a/packages/plasma-tokens-b2c/data/ds.ts
+++ b/packages/plasma-tokens-b2c/data/ds.ts
@@ -21,6 +21,7 @@ import type {
     Typograph as TypographyData,
 } from '../design-language/build/diez-plasma-tokens-b2c-web';
 import { colors } from './colors';
+import { general } from '@salutejs/plasma-colors';
 
 const ds = new DesignLanguage();
 
@@ -40,8 +41,51 @@ type ExtendedColors = Record<'inputErrorBackground', TokenData>;
 /* =                THEMES                = */
 /* ======================================== */
 
+const overlayTokens = {
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.72),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.72),
+    },
+};
+
 const light: FullColors & WebColors & ExtendedColors = {
     ...baseColors,
+    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.light_primary.color),
@@ -275,8 +319,10 @@ const light: FullColors & WebColors & ExtendedColors = {
         value: '',
     },
 };
+
 const dark: FullColors & WebColors & ExtendedColors = {
     ...baseColors,
+    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.dark_primary.color),

--- a/packages/plasma-tokens-web/data/ds.ts
+++ b/packages/plasma-tokens-web/data/ds.ts
@@ -15,6 +15,8 @@ import {
     FullColorsList,
 } from '@salutejs/plasma-tokens-utils';
 
+import { general } from '@salutejs/plasma-colors';
+
 import { DesignLanguage } from '../design-language/build/diez-plasma-tokens-web-web';
 import type {
     Typography as TypographySet,
@@ -34,12 +36,55 @@ require('jsdom-global')();
 
 const baseColors = mapDesignToBaseColors(ds);
 
+const overlayTokens = {
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.72),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.72),
+    },
+};
+
 /* ======================================== */
 /* =                THEMES                = */
 /* ======================================== */
 
 const light: FullColors & WebColors = {
     ...baseColors,
+    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.light_primary.color),
@@ -269,8 +314,10 @@ const light: FullColors & WebColors = {
         value: '',
     },
 };
+
 const dark: FullColors & WebColors = {
     ...baseColors,
+    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.dark_primary.color),

--- a/packages/plasma-tokens/data/ds.ts
+++ b/packages/plasma-tokens/data/ds.ts
@@ -1,4 +1,5 @@
 import type { TokenData, TColor } from '@salutejs/plasma-tokens-utils';
+
 import {
     mapDesignToBaseColors,
     mapDesignToTypography,
@@ -12,6 +13,7 @@ import {
     normalizeFontWeight,
     normalizeLetterSpace,
     FullColorsList,
+    alphenColor,
 } from '@salutejs/plasma-tokens-utils';
 
 import { DesignLanguage } from '../design-language/build/diez-plasma-tokens-web';
@@ -21,6 +23,7 @@ import type {
 } from '../design-language/build/diez-plasma-tokens-web';
 
 import { colors } from './colors';
+import { general } from '@salutejs/plasma-colors';
 
 const ds = new DesignLanguage();
 
@@ -45,8 +48,51 @@ type BaseTheme = Omit<
     'accent' | 'gradient' | 'gradientDevice' | 'voicePhraseGradient' | 'buttonAccent' | 'buttonFocused'
 >;
 
+const overlayTokens = {
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.72),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.72),
+    },
+};
+
 const darkTheme: BaseTheme = {
     ...baseColors,
+    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.dark_primary.color),
@@ -180,8 +226,10 @@ const darkTheme: BaseTheme = {
         comment: FullColorsList.speechBubbleReceived,
     },
 };
+
 const lightTheme: BaseTheme = {
     ...baseColors,
+    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.light_primary.color),


### PR DESCRIPTION
Добавляем новые токены для overlay в **plasma-tokens/-web/-b2c/-b2b**

Команда `npm run build` выдает результат для новых токенов: 

```js
exports.overlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.overlayHard = 'rgba(8, 8, 8, 0.9)';
exports.overlayBlur = 'rgba(35, 35, 35, 0.2)';
exports.darkOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.darkOverlayHard = 'rgba(8, 8, 8, 0.9)';
exports.darkOverlayBlur = 'rgba(35, 35, 35, 0.2)';
exports.lightOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.lightOverlayHard = 'rgba(8, 8, 8, 0.9)';
exports.lightOverlayBlur = 'rgba(35, 35, 35, 0.28)';
exports.inverseOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.inverseOverlayHard = 'rgba(8, 8, 8, 0.9)';
exports.inverseOverlayBlur = 'rgba(35, 35, 35, 0.28)';
``` 
  
```css
"--plasma-colors-overlaySoft": "rgba(8, 8, 8, 0.56)",
 "--plasma-colors-overlayHard": "rgba(8, 8, 8, 0.9)",
"--plasma-colors-overlayBlur": "rgba(35, 35, 35, 0.2)",
"--plasma-colors-darkOverlaySoft": "rgba(8, 8, 8, 0.56)",
 "--plasma-colors-darkOverlayHard": "rgba(8, 8, 8, 0.9)",
"--plasma-colors-darkOverlayBlur": "rgba(35, 35, 35, 0.2)",
"--plasma-colors-lightOverlaySoft": "rgba(8, 8, 8, 0.56)",
"--plasma-colors-lightOverlayHard": "rgba(8, 8, 8, 0.9)",
"--plasma-colors-lightOverlayBlur": "rgba(35, 35, 35, 0.28)",
"--plasma-colors-inverseOverlaySoft": "rgba(8, 8, 8, 0.56)",
"--plasma-colors-inverseOverlayHard": "rgba(8, 8, 8, 0.9)",
"--plasma-colors-inverseOverlayBlur": "rgba(35, 35, 35, 0.28)",
```

**NOTE:** Комментарии для новых токенов пока не добавляем. Согласовано с @gibushnev.
  
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.256.3636525637.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.256.3636525637.xml)  
[color_sbermarket_ios-swift--canary.256.3636525637.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.256.3636525637.swift)  
[color_sbermarket_kotlin--canary.256.3636525637.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.256.3636525637.kt)  
[color_sbermarket_react-native--canary.256.3636525637.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.256.3636525637.ts)  
[color_sberprime_ios-swift--canary.256.3636525637.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.256.3636525637.swift)  
[color_sberprime_kotlin--canary.256.3636525637.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.256.3636525637.kt)  
[color_sberprime_react-native--canary.256.3636525637.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.256.3636525637.ts)  
[PlasmaTokensColor--canary.256.3636525637.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.256.3636525637.swift)  
[typo_mage_kotlin--canary.256.3636525637.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.256.3636525637.kt)  
[typo_mage_react-native--canary.256.3636525637.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.256.3636525637.ts)  
[typo_plasma_kotlin--canary.256.3636525637.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.256.3636525637.kt)  
[typo_plasma_react-native--canary.256.3636525637.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.256.3636525637.ts)  
[typo_ruler_kotlin--canary.256.3636525637.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.256.3636525637.kt)  
[typo_ruler_react-native--canary.256.3636525637.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.256.3636525637.ts)  
[typo_sage_kotlin--canary.256.3636525637.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.256.3636525637.kt)  
[typo_sage_react-native--canary.256.3636525637.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.256.3636525637.ts)  
[typo_sbermarket_kotlin--canary.256.3636525637.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.256.3636525637.kt)  
[typo_sbermarket_react-native--canary.256.3636525637.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.256.3636525637.ts)  
[typo_soulmate_kotlin--canary.256.3636525637.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.256.3636525637.kt)  
[typo_soulmate_react-native--canary.256.3636525637.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.256.3636525637.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.117.0-canary.256.3636525637.0
  npm install @salutejs/plasma-core@1.84.0-canary.256.3636525637.0
  npm install @salutejs/plasma-icons@1.111.0-canary.256.3636525637.0
  npm install @salutejs/plasma-temple@1.115.0-canary.256.3636525637.0
  npm install @salutejs/plasma-tokens-b2b@1.5.0-canary.256.3636525637.0
  npm install @salutejs/plasma-tokens-b2c@0.14.0-canary.256.3636525637.0
  npm install @salutejs/plasma-tokens-web@1.20.0-canary.256.3636525637.0
  npm install @salutejs/plasma-tokens@1.29.0-canary.256.3636525637.0
  npm install @salutejs/plasma-ui@1.148.0-canary.256.3636525637.0
  npm install @salutejs/plasma-web@1.145.0-canary.256.3636525637.0
  npm install @salutejs/plasma-cy-utils@0.35.0-canary.256.3636525637.0
  npm install @salutejs/plasma-sb-utils@0.82.0-canary.256.3636525637.0
  npm install @salutejs/plasma-tokens-android@2.36.0-canary.256.3636525637.0
  npm install @salutejs/plasma-tokens-ios-swift@2.36.0-canary.256.3636525637.0
  # or 
  yarn add @salutejs/plasma-b2c@1.117.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-core@1.84.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-icons@1.111.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-temple@1.115.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-tokens-b2b@1.5.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-tokens-b2c@0.14.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-tokens-web@1.20.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-tokens@1.29.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-ui@1.148.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-web@1.145.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-cy-utils@0.35.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-sb-utils@0.82.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-tokens-android@2.36.0-canary.256.3636525637.0
  yarn add @salutejs/plasma-tokens-ios-swift@2.36.0-canary.256.3636525637.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
