### PR TITLE
fix(plasma-tokens-web/b2b/b2c/ui): Change overlay tokens

### DIFF
--- a/packages/plasma-tokens-b2b/data/ds.ts
+++ b/packages/plasma-tokens-b2b/data/ds.ts
@@ -40,51 +40,8 @@ const baseColors = mapDesignToBaseColors(ds);
 /* =                THEMES                = */
 /* ======================================== */
 
-const overlayTokens = {
-    overlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    overlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    overlayBlur: {
-        value: alphenColor(general.gray['900'], -0.8),
-    },
-
-    darkOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    darkOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    darkOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.8),
-    },
-
-    lightOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    lightOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    lightOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.72),
-    },
-
-    inverseOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    inverseOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    inverseOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.72),
-    },
-};
-
 const light: FullColors & WebColors = {
     ...baseColors,
-    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.light_primary.color),
@@ -172,11 +129,6 @@ const light: FullColors & WebColors = {
     critical: {
         value: humanizeColor(ds.theme.light_critical.color),
         comment: FullColorsList.critical,
-    },
-
-    overlay: {
-        value: humanizeColor(ds.theme.light_overlay.color),
-        comment: FullColorsList.overlay,
     },
 
     surfaceLiquid01: {
@@ -313,11 +265,55 @@ const light: FullColors & WebColors = {
     speechBubbleReceived: {
         value: '',
     },
+
+    overlay: {
+        value: humanizeColor(ds.theme.light_overlay.color),
+        comment: FullColorsList.overlay,
+    },
+
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
 };
 
 const dark: FullColors & WebColors = {
     ...baseColors,
-    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.dark_primary.color),
@@ -405,11 +401,6 @@ const dark: FullColors & WebColors = {
     critical: {
         value: humanizeColor(ds.theme.dark_critical.color),
         comment: FullColorsList.critical,
-    },
-
-    overlay: {
-        value: humanizeColor(ds.theme.dark_overlay.color),
-        comment: FullColorsList.overlay,
     },
 
     surfaceLiquid01: {
@@ -545,6 +536,51 @@ const dark: FullColors & WebColors = {
     },
     speechBubbleReceived: {
         value: '',
+    },
+
+    overlay: {
+        value: humanizeColor(ds.theme.dark_overlay.color),
+        comment: FullColorsList.overlay,
+    },
+
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
     },
 };
 

--- a/packages/plasma-tokens-b2c/data/ds.ts
+++ b/packages/plasma-tokens-b2c/data/ds.ts
@@ -41,51 +41,8 @@ type ExtendedColors = Record<'inputErrorBackground', TokenData>;
 /* =                THEMES                = */
 /* ======================================== */
 
-const overlayTokens = {
-    overlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    overlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    overlayBlur: {
-        value: alphenColor(general.gray['900'], -0.8),
-    },
-
-    darkOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    darkOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    darkOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.8),
-    },
-
-    lightOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    lightOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    lightOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.72),
-    },
-
-    inverseOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    inverseOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    inverseOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.72),
-    },
-};
-
 const light: FullColors & WebColors & ExtendedColors = {
     ...baseColors,
-    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.light_primary.color),
@@ -177,11 +134,6 @@ const light: FullColors & WebColors & ExtendedColors = {
     critical: {
         value: humanizeColor(ds.theme.light_critical.color),
         comment: FullColorsList.critical,
-    },
-
-    overlay: {
-        value: humanizeColor(ds.theme.light_overlay.color),
-        comment: FullColorsList.overlay,
     },
 
     surfaceLiquid01: {
@@ -318,11 +270,55 @@ const light: FullColors & WebColors & ExtendedColors = {
     speechBubbleReceived: {
         value: '',
     },
+
+    overlay: {
+        value: humanizeColor(ds.theme.light_overlay.color),
+        comment: FullColorsList.overlay,
+    },
+
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
 };
 
 const dark: FullColors & WebColors & ExtendedColors = {
     ...baseColors,
-    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.dark_primary.color),
@@ -414,11 +410,6 @@ const dark: FullColors & WebColors & ExtendedColors = {
     critical: {
         value: humanizeColor(ds.theme.dark_critical.color),
         comment: FullColorsList.critical,
-    },
-
-    overlay: {
-        value: humanizeColor(ds.theme.dark_overlay.color),
-        comment: FullColorsList.overlay,
     },
 
     surfaceLiquid01: {
@@ -554,6 +545,51 @@ const dark: FullColors & WebColors & ExtendedColors = {
     },
     speechBubbleReceived: {
         value: '',
+    },
+
+    overlay: {
+        value: humanizeColor(ds.theme.dark_overlay.color),
+        comment: FullColorsList.overlay,
+    },
+
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
     },
 };
 

--- a/packages/plasma-tokens-web/data/ds.ts
+++ b/packages/plasma-tokens-web/data/ds.ts
@@ -36,55 +36,12 @@ require('jsdom-global')();
 
 const baseColors = mapDesignToBaseColors(ds);
 
-const overlayTokens = {
-    overlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    overlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    overlayBlur: {
-        value: alphenColor(general.gray['900'], -0.8),
-    },
-
-    darkOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    darkOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    darkOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.8),
-    },
-
-    lightOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    lightOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    lightOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.72),
-    },
-
-    inverseOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    inverseOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    inverseOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.72),
-    },
-};
-
 /* ======================================== */
 /* =                THEMES                = */
 /* ======================================== */
 
 const light: FullColors & WebColors = {
     ...baseColors,
-    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.light_primary.color),
@@ -172,11 +129,6 @@ const light: FullColors & WebColors = {
     critical: {
         value: humanizeColor(ds.theme.light_critical.color),
         comment: FullColorsList.critical,
-    },
-
-    overlay: {
-        value: humanizeColor(ds.theme.light_overlay.color),
-        comment: FullColorsList.overlay,
     },
 
     surfaceLiquid01: {
@@ -313,11 +265,55 @@ const light: FullColors & WebColors = {
     speechBubbleReceived: {
         value: '',
     },
+
+    overlay: {
+        value: humanizeColor(ds.theme.light_overlay.color),
+        comment: FullColorsList.overlay,
+    },
+
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
 };
 
 const dark: FullColors & WebColors = {
     ...baseColors,
-    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.dark_primary.color),
@@ -405,11 +401,6 @@ const dark: FullColors & WebColors = {
     critical: {
         value: humanizeColor(ds.theme.dark_critical.color),
         comment: FullColorsList.critical,
-    },
-
-    overlay: {
-        value: humanizeColor(ds.theme.dark_overlay.color),
-        comment: FullColorsList.overlay,
     },
 
     surfaceLiquid01: {
@@ -545,6 +536,51 @@ const dark: FullColors & WebColors = {
     },
     speechBubbleReceived: {
         value: '',
+    },
+
+    overlay: {
+        value: humanizeColor(ds.theme.dark_overlay.color),
+        comment: FullColorsList.overlay,
+    },
+
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
     },
 };
 

--- a/packages/plasma-tokens/data/ds.ts
+++ b/packages/plasma-tokens/data/ds.ts
@@ -14,6 +14,7 @@ import {
     normalizeLetterSpace,
     FullColorsList,
     alphenColor,
+    OverlayTokens,
 } from '@salutejs/plasma-tokens-utils';
 
 import { DesignLanguage } from '../design-language/build/diez-plasma-tokens-web';
@@ -48,51 +49,8 @@ type BaseTheme = Omit<
     'accent' | 'gradient' | 'gradientDevice' | 'voicePhraseGradient' | 'buttonAccent' | 'buttonFocused'
 >;
 
-const overlayTokens = {
-    overlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    overlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    overlayBlur: {
-        value: alphenColor(general.gray['900'], -0.8),
-    },
-
-    darkOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    darkOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    darkOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.8),
-    },
-
-    lightOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    lightOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    lightOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.72),
-    },
-
-    inverseOverlaySoft: {
-        value: alphenColor(baseColors.black.value, -0.44),
-    },
-    inverseOverlayHard: {
-        value: alphenColor(baseColors.black.value, -0.1),
-    },
-    inverseOverlayBlur: {
-        value: alphenColor(general.gray['900'], -0.72),
-    },
-};
-
-const darkTheme: BaseTheme = {
+const darkTheme: BaseTheme & OverlayTokens = {
     ...baseColors,
-    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.dark_primary.color),
@@ -149,11 +107,6 @@ const darkTheme: BaseTheme = {
     critical: {
         value: humanizeColor(ds.theme.dark_critical.color),
         comment: FullColorsList.critical,
-    },
-
-    overlay: {
-        value: humanizeColor(ds.theme.dark_overlay.color),
-        comment: FullColorsList.overlay,
     },
 
     surfaceLiquid01: {
@@ -225,11 +178,54 @@ const darkTheme: BaseTheme = {
         value: humanizeColor(ds.theme.dark_speech_bubble_received.color),
         comment: FullColorsList.speechBubbleReceived,
     },
+
+    overlay: {
+        value: humanizeColor(ds.theme.dark_overlay.color),
+        comment: FullColorsList.overlay,
+    },
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['950'], -0.72),
+    },
 };
 
-const lightTheme: BaseTheme = {
+const lightTheme: BaseTheme & OverlayTokens = {
     ...baseColors,
-    ...overlayTokens,
 
     text: {
         value: humanizeColor(ds.theme.light_primary.color),
@@ -286,11 +282,6 @@ const lightTheme: BaseTheme = {
     critical: {
         value: humanizeColor(ds.theme.light_critical.color),
         comment: FullColorsList.critical,
-    },
-
-    overlay: {
-        value: humanizeColor(ds.theme.light_overlay.color),
-        comment: FullColorsList.overlay,
     },
 
     surfaceLiquid01: {
@@ -361,6 +352,50 @@ const lightTheme: BaseTheme = {
     speechBubbleReceived: {
         value: humanizeColor(ds.theme.light_speech_bubble_received.color),
         comment: FullColorsList.speechBubbleReceived,
+    },
+
+    overlay: {
+        value: humanizeColor(ds.theme.light_overlay.color),
+        comment: FullColorsList.overlay,
+    },
+    overlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    overlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    overlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    darkOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    darkOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    darkOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    lightOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    lightOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    lightOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
+    },
+
+    inverseOverlaySoft: {
+        value: alphenColor(baseColors.black.value, -0.44),
+    },
+    inverseOverlayHard: {
+        value: alphenColor(baseColors.black.value, -0.1),
+    },
+    inverseOverlayBlur: {
+        value: alphenColor(general.gray['900'], -0.8),
     },
 };
 

--- a/utils/plasma-tokens-utils/src/types.ts
+++ b/utils/plasma-tokens-utils/src/types.ts
@@ -108,3 +108,19 @@ export type GeneratedFiles = Array<{
     file: string;
     content: string;
 }>;
+
+type OverlayTokensKeys =
+    | 'overlaySoft'
+    | 'overlayHard'
+    | 'overlayBlur'
+    | 'darkOverlaySoft'
+    | 'darkOverlayHard'
+    | 'darkOverlayBlur'
+    | 'lightOverlaySoft'
+    | 'lightOverlayHard'
+    | 'lightOverlayBlur'
+    | 'inverseOverlaySoft'
+    | 'inverseOverlayHard'
+    | 'inverseOverlayBlur';
+
+export type OverlayTokens = Record<OverlayTokensKeys, TokenData<TColor>>;


### PR DESCRIPTION
Необходимо изменить значения для токена overlay в plasma-tokens/-web/-b2c/-b2b. 

Новые значения для: 

dark theme 

```js
exports.overlayBlur = 'rgba(23, 23, 23, 0.28)';
exports.darkOverlayBlur = 'rgba(23, 23, 23, 0.28)';
exports.lightOverlayBlur = 'rgba(23, 23, 23, 0.28)';
exports.inverseOverlayBlur = 'rgba(23, 23, 23, 0.28)';
exports.overlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.overlayHard = 'rgba(8, 8, 8, 0.9)';
exports.darkOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.darkOverlayHard = 'rgba(8, 8, 8, 0.9)';
exports.lightOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.lightOverlayHard = 'rgba(8, 8, 8, 0.9)';
exports.inverseOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.inverseOverlayHard = 'rgba(8, 8, 8, 0.9)';
```

light theme 

```js
exports.overlayBlur = 'rgba(35, 35, 35, 0.2)';
exports.darkOverlayBlur = 'rgba(35, 35, 35, 0.2)';
exports.lightOverlayBlur = 'rgba(35, 35, 35, 0.2)';
exports.inverseOverlayBlur = 'rgba(35, 35, 35, 0.2)';
exports.overlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.overlayHard = 'rgba(8, 8, 8, 0.9)';
exports.darkOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.darkOverlayHard = 'rgba(8, 8, 8, 0.9)';
exports.lightOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.lightOverlayHard = 'rgba(8, 8, 8, 0.9)';
exports.inverseOverlaySoft = 'rgba(8, 8, 8, 0.56)';
exports.inverseOverlayHard = 'rgba(8, 8, 8, 0.9)';
```

NOTE: Согласовано и проверено @gibushnev.

------------------------------------------------------------------

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.265.3682712861.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.265.3682712861.xml)  
[color_metro_ios-swift--canary.265.3682712861.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.265.3682712861.swift)  
[color_metro_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.265.3682712861.kt)  
[color_metro_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.265.3682712861.ts)  
[color_sbermarket_ios-swift--canary.265.3682712861.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.265.3682712861.swift)  
[color_sbermarket_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.265.3682712861.kt)  
[color_sbermarket_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.265.3682712861.ts)  
[color_sberprime_ios-swift--canary.265.3682712861.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.265.3682712861.swift)  
[color_sberprime_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.265.3682712861.kt)  
[color_sberprime_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.265.3682712861.ts)  
[color_selgros_ios-swift--canary.265.3682712861.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.265.3682712861.swift)  
[color_selgros_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.265.3682712861.kt)  
[color_selgros_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.265.3682712861.ts)  
[color_smbusiness_ios-swift--canary.265.3682712861.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.265.3682712861.swift)  
[color_smbusiness_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.265.3682712861.kt)  
[color_smbusiness_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.265.3682712861.ts)  
[PlasmaTokensColor--canary.265.3682712861.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.265.3682712861.swift)  
[typo_mage_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.265.3682712861.kt)  
[typo_mage_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.265.3682712861.ts)  
[typo_plasma_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.265.3682712861.kt)  
[typo_plasma_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.265.3682712861.ts)  
[typo_ruler_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.265.3682712861.kt)  
[typo_ruler_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.265.3682712861.ts)  
[typo_sage_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.265.3682712861.kt)  
[typo_sage_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.265.3682712861.ts)  
[typo_sbermarket_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.265.3682712861.kt)  
[typo_sbermarket_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.265.3682712861.ts)  
[typo_soulmate_kotlin--canary.265.3682712861.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.265.3682712861.kt)  
[typo_soulmate_react-native--canary.265.3682712861.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.265.3682712861.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.117.0-canary.265.3682712861.0
  npm install @salutejs/plasma-core@1.84.0-canary.265.3682712861.0
  npm install @salutejs/plasma-icons@1.111.0-canary.265.3682712861.0
  npm install @salutejs/plasma-temple@1.116.0-canary.265.3682712861.0
  npm install @salutejs/plasma-tokens-b2b@1.5.0-canary.265.3682712861.0
  npm install @salutejs/plasma-tokens-b2c@0.14.0-canary.265.3682712861.0
  npm install @salutejs/plasma-tokens-web@1.20.0-canary.265.3682712861.0
  npm install @salutejs/plasma-tokens@1.29.0-canary.265.3682712861.0
  npm install @salutejs/plasma-ui@1.149.0-canary.265.3682712861.0
  npm install @salutejs/plasma-web@1.145.0-canary.265.3682712861.0
  npm install @salutejs/plasma-cy-utils@0.35.0-canary.265.3682712861.0
  npm install @salutejs/plasma-sb-utils@0.82.0-canary.265.3682712861.0
  npm install @salutejs/plasma-tokens-android@2.36.0-canary.265.3682712861.0
  npm install @salutejs/plasma-tokens-ios-swift@2.36.0-canary.265.3682712861.0
  npm install @salutejs/plasma-tokens-utils@0.14.0-canary.265.3682712861.0
  # or 
  yarn add @salutejs/plasma-b2c@1.117.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-core@1.84.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-icons@1.111.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-temple@1.116.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-tokens-b2b@1.5.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-tokens-b2c@0.14.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-tokens-web@1.20.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-tokens@1.29.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-ui@1.149.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-web@1.145.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-cy-utils@0.35.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-sb-utils@0.82.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-tokens-android@2.36.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-tokens-ios-swift@2.36.0-canary.265.3682712861.0
  yarn add @salutejs/plasma-tokens-utils@0.14.0-canary.265.3682712861.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
