### PR TITLE
feat(plasma-ui): add theme provider for ssg

### DIFF
--- a/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
+++ b/packages/plasma-ui/src/components/Device/DeviceDetection.tsx
@@ -1,22 +1,10 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 import { createGlobalStyle, ThemeProvider } from 'styled-components';
-import { sberPortal, sberBox, mobile, sberPortalScale, sizes } from '@salutejs/plasma-tokens';
-import { transformStyles } from '@salutejs/plasma-core';
+import { sberPortalScale, sizes } from '@salutejs/plasma-tokens';
 import { standard, compatible } from '@salutejs/plasma-typo';
 
 import { detectDevice, deviceScales, DeviceKind } from '../../utils';
-
-/* stylelint-disable */
-const transformWithRoot = (typo: typeof sberBox) => `
-:root {
-    ${transformStyles(typo[':root'])}
-}`;
-const typoSizes = {
-    sberBox: createGlobalStyle`${transformWithRoot(sberBox)}`,
-    sberPortal: createGlobalStyle`${transformWithRoot(sberPortal)}`,
-    mobile: createGlobalStyle`${transformWithRoot(mobile)}`,
-};
-/* stylelint-enable */
+import { Typo } from '../Typo';
 
 const StandardTypo = createGlobalStyle(standard);
 const CompatibleTypo = createGlobalStyle(compatible);
@@ -72,7 +60,6 @@ export const DeviceThemeProvider = ({
 }: DeviceThemeProps) => {
     const deviceKind = detectDeviceCallback();
     const deviceScale = deviceScales[deviceKind] || sberPortalScale;
-    const Typo = React.useMemo(() => typoSizes[deviceKind], [deviceKind]);
 
     return (
         <ThemeProvider theme={{ ...theme, deviceScale, lowPerformance, deviceKind }}>
@@ -83,9 +70,27 @@ export const DeviceThemeProvider = ({
                     <Size />
                 </>
             ) : (
-                <Typo />
+                <Typo deviceKind={deviceKind} />
             )}
             {children}
         </ThemeProvider>
     );
+};
+
+export const DeviceThemeProviderSSG = ({
+    theme,
+    children,
+    detectDeviceCallback = detectDevice,
+    lowPerformance = false,
+}: DeviceThemeProps) => {
+    const deviceKind = detectDeviceCallback();
+    const deviceScale = deviceScales[deviceKind] || sberPortalScale;
+    const memoizedThemeData = useMemo(() => ({ ...theme, deviceScale, lowPerformance, deviceKind }), [
+        theme,
+        deviceScale,
+        lowPerformance,
+        deviceKind,
+    ]);
+
+    return <ThemeProvider theme={memoizedThemeData}>{children}</ThemeProvider>;
 };

--- a/packages/plasma-ui/src/components/Typo/index.tsx
+++ b/packages/plasma-ui/src/components/Typo/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { sberPortal, sberBox, mobile } from '@salutejs/plasma-tokens';
+import { createGlobalStyle } from 'styled-components';
+
+import { DeviceKind, transformStyles } from '../../utils';
+
+/* stylelint-disable */
+const transformWithRoot = (typo: typeof sberBox) => `
+:root {
+    ${transformStyles(typo[':root'])}
+}`;
+
+const TypoSberbox = createGlobalStyle`${transformWithRoot(sberBox)}`;
+const TypoMobile = createGlobalStyle`${transformWithRoot(mobile)}`;
+const TypoPortal = createGlobalStyle`${transformWithRoot(sberPortal)}`;
+/* stylelint-enable */
+
+export const Typo = ({ deviceKind }: { deviceKind: DeviceKind }) => {
+    if (deviceKind === 'mobile') {
+        return <TypoMobile />;
+    }
+
+    if (deviceKind === 'sberPortal') {
+        return <TypoPortal />;
+    }
+
+    return <TypoSberbox />;
+};


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.267.3749489941.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.267.3749489941.xml)  
[color_metro_ios-swift--canary.267.3749489941.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.267.3749489941.swift)  
[color_metro_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.267.3749489941.kt)  
[color_metro_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.267.3749489941.ts)  
[color_sbermarket_ios-swift--canary.267.3749489941.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.267.3749489941.swift)  
[color_sbermarket_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.267.3749489941.kt)  
[color_sbermarket_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.267.3749489941.ts)  
[color_sberprime_ios-swift--canary.267.3749489941.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.267.3749489941.swift)  
[color_sberprime_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.267.3749489941.kt)  
[color_sberprime_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.267.3749489941.ts)  
[color_selgros_ios-swift--canary.267.3749489941.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.267.3749489941.swift)  
[color_selgros_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.267.3749489941.kt)  
[color_selgros_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.267.3749489941.ts)  
[color_smbusiness_ios-swift--canary.267.3749489941.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.267.3749489941.swift)  
[color_smbusiness_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.267.3749489941.kt)  
[color_smbusiness_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.267.3749489941.ts)  
[PlasmaTokensColor--canary.267.3749489941.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.267.3749489941.swift)  
[typo_mage_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.267.3749489941.kt)  
[typo_mage_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.267.3749489941.ts)  
[typo_plasma_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.267.3749489941.kt)  
[typo_plasma_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.267.3749489941.ts)  
[typo_ruler_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.267.3749489941.kt)  
[typo_ruler_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.267.3749489941.ts)  
[typo_sage_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.267.3749489941.kt)  
[typo_sage_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.267.3749489941.ts)  
[typo_sbermarket_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.267.3749489941.kt)  
[typo_sbermarket_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.267.3749489941.ts)  
[typo_soulmate_kotlin--canary.267.3749489941.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.267.3749489941.kt)  
[typo_soulmate_react-native--canary.267.3749489941.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.267.3749489941.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.119.0-canary.267.3749489941.0
  npm install @salutejs/plasma-ui@1.152.0-canary.267.3749489941.0
  # or 
  yarn add @salutejs/plasma-temple@1.119.0-canary.267.3749489941.0
  yarn add @salutejs/plasma-ui@1.152.0-canary.267.3749489941.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
