### PR TITLE
ci: improve ts-coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:js": "eslint --ext .js,.ts,.tsx .",
     "lint:packages": "./scripts/lint-packages.js",
     "test": "lerna run test",
-    "typescript-coverage": "lerna run typescript-coverage --no-bail",
+    "typescript-coverage": "lerna run typescript-coverage --no-bail --stream",
     "generate:theme-html": "lerna run generate:theme-html --scope @salutejs/plasma-tokens"
   },
   "devDependencies": {

--- a/packages/plasma-b2c/package.json
+++ b/packages/plasma-b2c/package.json
@@ -24,13 +24,10 @@
         "storybook": "start-storybook -s .storybook/public -p ${PORT:-7007} -c .storybook",
         "storybook:build": "build-storybook -s .storybook/public -c .storybook -o build-sb",
         "test": "jest",
-        "typescript-coverage": "npx typescript-coverage-report"
+        "typescript-coverage": "npx typescript-coverage-report > /dev/null"
     },
     "typeCoverage": {
-        "ignoreFiles": [
-            "src/**/*component-test.tsx",
-            "src/**/*stories.tsx"
-        ],
+        "ignoreFiles": ["src/**/*component-test.tsx", "src/**/*stories.tsx"],
         "atLeast": 99.97
     },
     "dependencies": {
@@ -91,23 +88,7 @@
         "typescript": "3.9.10",
         "typescript-coverage-report": "0.7.0"
     },
-    "keywords": [
-        "design-system",
-        "react-components",
-        "ui-kit",
-        "react"
-    ],
-    "files": [
-        "components",
-        "es",
-        "hocs",
-        "hooks",
-        "mixins",
-        "tokens",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js"
-    ],
+    "keywords": ["design-system", "react-components", "ui-kit", "react"],
+    "files": ["components", "es", "hocs", "hooks", "mixins", "tokens", "types", "utils", "index.d.ts", "index.js"],
     "sideEffects": false
 }

--- a/packages/plasma-core/package.json
+++ b/packages/plasma-core/package.json
@@ -6,18 +6,7 @@
     "main": "index.js",
     "module": "es/index.js",
     "types": "index.d.ts",
-    "files": [
-        "components",
-        "hocs",
-        "hooks",
-        "mixins",
-        "tokens",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js",
-        "es"
-    ],
+    "files": ["components", "hocs", "hooks", "mixins", "tokens", "types", "utils", "index.d.ts", "index.js", "es"],
     "peerDependencies": {
         "react": ">=16.13.1",
         "react-dom": ">=16.13.1",
@@ -64,19 +53,13 @@
         "build:esm": "BABEL_ENV=esm SC_NAMESPACE=plasma babel ./src --out-dir ./es --source-maps --extensions .ts,.tsx",
         "test": "NODE_ICU_DATA=node_modules/full-icu jest",
         "test:watch": "NODE_ICU_DATA=node_modules/full-icu jest --watch",
-        "typescript-coverage": "npx typescript-coverage-report"
+        "typescript-coverage": "npx typescript-coverage-report > /dev/null"
     },
     "typeCoverage": {
-        "ignoreFiles": [
-            "src/**/*component-test.tsx"
-        ],
+        "ignoreFiles": ["src/**/*component-test.tsx"],
         "atLeast": 99
     },
-    "contributors": [
-        "Vasiliy Loginevskiy",
-        "Виноградов Антон Александрович",
-        "Зубаиров Фаниль Асхатович"
-    ],
+    "contributors": ["Vasiliy Loginevskiy", "Виноградов Антон Александрович", "Зубаиров Фаниль Асхатович"],
     "sideEffects": false,
     "dependencies": {
         "@salutejs/plasma-typo": "0.29.0",

--- a/packages/plasma-temple/package.json
+++ b/packages/plasma-temple/package.json
@@ -84,22 +84,13 @@
         "storybook:build": "build-storybook --quiet -s .storybook/public -c .storybook -o build-sb",
         "storybook:extract": "sb extract build-sb ./build-sb/stories.json",
         "test": "BABEL_ENV=test jest",
-        "typescript-coverage": "npx typescript-coverage-report"
+        "typescript-coverage": "npx typescript-coverage-report > /dev/null"
     },
     "typeCoverage": {
-        "ignoreFiles": [
-            "src/**/*component-test.tsx",
-            "src/**/*stories.tsx"
-        ],
+        "ignoreFiles": ["src/**/*component-test.tsx", "src/**/*stories.tsx"],
         "atLeast": 99.89
     },
-    "files": [
-        "dist",
-        "mobile",
-        "sberbox",
-        "sberportal",
-        "assistant"
-    ],
+    "files": ["dist", "mobile", "sberbox", "sberportal", "assistant"],
     "contributors": [
         "Vasiliy Loginevskiy",
         "Виноградов Антон Александрович",

--- a/packages/plasma-ui/package.json
+++ b/packages/plasma-ui/package.json
@@ -92,15 +92,12 @@
         "storybook:extract": "sb extract build-sb ./build-sb/stories.json",
         "test": "BABEL_ENV=cjs jest",
         "test:watch": "BABEL_ENV=cjs jest --watch",
-        "typescript-coverage": "npx typescript-coverage-report",
+        "typescript-coverage": "npx typescript-coverage-report > /dev/null",
         "perftool:test": "node --experimental-specifier-resolution=node ./node_modules/.bin/perftool",
         "perftool:compare": "node --experimental-specifier-resolution=node ./node_modules/.bin/perftool-compare"
     },
     "typeCoverage": {
-        "ignoreFiles": [
-            "src/**/*component-test.tsx",
-            "src/**/*stories.tsx"
-        ],
+        "ignoreFiles": ["src/**/*component-test.tsx", "src/**/*stories.tsx"],
         "atLeast": 98.7
     },
     "jest": {
@@ -108,18 +105,7 @@
             "^styled-components": "<rootDir>/node_modules/styled-components"
         }
     },
-    "files": [
-        "components",
-        "hocs",
-        "hooks",
-        "mixins",
-        "tokens",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js",
-        "es"
-    ],
+    "files": ["components", "hocs", "hooks", "mixins", "tokens", "types", "utils", "index.d.ts", "index.js", "es"],
     "contributors": [
         "Vasiliy Loginevskiy",
         "Антонов Игорь Александрович",

--- a/packages/plasma-web/package.json
+++ b/packages/plasma-web/package.json
@@ -3,27 +3,11 @@
     "version": "1.152.0",
     "description": "Salute Design System / React UI kit for web applications",
     "author": "Salute Frontend Team <salute.developers@gmail.com>",
-    "keywords": [
-        "design-system",
-        "react-components",
-        "ui-kit",
-        "react"
-    ],
+    "keywords": ["design-system", "react-components", "ui-kit", "react"],
     "main": "index.js",
     "module": "es/index.js",
     "types": "index.d.ts",
-    "files": [
-        "components",
-        "es",
-        "hocs",
-        "hooks",
-        "mixins",
-        "tokens",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js"
-    ],
+    "files": ["components", "es", "hocs", "hooks", "mixins", "tokens", "types", "utils", "index.d.ts", "index.js"],
     "repository": {
         "type": "git",
         "url": "ssh://git@github.com:salute-developers/plasma.git",
@@ -91,19 +75,12 @@
         "storybook": "start-storybook -s .storybook/public -p ${PORT:-7007} -c .storybook",
         "storybook:build": "build-storybook -s .storybook/public -c .storybook -o build-sb",
         "storybook:build:docs": "DOCS=true build-storybook --quiet -s .storybook/public -c .storybook -o build-sb-docs --docs",
-        "typescript-coverage": "npx typescript-coverage-report"
+        "typescript-coverage": "npx typescript-coverage-report > /dev/null"
     },
     "typeCoverage": {
-        "ignoreFiles": [
-            "src/**/*component-test.tsx",
-            "src/**/*stories.tsx"
-        ],
+        "ignoreFiles": ["src/**/*component-test.tsx", "src/**/*stories.tsx"],
         "atLeast": 99.96
     },
-    "contributors": [
-        "Vasiliy Loginevskiy",
-        "Anton Vinogradov",
-        "Fanil Zubairov"
-    ],
+    "contributors": ["Vasiliy Loginevskiy", "Anton Vinogradov", "Fanil Zubairov"],
     "sideEffects": false
 }

--- a/utils/plasma-cy-utils/package.json
+++ b/utils/plasma-cy-utils/package.json
@@ -36,19 +36,14 @@
         "prebuild": "npm run clean",
         "build": "tsc",
         "clean": "rm -rf lib",
-        "typescript-coverage": "npx typescript-coverage-report"
+        "typescript-coverage": "npx typescript-coverage-report > /dev/null"
     },
     "typeCoverage": {
-        "ignoreFiles": [
-            "src/**/*component-test.tsx",
-            "src/**/*stories.tsx"
-        ],
+        "ignoreFiles": ["src/**/*component-test.tsx", "src/**/*stories.tsx"],
         "atLeast": 100
     },
     "publishConfig": {
         "access": "public"
     },
-    "files": [
-        "lib"
-    ]
+    "files": ["lib"]
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.282.3947329431.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.282.3947329431.xml)  
[color_metro_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.282.3947329431.swift)  
[color_metro_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.282.3947329431.kt)  
[color_metro_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.282.3947329431.ts)  
[color_sbermarket_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.282.3947329431.swift)  
[color_sbermarket_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.282.3947329431.kt)  
[color_sbermarket_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.282.3947329431.ts)  
[color_sberprime_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.282.3947329431.swift)  
[color_sberprime_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.282.3947329431.kt)  
[color_sberprime_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.282.3947329431.ts)  
[color_selgros_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.282.3947329431.swift)  
[color_selgros_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.282.3947329431.kt)  
[color_selgros_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.282.3947329431.ts)  
[color_smbusiness_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.282.3947329431.swift)  
[color_smbusiness_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.282.3947329431.kt)  
[color_smbusiness_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.282.3947329431.ts)  
[PlasmaTokensColor--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.282.3947329431.swift)  
[typo_mage_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.282.3947329431.swift)  
[typo_mage_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.282.3947329431.kt)  
[typo_mage_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.282.3947329431.ts)  
[typo_plasma_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.282.3947329431.swift)  
[typo_plasma_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.282.3947329431.kt)  
[typo_plasma_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.282.3947329431.ts)  
[typo_ruler_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.282.3947329431.swift)  
[typo_ruler_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.282.3947329431.kt)  
[typo_ruler_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.282.3947329431.ts)  
[typo_sage_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.282.3947329431.swift)  
[typo_sage_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.282.3947329431.kt)  
[typo_sage_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.282.3947329431.ts)  
[typo_sbermarket_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.282.3947329431.swift)  
[typo_sbermarket_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.282.3947329431.kt)  
[typo_sbermarket_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.282.3947329431.ts)  
[typo_soulmate_ios-swift--canary.282.3947329431.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.282.3947329431.swift)  
[typo_soulmate_kotlin--canary.282.3947329431.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.282.3947329431.kt)  
[typo_soulmate_react-native--canary.282.3947329431.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.282.3947329431.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.125.1-canary.282.3947329431.0
  npm install @salutejs/plasma-core@1.88.1-canary.282.3947329431.0
  npm install @salutejs/plasma-icons@1.116.1-canary.282.3947329431.0
  npm install @salutejs/plasma-temple@1.122.1-canary.282.3947329431.0
  npm install @salutejs/plasma-ui@1.155.1-canary.282.3947329431.0
  npm install @salutejs/plasma-web@1.152.1-canary.282.3947329431.0
  npm install @salutejs/plasma-cy-utils@0.38.1-canary.282.3947329431.0
  npm install @salutejs/plasma-sb-utils@0.86.1-canary.282.3947329431.0
  # or 
  yarn add @salutejs/plasma-b2c@1.125.1-canary.282.3947329431.0
  yarn add @salutejs/plasma-core@1.88.1-canary.282.3947329431.0
  yarn add @salutejs/plasma-icons@1.116.1-canary.282.3947329431.0
  yarn add @salutejs/plasma-temple@1.122.1-canary.282.3947329431.0
  yarn add @salutejs/plasma-ui@1.155.1-canary.282.3947329431.0
  yarn add @salutejs/plasma-web@1.152.1-canary.282.3947329431.0
  yarn add @salutejs/plasma-cy-utils@0.38.1-canary.282.3947329431.0
  yarn add @salutejs/plasma-sb-utils@0.86.1-canary.282.3947329431.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
