### PR TITLE
fix(plasma-web): prevent default safari datepicker appearance

### DIFF
--- a/packages/plasma-web/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-web/src/components/Calendar/Calendar.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, MouseEvent } from 'react';
 import styled from 'styled-components';
 import { Story, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
@@ -300,12 +300,23 @@ export const WithPopup: Story<CalendarProps> = ({ min, max, isDouble }) => {
         date: new Date(2022, 5, 11 + day),
     }));
 
+    // INFO: В onMouseDown так же используем preventDefault чтобы скрыть нативный datepicker для iOS
+    const hideSafariDefaultDatepicker = (event: MouseEvent<HTMLInputElement>) => event.preventDefault();
+
     return (
         <Popup
             isOpen={isOpen}
             trigger="click"
             placement="bottom"
-            disclosure={<StyledTextField type="date" value={textValue} onChange={handleOnTextChange} />}
+            disclosure={
+                <StyledTextField
+                    type="date"
+                    onClick={hideSafariDefaultDatepicker}
+                    onMouseDown={hideSafariDefaultDatepicker}
+                    value={textValue}
+                    onChange={handleOnTextChange}
+                />
+            }
             onToggle={onToggle}
         >
             <StyledCalendar


### PR DESCRIPTION
В примере для storybook необходимо показать как можно скрыть нативный date picker для браузера Safari. 

Было: 

<img width="351" alt="Снимок экрана 2023-01-23 в 13 23 47" src="https://user-images.githubusercontent.com/2895992/213978654-b942c09a-385d-49c3-aff1-d14634b27b5b.png">

Стало:

<img width="326" alt="Снимок экрана 2023-01-23 в 13 23 14" src="https://user-images.githubusercontent.com/2895992/213978697-d018ca97-018b-473b-b0b8-e47f740e4b47.png">
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.287.3993143077.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.287.3993143077.xml)  
[color_metro_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.287.3993143077.swift)  
[color_metro_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.287.3993143077.kt)  
[color_metro_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.287.3993143077.ts)  
[color_sbermarket_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.287.3993143077.swift)  
[color_sbermarket_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.287.3993143077.kt)  
[color_sbermarket_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.287.3993143077.ts)  
[color_sberprime_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.287.3993143077.swift)  
[color_sberprime_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.287.3993143077.kt)  
[color_sberprime_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.287.3993143077.ts)  
[color_selgros_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.287.3993143077.swift)  
[color_selgros_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.287.3993143077.kt)  
[color_selgros_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.287.3993143077.ts)  
[color_smbusiness_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.287.3993143077.swift)  
[color_smbusiness_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.287.3993143077.kt)  
[color_smbusiness_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.287.3993143077.ts)  
[PlasmaTokensColor--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.287.3993143077.swift)  
[typo_mage_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.287.3993143077.swift)  
[typo_mage_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.287.3993143077.kt)  
[typo_mage_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.287.3993143077.ts)  
[typo_plasma_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.287.3993143077.swift)  
[typo_plasma_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.287.3993143077.kt)  
[typo_plasma_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.287.3993143077.ts)  
[typo_ruler_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.287.3993143077.swift)  
[typo_ruler_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.287.3993143077.kt)  
[typo_ruler_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.287.3993143077.ts)  
[typo_sage_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.287.3993143077.swift)  
[typo_sage_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.287.3993143077.kt)  
[typo_sage_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.287.3993143077.ts)  
[typo_sbermarket_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.287.3993143077.swift)  
[typo_sbermarket_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.287.3993143077.kt)  
[typo_sbermarket_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.287.3993143077.ts)  
[typo_soulmate_ios-swift--canary.287.3993143077.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.287.3993143077.swift)  
[typo_soulmate_kotlin--canary.287.3993143077.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.287.3993143077.kt)  
[typo_soulmate_react-native--canary.287.3993143077.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.287.3993143077.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.126.1-canary.287.3993143077.0
  npm install @salutejs/plasma-temple@1.123.1-canary.287.3993143077.0
  npm install @salutejs/plasma-ui@1.156.1-canary.287.3993143077.0
  npm install @salutejs/plasma-web@1.153.1-canary.287.3993143077.0
  # or 
  yarn add @salutejs/plasma-b2c@1.126.1-canary.287.3993143077.0
  yarn add @salutejs/plasma-temple@1.123.1-canary.287.3993143077.0
  yarn add @salutejs/plasma-ui@1.156.1-canary.287.3993143077.0
  yarn add @salutejs/plasma-web@1.153.1-canary.287.3993143077.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
