### PR TITLE
feat(plasma-web/ui): Handling the onSearch event on pressing Enter

### DIFF
--- a/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
@@ -10,6 +10,7 @@ import { TextField, TextFieldProps } from '.';
 const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
+const onSearch = action('onSearch');
 
 const propsToDisable = [
     'helperBlock',
@@ -75,6 +76,7 @@ export const Default: Story<DefaultStoryProps> = ({ enableContentLeft, enableCon
             }}
             onFocus={onFocus}
             onBlur={onBlur}
+            onSearch={onSearch}
             {...rest}
         />
     );

--- a/packages/plasma-b2c/src/components/TextField/TextField.tsx
+++ b/packages/plasma-b2c/src/components/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, forwardRef, useCallback } from 'react';
+import React, { ChangeEventHandler, forwardRef, useCallback, KeyboardEvent } from 'react';
 import { FieldHelper } from '@salutejs/plasma-core';
 import type { FieldProps, InputProps } from '@salutejs/plasma-core';
 
@@ -31,6 +31,11 @@ export interface TextFieldProps extends Omit<FieldProps, 'size'>, InputProps {
      * Определяет внешний вид компонента и поведение label/placeholder.
      */
     view?: TextFieldView;
+
+    /**
+     * Callback по нажатию Enter
+     */
+    onSearch?: (value: string, event?: KeyboardEvent<HTMLInputElement>) => void;
 }
 
 /**
@@ -53,6 +58,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
         onChange,
         size = 'm',
         view,
+        onSearch,
         ...rest
     },
     ref,
@@ -81,6 +87,15 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
         [onChange],
     );
 
+    const handleSearch = useCallback(
+        (event: KeyboardEvent<HTMLInputElement>) => {
+            if (event.keyCode === 13 && onSearch) {
+                onSearch((event.target as HTMLInputElement).value, event);
+            }
+        },
+        [onSearch],
+    );
+
     return (
         <Field
             $disabled={disabled}
@@ -106,6 +121,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
                     aria-labelledby={currentId}
                     aria-describedby={ariaDescribedBy}
                     onChange={handleChange}
+                    onKeyUp={onSearch && handleSearch}
                     {...rest}
                 />
                 {captionOrPlaceholder && (

--- a/packages/plasma-ui/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-ui/src/components/TextField/TextField.stories.tsx
@@ -76,6 +76,7 @@ export const Default: Story<TextFieldProps & { enableLeftIcon: boolean; enableRi
             onChange={(v) => setValue(v.target.value)}
             onFocus={action('onFocus')}
             onBlur={action('onBlur')}
+            onSearch={action('onSearch')}
             {...rest}
         />
     );

--- a/packages/plasma-ui/src/components/TextField/TextField.tsx
+++ b/packages/plasma-ui/src/components/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useCallback, KeyboardEvent } from 'react';
 import styled from 'styled-components';
 import { FieldRoot, FieldPlaceholder, FieldContent, Input, secondary } from '@salutejs/plasma-core';
 import type { FieldProps, InputProps } from '@salutejs/plasma-core';
@@ -6,7 +6,12 @@ import type { FieldProps, InputProps } from '@salutejs/plasma-core';
 import { FieldHelper, applyInputStyles } from '../Field';
 import { spatnavClassNameAttrs } from '../../utils';
 
-export interface TextFieldProps extends FieldProps, InputProps {}
+export interface TextFieldProps extends FieldProps, InputProps {
+    /**
+     * Callback по нажатию Enter
+     */
+    onSearch?: (value: string, event?: KeyboardEvent<HTMLInputElement>) => void;
+}
 
 const StyledInput = styled(Input).attrs(spatnavClassNameAttrs)`
     ${applyInputStyles};
@@ -40,6 +45,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
         style,
         className,
         onChange,
+        onSearch,
         ...rest
     },
     ref,
@@ -57,6 +63,15 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
             onChange(event);
         },
         [onChange],
+    );
+
+    const handleSearch = useCallback(
+        (event: KeyboardEvent<HTMLInputElement>) => {
+            if (event.keyCode === 13 && onSearch) {
+                onSearch((event.target as HTMLInputElement).value, event);
+            }
+        },
+        [onSearch],
     );
 
     return (
@@ -80,6 +95,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
                 status={status}
                 aria-describedby={id ? `${id}-helpertext` : undefined}
                 onChange={handleChange}
+                onKeyUp={onSearch && handleSearch}
                 {...rest}
             />
             {placeLabel && size === 'l' && <FieldPlaceholder htmlFor={id}>{placeLabel}</FieldPlaceholder>}

--- a/packages/plasma-web/src/components/Input/Input.tsx
+++ b/packages/plasma-web/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, FC, forwardRef } from 'react';
+import React, { ChangeEventHandler, FC, forwardRef, KeyboardEvent, useCallback } from 'react';
 import styled, { css, InterpolationFunction } from 'styled-components';
 import type { InputHTMLAttributes } from '@salutejs/plasma-core';
 
@@ -42,6 +42,11 @@ export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
     label?: string | number;
     hasContentLeft?: boolean;
     hasContentRight?: boolean;
+
+    /**
+     * Callback по нажатию Enter
+     */
+    onSearch?: (value: string, event?: KeyboardEvent<HTMLInputElement>) => void;
 }
 
 const StyledHint = styled.span`
@@ -249,6 +254,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         hasContentLeft,
         hasContentRight,
         onChange,
+        onSearch,
         ...rest
     },
     ref,
@@ -266,6 +272,15 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         [onChange],
     );
 
+    const handleSearch = useCallback(
+        (event: KeyboardEvent<HTMLInputElement>) => {
+            if (event.keyCode === 13 && onSearch) {
+                onSearch((event.target as HTMLInputElement).value, event);
+            }
+        },
+        [onSearch],
+    );
+
     return (
         <>
             <StyledInput
@@ -279,6 +294,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
                 $hasContentLeft={hasContentLeft}
                 $hasContentRight={hasContentRight}
                 $animatedHint={animatedHint}
+                onKeyUp={onSearch && handleSearch}
                 {...rest}
             />
             {size === 'l' && animatedHint && (

--- a/packages/plasma-web/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.stories.tsx
@@ -9,6 +9,7 @@ import { TextField, TextFieldProps } from '.';
 const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
+const onSearch = action('onSearch');
 
 const sizes = ['l', 'm', 's'];
 const statuses = ['', 'success', 'warning', 'error'];
@@ -81,6 +82,7 @@ export const Default: Story<DefaultSortyProps> = ({
             }}
             onFocus={onFocus}
             onBlur={onBlur}
+            onSearch={onSearch}
         />
     );
 };

--- a/packages/plasma-web/src/components/TextField/TextField.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, KeyboardEvent } from 'react';
 
 import { Field } from '../Field';
 import type { FieldProps } from '../Field';
@@ -7,7 +7,12 @@ import type { InputProps } from '../Input';
 
 export interface TextFieldProps
     extends Pick<FieldProps, 'contentLeft' | 'contentRight' | 'helperText'>,
-        Omit<InputProps, 'hasContentLeft' | 'hasContentRight'> {}
+        Omit<InputProps, 'hasContentLeft' | 'hasContentRight'> {
+    /**
+     * Callback по нажатию Enter
+     */
+    onSearch?: (value: string, event?: KeyboardEvent<HTMLInputElement>) => void;
+}
 
 /**
  * Поле ввода текста.


### PR DESCRIPTION
Необходимо добавить для компонентов TextField и Input обработку события по нажатию клавиши Enter. 

По [мотивам ant-design Input](https://github.com/ant-design/ant-design/blob/master/components/input/Search.tsx#L72-L77)

**Раньше:** 

Пользователю приходилось писать каждый раз **свою реализацию** такого обработчика.

**Стало:** 

```jsx
<TextField value={value} onSearch={onSearch} />
```

<img width="1669" alt="Снимок экрана 2023-01-28 в 12 54 01" src="https://user-images.githubusercontent.com/2895992/215248978-dcddb77f-0e31-43eb-9554-69317a5748de.png">
     
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.294.4060402146.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.294.4060402146.xml)  
[color_metro_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.294.4060402146.swift)  
[color_metro_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.294.4060402146.kt)  
[color_metro_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.294.4060402146.ts)  
[color_sbermarket_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.294.4060402146.swift)  
[color_sbermarket_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.294.4060402146.kt)  
[color_sbermarket_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.294.4060402146.ts)  
[color_sberprime_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.294.4060402146.swift)  
[color_sberprime_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.294.4060402146.kt)  
[color_sberprime_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.294.4060402146.ts)  
[color_selgros_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.294.4060402146.swift)  
[color_selgros_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.294.4060402146.kt)  
[color_selgros_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.294.4060402146.ts)  
[color_smbusiness_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.294.4060402146.swift)  
[color_smbusiness_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.294.4060402146.kt)  
[color_smbusiness_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.294.4060402146.ts)  
[PlasmaTokensColor--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.294.4060402146.swift)  
[typo_mage_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.294.4060402146.swift)  
[typo_mage_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.294.4060402146.kt)  
[typo_mage_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.294.4060402146.ts)  
[typo_plasma_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.294.4060402146.swift)  
[typo_plasma_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.294.4060402146.kt)  
[typo_plasma_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.294.4060402146.ts)  
[typo_ruler_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.294.4060402146.swift)  
[typo_ruler_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.294.4060402146.kt)  
[typo_ruler_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.294.4060402146.ts)  
[typo_sage_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.294.4060402146.swift)  
[typo_sage_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.294.4060402146.kt)  
[typo_sage_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.294.4060402146.ts)  
[typo_sbermarket_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.294.4060402146.swift)  
[typo_sbermarket_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.294.4060402146.kt)  
[typo_sbermarket_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.294.4060402146.ts)  
[typo_soulmate_ios-swift--canary.294.4060402146.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.294.4060402146.swift)  
[typo_soulmate_kotlin--canary.294.4060402146.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.294.4060402146.kt)  
[typo_soulmate_react-native--canary.294.4060402146.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.294.4060402146.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.130.0-canary.294.4060402146.0
  npm install @salutejs/plasma-temple@1.127.0-canary.294.4060402146.0
  npm install @salutejs/plasma-ui@1.160.0-canary.294.4060402146.0
  npm install @salutejs/plasma-web@1.157.0-canary.294.4060402146.0
  # or 
  yarn add @salutejs/plasma-b2c@1.130.0-canary.294.4060402146.0
  yarn add @salutejs/plasma-temple@1.127.0-canary.294.4060402146.0
  yarn add @salutejs/plasma-ui@1.160.0-canary.294.4060402146.0
  yarn add @salutejs/plasma-web@1.157.0-canary.294.4060402146.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
