### PR TITLE
fix(plasma-core): fix IS_REACT_18

### DIFF
--- a/packages/plasma-core/src/utils/react.ts
+++ b/packages/plasma-core/src/utils/react.ts
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const { flushSync } = ReactDOM as any;
 
-export const IS_REACT_18 = typeof flushSync === 'function';
+export const IS_REACT_18 = ReactDOM.version.split('.')[0] === '18';
 
 export function safeFlushSync(fn: () => void): void {
     if (!IS_REACT_18) {


### PR DESCRIPTION
### Исправлен детект 18 реакта

– раньше ф-ия проверяла наличие `flushSync` но она присутствует уже в 16 реакте. Теперь мы проверяем совпадение по мажорной версии


<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.380.4322277405.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.380.4322277405.xml)  
[color_metro_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.380.4322277405.swift)  
[color_metro_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.380.4322277405.kt)  
[color_metro_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.380.4322277405.ts)  
[color_sberHealth_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.380.4322277405.swift)  
[color_sberHealth_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.380.4322277405.kt)  
[color_sberHealth_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.380.4322277405.ts)  
[color_sbermarket_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.380.4322277405.swift)  
[color_sbermarket_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.380.4322277405.kt)  
[color_sbermarket_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.380.4322277405.ts)  
[color_sberprime_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.380.4322277405.swift)  
[color_sberprime_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.380.4322277405.kt)  
[color_sberprime_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.380.4322277405.ts)  
[color_selgros_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.380.4322277405.swift)  
[color_selgros_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.380.4322277405.kt)  
[color_selgros_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.380.4322277405.ts)  
[color_smbusiness_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.380.4322277405.swift)  
[color_smbusiness_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.380.4322277405.kt)  
[color_smbusiness_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.380.4322277405.ts)  
[PlasmaTokensColor--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.380.4322277405.swift)  
[shadow_sbermarket_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.380.4322277405.ts)  
[typo_mage_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.380.4322277405.swift)  
[typo_mage_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.380.4322277405.kt)  
[typo_mage_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.380.4322277405.ts)  
[typo_plasma_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.380.4322277405.swift)  
[typo_plasma_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.380.4322277405.kt)  
[typo_plasma_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.380.4322277405.ts)  
[typo_ruler_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.380.4322277405.swift)  
[typo_ruler_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.380.4322277405.kt)  
[typo_ruler_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.380.4322277405.ts)  
[typo_sage_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.380.4322277405.swift)  
[typo_sage_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.380.4322277405.kt)  
[typo_sage_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.380.4322277405.ts)  
[typo_sbermarket_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.380.4322277405.swift)  
[typo_sbermarket_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.380.4322277405.kt)  
[typo_sbermarket_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.380.4322277405.ts)  
[typo_soulmate_ios-swift--canary.380.4322277405.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.380.4322277405.swift)  
[typo_soulmate_kotlin--canary.380.4322277405.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.380.4322277405.kt)  
[typo_soulmate_react-native--canary.380.4322277405.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.380.4322277405.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.152.1-canary.380.4322277405.0
  npm install @salutejs/plasma-core@1.100.1-canary.380.4322277405.0
  npm install @salutejs/plasma-hope@0.11.1-canary.380.4322277405.0
  npm install @salutejs/plasma-icons@1.128.1-canary.380.4322277405.0
  npm install @salutejs/plasma-temple@1.139.1-canary.380.4322277405.0
  npm install @salutejs/plasma-ui@1.172.1-canary.380.4322277405.0
  npm install @salutejs/plasma-web@1.177.1-canary.380.4322277405.0
  npm install @salutejs/plasma-sb-utils@0.98.1-canary.380.4322277405.0
  # or 
  yarn add @salutejs/plasma-b2c@1.152.1-canary.380.4322277405.0
  yarn add @salutejs/plasma-core@1.100.1-canary.380.4322277405.0
  yarn add @salutejs/plasma-hope@0.11.1-canary.380.4322277405.0
  yarn add @salutejs/plasma-icons@1.128.1-canary.380.4322277405.0
  yarn add @salutejs/plasma-temple@1.139.1-canary.380.4322277405.0
  yarn add @salutejs/plasma-ui@1.172.1-canary.380.4322277405.0
  yarn add @salutejs/plasma-web@1.177.1-canary.380.4322277405.0
  yarn add @salutejs/plasma-sb-utils@0.98.1-canary.380.4322277405.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
