### PR TITLE
chore(plasma-*): disabled axe check

### DIFF
--- a/cypress/config/b2b-config.json
+++ b/cypress/config/b2b-config.json
@@ -11,7 +11,7 @@
         "packageDir": "../../packages/plasma-web",
         "package": "plasma-web",
         "tokens": "plasma-tokens-b2b",
-        "a11yCheck": true
+        "a11yCheck": false
     },
     "video": false,
     "retries": 3

--- a/cypress/config/b2c-config.json
+++ b/cypress/config/b2c-config.json
@@ -7,7 +7,7 @@
         "snapshotsDir": "cypress/snapshots/b2c",
         "packageDir": "../../packages/plasma-b2c",
         "package": "plasma-b2c",
-        "a11yCheck": true
+        "a11yCheck": false
     },
     "video": false,
     "retries": 3

--- a/cypress/config/ui-config.json
+++ b/cypress/config/ui-config.json
@@ -7,7 +7,7 @@
         "snapshotsDir": "cypress/snapshots/ui",
         "packageDir": "../../packages/plasma-ui",
         "package": "plasma-ui",
-        "a11yCheck": true
+        "a11yCheck": false
     },
     "animationDistanceThreshold": 0,
     "video": false,

--- a/cypress/config/web-config.json
+++ b/cypress/config/web-config.json
@@ -7,7 +7,7 @@
         "snapshotsDir": "cypress/snapshots/web",
         "packageDir": "../../packages/plasma-web",
         "package": "plasma-web",
-        "a11yCheck": true
+        "a11yCheck": false
     },
     "video": false,
     "retries": 3


### PR DESCRIPTION
Временно выключаем проверки доступность в **cypress** тестах. 

Чуть позже включим уже с другой конфигурацией и понятным отчетом.     
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.403.4401566688.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.403.4401566688.xml)  
[color_metro_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.403.4401566688.swift)  
[color_metro_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.403.4401566688.kt)  
[color_metro_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.403.4401566688.ts)  
[color_sberHealth_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.403.4401566688.swift)  
[color_sberHealth_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.403.4401566688.kt)  
[color_sberHealth_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.403.4401566688.ts)  
[color_sbermarket_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.403.4401566688.swift)  
[color_sbermarket_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.403.4401566688.kt)  
[color_sbermarket_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.403.4401566688.ts)  
[color_sberprime_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.403.4401566688.swift)  
[color_sberprime_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.403.4401566688.kt)  
[color_sberprime_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.403.4401566688.ts)  
[color_selgros_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.403.4401566688.swift)  
[color_selgros_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.403.4401566688.kt)  
[color_selgros_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.403.4401566688.ts)  
[color_smbusiness_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.403.4401566688.swift)  
[color_smbusiness_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.403.4401566688.kt)  
[color_smbusiness_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.403.4401566688.ts)  
[PlasmaTokensColor--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.403.4401566688.swift)  
[shadow_sbermarket_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.403.4401566688.ts)  
[typo_mage_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.403.4401566688.swift)  
[typo_mage_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.403.4401566688.kt)  
[typo_mage_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.403.4401566688.ts)  
[typo_plasma_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.403.4401566688.swift)  
[typo_plasma_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.403.4401566688.kt)  
[typo_plasma_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.403.4401566688.ts)  
[typo_ruler_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.403.4401566688.swift)  
[typo_ruler_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.403.4401566688.kt)  
[typo_ruler_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.403.4401566688.ts)  
[typo_sage_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.403.4401566688.swift)  
[typo_sage_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.403.4401566688.kt)  
[typo_sage_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.403.4401566688.ts)  
[typo_sbermarket_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.403.4401566688.swift)  
[typo_sbermarket_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.403.4401566688.kt)  
[typo_sbermarket_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.403.4401566688.ts)  
[typo_soulmate_ios-swift--canary.403.4401566688.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.403.4401566688.swift)  
[typo_soulmate_kotlin--canary.403.4401566688.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.403.4401566688.kt)  
[typo_soulmate_react-native--canary.403.4401566688.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.403.4401566688.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.140.2-canary.403.4401566688.0
  npm install @salutejs/plasma-ui@1.173.2-canary.403.4401566688.0
  # or 
  yarn add @salutejs/plasma-temple@1.140.2-canary.403.4401566688.0
  yarn add @salutejs/plasma-ui@1.173.2-canary.403.4401566688.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
