### PR TITLE
ci: skip husky when run CI pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "lerna run test",
     "typescript-coverage": "lerna run typescript-coverage --no-bail --stream",
     "generate:theme-html": "lerna run generate:theme-html --scope @salutejs/plasma-tokens",
-    "prepare": "[[ -z $CI ]] && husky install || echo skip husky"
+    "prepare": "test ! -n \"$CI\" && husky install || echo skip husky"
   },
   "devDependencies": {
     "@actions/core": "1.2.7",


### PR DESCRIPTION
В этом PR исправляется неправильный формат скрипта установленный в #417. 

### Было:

` [[ -z $CI ]] && husky install || echo skip husky` 

<img width="513" alt="Снимок экрана 2023-03-16 в 16 33 26" src="https://user-images.githubusercontent.com/2895992/225814311-2e027327-346d-4a0f-949e-ebd54f2d3b10.png">

--------

### Стало:

`test ! -n \"$CI\" && husky install || echo skip husky`

<img width="617" alt="Снимок экрана 2023-03-17 в 11 38 02" src="https://user-images.githubusercontent.com/2895992/225814370-14b4d7e7-3f02-49dc-a9b4-72b202fcbb69.png">

--------

### Локальный запуск (husky - Git hooks installed)

<img width="656" alt="Снимок экрана 2023-03-17 в 11 42 33" src="https://user-images.githubusercontent.com/2895992/225814550-22699ee7-86ce-4b82-8199-965f55ba7b14.png">

