### PR TITLE
fix(plasma-ui): Omit types for HeaderLogo

### DIFF
--- a/packages/plasma-ui/src/components/Header/HeaderLogo.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderLogo.tsx
@@ -2,7 +2,12 @@ import styled from 'styled-components';
 
 import { Image, ImageProps } from '../Image';
 
-export type HeaderLogoProps = Omit<ImageProps, 'height' | 'ratio' | 'customRatio'>;
+// INFO: Omit 'onResize' | 'onResizeCapture' | 'nonce'
+// because this types coming with @types/react@18.0.25 and breaks react@17.0.2 with @types/react@18.0.18
+export type HeaderLogoProps = Omit<
+    ImageProps,
+    'height' | 'ratio' | 'customRatio' | 'onResize' | 'onResizeCapture' | 'nonce'
+>;
 
 /**
  * Компонент для размещения логотипа.


### PR DESCRIPTION
## Проблема

В React 18 и начиная с @types/react@18.0.25 появились типы:

**onResize**: An [Event handler](https://react.dev/reference/react-dom/components/common#event-handler) function. Fires when video changes size.

**onResizeCapture**: A version of onResize that fires in the [capture phase.](https://react.dev/learn/responding-to-events#capture-phase-events)

**nonce**:  [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)

Для пользователей оставшихся на, как пример: 

```json
{
"@types/react": "16.9.38",
"react": "17.0.2",
"react-dom": "17.0.2"
}
``` 

ломается компилция TS 

<img width="968" alt="Снимок экрана 2023-03-22 в 12 38 19" src="https://user-images.githubusercontent.com/2895992/226812368-fbb6e15a-5123-4531-86ab-eadc3e1d080c.png">


## Решение  

Явно сузить тип для `HeaderLogoProps` и исключить ` 'onResize' | 'onResizeCapture' | 'nonce'`. 

Так как под капотом TS через Pick выбирает все свойства и атрибуты у `Pick<import("@salutejs/plasma-core")
    .ImageProps, "base" | "slot" | "style" | "title" | "className" | "color" | "id" ....`

-------

Примечание: 

[[Popper] Incompatible props: onResize and onResizeCapture](https://github.com/mui/material-ui/issues/35287) -здесь сталкиваются с такой же проблемой, но предлагают другие решение. 

- Для тех кто использует React 18, обновить @types/react до 18.0.25
- Для тех кто использует React 17, явно указывать returnType для проблемных мест    

----------  

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.434.4487598826.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.434.4487598826.xml)  
[color_metro_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.434.4487598826.swift)  
[color_metro_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.434.4487598826.kt)  
[color_metro_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.434.4487598826.ts)  
[color_sberHealth_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.434.4487598826.swift)  
[color_sberHealth_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.434.4487598826.kt)  
[color_sberHealth_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.434.4487598826.ts)  
[color_sbermarket_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.434.4487598826.swift)  
[color_sbermarket_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.434.4487598826.kt)  
[color_sbermarket_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.434.4487598826.ts)  
[color_sberprime_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.434.4487598826.swift)  
[color_sberprime_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.434.4487598826.kt)  
[color_sberprime_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.434.4487598826.ts)  
[color_selgros_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.434.4487598826.swift)  
[color_selgros_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.434.4487598826.kt)  
[color_selgros_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.434.4487598826.ts)  
[color_smbusiness_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.434.4487598826.swift)  
[color_smbusiness_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.434.4487598826.kt)  
[color_smbusiness_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.434.4487598826.ts)  
[PlasmaTokensColor--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.434.4487598826.swift)  
[shadow_sbermarket_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.434.4487598826.ts)  
[typo_mage_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.434.4487598826.swift)  
[typo_mage_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.434.4487598826.kt)  
[typo_mage_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.434.4487598826.ts)  
[typo_plasma_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.434.4487598826.swift)  
[typo_plasma_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.434.4487598826.kt)  
[typo_plasma_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.434.4487598826.ts)  
[typo_ruler_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.434.4487598826.swift)  
[typo_ruler_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.434.4487598826.kt)  
[typo_ruler_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.434.4487598826.ts)  
[typo_sage_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.434.4487598826.swift)  
[typo_sage_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.434.4487598826.kt)  
[typo_sage_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.434.4487598826.ts)  
[typo_sbermarket_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.434.4487598826.swift)  
[typo_sbermarket_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.434.4487598826.kt)  
[typo_sbermarket_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.434.4487598826.ts)  
[typo_soulmate_ios-swift--canary.434.4487598826.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.434.4487598826.swift)  
[typo_soulmate_kotlin--canary.434.4487598826.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.434.4487598826.kt)  
[typo_soulmate_react-native--canary.434.4487598826.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.434.4487598826.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.145.1-canary.434.4487598826.0
  npm install @salutejs/plasma-ui@1.178.1-canary.434.4487598826.0
  # or 
  yarn add @salutejs/plasma-temple@1.145.1-canary.434.4487598826.0
  yarn add @salutejs/plasma-ui@1.178.1-canary.434.4487598826.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
