### PR TITLE
fix(plasmas-hope): Fix `Container` component for rest props in Grid

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -98,7 +98,6 @@ import { Editable } from '@salutejs/plasma-hope';
 import { EditableProps } from '@salutejs/plasma-hope';
 import { ElasticGrid } from '@salutejs/plasma-hope';
 import { ElasticGridProps } from '@salutejs/plasma-hope';
-import { FC } from 'react';
 import { FocusProps } from '@salutejs/plasma-core';
 import { Footnote1 } from '@salutejs/plasma-hope';
 import { Footnote2 } from '@salutejs/plasma-hope';
@@ -119,6 +118,7 @@ import { Headline2 } from '@salutejs/plasma-hope';
 import { Headline3 } from '@salutejs/plasma-hope';
 import { Headline4 } from '@salutejs/plasma-hope';
 import { Headline5 } from '@salutejs/plasma-hope';
+import { HTMLAttributes } from 'react';
 import { Image as Image_2 } from '@salutejs/plasma-hope';
 import { ImageBaseProps } from '@salutejs/plasma-hope';
 import { ImageProps } from '@salutejs/plasma-hope';
@@ -162,7 +162,6 @@ import { Price } from '@salutejs/plasma-hope';
 import { PriceProps } from '@salutejs/plasma-hope';
 import { Progress } from '@salutejs/plasma-hope';
 import { ProgressProps } from '@salutejs/plasma-hope';
-import { PropsWithChildren } from 'react';
 import { Radiobox } from '@salutejs/plasma-hope';
 import { RadioboxProps } from '@salutejs/plasma-hope';
 import { RadioGroup } from '@salutejs/plasma-hope';
@@ -428,9 +427,11 @@ export { ColProps }
 export { ColSizeProps }
 
 // @public
-export const Container: StyledComponent<FC<PropsWithChildren<    {
+export const Container: StyledComponent<ForwardRefExoticComponent<HTMLAttributes<HTMLDivElement> & {
 design: "b2c" | "web";
-}>>, any, {
+} & {
+children?: ReactNode;
+} & RefAttributes<HTMLDivElement>>, any, {
 design: "b2c";
 }, "design">;
 

--- a/packages/plasma-hope/api/plasma-hope.api.md
+++ b/packages/plasma-hope/api/plasma-hope.api.md
@@ -528,9 +528,11 @@ export interface ColSizeProps {
 }
 
 // @public
-export const Container: FC<PropsWithChildren<{
+export const Container: React_2.ForwardRefExoticComponent<React_2.HTMLAttributes<HTMLDivElement> & {
     design: 'b2c' | 'web';
-}>>;
+} & {
+    children?: React_2.ReactNode;
+} & React_2.RefAttributes<HTMLDivElement>>;
 
 export { convertRoundnessMatrix }
 

--- a/packages/plasma-hope/src/components/Grid/Container.tsx
+++ b/packages/plasma-hope/src/components/Grid/Container.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, FC, PropsWithChildren } from 'react';
+import React, { useMemo, PropsWithChildren, forwardRef, HTMLAttributes } from 'react';
 
 import { Container as ContainerWeb } from './views/web/Container';
 import { Container as ContainerB2C } from './views/b2c/Container';
@@ -8,13 +8,22 @@ const componentMap = {
     b2c: ContainerB2C,
 };
 
+export type ContainerProps = HTMLAttributes<HTMLDivElement> & {
+    design: 'b2c' | 'web';
+};
+
 /**
  * Блок с полями по бокам для размещения контента по вертикали.
  * Блок нельзя вкладывать сам в себя или дальше по дереву.
  */
-export const Container: FC<PropsWithChildren<{ design: 'b2c' | 'web' }>> = (props): JSX.Element => {
-    const { design, children } = props;
-    const ContainerView = useMemo(() => componentMap[design], [design]);
+export const Container = forwardRef<HTMLDivElement, PropsWithChildren<ContainerProps>>(
+    ({ design, children, ...rest }, ref) => {
+        const ContainerView = useMemo(() => componentMap[design], [design]);
 
-    return <ContainerView> {children} </ContainerView>;
-};
+        return (
+            <ContainerView {...rest} ref={ref}>
+                {children}
+            </ContainerView>
+        );
+    },
+);

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -161,7 +161,6 @@ import { Price } from '@salutejs/plasma-hope';
 import { PriceProps } from '@salutejs/plasma-hope';
 import { Progress } from '@salutejs/plasma-hope';
 import { ProgressProps } from '@salutejs/plasma-hope';
-import { PropsWithChildren } from 'react';
 import { Radiobox } from '@salutejs/plasma-hope';
 import { RadioboxProps } from '@salutejs/plasma-hope';
 import { RadioGroup } from '@salutejs/plasma-hope';
@@ -169,7 +168,7 @@ import { radiuses } from '@salutejs/plasma-core';
 import { Ratio } from '@salutejs/plasma-hope';
 import { default as React_2 } from 'react';
 import { ReactElement } from 'react';
-import type { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { RectSkeleton } from '@salutejs/plasma-hope';
 import { RectSkeletonProps } from '@salutejs/plasma-hope';
 import { RefAttributes } from 'react';
@@ -408,9 +407,11 @@ export { ColProps }
 export { ColSizeProps }
 
 // @public
-export const Container: StyledComponent<FC<PropsWithChildren<    {
+export const Container: StyledComponent<ForwardRefExoticComponent<HTMLAttributes<HTMLDivElement> & {
 design: "web" | "b2c";
-}>>, any, {
+} & {
+children?: ReactNode;
+} & RefAttributes<HTMLDivElement>>, any, {
 design: "web";
 }, "design">;
 


### PR DESCRIPTION
Добавлено прокидывание всех пропсов в компонент, т.к. стилизация (а именно className и style) не применяются, если его оборачивать в style-component. 

Так же компонент обёрнут в forwardRef для возможности использовать свойство `ref`.

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.446.4535244348.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.446.4535244348.xml)  
[color_metro_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.446.4535244348.swift)  
[color_metro_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.446.4535244348.kt)  
[color_metro_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.446.4535244348.ts)  
[color_sberHealth_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.446.4535244348.swift)  
[color_sberHealth_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.446.4535244348.kt)  
[color_sberHealth_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.446.4535244348.ts)  
[color_sbermarket_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.446.4535244348.swift)  
[color_sbermarket_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.446.4535244348.kt)  
[color_sbermarket_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.446.4535244348.ts)  
[color_sberprime_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.446.4535244348.swift)  
[color_sberprime_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.446.4535244348.kt)  
[color_sberprime_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.446.4535244348.ts)  
[color_selgros_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.446.4535244348.swift)  
[color_selgros_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.446.4535244348.kt)  
[color_selgros_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.446.4535244348.ts)  
[color_smbusiness_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.446.4535244348.swift)  
[color_smbusiness_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.446.4535244348.kt)  
[color_smbusiness_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.446.4535244348.ts)  
[PlasmaTokensColor--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.446.4535244348.swift)  
[shadow_sbermarket_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.446.4535244348.ts)  
[typo_mage_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.446.4535244348.swift)  
[typo_mage_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.446.4535244348.kt)  
[typo_mage_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.446.4535244348.ts)  
[typo_plasma_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.446.4535244348.swift)  
[typo_plasma_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.446.4535244348.kt)  
[typo_plasma_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.446.4535244348.ts)  
[typo_ruler_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.446.4535244348.swift)  
[typo_ruler_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.446.4535244348.kt)  
[typo_ruler_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.446.4535244348.ts)  
[typo_sage_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.446.4535244348.swift)  
[typo_sage_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.446.4535244348.kt)  
[typo_sage_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.446.4535244348.ts)  
[typo_sbermarket_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.446.4535244348.swift)  
[typo_sbermarket_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.446.4535244348.kt)  
[typo_sbermarket_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.446.4535244348.ts)  
[typo_soulmate_ios-swift--canary.446.4535244348.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.446.4535244348.swift)  
[typo_soulmate_kotlin--canary.446.4535244348.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.446.4535244348.kt)  
[typo_soulmate_react-native--canary.446.4535244348.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.446.4535244348.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.166.1-canary.446.4535244348.0
  npm install @salutejs/plasma-hope@0.24.1-canary.446.4535244348.0
  npm install @salutejs/plasma-web@1.191.1-canary.446.4535244348.0
  # or 
  yarn add @salutejs/plasma-b2c@1.166.1-canary.446.4535244348.0
  yarn add @salutejs/plasma-hope@0.24.1-canary.446.4535244348.0
  yarn add @salutejs/plasma-web@1.191.1-canary.446.4535244348.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
