### PR TITLE
fix(plasma-website): Fix by design review

### DIFF
--- a/website/plasma-website/components/main/Product.tsx
+++ b/website/plasma-website/components/main/Product.tsx
@@ -11,7 +11,7 @@ const MetaInfo = styled.div`
     display: flex;
 `;
 const Content = styled(BodyXS)`
-    margin-right: 2rem;
+    margin-right: 1rem;
 `;
 const Title = styled(DsplS)`
     display: inline-flex;

--- a/website/plasma-website/components/main/ProductList.tsx
+++ b/website/plasma-website/components/main/ProductList.tsx
@@ -2,7 +2,9 @@ import styled from 'styled-components';
 
 import { Product, ProductProps } from './Product';
 
-const Root = styled.main``;
+const Root = styled.main`
+    margin-bottom: 2rem;
+`;
 
 interface ProductListProps {
     items: Array<ProductProps>;

--- a/website/plasma-website/components/roster/Main.tsx
+++ b/website/plasma-website/components/roster/Main.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { Container } from '@salutejs/plasma-b2c';
 
-export const Main = styled(Container).attrs(() => ({ as: 'main' }))`
+export const Main = styled(Container).attrs(() => ({ forwardedAs: 'main' }))`
     padding-top: 3.75rem;
     padding-bottom: 3.75rem;
 `;


### PR DESCRIPTION
После дизайн ревью были исправлены следующие места:
1. Добавлен отступ снизу главного блока;
2. Уменьшенно расстояние между версией релиза и датой;
3. Исправлена страница с икокнами: раньше свойство для грида не применялось, поэтому вместо `as`  использовал `forwardedAs`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.452.4545613906.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.452.4545613906.xml)  
[color_metro_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_ios-swift--canary.452.4545613906.swift)  
[color_metro_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_kotlin--canary.452.4545613906.kt)  
[color_metro_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_metro_react-native--canary.452.4545613906.ts)  
[color_sberHealth_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.452.4545613906.swift)  
[color_sberHealth_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.452.4545613906.kt)  
[color_sberHealth_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.452.4545613906.ts)  
[color_sbermarket_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.452.4545613906.swift)  
[color_sbermarket_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.452.4545613906.kt)  
[color_sbermarket_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.452.4545613906.ts)  
[color_sberprime_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.452.4545613906.swift)  
[color_sberprime_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.452.4545613906.kt)  
[color_sberprime_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.452.4545613906.ts)  
[color_selgros_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_ios-swift--canary.452.4545613906.swift)  
[color_selgros_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_kotlin--canary.452.4545613906.kt)  
[color_selgros_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_selgros_react-native--canary.452.4545613906.ts)  
[color_smbusiness_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_ios-swift--canary.452.4545613906.swift)  
[color_smbusiness_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_kotlin--canary.452.4545613906.kt)  
[color_smbusiness_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_smbusiness_react-native--canary.452.4545613906.ts)  
[PlasmaTokensColor--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.452.4545613906.swift)  
[shadow_sbermarket_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.452.4545613906.ts)  
[typo_mage_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.452.4545613906.swift)  
[typo_mage_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.452.4545613906.kt)  
[typo_mage_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.452.4545613906.ts)  
[typo_plasma_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.452.4545613906.swift)  
[typo_plasma_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.452.4545613906.kt)  
[typo_plasma_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.452.4545613906.ts)  
[typo_ruler_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.452.4545613906.swift)  
[typo_ruler_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.452.4545613906.kt)  
[typo_ruler_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.452.4545613906.ts)  
[typo_sage_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.452.4545613906.swift)  
[typo_sage_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.452.4545613906.kt)  
[typo_sage_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.452.4545613906.ts)  
[typo_sbermarket_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.452.4545613906.swift)  
[typo_sbermarket_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.452.4545613906.kt)  
[typo_sbermarket_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.452.4545613906.ts)  
[typo_soulmate_ios-swift--canary.452.4545613906.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.452.4545613906.swift)  
[typo_soulmate_kotlin--canary.452.4545613906.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.452.4545613906.kt)  
[typo_soulmate_react-native--canary.452.4545613906.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.452.4545613906.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
