### PR TITLE
fix(plasma-ui): [Picker] Fix flicking and fake onChange in Safari 14.5 and bellow

### DIFF
--- a/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
@@ -85,6 +85,7 @@ export const DatePicker = ({
     monthsAriaLabel: monthAriaLabel,
     yearsAriaLabel: yearAriaLabel,
     infiniteScroll,
+    disableScrollSnapAlign = false,
     ...rest
 }: DatePickerProps) => {
     const normalizeValues = React.useMemo(() => getNormalizeValues(getDateValues, getSeconds)(value, min, max), [
@@ -263,6 +264,7 @@ export const DatePicker = ({
                     infiniteScroll={infiniteScroll}
                     onChange={onDayChange}
                     aria-label={dayAriaLabel}
+                    disableScrollSnapAlign={disableScrollSnapAlign}
                 />
             )}
             {monthsOption && (
@@ -281,6 +283,7 @@ export const DatePicker = ({
                     infiniteScroll={infiniteScroll}
                     onChange={onMonthChange}
                     aria-label={monthAriaLabel}
+                    disableScrollSnapAlign={disableScrollSnapAlign}
                 />
             )}
             {yearsOption && (
@@ -298,6 +301,7 @@ export const DatePicker = ({
                     infiniteScroll={infiniteScroll}
                     onChange={onYearChange}
                     aria-label={yearAriaLabel}
+                    disableScrollSnapAlign={disableScrollSnapAlign}
                 />
             )}
             {enableNativeControl && <input type="hidden" value={value.toISOString()} name={name} />}

--- a/packages/plasma-ui/src/components/Pickers/Picker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Picker.tsx
@@ -273,6 +273,11 @@ export interface PickerProps
      * Бесконечная прокрутка; выключена по умолчанию для lowPerformance Devices
      */
     infiniteScroll?: boolean;
+    /**
+     * Выключаем css свойства для указания стороны привязки в scroll-snap контейнере.
+     * @default false
+     */
+    disableScrollSnapAlign?: boolean;
 }
 
 /**
@@ -290,6 +295,7 @@ export const Picker = ({
     scrollSnapType,
     'aria-label': ariaLabel,
     onChange,
+    disableScrollSnapAlign,
     ...rest
 }: PickerProps) => {
     const isSingleItem = items.length === 1;
@@ -536,6 +542,7 @@ export const Picker = ({
                         isSnapAlwaysStop={
                             i === min + INDEX_STOP_BUFFER || i === virtualItems.length - 1 - INDEX_STOP_BUFFER
                         }
+                        disableScrollSnapAlign={disableScrollSnapAlign}
                     />
                 ))}
             </StyledCarousel>

--- a/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
+++ b/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
@@ -25,6 +25,7 @@ interface StyledSizeProps {
     $size: keyof typeof sizes;
     $noScrollBehavior: boolean;
     isSnapAlwaysStop?: boolean;
+    $disableScrollSnapAlign?: boolean;
 }
 
 export const StyledPickerItem = styled.div<StyledSizeProps>`
@@ -41,10 +42,11 @@ export const StyledPickerItem = styled.div<StyledSizeProps>`
     cursor: pointer;
     user-select: none;
 
-    ${({ $noScrollBehavior }) =>
+    ${({ $noScrollBehavior, $disableScrollSnapAlign }) =>
         !$noScrollBehavior &&
         css`
-            scroll-snap-align: center;
+            //INFO: Используем значение "initial" для корректного отображения на iOS 14.5 и ниже
+            scroll-snap-align: ${$disableScrollSnapAlign ? 'initial' : 'center'};
         `}
 
     &:focus {
@@ -64,7 +66,13 @@ export const StyledPickerItem = styled.div<StyledSizeProps>`
 // TODO: https://github.com/salute-developers/plasma/issues/232
 const StyledTransformable = styled.div<StyledSizeProps>`
     width: 100%;
-    height: 100%;
+
+    // INFO: Убираем высоту для корректного отображения на iOS 14.0
+    ${({ $disableScrollSnapAlign }) =>
+        !$disableScrollSnapAlign &&
+        css`
+            height: 100%;
+        `}
 
     flex-direction: column;
 
@@ -109,6 +117,11 @@ export interface PickerItemProps extends React.HTMLAttributes<HTMLDivElement>, S
      * и перебросит на элемент с индексом <6> (т.е. числом 2)
      */
     isSnapAlwaysStop?: boolean;
+    /**
+     * Выключаем css свойства для указания стороны привязки в scroll-snap контейнере
+     * @default false
+     */
+    disableScrollSnapAlign?: boolean;
 }
 
 export const PickerItem = ({
@@ -120,6 +133,7 @@ export const PickerItem = ({
     onItemClick,
     autofocus,
     disabled,
+    disableScrollSnapAlign,
     ...rest
 }: PickerItemProps) => {
     const itemRef = React.useRef<HTMLDivElement | null>(null);
@@ -144,8 +158,20 @@ export const PickerItem = ({
     }, [autofocus]);
 
     return (
-        <StyledPickerItem $noScrollBehavior={noScrollBehavior} ref={itemRef} $size={size} onClick={onClick} {...rest}>
-            <StyledTransformable $noScrollBehavior={noScrollBehavior} $size={size} style={styles.wrapper}>
+        <StyledPickerItem
+            $noScrollBehavior={noScrollBehavior}
+            $disableScrollSnapAlign={disableScrollSnapAlign}
+            ref={itemRef}
+            $size={size}
+            onClick={onClick}
+            {...rest}
+        >
+            <StyledTransformable
+                $noScrollBehavior={noScrollBehavior}
+                $disableScrollSnapAlign={disableScrollSnapAlign}
+                $size={size}
+                style={styles.wrapper}
+            >
                 <StyledText style={styles.text}>{item.label}</StyledText>
                 <StyledWhiteText style={styles.whiteText} aria-hidden="true">
                     {item.label}

--- a/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
@@ -54,9 +54,10 @@ interface DefaultStoryProps extends DatePickerProps {
     optionsHours: boolean;
     optionsMinutes: boolean;
     optionsSeconds: boolean;
+    disableScrollSnapAlign: boolean;
 }
 
-export const Default: Story<DefaultStoryProps> = (args) => {
+export const Default: Story<DefaultStoryProps> = ({ disableScrollSnapAlign, ...args }) => {
     const [value, setValue] = React.useState(parseDateTime(args.initialValue));
     const min = React.useMemo(() => parseDateTime(args.minDate), [args.minDate]);
     const max = React.useMemo(() => parseDateTime(args.maxDate), [args.maxDate]);
@@ -67,6 +68,7 @@ export const Default: Story<DefaultStoryProps> = (args) => {
     const hours = args.optionsHours;
     const minutes = args.optionsMinutes;
     const seconds = args.optionsSeconds;
+
     const dateOptions = React.useMemo(
         () => ({
             years,
@@ -105,6 +107,7 @@ export const Default: Story<DefaultStoryProps> = (args) => {
                 daysAriaLabel="день"
                 monthsAriaLabel="месяц"
                 yearsAriaLabel="год"
+                disableScrollSnapAlign={disableScrollSnapAlign}
             />
             <TimePicker
                 key={`time-${args.TimePickerSize}-${args.TimePickerVisibleItems}`}
@@ -124,6 +127,7 @@ export const Default: Story<DefaultStoryProps> = (args) => {
                 secondsAriaLabel="секунды"
                 minutesAriaLabel="минуты"
                 hoursAriaLabel="часы"
+                disableScrollSnapAlign={disableScrollSnapAlign}
             />
         </StyledWrapper>
     );
@@ -151,6 +155,7 @@ Default.args = {
     TimePickerVisibleItems: 5,
     DatePickerNativeControl: false,
     TimePickerNativeControl: false,
+    disableScrollSnapAlign: false,
 };
 
 Default.argTypes = {

--- a/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
@@ -91,6 +91,7 @@ export const TimePicker = ({
     minutesAriaLabel,
     hoursAriaLabel,
     infiniteScroll,
+    disableScrollSnapAlign = false,
     ...rest
 }: TimePickerProps) => {
     const normalizeValues = React.useMemo(() => getNormalizeValues(getTimeValues, getSeconds)(value, min, max), [
@@ -230,6 +231,7 @@ export const TimePicker = ({
                     infiniteScroll={infiniteScroll}
                     onChange={onHoursChange}
                     aria-label={hoursAriaLabel}
+                    disableScrollSnapAlign={disableScrollSnapAlign}
                 />
             )}
             {options.hours && options.minutes && <PickerDots $size={size} />}
@@ -248,6 +250,7 @@ export const TimePicker = ({
                     infiniteScroll={infiniteScroll}
                     onChange={onMinutesChange}
                     aria-label={minutesAriaLabel}
+                    disableScrollSnapAlign={disableScrollSnapAlign}
                 />
             )}
             {options.minutes && options.seconds && <PickerDots $size={size} />}
@@ -266,6 +269,7 @@ export const TimePicker = ({
                     infiniteScroll={infiniteScroll}
                     onChange={onSecondsChange}
                     aria-label={secondsAriaLabel}
+                    disableScrollSnapAlign={disableScrollSnapAlign}
                 />
             )}
             {enableNativeControl && <input type="hidden" value={value.toISOString()} name={name} />}

--- a/website/plasma-ui-docs/docs/components/Pickers.mdx
+++ b/website/plasma-ui-docs/docs/components/Pickers.mdx
@@ -87,3 +87,27 @@ export function App() {
 
 При этом, с активированным экранным считывающим устройством (screen reader),
 происходит объявление переключаемых опций.
+
+## Проблемы в Safari iOS 14.5 и ниже
+
+Для корректной работы необходимо **выключить** `scroll-snap-align`.
+
+Для этого нужно использовать - **disableScrollSnapAlign**.
+
+По-умолчанию значение для этого свойства - **false**.
+
+```tsx live
+import React from 'react';
+import { DatePicker } from '@salutejs/plasma-ui';
+
+export function App() {
+    return (
+        <DatePicker
+            min={new Date(1970, 0, 0, 0, 0, 0)}
+            max={new Date(2021, 10, 10, 0, 0, 0)}
+            value={new Date(2007, 3, 5, 0, 0, 0)}
+            disableScrollSnapAlign
+        />
+    );
+}
+```


### PR DESCRIPTION
### Проблема 

В Safari iOS 14.5 и ниже наблюдаются следующее

- ложные срабатывания onChange 
- flicking/мерцания/дёргание дочерних элементов компонента

Важное замечание - проблемы **взаимосвязаны**.

### Было:

![Screen Recording 2023-04-05 at 17 16 50](https://user-images.githubusercontent.com/2895992/230052801-6b4668d6-f1f4-431f-ac84-eaf40e79898f.gif)


### Стало: 

![Screen Recording 2023-04-05 at 17 22 33](https://user-images.githubusercontent.com/2895992/230054609-7ac6e958-7238-4f34-9ca6-5071c7a84708.gif)


------

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.464.4626740634.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.464.4626740634.xml)  
[color_sberHealth_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.464.4626740634.swift)  
[color_sberHealth_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.464.4626740634.kt)  
[color_sberHealth_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.464.4626740634.ts)  
[color_sbermarket_business_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_ios-swift--canary.464.4626740634.swift)  
[color_sbermarket_business_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_kotlin--canary.464.4626740634.kt)  
[color_sbermarket_business_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_react-native--canary.464.4626740634.ts)  
[color_sbermarket_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.464.4626740634.swift)  
[color_sbermarket_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.464.4626740634.kt)  
[color_sbermarket_metro_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_ios-swift--canary.464.4626740634.swift)  
[color_sbermarket_metro_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_kotlin--canary.464.4626740634.kt)  
[color_sbermarket_metro_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_react-native--canary.464.4626740634.ts)  
[color_sbermarket_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.464.4626740634.ts)  
[color_sbermarket_selgros_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_ios-swift--canary.464.4626740634.swift)  
[color_sbermarket_selgros_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_kotlin--canary.464.4626740634.kt)  
[color_sbermarket_selgros_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_react-native--canary.464.4626740634.ts)  
[color_sbermarket_vinlab_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_vinlab_ios-swift--canary.464.4626740634.swift)  
[color_sbermarket_vinlab_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_vinlab_kotlin--canary.464.4626740634.kt)  
[color_sbermarket_vinlab_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_vinlab_react-native--canary.464.4626740634.ts)  
[color_sberprime_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.464.4626740634.swift)  
[color_sberprime_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.464.4626740634.kt)  
[color_sberprime_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.464.4626740634.ts)  
[PlasmaTokensColor--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.464.4626740634.swift)  
[shadow_sbermarket_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.464.4626740634.ts)  
[typo_mage_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.464.4626740634.swift)  
[typo_mage_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.464.4626740634.kt)  
[typo_mage_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.464.4626740634.ts)  
[typo_plasma_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.464.4626740634.swift)  
[typo_plasma_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.464.4626740634.kt)  
[typo_plasma_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.464.4626740634.ts)  
[typo_ruler_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.464.4626740634.swift)  
[typo_ruler_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.464.4626740634.kt)  
[typo_ruler_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.464.4626740634.ts)  
[typo_sage_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.464.4626740634.swift)  
[typo_sage_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.464.4626740634.kt)  
[typo_sage_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.464.4626740634.ts)  
[typo_sbermarket_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.464.4626740634.swift)  
[typo_sbermarket_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.464.4626740634.kt)  
[typo_sbermarket_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.464.4626740634.ts)  
[typo_soulmate_ios-swift--canary.464.4626740634.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.464.4626740634.swift)  
[typo_soulmate_kotlin--canary.464.4626740634.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.464.4626740634.kt)  
[typo_soulmate_react-native--canary.464.4626740634.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.464.4626740634.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.149.0-canary.464.4626740634.0
  npm install @salutejs/plasma-ui@1.181.0-canary.464.4626740634.0
  # or 
  yarn add @salutejs/plasma-temple@1.149.0-canary.464.4626740634.0
  yarn add @salutejs/plasma-ui@1.181.0-canary.464.4626740634.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
