### PR TITLE
feat(plasma-core): [Button] Add test for prop 'as'

### DIFF
--- a/packages/plasma-core/src/components/Button/Button.component-test.tsx
+++ b/packages/plasma-core/src/components/Button/Button.component-test.tsx
@@ -6,7 +6,6 @@ const Icon = () => <IconDownload color="inherit" />;
 
 describe('plasma-core: Button', () => {
     const Button = getComponent('Button');
-    const Spinner = getComponent('Spinner');
 
     it('simple', () => {
         mount(
@@ -176,5 +175,18 @@ describe('plasma-core: Button', () => {
             </CypressTestDecorator>,
         );
         cy.matchImageSnapshot();
+    });
+
+    it('as', () => {
+        // INFO: Почему и как может сломаться?
+        // https://plasma.sberdevices.ru/ui/types/as-and-forwardedas/#forwardedas
+
+        mount(
+            <CypressTestDecorator>
+                <Button as="a">Hello Plasma</Button>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('[type="button"]').first().should('have.prop', 'tagName').should('eq', 'A');
     });
 });


### PR DESCRIPTION
### Мотивация: 

При изменении реализации наших компонентов хотелось бы понимать и контролировать ту часть API, что может сломаться. 

Например свойство `as` **некорректно** работает на компонентах, которые обернуты в **styled**.

Например:

```jsx
const StyledButton = styled(Button)`
     color: 'red';
`;

<StyledButton as="a">Hello Plasma</StyledButton>
```
в этом случае мы не получим ожидаемого результата.

Добавленный тест укажет на это.    
