### PR TITLE
feat(plasma-tokens,plama-tokens-utils): Update theme name convention

### DIFF
--- a/packages/plasma-tokens/data/ds.ts
+++ b/packages/plasma-tokens/data/ds.ts
@@ -682,16 +682,16 @@ const lightB2E: ThemeTokens = {
 };
 
 export const colorThemes = {
-    darkSber,
-    darkEva,
-    darkJoy,
-    darkBrand,
-    darkB2E,
-    lightSber,
-    lightEva,
-    lightJoy,
-    lightBrand,
-    lightB2E,
+    salutejs_sber__dark: darkSber,
+    salutejs_eva__dark: darkEva,
+    salutejs_joy__dark: darkJoy,
+    salutejs_brand__dark: darkBrand,
+    salutejs_B2E__dark: darkB2E,
+    salutejs_sber__light: lightSber,
+    salutejs_eva__light: lightEva,
+    salutejs_joy__light: lightJoy,
+    salutejs_brand__light: lightBrand,
+    salutejs_B2E__light: lightB2E,
 };
 
 export type SimpleTokens = {

--- a/packages/plasma-tokens/data/themes/sbermarket_winelab.json
+++ b/packages/plasma-tokens/data/themes/sbermarket_winelab.json
@@ -1,6 +1,6 @@
 {
     "config": {
-        "name": "sbermarket_vinlab",
+        "name": "sbermarket_winelab",
         "accentColor": {
             "light": "#21A038",
             "dark": "#2EE850"

--- a/packages/plasma-tokens/generate.ts
+++ b/packages/plasma-tokens/generate.ts
@@ -22,7 +22,6 @@ import type { ThemeTokens, TypographyTypes } from './data';
 import * as tokenGroups from './tokenGroups';
 import { generateColorThemesTokenDataGroups, typoArchetypes, shadows } from './lib/themeBuilder/generateTokens';
 import { mapDeprecatedColorTokens } from './lib/themeBuilder/mapDeprecatedTokens';
-import { upperFirstLetter } from './lib/themeBuilder/utils';
 
 const OUT_DIR = 'src';
 const COLORS_DIR = path.join(OUT_DIR, 'colors');
@@ -45,9 +44,9 @@ fs.existsSync(BRANDS_DIR) || fs.mkdirSync(BRANDS_DIR);
 // Генерация цветов
 writeGeneratedToFS(COLORS_DIR, [
     // Файл с токенами CSS-Variables (с дефолтными значениями)
-    { file: 'index.ts', content: generateTokens(colorThemes.darkSber, 'css', 'colors') },
+    { file: 'index.ts', content: generateTokens(colorThemes.salutejs_sber__dark, 'css', 'colors') },
     // Файл с токенами (JS-переменными) для инъекции значения напрямую
-    { file: 'values.ts', content: generateTokens(colorThemes.darkSber) },
+    { file: 'values.ts', content: generateTokens(colorThemes.salutejs_sber__dark) },
 ]);
 
 // Генерация токенов для кастомных тем из data/themes
@@ -56,7 +55,11 @@ const themesColorTokenGroups = generateColorThemesTokenDataGroups();
 const themesColorTokenGroupsFallback = mapDeprecatedColorTokens(themesColorTokenGroups);
 
 // Генерация и запись файлов тем для создания глобальных стилей
-writeGeneratedToFS(THEMES_DIR, generateColorThemes({ ...themesColorTokenGroupsFallback, ...colorThemes }));
+const withDeprecated = true;
+writeGeneratedToFS(
+    THEMES_DIR,
+    generateColorThemes({ ...themesColorTokenGroupsFallback, ...colorThemes }, undefined, withDeprecated),
+);
 
 // Отдельные файлы для импорта в компонентах
 writeGeneratedToFS(THEMES_VALUES_DIR, generateColorThemeValues({ ...themesColorTokenGroupsFallback, ...colorThemes }));
@@ -65,7 +68,7 @@ const brands = Object.keys(themesColorTokenGroups);
 
 brands.forEach((brand) => {
     const brandDir = path.join(BRANDS_DIR, brand);
-    const themeName = `dark${upperFirstLetter(brand)}`;
+    const themeName = `${brand}__dark`;
     const theme = themesColorTokenGroupsFallback[themeName];
 
     writeGeneratedToFS(brandDir, [
@@ -290,8 +293,8 @@ const addStylesToTypo = (t: TypoSystem<TypographyTypes>) => {
         },
         root: {
             ...typoStyles.body1,
-            color: extractTokenData(colorThemes.darkSber).text,
-            backgroundColor: extractTokenData(colorThemes.darkSber).background,
+            color: extractTokenData(colorThemes.salutejs_sber__dark).text,
+            backgroundColor: extractTokenData(colorThemes.salutejs_sber__dark).background,
         },
     };
 
@@ -303,15 +306,15 @@ fs.writeFileSync(
     generateThemeJSON(
         addStylesToTypo(typoSystem),
         // Dark Sber is default
-        extractTokenData(colorThemes.darkSber),
+        extractTokenData(colorThemes.salutejs_sber__dark),
         // Check https://theme-ui.com/theme-spec/#color-modes
         {
-            darkSber: extractTokenData(colorThemes.darkSber),
-            darkEva: extractTokenData(colorThemes.darkEva),
-            darkJoy: extractTokenData(colorThemes.darkJoy),
-            lightSber: extractTokenData(colorThemes.lightSber),
-            lightEva: extractTokenData(colorThemes.lightEva),
-            lightJoy: extractTokenData(colorThemes.lightJoy),
+            darkSber: extractTokenData(colorThemes.salutejs_sber__dark),
+            darkEva: extractTokenData(colorThemes.salutejs_eva__dark),
+            darkJoy: extractTokenData(colorThemes.salutejs_joy__dark),
+            lightSber: extractTokenData(colorThemes.salutejs_sber__light),
+            lightEva: extractTokenData(colorThemes.salutejs_eva__light),
+            lightJoy: extractTokenData(colorThemes.salutejs_joy__light),
         },
     ),
 );

--- a/packages/plasma-tokens/lib/generator/formatters/colorKotlin.ts
+++ b/packages/plasma-tokens/lib/generator/formatters/colorKotlin.ts
@@ -1,6 +1,6 @@
 import type { Dictionary, File, TransformedToken } from 'style-dictionary';
 
-import { lowerFirstLetter } from '../../themeBuilder/utils';
+import { camelize, lowerFirstLetter } from '../../themeBuilder/utils';
 import { ThemeColor, ThemeColorType } from '../types';
 
 const getKotlinTemplate = (lightThemeContent: string, darkThemeContent: string, name: string) => {
@@ -41,12 +41,12 @@ import ru.${lowerFirstLetter(name)}.sm_theme.theme.tokens.SMColor`;
 
 const getTheme = (tokenItems: TransformedToken[], theme: ThemeColorType) =>
     tokenItems
-        .filter((tokens) => tokens.attributes?.type?.includes(theme))
+        .filter((token) => (camelize(token.attributes?.type) || '').includes(theme))
         .map((token) => `    ${token.attributes?.item} = ${token.value},`)
         .join(`\n`);
 
 export const colorKotlinCustomFormatter = ({ dictionary, file }: { dictionary: Dictionary; file: File }) => {
-    const themeName = file.className || '';
+    const themeName = lowerFirstLetter(file.className || '');
 
     const lightTheme = getTheme(dictionary.allTokens, ThemeColor.light);
     const darkTheme = getTheme(dictionary.allTokens, ThemeColor.dark);

--- a/packages/plasma-tokens/lib/generator/formatters/colorReactNative.ts
+++ b/packages/plasma-tokens/lib/generator/formatters/colorReactNative.ts
@@ -1,6 +1,6 @@
 import type { Dictionary, File, TransformedToken } from 'style-dictionary';
 
-import { upperFirstLetter } from '../../themeBuilder/utils';
+import { camelize, upperFirstLetter } from '../../themeBuilder/utils';
 import { ThemeColor, ThemeColorType } from '../types';
 
 const getExportColorThemes = (theme: string) => `const ${theme}ColorsMapping = {
@@ -36,8 +36,7 @@ interface LinearGradientProps extends ReactNative.ViewProps {
   angle?: number
 }`;
 
-    const gradientKeys = `type GradientKey = 
-  ${gradientKeysContent}
+    const gradientKeys = `type GradientKey = ${gradientKeysContent}
 
 type GradientsMap = Record<GradientKey, LinearGradientProps>`;
 
@@ -76,13 +75,16 @@ const getTokenValue = (token: TransformedToken) => {
 };
 
 const isGradientToken = (token: TransformedToken, theme: string) =>
-    token.attributes?.type?.includes(theme) && token.original.value.linearGradient;
+    (camelize(token.attributes?.type) || '').includes(theme) && token.original.value.linearGradient;
 
-const getGradientKeys = (tokenItems: TransformedToken[]) =>
-    tokenItems
+const getGradientKeys = (tokenItems: TransformedToken[]) => {
+    const keys = `\n  ${tokenItems
         .filter((token) => isGradientToken(token, ThemeColor.light))
         .map((token) => `| '${token.attributes?.item}'`)
-        .join('\n  ');
+        .join('\n  ')}`;
+
+    return keys.replace(/\s/g, '') ? keys : 'any';
+};
 
 const getGradientTokens = (tokenItems: TransformedToken[], theme: ThemeColorType) =>
     tokenItems
@@ -92,7 +94,9 @@ const getGradientTokens = (tokenItems: TransformedToken[], theme: ThemeColorType
 
 const getTheme = (tokenItems: TransformedToken[], theme: ThemeColorType) =>
     tokenItems
-        .filter((token) => token.attributes?.type?.includes(theme) && !token.original.value.linearGradient)
+        .filter(
+            (token) => (camelize(token.attributes?.type) || '').includes(theme) && !token.original.value.linearGradient,
+        )
         .map(getTokenValue)
         .join(`\n`);
 

--- a/packages/plasma-tokens/lib/generator/types.ts
+++ b/packages/plasma-tokens/lib/generator/types.ts
@@ -12,11 +12,11 @@ export interface Gradient {
 }
 
 export const enum ThemeColor {
-    light = 'light',
-    dark = 'dark',
+    light = 'Light',
+    dark = 'Dark',
 }
 
-export type ThemeColorType = keyof typeof ThemeColor;
+export type ThemeColorType = 'Light' | 'Dark';
 
 export interface GradientToken {
     startColor: string;

--- a/packages/plasma-tokens/lib/themeBuilder/generateTokens.ts
+++ b/packages/plasma-tokens/lib/themeBuilder/generateTokens.ts
@@ -57,8 +57,8 @@ export const theme2ColorTokenDataGroups = (theme: Theme): Record<string, ThemeTo
 
     return {
         [name]: {
-            [`dark${upperFirstLetter(name)}`]: dataObject2TokenDataGroup((dark as unknown) as DataObject, ''),
-            [`light${upperFirstLetter(name)}`]: dataObject2TokenDataGroup((light as unknown) as DataObject, ''),
+            [`${name}__dark`]: dataObject2TokenDataGroup((dark as unknown) as DataObject, ''),
+            [`${name}__light`]: dataObject2TokenDataGroup((light as unknown) as DataObject, ''),
         },
     };
 };

--- a/packages/plasma-tokens/lib/themeBuilder/mapDeprecatedTokens.ts
+++ b/packages/plasma-tokens/lib/themeBuilder/mapDeprecatedTokens.ts
@@ -95,7 +95,7 @@ export const mapDeprecatedColorTokens = (
             );
 
         const { skeletonGradient, skeletonGradientLighter } = gradientColors[
-            themeName.startsWith('dark') ? 'dark' : 'light'
+            themeName.endsWith('dark') ? 'dark' : 'light'
         ];
 
         return {

--- a/packages/plasma-tokens/lib/themeBuilder/utils.ts
+++ b/packages/plasma-tokens/lib/themeBuilder/utils.ts
@@ -22,4 +22,4 @@ export const lowerFirstLetter = (value: string) => `${value[0].toLocaleLowerCase
 
 export const upperFirstLetter = (value: string) => `${value[0].toLocaleUpperCase()}${value.slice(1)}`;
 
-export const camelize = (source?: string) => source?.replace(/[-|_]./g, (x) => x[1].toUpperCase());
+export const camelize = (source?: string) => source?.replace(/[_-]+(.)/g, (_, p1) => p1.toUpperCase());

--- a/utils/plasma-tokens-utils/src/generators/generateFile.ts
+++ b/utils/plasma-tokens-utils/src/generators/generateFile.ts
@@ -3,12 +3,12 @@ import { ROBO_COMMENT } from '../constants';
 /**
  * Создает дескриптор на файл с определенным именем и контентом.
  */
-export const generateFile = (name: string, content: string | object) => {
+export const generateFile = (name: string, content: string | object, deprecated?: string) => {
     if (typeof content !== 'string') {
         content = JSON.stringify(content, null, 4);
     }
     return {
         file: `${name}.ts`,
-        content: `${ROBO_COMMENT}export const ${name} = ${content};\n`,
+        content: `${ROBO_COMMENT}export const ${name} = ${content};${deprecated}\n`,
     };
 };

--- a/utils/plasma-tokens-utils/src/utils/getDeprecatedVars.ts
+++ b/utils/plasma-tokens-utils/src/utils/getDeprecatedVars.ts
@@ -1,0 +1,20 @@
+import { upperFirstLetter } from './upperFirstLetter';
+
+const deprecatedRegexList = new RegExp('salutejs_');
+
+export const getDeprecatedVars = (name: string) => {
+    const fileName = name.replace(deprecatedRegexList, '');
+
+    const [themeName, themeMode] = fileName.split('__');
+
+    if (!themeName || !themeMode) {
+        return ['', ''];
+    }
+
+    const deprecatedThemeName = `${themeMode}${upperFirstLetter(themeName)}`;
+    const deprecated = `
+/** @deprecated использовать вместо этого ${name} */
+export const ${deprecatedThemeName} = ${name};`;
+
+    return [deprecated, deprecatedThemeName];
+};

--- a/utils/plasma-tokens-utils/src/utils/index.ts
+++ b/utils/plasma-tokens-utils/src/utils/index.ts
@@ -3,3 +3,5 @@ export { escapeValue, getCSSVariableName } from './other';
 export { extractTokenData } from './extractTokenData';
 export { filterTypoStyles } from './filterTypoStyles';
 export { objectToCSSVariables } from './objectToCSSVariables';
+export { upperFirstLetter } from './upperFirstLetter';
+export { getDeprecatedVars } from './getDeprecatedVars';

--- a/utils/plasma-tokens-utils/src/utils/upperFirstLetter.ts
+++ b/utils/plasma-tokens-utils/src/utils/upperFirstLetter.ts
@@ -1,0 +1,1 @@
+export const upperFirstLetter = (value: string) => `${value[0].toLocaleUpperCase()}${value.slice(1)}`;


### PR DESCRIPTION
Согласно новой конвенции именования тем, принимается следующий формат:
`<название_темы>_<вид_темы>__<модификаторы_темы>` или `<название_темы>__<модификаторы_темы>`.

Так сейчас выглядит список тем с поддержкой обратной совместимости:

<img width="745" alt="Screenshot 2023-04-11 at 23 55 34" src="https://user-images.githubusercontent.com/26903236/231371925-a0fc87cb-4d3b-4606-ac58-d878e9ab7b6d.png">

В случае использовании старых названий тем они будут помечены как `deprecated`, с комментарием, какое название вместо этого лучше использовать:

<img width="583" alt="Screenshot 2023-04-11 at 23 55 21" src="https://user-images.githubusercontent.com/26903236/231372344-d7e65051-03ba-4b7d-99f1-5dc999132ec8.png">

Так же для улучшения консистентности, для тем, которые используются в canvas приложениях, был добавлен префикс `salutejs`.

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[colors--canary.475.4680213255.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/colors--canary.475.4680213255.xml)  
[color_sberHealth_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.475.4680213255.swift)  
[color_sberHealth_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.475.4680213255.kt)  
[color_sberHealth_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.475.4680213255.ts)  
[color_sbermarket_business_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_ios-swift--canary.475.4680213255.swift)  
[color_sbermarket_business_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_kotlin--canary.475.4680213255.kt)  
[color_sbermarket_business_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_react-native--canary.475.4680213255.ts)  
[color_sbermarket_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.475.4680213255.swift)  
[color_sbermarket_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.475.4680213255.kt)  
[color_sbermarket_metro_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_ios-swift--canary.475.4680213255.swift)  
[color_sbermarket_metro_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_kotlin--canary.475.4680213255.kt)  
[color_sbermarket_metro_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_react-native--canary.475.4680213255.ts)  
[color_sbermarket_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.475.4680213255.ts)  
[color_sbermarket_selgros_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_ios-swift--canary.475.4680213255.swift)  
[color_sbermarket_selgros_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_kotlin--canary.475.4680213255.kt)  
[color_sbermarket_selgros_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_react-native--canary.475.4680213255.ts)  
[color_sbermarket_winelab_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_winelab_ios-swift--canary.475.4680213255.swift)  
[color_sbermarket_winelab_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_winelab_kotlin--canary.475.4680213255.kt)  
[color_sbermarket_winelab_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_winelab_react-native--canary.475.4680213255.ts)  
[color_sberprime_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.475.4680213255.swift)  
[color_sberprime_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.475.4680213255.kt)  
[color_sberprime_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.475.4680213255.ts)  
[PlasmaTokensColor--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/PlasmaTokensColor--canary.475.4680213255.swift)  
[shadow_sbermarket_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.475.4680213255.ts)  
[typo_mage_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.475.4680213255.swift)  
[typo_mage_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.475.4680213255.kt)  
[typo_mage_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.475.4680213255.ts)  
[typo_plasma_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.475.4680213255.swift)  
[typo_plasma_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.475.4680213255.kt)  
[typo_plasma_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.475.4680213255.ts)  
[typo_ruler_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.475.4680213255.swift)  
[typo_ruler_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.475.4680213255.kt)  
[typo_ruler_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.475.4680213255.ts)  
[typo_sage_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.475.4680213255.swift)  
[typo_sage_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.475.4680213255.kt)  
[typo_sage_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.475.4680213255.ts)  
[typo_sbermarket_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.475.4680213255.swift)  
[typo_sbermarket_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.475.4680213255.kt)  
[typo_sbermarket_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.475.4680213255.ts)  
[typo_soulmate_ios-swift--canary.475.4680213255.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.475.4680213255.swift)  
[typo_soulmate_kotlin--canary.475.4680213255.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.475.4680213255.kt)  
[typo_soulmate_react-native--canary.475.4680213255.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.475.4680213255.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.175.0-canary.475.4680213255.0
  npm install @salutejs/plasma-core@1.109.0-canary.475.4680213255.0
  npm install @salutejs/plasma-hope@0.33.0-canary.475.4680213255.0
  npm install @salutejs/plasma-icons@1.138.0-canary.475.4680213255.0
  npm install @salutejs/plasma-temple@1.151.0-canary.475.4680213255.0
  npm install @salutejs/plasma-tokens-b2b@1.15.0-canary.475.4680213255.0
  npm install @salutejs/plasma-tokens-b2c@0.24.0-canary.475.4680213255.0
  npm install @salutejs/plasma-tokens-web@1.30.0-canary.475.4680213255.0
  npm install @salutejs/plasma-tokens@1.45.0-canary.475.4680213255.0
  npm install @salutejs/plasma-ui@1.183.0-canary.475.4680213255.0
  npm install @salutejs/plasma-web@1.200.0-canary.475.4680213255.0
  npm install @salutejs/plasma-cy-utils@0.52.0-canary.475.4680213255.0
  npm install @salutejs/plasma-sb-utils@0.107.0-canary.475.4680213255.0
  npm install @salutejs/plasma-tokens-android@2.52.0-canary.475.4680213255.0
  npm install @salutejs/plasma-tokens-ios-swift@2.52.0-canary.475.4680213255.0
  npm install @salutejs/plasma-tokens-utils@0.21.0-canary.475.4680213255.0
  # or 
  yarn add @salutejs/plasma-b2c@1.175.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-core@1.109.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-hope@0.33.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-icons@1.138.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-temple@1.151.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-tokens-b2b@1.15.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-tokens-b2c@0.24.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-tokens-web@1.30.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-tokens@1.45.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-ui@1.183.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-web@1.200.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-cy-utils@0.52.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-sb-utils@0.107.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-tokens-android@2.52.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-tokens-ios-swift@2.52.0-canary.475.4680213255.0
  yarn add @salutejs/plasma-tokens-utils@0.21.0-canary.475.4680213255.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
