### PR TITLE
feat(plasma-hope): maxWidth for Grid

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -86,6 +86,7 @@ import { ColCount } from '@salutejs/plasma-hope';
 import { ColOffsetProps } from '@salutejs/plasma-hope';
 import { ColProps } from '@salutejs/plasma-hope';
 import { ColSizeProps } from '@salutejs/plasma-hope';
+import { ContainerProps } from '@salutejs/plasma-hope/components/Grid/types';
 import { convertRoundnessMatrix } from '@salutejs/plasma-core';
 import { defaultValidate } from '@salutejs/plasma-hope';
 import { DisabledProps } from '@salutejs/plasma-core';
@@ -127,7 +128,6 @@ import { Headline2 } from '@salutejs/plasma-hope';
 import { Headline3 } from '@salutejs/plasma-hope';
 import { Headline4 } from '@salutejs/plasma-hope';
 import { Headline5 } from '@salutejs/plasma-hope';
-import { HTMLAttributes } from 'react';
 import { Image as Image_2 } from '@salutejs/plasma-hope';
 import { ImageBaseProps } from '@salutejs/plasma-hope';
 import { ImageProps } from '@salutejs/plasma-hope';
@@ -444,7 +444,7 @@ export { ColProps }
 export { ColSizeProps }
 
 // @public
-export const Container: StyledComponent<"div", any, HTMLAttributes<HTMLDivElement>, never>;
+export const Container: StyledComponent<"div", any, ContainerProps, never>;
 
 export { convertRoundnessMatrix }
 

--- a/packages/plasma-b2c/src/components/Grid/Container.tsx
+++ b/packages/plasma-b2c/src/components/Grid/Container.tsx
@@ -5,5 +5,6 @@ export const ContainerBase = ContainerHope({ design: 'b2c' });
 /**
  * Блок с полями по бокам для размещения контента по вертикали.
  * Блок нельзя вкладывать сам в себя или дальше по дереву.
+ * Для настройки максимальной ширины необходимо использовать свойство `maxWidth`.
  */
 export const Container = ContainerBase;

--- a/packages/plasma-b2c/src/components/Grid/Grid.stories.tsx
+++ b/packages/plasma-b2c/src/components/Grid/Grid.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Filler, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import { Meta } from '@storybook/react';
+import { Meta, Story } from '@storybook/react';
 
 import { Container, Row, Col } from '.';
 
@@ -9,8 +9,8 @@ export default {
     decorators: [InSpacingDecorator],
 } as Meta;
 
-export const Default = () => (
-    <Container>
+export const Default: Story<{ maxWidth: string }> = ({ maxWidth }) => (
+    <Container maxWidth={maxWidth}>
         <Row>
             <Col sizeS={1} sizeM={2} sizeL={3} sizeXL={4}>
                 <Filler style={{ marginBottom: '1rem' }}>1</Filler>
@@ -31,3 +31,7 @@ export const Default = () => (
         </Row>
     </Container>
 );
+
+Default.args = {
+    maxWidth: '125rem',
+};

--- a/packages/plasma-hope/api/plasma-hope.api.md
+++ b/packages/plasma-hope/api/plasma-hope.api.md
@@ -532,9 +532,10 @@ export interface ColSizeProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "Design_2" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ContainerProps" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Container: ({ design }: Design_2) => StyledComponent<"div", any, HTMLAttributes<HTMLDivElement>, never>;
+export const Container: ({ design }: Design_2) => StyledComponent<"div", any, ContainerProps, never>;
 
 export { convertRoundnessMatrix }
 

--- a/packages/plasma-hope/src/components/Grid/types.ts
+++ b/packages/plasma-hope/src/components/Grid/types.ts
@@ -1,3 +1,5 @@
+import { HTMLAttributes } from 'react';
+
 import type { Breakpoint } from '../../utils';
 
 type IntCount = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16;
@@ -69,3 +71,10 @@ export const offsets: Record<Breakpoint, keyof ColOffsetProps> = {
 export type Design = {
     design: 'b2c' | 'web';
 };
+
+export interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
+    /**
+     * Максимальная ширина контейнера. По умолчанию 125rem/90rem для b2c/web соотвественно
+     */
+    maxWidth?: string;
+}

--- a/packages/plasma-hope/src/components/Grid/views/applyMaxWidth.tsx
+++ b/packages/plasma-hope/src/components/Grid/views/applyMaxWidth.tsx
@@ -1,0 +1,11 @@
+import { css, InterpolationFunction } from 'styled-components';
+
+import { ContainerProps } from '../types';
+
+export const applyMaxWidth: InterpolationFunction<ContainerProps & { defaultMaxWidth?: string }> = ({
+    defaultMaxWidth = '125rem',
+    maxWidth,
+}) =>
+    css`
+        max-width: ${maxWidth ?? defaultMaxWidth};
+    `;

--- a/packages/plasma-hope/src/components/Grid/views/b2c/ContainerB2C.tsx
+++ b/packages/plasma-hope/src/components/Grid/views/b2c/ContainerB2C.tsx
@@ -1,8 +1,9 @@
-import { HTMLAttributes } from 'react';
 import styled from 'styled-components';
 
 import { ContainerWeb } from '../web/ContainerWeb';
+import { applyMaxWidth } from '../applyMaxWidth';
+import { ContainerProps } from '../../types';
 
-export const ContainerB2C = styled(ContainerWeb)<HTMLAttributes<HTMLDivElement>>`
-    max-width: 125rem;
+export const ContainerB2C = styled(ContainerWeb)<ContainerProps>`
+    ${({ maxWidth }) => applyMaxWidth({ maxWidth, defaultMaxWidth: '125rem' })}
 `;

--- a/packages/plasma-hope/src/components/Grid/views/web/ContainerWeb.tsx
+++ b/packages/plasma-hope/src/components/Grid/views/web/ContainerWeb.tsx
@@ -1,14 +1,13 @@
-import { HTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 
 import { gridGutters, gridMargins, gridSizes, mediaQuery } from '../../../../utils';
+import { ContainerProps } from '../../types';
+import { applyMaxWidth } from '../applyMaxWidth';
 
 const deviceScale = 1;
 const sidesCount = 2;
 
-export const ContainerWeb = styled.div<HTMLAttributes<HTMLDivElement>>`
-    margin: 0 auto;
-
+export const ContainerWeb = styled.div<ContainerProps>`
     display: flex;
     box-sizing: border-box;
     flex-direction: column;
@@ -17,7 +16,9 @@ export const ContainerWeb = styled.div<HTMLAttributes<HTMLDivElement>>`
     padding-left: var(--plasma-grid-margin);
     padding-right: var(--plasma-grid-margin);
 
-    max-width: 90rem;
+    ${({ maxWidth }) => css`
+        ${applyMaxWidth({ maxWidth, defaultMaxWidth: '90rem' })}
+    `}
 
     ${() =>
         gridSizes.map((breakpoint) =>

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -86,6 +86,7 @@ import { ColCount } from '@salutejs/plasma-hope';
 import { ColOffsetProps } from '@salutejs/plasma-hope';
 import { ColProps } from '@salutejs/plasma-hope';
 import { ColSizeProps } from '@salutejs/plasma-hope';
+import { ContainerProps } from '@salutejs/plasma-hope/components/Grid/types';
 import { convertRoundnessMatrix } from '@salutejs/plasma-core';
 import { defaultValidate } from '@salutejs/plasma-hope';
 import { DisabledProps } from '@salutejs/plasma-core';
@@ -127,7 +128,6 @@ import { Headline2 } from '@salutejs/plasma-hope';
 import { Headline3 } from '@salutejs/plasma-hope';
 import { Headline4 } from '@salutejs/plasma-hope';
 import { Headline5 } from '@salutejs/plasma-hope';
-import { HTMLAttributes } from 'react';
 import { Image as Image_2 } from '@salutejs/plasma-hope';
 import { ImageBaseProps } from '@salutejs/plasma-hope';
 import { ImageProps } from '@salutejs/plasma-hope';
@@ -444,7 +444,7 @@ export { ColProps }
 export { ColSizeProps }
 
 // @public
-export const Container: StyledComponent<"div", any, HTMLAttributes<HTMLDivElement>, never>;
+export const Container: StyledComponent<"div", any, ContainerProps, never>;
 
 export { convertRoundnessMatrix }
 

--- a/packages/plasma-web/src/components/Grid/Container.tsx
+++ b/packages/plasma-web/src/components/Grid/Container.tsx
@@ -5,5 +5,6 @@ export const ContainerBase = ContainerHope({ design: 'web' });
 /**
  * Блок с полями по бокам для размещения контента по вертикали.
  * Блок нельзя вкладывать сам в себя или дальше по дереву.
+ * Для настройки максимальной ширины необходимо использовать свойство `maxWidth`.
  */
 export const Container = ContainerBase;

--- a/packages/plasma-web/src/components/Grid/Grid.stories.tsx
+++ b/packages/plasma-web/src/components/Grid/Grid.stories.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { Meta } from '@storybook/react';
-import { Filler } from '@salutejs/plasma-sb-utils';
-
-import { InSpacingDecorator } from '../../helpers';
+import { Filler, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import { Meta, Story } from '@storybook/react';
 
 import { Container, Row, Col } from '.';
 
@@ -11,8 +9,8 @@ export default {
     decorators: [InSpacingDecorator],
 } as Meta;
 
-export const Default = () => (
-    <Container>
+export const Default: Story<{ maxWidth: string }> = ({ maxWidth }) => (
+    <Container maxWidth={maxWidth}>
         <Row>
             <Col sizeS={1} sizeM={2} sizeL={3} sizeXL={4}>
                 <Filler style={{ marginBottom: '1rem' }}>1</Filler>
@@ -33,3 +31,7 @@ export const Default = () => (
         </Row>
     </Container>
 );
+
+Default.args = {
+    maxWidth: '90rem',
+};


### PR DESCRIPTION
 Добавлена возможность настроить максимальную ширину компонента `Container`, входящего  в `Grid`, с помощью свойства `maxWidth`:
 
 ``` js
 <Container maxWidth="60rem">
 /* необходимые Row, Col */
</Container>
 ```

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[color_sberHealth_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.495.4829781543.swift)  
[color_sberHealth_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.495.4829781543.kt)  
[color_sberHealth_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.495.4829781543.ts)  
[color_sbermarket_business_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_ios-swift--canary.495.4829781543.swift)  
[color_sbermarket_business_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_kotlin--canary.495.4829781543.kt)  
[color_sbermarket_business_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_react-native--canary.495.4829781543.ts)  
[color_sbermarket_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.495.4829781543.swift)  
[color_sbermarket_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.495.4829781543.kt)  
[color_sbermarket_metro_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_ios-swift--canary.495.4829781543.swift)  
[color_sbermarket_metro_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_kotlin--canary.495.4829781543.kt)  
[color_sbermarket_metro_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_react-native--canary.495.4829781543.ts)  
[color_sbermarket_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.495.4829781543.ts)  
[color_sbermarket_selgros_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_ios-swift--canary.495.4829781543.swift)  
[color_sbermarket_selgros_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_kotlin--canary.495.4829781543.kt)  
[color_sbermarket_selgros_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_react-native--canary.495.4829781543.ts)  
[color_sbermarket_wlbusiness_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_ios-swift--canary.495.4829781543.swift)  
[color_sbermarket_wlbusiness_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_kotlin--canary.495.4829781543.kt)  
[color_sbermarket_wlbusiness_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_react-native--canary.495.4829781543.ts)  
[color_sberprime_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.495.4829781543.swift)  
[color_sberprime_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.495.4829781543.kt)  
[color_sberprime_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.495.4829781543.ts)  
[shadow_sbermarket_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.495.4829781543.ts)  
[typo_mage_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.495.4829781543.swift)  
[typo_mage_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.495.4829781543.kt)  
[typo_mage_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.495.4829781543.ts)  
[typo_plasma_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.495.4829781543.swift)  
[typo_plasma_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.495.4829781543.kt)  
[typo_plasma_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.495.4829781543.ts)  
[typo_ruler_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.495.4829781543.swift)  
[typo_ruler_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.495.4829781543.kt)  
[typo_ruler_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.495.4829781543.ts)  
[typo_sage_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.495.4829781543.swift)  
[typo_sage_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.495.4829781543.kt)  
[typo_sage_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.495.4829781543.ts)  
[typo_sbermarket_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.495.4829781543.swift)  
[typo_sbermarket_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.495.4829781543.kt)  
[typo_sbermarket_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.495.4829781543.ts)  
[typo_soulmate_ios-swift--canary.495.4829781543.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.495.4829781543.swift)  
[typo_soulmate_kotlin--canary.495.4829781543.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.495.4829781543.kt)  
[typo_soulmate_react-native--canary.495.4829781543.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.495.4829781543.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.207.0-canary.495.4829781543.0
  npm install @salutejs/plasma-core@1.114.0-canary.495.4829781543.0
  npm install @salutejs/plasma-hope@1.207.0-canary.495.4829781543.0
  npm install @salutejs/plasma-icons@1.143.0-canary.495.4829781543.0
  npm install @salutejs/plasma-temple@1.158.0-canary.495.4829781543.0
  npm install @salutejs/plasma-tokens@1.49.0-canary.495.4829781543.0
  npm install @salutejs/plasma-ui@1.190.0-canary.495.4829781543.0
  npm install @salutejs/plasma-web@1.207.0-canary.495.4829781543.0
  npm install @salutejs/plasma-cy-utils@0.56.0-canary.495.4829781543.0
  npm install @salutejs/plasma-sb-utils@0.112.0-canary.495.4829781543.0
  # or 
  yarn add @salutejs/plasma-b2c@1.207.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-core@1.114.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-hope@1.207.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-icons@1.143.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-temple@1.158.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-tokens@1.49.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-ui@1.190.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-web@1.207.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-cy-utils@0.56.0-canary.495.4829781543.0
  yarn add @salutejs/plasma-sb-utils@0.112.0-canary.495.4829781543.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
