### PR TITLE
fix(plasma-ui): [ActionButtonProps] Omit 'onResize', 'onResizeCapture', 'nonce'

### DIFF
--- a/packages/plasma-ui/src/components/Button/ActionButton.tsx
+++ b/packages/plasma-ui/src/components/Button/ActionButton.tsx
@@ -22,10 +22,14 @@ import { applyInteraction, InteractionProps } from '../../mixins';
 
 import { sizes } from './ActionButton.sizes';
 
-export type ActionButtonProps = Omit<BaseProps, 'stretch' | 'pin'> &
+type ActionButtonBaseProps = Omit<BaseProps, 'stretch' | 'pin'> &
     Partial<ButtonSizeProps> &
     Partial<ButtonViewProps> &
     InteractionProps & { pin?: Extract<PinProps['pin'], 'square-square' | 'circle-circle'> };
+
+// INFO: Omit 'onResize' | 'onResizeCapture' | 'nonce'
+// because this types coming with @types/react@18 and breaks react@17.0.2 with @types/react@18
+export type ActionButtonProps = Omit<ActionButtonBaseProps, 'nonce' | 'onResize' | 'onResizeCapture'>;
 
 const buttonSizes = {
     l: {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[color_sberHealth_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.506.4989786425.swift)  
[color_sberHealth_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.506.4989786425.kt)  
[color_sberHealth_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.506.4989786425.ts)  
[color_sbermarket_business_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_ios-swift--canary.506.4989786425.swift)  
[color_sbermarket_business_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_kotlin--canary.506.4989786425.kt)  
[color_sbermarket_business_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_react-native--canary.506.4989786425.ts)  
[color_sbermarket_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.506.4989786425.swift)  
[color_sbermarket_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.506.4989786425.kt)  
[color_sbermarket_metro_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_ios-swift--canary.506.4989786425.swift)  
[color_sbermarket_metro_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_kotlin--canary.506.4989786425.kt)  
[color_sbermarket_metro_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_react-native--canary.506.4989786425.ts)  
[color_sbermarket_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.506.4989786425.ts)  
[color_sbermarket_selgros_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_ios-swift--canary.506.4989786425.swift)  
[color_sbermarket_selgros_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_kotlin--canary.506.4989786425.kt)  
[color_sbermarket_selgros_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_react-native--canary.506.4989786425.ts)  
[color_sbermarket_wlbusiness_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_ios-swift--canary.506.4989786425.swift)  
[color_sbermarket_wlbusiness_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_kotlin--canary.506.4989786425.kt)  
[color_sbermarket_wlbusiness_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_react-native--canary.506.4989786425.ts)  
[color_sberprime_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.506.4989786425.swift)  
[color_sberprime_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.506.4989786425.kt)  
[color_sberprime_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.506.4989786425.ts)  
[shadow_sbermarket_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.506.4989786425.ts)  
[typo_mage_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.506.4989786425.swift)  
[typo_mage_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.506.4989786425.kt)  
[typo_mage_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.506.4989786425.ts)  
[typo_plasma_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.506.4989786425.swift)  
[typo_plasma_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.506.4989786425.kt)  
[typo_plasma_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.506.4989786425.ts)  
[typo_ruler_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.506.4989786425.swift)  
[typo_ruler_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.506.4989786425.kt)  
[typo_ruler_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.506.4989786425.ts)  
[typo_sage_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.506.4989786425.swift)  
[typo_sage_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.506.4989786425.kt)  
[typo_sage_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.506.4989786425.ts)  
[typo_sbermarket_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.506.4989786425.swift)  
[typo_sbermarket_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.506.4989786425.kt)  
[typo_sbermarket_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.506.4989786425.ts)  
[typo_soulmate_ios-swift--canary.506.4989786425.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.506.4989786425.swift)  
[typo_soulmate_kotlin--canary.506.4989786425.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.506.4989786425.kt)  
[typo_soulmate_react-native--canary.506.4989786425.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.506.4989786425.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-temple@1.158.2-canary.506.4989786425.0
  npm install @salutejs/plasma-ui@1.190.1-canary.506.4989786425.0
  # or 
  yarn add @salutejs/plasma-temple@1.158.2-canary.506.4989786425.0
  yarn add @salutejs/plasma-ui@1.190.1-canary.506.4989786425.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
