### PR TITLE
ci: Enable cache for install dependencies

### DIFF
--- a/.github/workflows/clean-pr-documentation.yml
+++ b/.github/workflows/clean-pr-documentation.yml
@@ -1,4 +1,4 @@
-name: PR documentation
+name: Clean up S3
 
 on:
   pull_request:
@@ -6,6 +6,11 @@ on:
     branches:
       - dev
       - master
+
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   clean:

--- a/.github/workflows/cleanup-cache-pr.yml
+++ b/.github/workflows/cleanup-cache-pr.yml
@@ -1,0 +1,35 @@
+# https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+name: Cleanup caches by a branch
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/cypress-ct-17.yml
+++ b/.github/workflows/cypress-ct-17.yml
@@ -1,7 +1,15 @@
 name: Cypress component testing react-17
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
+      - dev
+
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   cypress:
@@ -16,18 +24,26 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'
+        cache: 'npm'
 
-    - name: Cache node modules
-      uses: actions/cache@v1
+    - name: Cache dependencies
+      id: cache-npm
+      uses: actions/cache@v3
       with:
-        path: node_modules
-        key: npm-deps-${{ hashFiles('package-lock.json') }}
+        path: |
+          node_modules
+          ~/.cache
+        key: npm-${{ hashFiles('package-lock.json') }}
         restore-keys: |
-          npm-deps-${{ hashFiles('package-lock.json') }}
+          npm-${{ hashFiles('package-lock.json') }}
+          npm-
 
     - name: Setup packages
+      if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+      run: npm ci --no-progress
+
+    - name: Setup react@17
       run: |
-        npm ci --no-progress
         npm i --no-progress react@17 react-dom@17 --prefix="./packages/plasma-ui"
         npm i --no-progress react@17 react-dom@17 --prefix="./packages/plasma-temple"
         npm i --no-progress react@17 react-dom@17 --prefix="./packages/plasma-b2c"

--- a/.github/workflows/cypress-ct-17.yml
+++ b/.github/workflows/cypress-ct-17.yml
@@ -1,6 +1,7 @@
 name: Cypress component testing react-17
 
 on:
+  merge_group:
   pull_request:
     branches:
       - master

--- a/.github/workflows/cypress-ct.yml
+++ b/.github/workflows/cypress-ct.yml
@@ -1,7 +1,15 @@
 name: Cypress component testing
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
+      - dev
+
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   cypress:
@@ -16,8 +24,22 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'
+        cache: 'npm'
+
+    - name: Cache dependencies
+      id: cache-npm
+      uses: actions/cache@v3
+      with:
+        path: |
+          node_modules
+          ~/.cache
+        key: npm-${{ hashFiles('package-lock.json') }}
+        restore-keys: |
+          npm-${{ hashFiles('package-lock.json') }}
+          npm-
 
     - name: Setup packages
+      if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
       run: npm ci --no-progress
 
     - name: Lerna bootstrap

--- a/.github/workflows/cypress-ct.yml
+++ b/.github/workflows/cypress-ct.yml
@@ -1,6 +1,7 @@
 name: Cypress component testing
 
 on:
+  merge_group:
   pull_request:
     branches:
       - master

--- a/.github/workflows/documentation-main.yml
+++ b/.github/workflows/documentation-main.yml
@@ -23,17 +23,23 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       # Данный шаг не исполняется, т.к. в настоящее время actions/cache поддерживается только для типов событий push и pull_request
-      - name: Cache node modules
-        uses: actions/cache@v1
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Lerna bootstrap

--- a/.github/workflows/documentation-pr.yml
+++ b/.github/workflows/documentation-pr.yml
@@ -6,6 +6,11 @@ on:
       - dev
       - master
 
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
@@ -24,16 +29,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
-      - name: Cache node modules
-        uses: actions/cache@v1
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
       - name: Lerna bootstrap
         run: npx lerna bootstrap

--- a/.github/workflows/examples-pr.yml
+++ b/.github/workflows/examples-pr.yml
@@ -6,6 +6,11 @@ on:
       - dev
       - master
 
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
@@ -23,16 +28,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
-      - name: Cache node modules
-        uses: actions/cache@v1
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Lerna bootstrap

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -21,16 +21,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
-      - name: Cache node modules
-        uses: actions/cache@v1
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Lerna bootstrap

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -6,6 +6,11 @@ on:
       - master
       - dev
 
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   perftest:
     runs-on: ubuntu-latest
@@ -20,23 +25,29 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
-      - name: Cache node modules for PR
-        uses: actions/cache@v1
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages for PR
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Lerna bootstrap for PR
         run: npx lerna bootstrap
 
       - name: Use Node.js 16.15.x for PR
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.15.x
 
@@ -57,18 +68,21 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Cache node modules for base ref
-        uses: actions/cache@v1
+      - name: Cache dependencies for base ref
+        id: cache-npm-base-ref
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-base-ref-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-base-ref-${{ hashFiles('package-lock.json') }}
+            npm-base-ref
 
       - name: Setup packages for base ref
-        run: |
-          npm i -g --no-audit npm@6.14.17 
-          npm ci --no-progress
+        if: ${{ steps.cache-npm-base-ref.outputs.cache-hit != 'true' }}
+        run: npm ci --no-progress
 
       - name: Lerna bootstrap for base ref
         run: npx lerna bootstrap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
     types:
       - completed
 
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: Publish
@@ -37,16 +42,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
-      - name: Cache node modules
-        uses: actions/cache@v1
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Lerna bootstrap

--- a/.github/workflows/tests-17.yml
+++ b/.github/workflows/tests-17.yml
@@ -11,6 +11,11 @@ on:
       - dev
       - master
 
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
@@ -28,16 +33,23 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        run: npm ci --no-progress
+
+      - name: Setup react@17
         run: |
-          npm ci --no-progress
           npm i react@17 react-dom@17 --no-progress --prefix="./packages/plasma-ui"
           npm i react@17 react-dom@17 --no-progress --prefix="./packages/plasma-temple"
           npm i react@17 react-dom@17 --no-progress --prefix="./packages/plasma-b2c"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,11 @@ on:
       - dev
       - master
 
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
@@ -26,16 +31,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Lerna bootstrap

--- a/.github/workflows/theme-builder-pr.yml
+++ b/.github/workflows/theme-builder-pr.yml
@@ -6,6 +6,11 @@ on:
       - dev
       - master
 
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
@@ -23,17 +28,23 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
-      - name: Cache node modules
-        uses: actions/cache@v1
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       # ToDo: https://github.com/salute-developers/plasma/issues/255
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Prepare directory for build

--- a/.github/workflows/theme-builder.yml
+++ b/.github/workflows/theme-builder.yml
@@ -21,17 +21,23 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
-      - name: Cache node modules
-        uses: actions/cache@v1
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
         with:
-          path: node_modules
-          key: npm-deps-${{ hashFiles('package-lock.json') }}
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            npm-deps-${{ hashFiles('package-lock.json') }}
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       # ToDo: https://github.com/salute-developers/plasma/issues/255
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Prepare directory build

--- a/.github/workflows/typescript-coverage.yml
+++ b/.github/workflows/typescript-coverage.yml
@@ -1,6 +1,7 @@
 name: Typescript coverage
 
 on:
+  merge_group:
   pull_request:
     branches:
       - master

--- a/.github/workflows/typescript-coverage.yml
+++ b/.github/workflows/typescript-coverage.yml
@@ -1,7 +1,15 @@
 name: Typescript coverage
 
 on:
-  push:
+  pull_request:
+    branches:
+      - master
+      - dev
+
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   typescript-coverage:
@@ -15,8 +23,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Lerna bootstrap

--- a/.github/workflows/versionate-docs.yml
+++ b/.github/workflows/versionate-docs.yml
@@ -25,8 +25,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
 
       - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
       - name: Setup packages


### PR DESCRIPTION
### Мотивация

Необходимо ускорить наш CI. 

Один из способов это, начинать использовать **cache** для ускорения установки зависимостей.

#### Область видимости для cache

> Access restrictions provide cache isolation and security by creating a logical boundary between different branches or tags. > Workflow runs can restore caches created in either the current branch or the default branch (usually main). 

> If a workflow run is triggered for a pull request, it can also restore caches created in the base branch, including base branches of forked repositories.

#### Документация

[actions/setup-node](
https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#working-with-lockfiles)

[actions/cache ](https://github.com/actions/cache)

[restrictions-for-accessing-a-cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)

На скриншотах данные по запускам. Сверху вниз. 

Первый запуск без использования **cache**, последующие запуски уже с ним.       

#### Component Performance Testing

<img width="1449" alt="Screenshot 2023-05-30 at 22 51 59" src="https://github.com/salute-developers/plasma/assets/2895992/69b272e6-a306-4ffb-80ba-391d06ae80a9">

#### Typescript coverage
<img width="1893" alt="Screenshot 2023-06-01 at 13 29 00" src="https://github.com/salute-developers/plasma/assets/2895992/b43e990e-c516-4f47-b2c6-b85dd543f288">


### Примечания 

На скриншоте для `Typescript coverage` можно увидеть **"аномалию"** с включенным **cache** время исполнения процесса даже дольше (12м39сек), чем у первого запуска. 

В данном случае самый долгий процесс это `npx lerna bootstrap` и он не всегда проходит стабильно за одно и тоже время, бывают отклонения, что и произошло в этом запуске.

Все последующие улучшения связанные с CI будут направлены на стабилизацию и ускорения шага с `npx lerna bootstrap`.                     

-----------

#### Using concurrency

Так же добавили логику для отключения workflows в PR на событие push, что не отключать руками и не засорять ресурсы.        

[Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency)


---------

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[color_sberHealth_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.531.5145055056.swift)  
[color_sberHealth_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.531.5145055056.kt)  
[color_sberHealth_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.531.5145055056.ts)  
[color_sbermarket_business_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_ios-swift--canary.531.5145055056.swift)  
[color_sbermarket_business_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_kotlin--canary.531.5145055056.kt)  
[color_sbermarket_business_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_react-native--canary.531.5145055056.ts)  
[color_sbermarket_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.531.5145055056.swift)  
[color_sbermarket_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.531.5145055056.kt)  
[color_sbermarket_metro_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_ios-swift--canary.531.5145055056.swift)  
[color_sbermarket_metro_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_kotlin--canary.531.5145055056.kt)  
[color_sbermarket_metro_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_react-native--canary.531.5145055056.ts)  
[color_sbermarket_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.531.5145055056.ts)  
[color_sbermarket_selgros_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_ios-swift--canary.531.5145055056.swift)  
[color_sbermarket_selgros_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_kotlin--canary.531.5145055056.kt)  
[color_sbermarket_selgros_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_react-native--canary.531.5145055056.ts)  
[color_sbermarket_wlbusiness_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_ios-swift--canary.531.5145055056.swift)  
[color_sbermarket_wlbusiness_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_kotlin--canary.531.5145055056.kt)  
[color_sbermarket_wlbusiness_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_react-native--canary.531.5145055056.ts)  
[color_sberonline_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_ios-swift--canary.531.5145055056.swift)  
[color_sberonline_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_kotlin--canary.531.5145055056.kt)  
[color_sberonline_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_react-native--canary.531.5145055056.ts)  
[color_sberprime_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.531.5145055056.swift)  
[color_sberprime_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.531.5145055056.kt)  
[color_sberprime_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.531.5145055056.ts)  
[shadow_sbermarket_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.531.5145055056.ts)  
[typo_mage_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.531.5145055056.swift)  
[typo_mage_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.531.5145055056.kt)  
[typo_mage_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.531.5145055056.ts)  
[typo_plasma_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.531.5145055056.swift)  
[typo_plasma_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.531.5145055056.kt)  
[typo_plasma_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.531.5145055056.ts)  
[typo_ruler_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.531.5145055056.swift)  
[typo_ruler_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.531.5145055056.kt)  
[typo_ruler_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.531.5145055056.ts)  
[typo_sage_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.531.5145055056.swift)  
[typo_sage_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.531.5145055056.kt)  
[typo_sage_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.531.5145055056.ts)  
[typo_sbermarket_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.531.5145055056.swift)  
[typo_sbermarket_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.531.5145055056.kt)  
[typo_sbermarket_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.531.5145055056.ts)  
[typo_soulmate_ios-swift--canary.531.5145055056.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.531.5145055056.swift)  
[typo_soulmate_kotlin--canary.531.5145055056.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.531.5145055056.kt)  
[typo_soulmate_react-native--canary.531.5145055056.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.531.5145055056.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.215.1-canary.531.5145055056.0
  npm install @salutejs/plasma-core@1.120.1-canary.531.5145055056.0
  npm install @salutejs/plasma-hope@1.215.1-canary.531.5145055056.0
  npm install @salutejs/plasma-icons@1.149.1-canary.531.5145055056.0
  npm install @salutejs/plasma-temple@1.164.1-canary.531.5145055056.0
  npm install @salutejs/plasma-tokens@1.54.1-canary.531.5145055056.0
  npm install @salutejs/plasma-typo@0.33.1-canary.531.5145055056.0
  npm install @salutejs/plasma-ui@1.196.1-canary.531.5145055056.0
  npm install @salutejs/plasma-web@1.215.1-canary.531.5145055056.0
  npm install @salutejs/plasma-cy-utils@0.61.1-canary.531.5145055056.0
  npm install @salutejs/plasma-sb-utils@0.118.1-canary.531.5145055056.0
  # or 
  yarn add @salutejs/plasma-b2c@1.215.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-core@1.120.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-hope@1.215.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-icons@1.149.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-temple@1.164.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-tokens@1.54.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-typo@0.33.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-ui@1.196.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-web@1.215.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-cy-utils@0.61.1-canary.531.5145055056.0
  yarn add @salutejs/plasma-sb-utils@0.118.1-canary.531.5145055056.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
