### PR TITLE
fix(plasma-core, plasma-hope): Add promise resolve for forceUpdate method in `Popup` and `Tooltip` components

### DIFF
--- a/packages/plasma-core/src/components/Popup/Popup.tsx
+++ b/packages/plasma-core/src/components/Popup/Popup.tsx
@@ -158,8 +158,14 @@ export const Popup = memo<PopupProps & RefAttributes<HTMLDivElement>>(
                     return;
                 }
 
-                forceUpdate();
-            }, [isOpen]);
+                /*
+                 * INFO: Метод forceUpdate содержит в себе flushSync и приводит
+                 * к повторному рендеру компонента, который уже находится в процессе рендера.
+                 * Данный хак, нужен для того, чтобы это поведение избежать и перенаправить
+                 * вызов метода в очередь микрозадач.
+                 */
+                Promise.resolve().then(forceUpdate);
+            }, [isOpen, forceUpdate]);
 
             return (
                 <StyledRoot

--- a/packages/plasma-hope/src/components/Tooltip/Tooltip.tsx
+++ b/packages/plasma-hope/src/components/Tooltip/Tooltip.tsx
@@ -154,8 +154,14 @@ export const Tooltip = forwardRef<HTMLSpanElement, TooltipProps>(
                 return;
             }
 
-            forceUpdate();
-        }, [isVisible]);
+            /*
+             * INFO: Метод forceUpdate содержит в себе flushSync и приводит
+             * к повторному рендеру компонента, который уже находится в процессе рендера.
+             * Данный хак, нужен для того, чтобы это поведение избежать и перенаправить
+             * вызов метода в очередь микрозадач.
+             */
+            Promise.resolve().then(forceUpdate);
+        }, [isVisible, forceUpdate]);
 
         return (
             <>


### PR DESCRIPTION
Исправлено поведение компонентов `Tooltip` и `Popup`, при использовании которых при изменении стейта возникала ошибка: Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task. 

Это связано с тем, что в новой версии библиотеки `popper`  метод `forceUpdate` содержит в себе `flushSync` и [приводит](https://github.com/floating-ui/react-popper/issues/458) к повторному рендеру компонента, который уже находится в процессе рендера. 

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[color_sberHealth_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.554.5210791882.swift)  
[color_sberHealth_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.554.5210791882.kt)  
[color_sberHealth_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.554.5210791882.ts)  
[color_sbermarket_business_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_ios-swift--canary.554.5210791882.swift)  
[color_sbermarket_business_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_kotlin--canary.554.5210791882.kt)  
[color_sbermarket_business_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_react-native--canary.554.5210791882.ts)  
[color_sbermarket_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.554.5210791882.swift)  
[color_sbermarket_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.554.5210791882.kt)  
[color_sbermarket_metro_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_ios-swift--canary.554.5210791882.swift)  
[color_sbermarket_metro_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_kotlin--canary.554.5210791882.kt)  
[color_sbermarket_metro_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_react-native--canary.554.5210791882.ts)  
[color_sbermarket_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.554.5210791882.ts)  
[color_sbermarket_selgros_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_ios-swift--canary.554.5210791882.swift)  
[color_sbermarket_selgros_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_kotlin--canary.554.5210791882.kt)  
[color_sbermarket_selgros_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_react-native--canary.554.5210791882.ts)  
[color_sbermarket_wlbusiness_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_ios-swift--canary.554.5210791882.swift)  
[color_sbermarket_wlbusiness_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_kotlin--canary.554.5210791882.kt)  
[color_sbermarket_wlbusiness_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_react-native--canary.554.5210791882.ts)  
[color_sberonline_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_ios-swift--canary.554.5210791882.swift)  
[color_sberonline_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_kotlin--canary.554.5210791882.kt)  
[color_sberonline_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_react-native--canary.554.5210791882.ts)  
[color_sberprime_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.554.5210791882.swift)  
[color_sberprime_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.554.5210791882.kt)  
[color_sberprime_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.554.5210791882.ts)  
[shadow_sbermarket_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.554.5210791882.ts)  
[typo_mage_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.554.5210791882.swift)  
[typo_mage_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.554.5210791882.kt)  
[typo_mage_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.554.5210791882.ts)  
[typo_plasma_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.554.5210791882.swift)  
[typo_plasma_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.554.5210791882.kt)  
[typo_plasma_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.554.5210791882.ts)  
[typo_ruler_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.554.5210791882.swift)  
[typo_ruler_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.554.5210791882.kt)  
[typo_ruler_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.554.5210791882.ts)  
[typo_sage_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.554.5210791882.swift)  
[typo_sage_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.554.5210791882.kt)  
[typo_sage_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.554.5210791882.ts)  
[typo_sbermarket_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.554.5210791882.swift)  
[typo_sbermarket_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.554.5210791882.kt)  
[typo_sbermarket_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.554.5210791882.ts)  
[typo_soulmate_ios-swift--canary.554.5210791882.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.554.5210791882.swift)  
[typo_soulmate_kotlin--canary.554.5210791882.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.554.5210791882.kt)  
[typo_soulmate_react-native--canary.554.5210791882.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.554.5210791882.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.216.1-canary.554.5210791882.0
  npm install @salutejs/plasma-core@1.121.1-canary.554.5210791882.0
  npm install @salutejs/plasma-hope@1.216.1-canary.554.5210791882.0
  npm install @salutejs/plasma-icons@1.150.1-canary.554.5210791882.0
  npm install @salutejs/plasma-temple@1.165.1-canary.554.5210791882.0
  npm install @salutejs/plasma-tokens-b2b@1.21.1-canary.554.5210791882.0
  npm install @salutejs/plasma-tokens-b2c@0.30.1-canary.554.5210791882.0
  npm install @salutejs/plasma-tokens-web@1.36.1-canary.554.5210791882.0
  npm install @salutejs/plasma-tokens@1.55.1-canary.554.5210791882.0
  npm install @salutejs/plasma-ui@1.197.1-canary.554.5210791882.0
  npm install @salutejs/plasma-web@1.216.1-canary.554.5210791882.0
  npm install @salutejs/plasma-cy-utils@0.62.1-canary.554.5210791882.0
  npm install @salutejs/plasma-sb-utils@0.119.1-canary.554.5210791882.0
  npm install @salutejs/plasma-tokens-utils@0.26.1-canary.554.5210791882.0
  # or 
  yarn add @salutejs/plasma-b2c@1.216.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-core@1.121.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-hope@1.216.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-icons@1.150.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-temple@1.165.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-tokens-b2b@1.21.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-tokens-b2c@0.30.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-tokens-web@1.36.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-tokens@1.55.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-ui@1.197.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-web@1.216.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-cy-utils@0.62.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-sb-utils@0.119.1-canary.554.5210791882.0
  yarn add @salutejs/plasma-tokens-utils@0.26.1-canary.554.5210791882.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
