### PR TITLE
ci: add cache for perftool tasks

### DIFF
--- a/.github/workflows/performance-test-base.yml
+++ b/.github/workflows/performance-test-base.yml
@@ -1,0 +1,77 @@
+name: Perftest (base branch cache)
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+
+jobs:
+  perftest:
+    runs-on: ubuntu-latest
+    env:
+      NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Cache dependencies
+        id: cache-npm
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            ~/.cache
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ hashFiles('package-lock.json') }}
+            npm-
+
+      - name: Setup packages
+        if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        run: npm ci --no-progress
+
+      - name: Lerna bootstrap
+        run: npx lerna bootstrap
+
+      - name: Install s3cmd
+        run: pip3 install s3cmd
+
+      - name: Restore perftool cache
+        run: >
+          s3cmd
+          --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+          --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          --host ${{ secrets.AWS_ENDPOINT }}
+          --host-bucket ${{ secrets.AWS_ENDPOINT }}
+          --bucket-location ${{ secrets.AWS_REGION }}
+          --signature-v2
+          --no-mime-magic
+          sync
+          s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
+          ./.perftool/cache/
+
+      - name: Run performance test
+        run: >
+          npx perftool
+          --currentBranchRef ${{ github.sha }}
+
+      - name: Save perftool cache
+        run: >
+          s3cmd
+          --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+          --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          --host ${{ secrets.AWS_ENDPOINT }}
+          --host-bucket ${{ secrets.AWS_ENDPOINT }}
+          --bucket-location ${{ secrets.AWS_REGION }}
+          --signature-v2
+          --delete-removed
+          --no-mime-magic
+          sync
+          ./.perftool/cache/
+          s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/

--- a/.github/workflows/performance-test-pr.yml
+++ b/.github/workflows/performance-test-pr.yml
@@ -17,15 +17,17 @@ jobs:
     env:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       PR_NAME: pr-${{ github.event.number }}
-      ICONS_PUBLIC_URL: /icons
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Setup Node.js for PR
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+
+      - name: Install s3cmd
+        run: pip3 install s3cmd
 
       - name: Cache dependencies
         id: cache-npm
@@ -46,29 +48,33 @@ jobs:
       - name: Lerna bootstrap for PR
         run: npx lerna bootstrap
 
-      - name: Use Node.js 16.15.x for PR
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.15.x
+      - name: Restore perftool cache
+        run: >
+          s3cmd
+          --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+          --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          --host ${{ secrets.AWS_ENDPOINT }}
+          --host-bucket ${{ secrets.AWS_ENDPOINT }}
+          --bucket-location ${{ secrets.AWS_REGION }}
+          --signature-v2
+          --no-mime-magic
+          sync
+          s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
+          ./.perftool/cache/
 
       - name: Run performance test for PR
-        run: |
-          npx perftool -o perftest/pr-result.json
+        run: >
+          npx perftool
+          -o perftest/pr-result.json
+          --baseBranchRef ${{ github.event.pull_request.base.sha }}
+          --currentBranchRef ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
-          ref: ${{github.event.pull_request.base.ref}}
+          ref: ${{ github.event.pull_request.base.ref }}
           clean: false
 
-      - name: Prepare repository for base ref
-        run: git fetch --unshallow --tags
-
-      - name: Setup Node.js for base ref
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Cache dependencies for base ref
+      - name: Cache dependencies for ${{ github.event.pull_request.base.ref }}
         id: cache-npm-base-ref
         uses: actions/cache@v3
         with:
@@ -80,25 +86,39 @@ jobs:
             npm-base-ref-${{ hashFiles('package-lock.json') }}
             npm-base-ref
 
-      - name: Setup packages for base ref
+      - name: Setup packages for ${{ github.event.pull_request.base.ref }}
         if: ${{ steps.cache-npm-base-ref.outputs.cache-hit != 'true' }}
         run: npm ci --no-progress
 
-      - name: Lerna bootstrap for base ref
+      - name: Lerna bootstrap for ${{ github.event.pull_request.base.ref }}
         run: npx lerna bootstrap
 
-      - name: Use Node.js 16.15.x for base ref
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16.15.x
+      - name: Run performance test for ${{ github.event.pull_request.base.ref }}
+        run: >
+          npx perftool
+          -o perftest/base-result.json
+          --currentBranchRef ${{ github.event.pull_request.base.sha }}
 
-      - name: Run performance test for base ref
-        run: |
-          npx perftool -o perftest/master-result.json
+      - name: Save perftool cache
+        run: >
+          s3cmd
+          --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+          --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          --host ${{ secrets.AWS_ENDPOINT }}
+          --host-bucket ${{ secrets.AWS_ENDPOINT }}
+          --bucket-location ${{ secrets.AWS_REGION }}
+          --signature-v2
+          --no-mime-magic
+          sync
+          ./.perftool/cache/
+          s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
 
       - name: Compare test results
-        run: |
-          npx perftool-compare -o perftest/comparison.json perftest/pr-result.json perftest/master-result.json
+        run: >
+          npx perftool-compare
+          -o perftest/comparison.json
+          perftest/pr-result.json
+          perftest/base-result.json
 
       - name: Save comparison result
         if: always()
@@ -176,8 +196,8 @@ jobs:
             });
 
       - name: Send report
-        run: |
-          ./scripts/perftool-send-report.js \
+        run: >
+          ./scripts/perftool-send-report.js
           --reportPath /home/runner/work/plasma/plasma/perftest/comparison.json
         env:
           GITHUB_SHA: ${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ cypress/results
 coverage
 coverage-ts
 perftest
+.perftool
 s3_build
 temp

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@cypress/react": "5.9.2",
         "@cypress/webpack-dev-server": "1.4.0",
         "@cypress/webpack-preprocessor": "5.9.1",
-        "@salutejs/perftool": "0.7.0",
+        "@salutejs/perftool": "0.10.1",
         "@storybook/addon-actions": "6.0.0-rc.13",
         "@storybook/addon-backgrounds": "6.0.0-rc.13",
         "@storybook/addon-knobs": "6.0.0-rc.13",
@@ -80,7 +80,7 @@
         "stylelint-prettier": "1.1.2",
         "stylelint-processor-styled-components": "1.10.0",
         "ts-loader": "9.2.3",
-        "typescript": "5.0.4",
+        "typescript": "4.0.8",
         "webpack": "5.46.0",
         "webpack-dev-server": "3.11.2"
       },
@@ -5910,6 +5910,38 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
     "node_modules/@lerna/child-process": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-6.5.1.tgz",
@@ -7771,9 +7803,9 @@
       }
     },
     "node_modules/@salutejs/perftool": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/perftool/-/perftool-0.7.0.tgz",
-      "integrity": "sha512-03YUvDYYWjtnFf1YKfK5pEmpV2Vxvn00uEoXCVVpP6r5m3gLrv+xoDCriZLgXnNBVBY6ky42clJhlhys3xyS+g==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@salutejs/perftool/-/perftool-0.10.1.tgz",
+      "integrity": "sha512-aPzZs2mZR2zK210x2jhFaKNGmU7yp08HAHz5WcY0dsKFO/lFdCz6CCcSlm9WkoSuc+7cFLjA3W+0/XJ1zgR4+A==",
       "dev": true,
       "dependencies": {
         "@babel/preset-env": "7.21.4",
@@ -7792,7 +7824,9 @@
         "loglevel-plugin-prefix": "0.8.4",
         "morgan": "1.10.0",
         "puppeteer": "19.9.1",
+        "simple-git": "3.18.0",
         "ts-node": "10.9.1",
+        "typescript": "5.0.4",
         "webpack": "5.79.0"
       },
       "bin": {
@@ -10455,6 +10489,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/@salutejs/perftool/node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/@salutejs/perftool/node_modules/unicode-canonical-property-names-ecmascript": {
@@ -41466,6 +41513,38 @@
         }
       ]
     },
+    "node_modules/simple-git": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.18.0.tgz",
+      "integrity": "sha512-Yt0GJ5aYrpPci3JyrYcsPz8Xc05Hi4JPSOb+Sgn/BmPX35fn/6Fp9Mef8eMBCrL2siY5w4j49TA5Q+bxPpri1Q==",
+      "dev": true,
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -44919,16 +44998,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
+      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/typescript-memoize": {
@@ -51905,6 +51984,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
     "@lerna/child-process": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-6.5.1.tgz",
@@ -53341,9 +53446,9 @@
       }
     },
     "@salutejs/perftool": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/perftool/-/perftool-0.7.0.tgz",
-      "integrity": "sha512-03YUvDYYWjtnFf1YKfK5pEmpV2Vxvn00uEoXCVVpP6r5m3gLrv+xoDCriZLgXnNBVBY6ky42clJhlhys3xyS+g==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@salutejs/perftool/-/perftool-0.10.1.tgz",
+      "integrity": "sha512-aPzZs2mZR2zK210x2jhFaKNGmU7yp08HAHz5WcY0dsKFO/lFdCz6CCcSlm9WkoSuc+7cFLjA3W+0/XJ1zgR4+A==",
       "dev": true,
       "requires": {
         "@babel/preset-env": "7.21.4",
@@ -53362,7 +53467,9 @@
         "loglevel-plugin-prefix": "0.8.4",
         "morgan": "1.10.0",
         "puppeteer": "19.9.1",
+        "simple-git": "3.18.0",
         "ts-node": "10.9.1",
+        "typescript": "5.0.4",
         "webpack": "5.79.0"
       },
       "dependencies": {
@@ -55269,6 +55376,12 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
           "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+          "dev": true
+        },
+        "typescript": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+          "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
           "dev": true
         },
         "unicode-canonical-property-names-ecmascript": {
@@ -79595,6 +79708,28 @@
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "dev": true
     },
+    "simple-git": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.18.0.tgz",
+      "integrity": "sha512-Yt0GJ5aYrpPci3JyrYcsPz8Xc05Hi4JPSOb+Sgn/BmPX35fn/6Fp9Mef8eMBCrL2siY5w4j49TA5Q+bxPpri1Q==",
+      "dev": true,
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -82248,9 +82383,9 @@
       }
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
+      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
       "dev": true
     },
     "typescript-memoize": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@cypress/react": "5.9.2",
     "@cypress/webpack-dev-server": "1.4.0",
     "@cypress/webpack-preprocessor": "5.9.1",
-    "@salutejs/perftool": "0.7.0",
+    "@salutejs/perftool": "0.10.1",
     "@storybook/addon-actions": "6.0.0-rc.13",
     "@storybook/addon-backgrounds": "6.0.0-rc.13",
     "@storybook/addon-knobs": "6.0.0-rc.13",
@@ -111,7 +111,7 @@
     "stylelint-prettier": "1.1.2",
     "stylelint-processor-styled-components": "1.10.0",
     "ts-loader": "9.2.3",
-    "typescript": "5.0.4",
+    "typescript": "4.0.8",
     "webpack": "5.46.0",
     "webpack-dev-server": "3.11.2"
   },

--- a/perftool.config.mts
+++ b/perftool.config.mts
@@ -1,8 +1,8 @@
 import type { Config } from '@salutejs/perftool';
 
 const config: Config = {
-    jobs: 2,
-    retries: 30,
+    jobs: 1,
+    retries: 20,
     taskConfiguration: {
         render: {
             renderWaitTimeout: 500,
@@ -23,6 +23,11 @@ const config: Config = {
     failOnSignificantChanges: true,
     stabilizers: ['staticTask'],
     absoluteError: 1,
+    cache: {
+        taskState: true,
+    },
+    // Remove cache files older than 30 days
+    cacheExpirationTime: 1000 * 60 * 60 * 24 * 30,
     modifyWebpackConfig(config) {
         const babelLoaderOpts = config.module?.rules?.find(
             (rule) => typeof rule === 'object' && rule.loader?.includes('babel-loader'),


### PR DESCRIPTION
**[Hotfix]: Into master**

Дубликат этого PR - #519

### Что изменили: 

>1. update perftool
>2. add base branch workflow for caching
>3. update perftest workflow to use cache
>4. return typescript@4.0.8
>5. remove unnecessary prepare repository step
>6. use one thread for perftool, use 20 retries