### PR TITLE
feat(plasma-tokens-native): Add generate complex gradient for Android

### DIFF
--- a/.github/workflows/typescript-coverage.yml
+++ b/.github/workflows/typescript-coverage.yml
@@ -25,7 +25,8 @@ jobs:
       - uses: ./.github/actions/prepare-environment
 
       - name: Lerna bootstrap
-        run: npx lerna bootstrap --since=$(git merge-base --fork-point origin/dev)
+      # INFO: Игнорируем пакеты связанные с plasma-tokens, т.к. в них не запускается typescript-coverage  
+        run: npx lerna bootstrap --since=$(git merge-base --fork-point origin/dev) --ignore "@salutejs/plasma-tokens*"
 
       - name: Run Typescript Coverage
         if: ${{ always() }}

--- a/utils/plasma-tokens-native/src/generator/formatters/colorXML.ts
+++ b/utils/plasma-tokens-native/src/generator/formatters/colorXML.ts
@@ -1,0 +1,128 @@
+import type { Dictionary, File, TransformedToken } from 'style-dictionary';
+import { lowerFirstLetter } from '@salutejs/plasma-tokens-utils';
+
+import type { GradientType, Point } from '../../types';
+
+const snakelize = (str: string) => str.replace(/([A-Z])/g, '_$1').toLowerCase();
+
+const getXMLTemplate = (themeContent: string) => {
+    const header = '<?xml version="1.0" encoding="UTF-8"?>';
+
+    const resources = `<resources>
+  ${themeContent}
+</resources>`;
+
+    return [header, resources].join('\n');
+};
+
+const getLinearGradient = (name: string, base: string, layerNumber: string) => (startPoint: Point, endPoint: Point) => {
+    const items = `<item name="${name}${layerNumber}_start_point_x" format="float" type="dimen">${startPoint.x}</item>
+  <item name="${name}${layerNumber}_start_point_y" format="float" type="dimen">${startPoint.y}</item>
+  <item name="${name}${layerNumber}_end_point_x" format="float" type="dimen">${endPoint.x}</item> 
+  <item name="${name}${layerNumber}_end_point_y" format="float" type="dimen">${endPoint.y}</item>`;
+
+    return [base, items].join('\n  ');
+};
+
+const getRadialGradient = (name: string, base: string, layerNumber: string) => (center: Point, radius: Point) => {
+    const items = `<item name="${name}${layerNumber}_center_x" format="float" type="dimen">${center.x}</item>
+  <item name="${name}${layerNumber}_center_y" format="float" type="dimen">${center.y}</item>
+  <item name="${name}${layerNumber}_start_radius" format="float" type="dimen">${radius.x}</item> 
+  <item name="${name}${layerNumber}_end_radius" format="float" type="dimen">${radius.y}</item>`;
+
+    return [base, items].join('\n  ');
+};
+
+interface GradientToken {
+    name: string;
+    type: GradientType;
+    layerNumber: string;
+    comment?: string;
+    colors: [string, string];
+    locations: [number, number];
+}
+
+const getGradient = ({ name, type, layerNumber, comment, colors, locations }: GradientToken) => {
+    const base = `<color name="${name}${layerNumber}_color_0">${colors[0]}</color><!-- ${comment} -->
+  <color name="${name}${layerNumber}_color_1">${colors[1]}</color>
+  <item name="${name}${layerNumber}_position_0" format="float" type="dimen">${locations[0]}</item>
+  <item name="${name}${layerNumber}_position_1" format="float" type="dimen">${locations[1]}</item>`;
+
+    if (type === '.linear') {
+        return getLinearGradient(name, base, layerNumber);
+    }
+
+    if (type === '.radial') {
+        return getRadialGradient(name, base, layerNumber);
+    }
+};
+
+const getGradientToken = (name: string, gradient: any, comment?: string, layer?: number) => {
+    const { startColor, endColor, locations, type } = gradient;
+    const layerNumber = layer !== undefined ? `_z${layer}` : '';
+
+    if (!type) {
+        return `<color name="${name}${layerNumber}_background_color">${gradient.backgroundColor}</color>`;
+    }
+
+    const getGradientTokenFunc = getGradient({
+        name,
+        type,
+        comment,
+        colors: [startColor, endColor],
+        locations,
+        layerNumber,
+    });
+
+    if (!getGradientTokenFunc) {
+        return;
+    }
+
+    if (type === '.linear') {
+        return getGradientTokenFunc(gradient.startPoint, gradient.endPoint);
+    }
+
+    if (type === '.radial') {
+        return getGradientTokenFunc(gradient.center, gradient.radius);
+    }
+};
+
+const getTokenValue = (token: TransformedToken, themeName: string) => {
+    const prefix = themeName.includes('asdk') ? 'sdkit_' : ''; // INFO: Условие специально для темы asdk
+
+    const name = token.name.replace(`color_${themeName}_`, prefix);
+    const { comment } = token;
+    const { value } = token.original;
+
+    if (Array.isArray(value)) {
+        const { gradient: gradients } = token.value;
+        const layersCount = gradients.length;
+
+        return gradients
+            .map((gradient: any, index: number) => getGradientToken(name, gradient, comment, layersCount - index - 1))
+            .join('\n  ');
+    }
+
+    if (value.xml) {
+        const { gradient } = token.value;
+        return getGradientToken(name, gradient, comment);
+    }
+
+    return `<color name="${name}">${token.value}</color><!-- ${comment} -->`;
+};
+
+const hasXMLInGradient = (value: any, gradients: any) =>
+    !(Array.isArray(value) && gradients.some((item: any) => item === undefined));
+
+const getTheme = (tokenItems: TransformedToken[], themeName: string) =>
+    tokenItems
+        .filter(({ original, value }) => hasXMLInGradient(original.value, value.gradient))
+        .map((item) => getTokenValue(item, themeName))
+        .join('\n  ');
+
+export const colorXMLCustomFormatter = ({ dictionary, file }: { dictionary: Dictionary; file: File }) => {
+    const themeName = snakelize(lowerFirstLetter(file.className || ''));
+    const theme = getTheme(dictionary.allTokens, themeName);
+
+    return getXMLTemplate(theme);
+};

--- a/utils/plasma-tokens-native/src/generator/formatters/index.ts
+++ b/utils/plasma-tokens-native/src/generator/formatters/index.ts
@@ -1,6 +1,7 @@
 export { colorIosSwiftCustomFormatter } from './colorIosSwift';
 export { colorReactNativeCustomFormatter } from './colorReactNative';
 export { colorKotlinCustomFormatter } from './colorKotlin';
+export { colorXMLCustomFormatter } from './colorXML';
 export { typoIosSwiftCustomFormatter } from './typoIosSwift';
 export { typoReactNativeCustomFormatter } from './typoReactNative';
 export { typoKotlinCustomFormatter } from './typoKotlin';

--- a/utils/plasma-tokens-native/src/generator/index.ts
+++ b/utils/plasma-tokens-native/src/generator/index.ts
@@ -2,9 +2,15 @@ export {
     colorIosSwiftCustomFormatter,
     colorKotlinCustomFormatter,
     colorReactNativeCustomFormatter,
+    colorXMLCustomFormatter,
     typoIosSwiftCustomFormatter,
     typoKotlinCustomFormatter,
     typoReactNativeCustomFormatter,
     shadowReactNativeCustomFormatter,
 } from './formatters';
-export { gradientSwiftTransformer, gradientKotlinTransformer, gradientReactNativeTransformer } from './transformers';
+export {
+    gradientSwiftTransformer,
+    gradientKotlinTransformer,
+    gradientReactNativeTransformer,
+    gradientXMLTransformer,
+} from './transformers';

--- a/utils/plasma-tokens-native/src/generator/transformers/gradientXML.ts
+++ b/utils/plasma-tokens-native/src/generator/transformers/gradientXML.ts
@@ -1,0 +1,81 @@
+import type { TransformedToken } from 'style-dictionary';
+import { getHEXAColor } from '@salutejs/plasma-tokens-utils';
+
+const getNormalizeValue = (color: string) => {
+    const hex = color.slice(1, 7);
+    const alfa = color.length === 9 ? `${color.slice(7)}` : 'FF';
+    return `#${alfa}${hex}`;
+};
+
+const getAndroidColor = (color: string) => {
+    const hexColor = getHEXAColor(color);
+    return getNormalizeValue(hexColor);
+};
+
+const getGradientStops = (colors: Array<string>) => [getAndroidColor(colors[0]), getAndroidColor(colors[1])];
+
+const getGradient = (value: any) => {
+    const { type, colors, locations } = value;
+    const [startColor, endColor] = getGradientStops(colors);
+
+    const base = {
+        type,
+        startColor,
+        endColor,
+        locations,
+    };
+
+    if (type === '.linear') {
+        const { startPoint, endPoint } = value;
+
+        return {
+            ...base,
+            startPoint,
+            endPoint,
+        };
+    }
+
+    if (type === '.radial') {
+        const { center, radius } = value;
+
+        return {
+            ...base,
+            center,
+            radius,
+        };
+    }
+};
+
+const getGradientLayer = (item: any) => {
+    const { xml, backgroundColor } = item;
+
+    if (xml) {
+        return getGradient(xml);
+    }
+
+    if (backgroundColor) {
+        return {
+            backgroundColor: getAndroidColor(backgroundColor),
+        };
+    }
+
+    return undefined;
+};
+
+export const gradientXMLTransformer = (prop: TransformedToken) => {
+    const { value } = prop.original;
+
+    if (Array.isArray(value)) {
+        return {
+            gradient: value.map(getGradientLayer),
+        };
+    }
+
+    const { xml } = value;
+
+    if (xml && xml.colors.length > 1) {
+        return { gradient: getGradient(xml) };
+    }
+
+    return prop.value;
+};

--- a/utils/plasma-tokens-native/src/generator/transformers/index.ts
+++ b/utils/plasma-tokens-native/src/generator/transformers/index.ts
@@ -1,3 +1,4 @@
 export { gradientSwiftTransformer } from './gradientSwift';
 export { gradientKotlinTransformer } from './gradientKotlin';
 export { gradientReactNativeTransformer } from './gradientReactNative';
+export { gradientXMLTransformer } from './gradientXML';


### PR DESCRIPTION
Добавлена генерация наборов токенов для `Android` в формате XML, а так же поддержка сложных (многослойных) градиентов.

Добавлено исключение в воркфлоу `typescript-coverage` на шаге "Lerna bootstrap" для пакетов plasma-tokens-*, т.к. в них не выполняется этот скрипт.

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[color_asdk_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_asdk_ios-swift--canary.565.5387372327.swift)  
[color_asdk_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_asdk_kotlin--canary.565.5387372327.kt)  
[color_asdk_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_asdk_react-native--canary.565.5387372327.ts)  
[color_asdk_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_asdk_xml--canary.565.5387372327.xml)  
[color_sberHealth_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_ios-swift--canary.565.5387372327.swift)  
[color_sberHealth_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_kotlin--canary.565.5387372327.kt)  
[color_sberHealth_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_react-native--canary.565.5387372327.ts)  
[color_sberHealth_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberHealth_xml--canary.565.5387372327.xml)  
[color_sbermarket_business_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_ios-swift--canary.565.5387372327.swift)  
[color_sbermarket_business_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_kotlin--canary.565.5387372327.kt)  
[color_sbermarket_business_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_react-native--canary.565.5387372327.ts)  
[color_sbermarket_business_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_business_xml--canary.565.5387372327.xml)  
[color_sbermarket_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_ios-swift--canary.565.5387372327.swift)  
[color_sbermarket_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_kotlin--canary.565.5387372327.kt)  
[color_sbermarket_metro_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_ios-swift--canary.565.5387372327.swift)  
[color_sbermarket_metro_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_kotlin--canary.565.5387372327.kt)  
[color_sbermarket_metro_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_react-native--canary.565.5387372327.ts)  
[color_sbermarket_metro_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_metro_xml--canary.565.5387372327.xml)  
[color_sbermarket_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_react-native--canary.565.5387372327.ts)  
[color_sbermarket_selgros_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_ios-swift--canary.565.5387372327.swift)  
[color_sbermarket_selgros_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_kotlin--canary.565.5387372327.kt)  
[color_sbermarket_selgros_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_react-native--canary.565.5387372327.ts)  
[color_sbermarket_selgros_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_selgros_xml--canary.565.5387372327.xml)  
[color_sbermarket_wlbusiness_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_ios-swift--canary.565.5387372327.swift)  
[color_sbermarket_wlbusiness_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_kotlin--canary.565.5387372327.kt)  
[color_sbermarket_wlbusiness_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_react-native--canary.565.5387372327.ts)  
[color_sbermarket_wlbusiness_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_wlbusiness_xml--canary.565.5387372327.xml)  
[color_sbermarket_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sbermarket_xml--canary.565.5387372327.xml)  
[color_sberonline_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_ios-swift--canary.565.5387372327.swift)  
[color_sberonline_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_kotlin--canary.565.5387372327.kt)  
[color_sberonline_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_react-native--canary.565.5387372327.ts)  
[color_sberonline_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberonline_xml--canary.565.5387372327.xml)  
[color_sberprime_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_ios-swift--canary.565.5387372327.swift)  
[color_sberprime_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_kotlin--canary.565.5387372327.kt)  
[color_sberprime_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_react-native--canary.565.5387372327.ts)  
[color_sberprime_xml--canary.565.5387372327.xml](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/color_sberprime_xml--canary.565.5387372327.xml)  
[shadow_sbermarket_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/shadow_sbermarket_react-native--canary.565.5387372327.ts)  
[typo_mage_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_ios-swift--canary.565.5387372327.swift)  
[typo_mage_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_kotlin--canary.565.5387372327.kt)  
[typo_mage_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_mage_react-native--canary.565.5387372327.ts)  
[typo_plasma_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_ios-swift--canary.565.5387372327.swift)  
[typo_plasma_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_kotlin--canary.565.5387372327.kt)  
[typo_plasma_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_plasma_react-native--canary.565.5387372327.ts)  
[typo_ruler_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_ios-swift--canary.565.5387372327.swift)  
[typo_ruler_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_kotlin--canary.565.5387372327.kt)  
[typo_ruler_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_ruler_react-native--canary.565.5387372327.ts)  
[typo_sage_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_ios-swift--canary.565.5387372327.swift)  
[typo_sage_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_kotlin--canary.565.5387372327.kt)  
[typo_sage_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sage_react-native--canary.565.5387372327.ts)  
[typo_sbermarket_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_ios-swift--canary.565.5387372327.swift)  
[typo_sbermarket_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_kotlin--canary.565.5387372327.kt)  
[typo_sbermarket_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_sbermarket_react-native--canary.565.5387372327.ts)  
[typo_soulmate_ios-swift--canary.565.5387372327.swift](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_ios-swift--canary.565.5387372327.swift)  
[typo_soulmate_kotlin--canary.565.5387372327.kt](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_kotlin--canary.565.5387372327.kt)  
[typo_soulmate_react-native--canary.565.5387372327.ts](https://github.com/salute-developers/plasma/releases/download/v0.0.0-canary/typo_soulmate_react-native--canary.565.5387372327.ts)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.218.0-canary.565.5387372327.0
  npm install @salutejs/cra-template-plasma-basic-template@2.4.0-canary.565.5387372327.0
  npm install @salutejs/plasma-colors@0.8.0-canary.565.5387372327.0
  npm install @salutejs/plasma-core@1.123.0-canary.565.5387372327.0
  npm install @salutejs/plasma-hope@1.218.0-canary.565.5387372327.0
  npm install @salutejs/plasma-icons@1.152.0-canary.565.5387372327.0
  npm install @salutejs/cra-template-plasma-shop-template@2.3.0-canary.565.5387372327.0
  npm install @salutejs/plasma-temple@1.167.0-canary.565.5387372327.0
  npm install @salutejs/plasma-tokens-b2b@1.23.0-canary.565.5387372327.0
  npm install @salutejs/plasma-tokens-b2c@0.32.0-canary.565.5387372327.0
  npm install @salutejs/plasma-tokens-core@0.3.0-canary.565.5387372327.0
  npm install @salutejs/plasma-tokens-web@1.38.0-canary.565.5387372327.0
  npm install @salutejs/plasma-tokens@1.57.0-canary.565.5387372327.0
  npm install @salutejs/plasma-typo@0.35.0-canary.565.5387372327.0
  npm install @salutejs/plasma-ui@1.199.0-canary.565.5387372327.0
  npm install @salutejs/plasma-web@1.218.0-canary.565.5387372327.0
  npm install @salutejs/plasma-cy-utils@0.64.0-canary.565.5387372327.0
  npm install @salutejs/plasma-sb-utils@0.121.0-canary.565.5387372327.0
  npm install @salutejs/plasma-tokens-utils@0.28.0-canary.565.5387372327.0
  # or 
  yarn add @salutejs/plasma-b2c@1.218.0-canary.565.5387372327.0
  yarn add @salutejs/cra-template-plasma-basic-template@2.4.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-colors@0.8.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-core@1.123.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-hope@1.218.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-icons@1.152.0-canary.565.5387372327.0
  yarn add @salutejs/cra-template-plasma-shop-template@2.3.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-temple@1.167.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-tokens-b2b@1.23.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-tokens-b2c@0.32.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-tokens-core@0.3.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-tokens-web@1.38.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-tokens@1.57.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-typo@0.35.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-ui@1.199.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-web@1.218.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-cy-utils@0.64.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-sb-utils@0.121.0-canary.565.5387372327.0
  yarn add @salutejs/plasma-tokens-utils@0.28.0-canary.565.5387372327.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
