### PR TITLE
Fix perftest workflow

### DIFF
--- a/.github/workflows/performance-test-pr.yml
+++ b/.github/workflows/performance-test-pr.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache_base
-        uses: actions/cache/restore@v3
+        uses: actions/cache@v3
         with:
           path: ~/.cache
           key: cache-${{ hashFiles('package-lock.json') }}

--- a/scripts/perftool-send-report.js
+++ b/scripts/perftool-send-report.js
@@ -32,11 +32,19 @@ async function perftoolSendReport() {
         return;
     }
 
+    if (!Object.keys(result).length) {
+        console.info('No data to send');
+        return;
+    }
+
     console.info('Sending report...');
     const data = {
-        staticTaskChange,
         ...result,
     };
+
+    if (staticTaskChange) {
+        data.staticTaskChange = staticTaskChange;
+    }
 
     const body = [];
     const sessionId = crypto.randomUUID();
@@ -49,7 +57,7 @@ async function perftoolSendReport() {
                 const metric = data[componentId][taskId][metricId];
                 for (const typeId of ['old', 'new', 'change']) {
                     const item = {
-                        ua: 'perftool',
+                        ua: 'perftest/packages/plasma',
                         hostname: commitHash,
                         sessionId,
                         path: componentId,


### PR DESCRIPTION
1) Фиксит падение отправки в кликхаус (отсутствие staticTaskChange) (по мотивам https://github.com/salute-developers/plasma/actions/runs/5821423853/job/15783925109?pr=648). + не делает запрос если нечего отправлять
2) Добавляет создание кэша в ПРном прогоне базовой ветки (см https://github.com/salute-developers/plasma/pull/644#discussion_r1289868395)