### PR TITLE
plasma-infra: Pass GitHub token to action

### DIFF
--- a/.github/actions/update-package-lock/action.yml
+++ b/.github/actions/update-package-lock/action.yml
@@ -7,6 +7,9 @@ inputs:
     description: 'Commit message when updated package-lock'
     required: false
     default: 'chore: update package-locks [skip ci]'
+  token:
+    description: 'A Github Token'
+    required: true
 
 runs:
   using: "composite"
@@ -28,7 +31,7 @@ runs:
     - name: Commit & Push package-lock's
       uses: actions-js/push@master
       with:
-        github_token: ${{ secrets.GH_TOKEN }}
+        github_token: ${{ inputs.token }}
         message: ${{ inputs.commit-message }}
         branch: ${{ steps.branch_name.outputs.BRANCH }}
         author_name: Salute Frontend Team

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -15,5 +15,7 @@ jobs:
   publish:
     name: Publish canary version
     uses: ./.github/workflows/publish-common.yml
+    with:
+      cmd: 'bootstrap:since'
     secrets: inherit
 

--- a/.github/workflows/publish-common.yml
+++ b/.github/workflows/publish-common.yml
@@ -51,3 +51,4 @@ jobs:
         uses: ./.github/actions/update-package-lock
         with:
           commit-message: ${{ inputs.commit-message }}
+          token: ${{ env.GH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "api:generate-report": "lerna run api-report --since=$(git merge-base --fork-point origin/dev) --no-bail --stream",
     "api:diff": "./scripts/stable-diff.sh packages/plasma-web/api/* packages/plasma-b2c/api/* > reports/plasma-hope-diff.diff || echo 'diff generated'",
     "api:report": "npm run api:generate-report",
-    "release": "git diff && auto shipit",
+    "release": "tsc -p auto-plugins/tsconfig.json && git diff && auto shipit",
     "cy:clean": "rm -rf cypress/{results,reports,screenshots,videos}",
     "cy:accept-diffs": "docker run -it --rm -v $PWD:/e2e -w /e2e -e CYPRESS_updateSnapshots=true -e CYPRESS_BASE_URL=${PUBLIC_URL:-'http://host.docker.internal:6006'} cypress/included:8.0.0 run --browser chrome",
     "cy:run": "docker run -it --rm -v $PWD:/e2e -w /e2e -e CYPRESS_BASE_URL=${PUBLIC_URL:-'http://host.docker.internal:6006'} cypress/included:8.0.0 run --browser chrome",


### PR DESCRIPTION
## Release Notes

Добавлен GitHub token для корректной работы action - "Update package-lock files after publish RC or latest version"

## What/why Changed

Как оказалось secrets **не наследуются** для action(using: "composite"). 

Поэтому был добавлен соответствующий `inputs.token`  