### PR TITLE
plasma-icons: add SberSpasibo

### DIFF
--- a/packages/plasma-icons/src/Icon.assets/SberSpasibo.tsx
+++ b/packages/plasma-icons/src/Icon.assets/SberSpasibo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { IconProps } from '../IconRoot';
+
+export const SberSpasibo: React.FC<IconProps> = (props) => (
+    <svg width="100%" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+        <path
+            d="M8 2C4.7 2 2 4.7 2 8V14H8C11.3 14 14 11.3 14 8C14 4.7 11.3 2 8 2ZM8.05 11.2C6.3 11.2 4.85 9.75 4.85 8C4.85 6.25 6.3 4.8 8.05 4.8C9.05 4.8 9.95 5.25 10.55 6L9.25 7.05C8.95 6.7 8.55 6.5 8.05 6.5C7.2 6.5 6.55 7.2 6.55 8C6.55 8.85 7.25 9.5 8.05 9.5C8.5 9.5 8.95 9.3 9.25 8.9L10.6 9.95C10 10.75 9.05 11.2 8.05 11.2Z"
+            fill="currentColor"
+        />
+    </svg>
+);

--- a/packages/plasma-icons/src/Icon.tsx
+++ b/packages/plasma-icons/src/Icon.tsx
@@ -173,6 +173,7 @@ import { Pip1 } from './Icon.assets/Pip1';
 import { StoreGamepad } from './Icon.assets/StoreGamepad';
 import { StoreRemote } from './Icon.assets/StoreRemote';
 import { Ticket } from './Icon.assets/Ticket';
+import { SberSpasibo } from './Icon.assets/SberSpasibo';
 // Logo
 import { Salute } from './Icon.assets/Salute';
 import { SaluteCircle } from './Icon.assets/SaluteCircle';
@@ -365,6 +366,7 @@ export const iconSectionsSet = {
         storeGamepad: StoreGamepad,
         storeRemote: StoreRemote,
         ticket: Ticket,
+        sberSpasibo: SberSpasibo,
     },
     logo: {
         salute: Salute,

--- a/packages/plasma-icons/src/Icons/IconSberSpasibo.tsx
+++ b/packages/plasma-icons/src/Icons/IconSberSpasibo.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import { SberSpasibo } from '../Icon.assets/SberSpasibo';
+import { IconRoot, IconProps } from '../IconRoot';
+
+export const IconSberSpasibo: React.FC<IconProps> = ({ size = 's', color, className }) => {
+    return <IconRoot className={className} size={size} color={color} icon={SberSpasibo} />;
+};

--- a/packages/plasma-icons/src/index.ts
+++ b/packages/plasma-icons/src/index.ts
@@ -172,6 +172,7 @@ export { IconPip1 } from './Icons/IconPip1';
 export { IconStoreGamepad } from './Icons/IconStoreGamepad';
 export { IconStoreRemote } from './Icons/IconStoreRemote';
 export { IconTicket } from './Icons/IconTicket';
+export { IconSberSpasibo } from './Icons/IconSberSpasibo';
 // Logo
 export { IconSalute } from './Icons/IconSalute';
 export { IconSaluteCircle } from './Icons/IconSaluteCircle';


### PR DESCRIPTION
## Release Notes

Добавлена иконка: 

<img width="79" alt="Screenshot 2023-08-24 at 16 39 45" src="https://github.com/salute-developers/plasma/assets/2895992/4def910b-2594-4f1d-999d-51ad71b53ae2">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.223.0-canary.669.6033062361.0
  npm install @salutejs/plasma-hope@1.223.0-canary.669.6033062361.0
  npm install @salutejs/plasma-icons@1.157.0-canary.669.6033062361.0
  npm install @salutejs/plasma-temple@1.172.0-canary.669.6033062361.0
  npm install @salutejs/plasma-ui@1.204.0-canary.669.6033062361.0
  npm install @salutejs/plasma-web@1.223.0-canary.669.6033062361.0
  # or 
  yarn add @salutejs/plasma-b2c@1.223.0-canary.669.6033062361.0
  yarn add @salutejs/plasma-hope@1.223.0-canary.669.6033062361.0
  yarn add @salutejs/plasma-icons@1.157.0-canary.669.6033062361.0
  yarn add @salutejs/plasma-temple@1.172.0-canary.669.6033062361.0
  yarn add @salutejs/plasma-ui@1.204.0-canary.669.6033062361.0
  yarn add @salutejs/plasma-web@1.223.0-canary.669.6033062361.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
