### PR TITLE
Fix perftool cache sync

### DIFF
--- a/.github/workflows/performance-test-base.yml
+++ b/.github/workflows/performance-test-base.yml
@@ -32,6 +32,7 @@ jobs:
           --bucket-location ${{ secrets.AWS_REGION }}
           --signature-v2
           --no-mime-magic
+          --no-preserve
           sync
           s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
           ./.perftool/cache/
@@ -52,6 +53,7 @@ jobs:
           --signature-v2
           --delete-removed
           --no-mime-magic
+          --no-preserve
           sync
           ./.perftool/cache/
           s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/

--- a/.github/workflows/performance-test-pr.yml
+++ b/.github/workflows/performance-test-pr.yml
@@ -76,6 +76,7 @@ jobs:
           --bucket-location ${{ secrets.AWS_REGION }}
           --signature-v2
           --no-mime-magic
+          --no-preserve
           sync
           s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
           ./.perftool/cache/
@@ -97,6 +98,7 @@ jobs:
           --bucket-location ${{ secrets.AWS_REGION }}
           --signature-v2
           --no-mime-magic
+          --no-preserve
           sync
           ./.perftool/cache/
           s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/


### PR DESCRIPTION
С s3 начали приходить файлики с некорректными правами доступа/владельцем, причина внешняя, вероятнее всего сменился пользователь на виртуалке. Фикс заключается в удалении пермишенов при загрузке-выгрузке на s3, соответственно при записи файлов устанавливаются дефолтные флаги.