### PR TITLE
plasma-infra: Enable full bootstrap [Publish canary]

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -15,8 +15,6 @@ jobs:
   publish:
     name: Publish canary version
     uses: ./.github/workflows/publish-common.yml
-    with:
-      cmd: 'bootstrap:since'
     secrets:
       gh_token: ${{ secrets.GH_TOKEN }}
       npm_registry_token: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -6,14 +6,7 @@
     "exact": true,
     "command": {
         "bootstrap": {
-            "npmClientArgs": [
-                "--no-audit",
-                "--no-optional",
-                "--loglevel error",
-                "--no-progress",
-                "--unsafe-perm",
-                "--prefer-offline"
-            ]
+            "npmClientArgs": ["--no-audit", "--no-optional", "--loglevel error", "--no-progress", "--unsafe-perm"]
         },
         "publish": {
             "verifyAccess": false


### PR DESCRIPTION
## Release Notes

Выключили флаг `--since` для workflow "Publish Canary" 

## What/why Changed

Столкнулись с тем что во время публикации версии ловим ошибку.

Если коротко то 

1. Делаем `npx lerna bootstrap --since=$(git merge-base --fork-point origin/dev)`
 1.1 Собрали только то что изменили
2. Публикация пытается собрать все и падает с ошибкой     

Если правильно понял - https://github.com/intuit/auto/issues/2081 

Похоже на наш кейс.  

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.221.1-canary.673.5972477545.0
  npm install @salutejs/plasma-colors@0.8.1-canary.673.5972477545.0
  npm install @salutejs/plasma-core@1.126.1-canary.673.5972477545.0
  npm install @salutejs/plasma-hope@1.221.1-canary.673.5972477545.0
  npm install @salutejs/plasma-icons@1.155.1-canary.673.5972477545.0
  npm install @salutejs/cra-template-plasma-shop-template@2.3.1-canary.673.5972477545.0
  npm install @salutejs/plasma-temple@1.170.1-canary.673.5972477545.0
  npm install @salutejs/plasma-tokens-b2b@1.25.1-canary.673.5972477545.0
  npm install @salutejs/plasma-tokens-b2c@0.34.1-canary.673.5972477545.0
  npm install @salutejs/plasma-tokens-core@0.3.1-canary.673.5972477545.0
  npm install @salutejs/plasma-tokens-web@1.40.1-canary.673.5972477545.0
  npm install @salutejs/plasma-tokens@1.59.1-canary.673.5972477545.0
  npm install @salutejs/plasma-typo@0.36.1-canary.673.5972477545.0
  npm install @salutejs/plasma-ui@1.202.1-canary.673.5972477545.0
  npm install @salutejs/plasma-web@1.221.1-canary.673.5972477545.0
  npm install @salutejs/plasma-cy-utils@0.66.1-canary.673.5972477545.0
  npm install @salutejs/plasma-sb-utils@0.124.1-canary.673.5972477545.0
  npm install @salutejs/plasma-tokens-utils@0.30.1-canary.673.5972477545.0
  # or 
  yarn add @salutejs/plasma-b2c@1.221.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-colors@0.8.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-core@1.126.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-hope@1.221.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-icons@1.155.1-canary.673.5972477545.0
  yarn add @salutejs/cra-template-plasma-shop-template@2.3.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-temple@1.170.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-tokens-b2b@1.25.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-tokens-b2c@0.34.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-tokens-core@0.3.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-tokens-web@1.40.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-tokens@1.59.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-typo@0.36.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-ui@1.202.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-web@1.221.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-cy-utils@0.66.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-sb-utils@0.124.1-canary.673.5972477545.0
  yarn add @salutejs/plasma-tokens-utils@0.30.1-canary.673.5972477545.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
