### PR TITLE
plasma-infra: Checkout to "master" ["Main Documentation and Storybook"]

### DIFF
--- a/.github/workflows/documentation-main.yml
+++ b/.github/workflows/documentation-main.yml
@@ -14,7 +14,15 @@ jobs:
     env:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
+      # [NOTE]: В проекте default branch - dev, что бы правильно собрать
+      # актуальную версию для branch master, нужно указать ref = 'master'
       - uses: actions/checkout@v3
+      # [DOC]: About REF. The branch, tag or SHA to checkout. When checking out the repository that
+      # triggered a workflow, this defaults to the reference or SHA for that event.
+      # Otherwise, **uses the default branch**.
+      # [DOC]: Last commit on default branch
+        with:
+          ref: 'master'
 
       - name: Prepare repository
         run: git fetch --unshallow --tags


### PR DESCRIPTION
## Release Notes

Для workflow: 

- `"Main Documentation and Storybook"`

делаем **явный** checkout на **master** ветку. 

### What/why Changed

Что бы правильно собирать документацию после релиза, нужно указать ref на master ветку.

Так как на проекте **default** branch - **dev**. Из-за этого документация собирается под тегем dev.     

[About workflow run](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)

<img width="764" alt="Screenshot 2023-09-11 at 12 58 18" src="https://github.com/salute-developers/plasma/assets/2895992/83ab90d6-7a44-4cde-b3e8-1039b86e54e8">
