### PR TITLE
web-docs: Fix parse components list [Docusaurus]

### DIFF
--- a/website/plasma-web-docs/docusaurus.config.js
+++ b/website/plasma-web-docs/docusaurus.config.js
@@ -158,6 +158,8 @@ module.exports = {
                             await fg([
                                 '../../packages/plasma-web/src/**/*.{ts,tsx}',
                                 '!../../packages/plasma-web/src/**/*.test.*',
+                                '../../packages/plasma-hope/src/**/*.{ts,tsx}',
+                                '!../../packages/plasma-hope/src/**/*.test.*',
                             ]),
                         );
                 },

--- a/website/plasma-web-docs/package.json
+++ b/website/plasma-web-docs/package.json
@@ -14,15 +14,16 @@
         "access": "restricted"
     },
     "scripts": {
+        "NODE_OPTIONS": "NODE_OPTIONS=--openssl-legacy-provider",
         "docusaurus": "docusaurus",
-        "start": "docusaurus start",
-        "build": "docusaurus build",
-        "swizzle": "docusaurus swizzle",
-        "deploy": "docusaurus deploy",
-        "clear": "docusaurus clear",
-        "serve": "docusaurus serve",
-        "write-translations": "docusaurus write-translations",
-        "write-heading-ids": "docusaurus write-heading-ids",
+        "start": "npm run NODE_OPTIONS && docusaurus start",
+        "build": "npm run NODE_OPTIONS && docusaurus build",
+        "swizzle": "npm run NODE_OPTIONS && docusaurus swizzle",
+        "deploy": "npm run NODE_OPTIONS && docusaurus deploy",
+        "clear": "npm run NODE_OPTIONS && docusaurus clear",
+        "serve": "npm run NODE_OPTIONS && docusaurus serve",
+        "write-translations": "npm run NODE_OPTIONS && docusaurus write-translations",
+        "write-heading-ids": "npm run NODE_OPTIONS && docusaurus write-heading-ids",
         "lint": "../../node_modules/.bin/eslint ./src --ext .ts,.tsx --quiet"
     },
     "dependencies": {
@@ -47,16 +48,8 @@
         "url-loader": "^4.1.1"
     },
     "browserslist": {
-        "production": [
-            ">0.5%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
+        "production": [">0.5%", "not dead", "not op_mini all"],
+        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
     },
     "devDependencies": {
         "@docusaurus/module-type-aliases": "^2.0.0-beta.4",


### PR DESCRIPTION
## Release Notes

Добавлена недостающая информация в `PropsTable`. 

### What/why Changed

Из-за того что у ряда компонентов нет явного `returnType` и они импортируются через `re-export` то документация не могла корректно отобразить `PropsTable`. 

### Before 

```
Not found module in @docgen/Cell. Error: Cannot find module './Cell.json'
```

<img width="994" alt="Screenshot 2023-09-08 at 11 36 38" src="https://github.com/salute-developers/plasma/assets/2895992/349f6053-8ced-41a6-ab62-b03f1df8f400">

### After

<img width="914" alt="Screenshot 2023-09-08 at 11 37 11" src="https://github.com/salute-developers/plasma/assets/2895992/52a21db1-7886-4722-a0d1-4edb61d59827">

         
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.225.2-canary.693.6117775528.0
  npm install @salutejs/plasma-hope@1.225.2-canary.693.6117775528.0
  npm install @salutejs/plasma-web@1.225.2-canary.693.6117775528.0
  # or 
  yarn add @salutejs/plasma-b2c@1.225.2-canary.693.6117775528.0
  yarn add @salutejs/plasma-hope@1.225.2-canary.693.6117775528.0
  yarn add @salutejs/plasma-web@1.225.2-canary.693.6117775528.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
