### PR TITLE
plasma-infra: Enable GitHub security analysis options

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,39 @@
+name: Semgrep
+
+on:
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    name: semgrep/ci
+    runs-on: ubuntu-latest
+
+    container:
+      image: returntocorp/semgrep
+
+    # Skip any PR created by dependabot to avoid permission issues:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: "Run the 'semgrep ci' command on the command line of the docker image."
+        run: semgrep ci --sarif --output=semgrep.sarif --config auto --config "p/gitlab" --exclude-rule yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha
+        env:
+          # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable.
+          # more at semgrep.dev/explore
+          SEMGREP_RULES: p/default
+
+      - name: Upload SARIF file for GitHub Advanced Security Dashboard
+        if: always()
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: semgrep.sarif


### PR DESCRIPTION
## Release Notes

**Включили** настройки GitHub по security analysis. 

### What/why Changed

Включены/добавлены следующие опции:

- [x] Включен workflow [semgrep](https://github.com/returntocorp/semgrep) 
- [x] Dependabot
- [x] CodeQL analysis
- [x] Secret scanning
- [x] Private vulnerability reporting 

<img width="1412" alt="Screenshot 2023-09-21 at 11 40 03" src="https://github.com/salute-developers/plasma/assets/2895992/312dbb77-6aee-4022-875a-9700dbb1954c">

<img width="880" alt="Screenshot 2023-09-21 at 12 25 45" src="https://github.com/salute-developers/plasma/assets/2895992/b71cead8-29f9-4051-b204-012367445b96">

