### PR TITLE
fix(plasma-web-docs): Remove button blur prop from component & docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ npx lerna bootstrap --scope [имя пакета 1] --scope [имя пакета
 Если возникла какая-либо проблема со сборкой, можно попробовать полностью удалить все зависимости и установить их заново:
 
 ```sh
-rm -rm ./node_modules/
+rm -rf ./node_modules/
 npm ci
 npx lerna clean -y
 npx lerna bootstrap

--- a/packages/plasma-core/src/components/Button/Button.tsx
+++ b/packages/plasma-core/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { applyDisabled, applyBlur, applyEllipsis } from '../../mixins';
+import { applyDisabled, applyEllipsis } from '../../mixins';
 import { Spinner } from '../Spinner';
 
 import type { ButtonIsContentProps, ButtonIsLoading, StyledButtonProps } from './Button.types';
@@ -31,8 +31,6 @@ export const ButtonRoot = styled.button<StyledButtonProps>`
     }
 
     ${({ $isLoading: isLoading }) => !isLoading && applyDisabled}
-
-    ${applyBlur}
 `;
 
 /**

--- a/packages/plasma-core/src/components/Button/Button.types.ts
+++ b/packages/plasma-core/src/components/Button/Button.types.ts
@@ -1,6 +1,6 @@
 import type { FlattenSimpleInterpolation, CSSObject } from 'styled-components';
 
-import type { DisabledProps, FocusProps, OutlinedProps, BlurProps } from '../../mixins';
+import type { DisabledProps, FocusProps, OutlinedProps } from '../../mixins';
 import type { ShiftProps, AsProps } from '../../types';
 import type { PinProps } from '../../utils';
 
@@ -16,7 +16,6 @@ export interface ButtonProps<T = HTMLElement>
         OutlinedProps,
         DisabledProps,
         ShiftProps,
-        BlurProps,
         AsProps,
         Omit<React.AnchorHTMLAttributes<T>, 'type'>,
         React.ButtonHTMLAttributes<T> {
@@ -141,7 +140,6 @@ export interface StyledButtonProps
         OutlinedProps,
         DisabledProps,
         ShiftProps,
-        BlurProps,
         ButtonIsContentProps,
         Pick<ButtonProps, 'square' | 'stretch'> {}
 


### PR DESCRIPTION
**What/why Changed**
Удалил blur property из plasma-core для компонента Button, так как на цвет/фон кнопки не оказывало никакого эффекта.

**Было** в доке

<img width="1307" alt="Снимок экрана 2023-09-29 в 14 02 53" src="https://github.com/salute-developers/plasma/assets/40370966/e12cff8b-56f5-4ca6-b1ba-fc2790b4fc79">

**Стало**
<img width="1312" alt="Снимок экрана 2023-09-29 в 14 03 31" src="https://github.com/salute-developers/plasma/assets/40370966/2c129d01-032b-4d5f-addb-8b6fc924a70d">

