### PR TITLE
plasma-infra(semgrep): Use "continue-on-error" option

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -26,6 +26,7 @@ jobs:
           show-progress: false
 
       - name: "Run the 'semgrep ci' command on the command line of the docker image."
+        continue-on-error: true
         run: semgrep ci --sarif --output=semgrep.sarif --config auto --config "p/gitlab" --exclude-rule yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha
         env:
           # Add the rules that Semgrep uses by setting the SEMGREP_RULES environment variable.


### PR DESCRIPTION
## Release Notes

используем опцию `continue-on-error` для semgrep workflow, что бы alert не считался как failed pipeline.   

### What/why Changed

Когда semgrep отправляет alert для PR то сам workflow помечался как **failed**. 

Данное поведение переопределено.  