### PR TITLE
plasma-infra: Pass cli options for "@auto-it"

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -33,6 +33,7 @@ jobs:
     with:
       ref: refs/pull/${{github.event.pull_request.number}}/merge
       upload_assets: ${{ needs.scope.outputs.HAS_ASSETS == 'true' }}
+      auto-options: '--no-changelog'
     secrets:
       gh_token: ${{ secrets.GH_TOKEN }}
       npm_registry_token: ${{ secrets.NPM_REGISTRY_TOKEN }}

--- a/.github/workflows/publish-common.yml
+++ b/.github/workflows/publish-common.yml
@@ -20,6 +20,10 @@ on:
       upload_assets:
         type: boolean
         default: false
+      auto-options:
+        type: string
+        description: "@auto-it cli arguments for example --no-changelog"
+        default: ''
     secrets:
       gh_token:
         required: true
@@ -61,7 +65,7 @@ jobs:
         run: npm whoami && npx lerna info && npx auto info || echo 'auto info returned 1'
       
       - name: Create Release
-        run: upload_assets="${{ inputs.upload_assets }}" npm run release
+        run: upload_assets="${{ inputs.upload_assets }}" npm run release -- ${{ inputs.auto-options }}
       
       - name: Update package-lock files
         if: ${{ inputs.with-update-package-lock }}

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -70,6 +70,7 @@ jobs:
       with-update-package-lock: true
       commit-message: "Update package-lock.json files"
       upload_assets: ${{ needs.change-state.outputs.HAS_ASSETS == 'true' }}
+      auto-options: '--no-changelog'
     secrets:
       gh_token: ${{ secrets.GH_TOKEN }}
       npm_registry_token: ${{ secrets.NPM_REGISTRY_TOKEN }}


### PR DESCRIPTION
### @Auto-it CLI 

- добавлена возможность прокинуть опции/флаги для запуска - **auto shipit**;
- выключили генерацию changelog для pubslish: canary, RC;  

### What/why changed

changelog нужен нам только когда делаем latest release во всех остальных случаях - нет.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.10.1-canary.890.7096675247.0
  npm install @salutejs/plasma-b2c@1.250.1-canary.890.7096675247.0
  npm install @salutejs/plasma-new-hope@0.17.1-canary.890.7096675247.0
  npm install @salutejs/plasma-web@1.250.1-canary.890.7096675247.0
  # or 
  yarn add @salutejs/plasma-asdk@0.10.1-canary.890.7096675247.0
  yarn add @salutejs/plasma-b2c@1.250.1-canary.890.7096675247.0
  yarn add @salutejs/plasma-new-hope@0.17.1-canary.890.7096675247.0
  yarn add @salutejs/plasma-web@1.250.1-canary.890.7096675247.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
