### PR TITLE
plasma-infra: Upload assets when publish rc

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -6,20 +6,70 @@ on:
       - dev
 
 jobs:
-  scope:
-    name: Computed changed state
-    uses: ./.github/workflows/change-detection.yml
-    secrets: inherit
-    
+  change-state:
+    if: ${{ github.actor == 'github-merge-queue[bot]' }}
+    name: Computed state of change
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    outputs:
+      HAS_ASSETS: ${{ steps.scope.outputs.result }}
+    steps:
+      ## Получаем актуальное состояние dev branch
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+          fetch-depth: 0
+          
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-environment
+      
+      ## Получаем base sha commit из merged pull request который запустил это событие
+      ## context.sha - это последний commit в dev ветку
+      ## base.sha - это последний commit base branch до влития целевого pull request
+      - name: Get associated pull request by commit
+        id: sha
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const res = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              commit_sha: context.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            
+            return res?.data[0]?.base?.sha || context.sha;
+      
+      ## Сохраняем вывод команды lerna ls в формате json array
+      - name: Preserve lerna ls state
+        id: lerna_ls
+        run: |
+          echo "STATE=$(npx lerna la --json --since=${{ steps.sha.outputs.result }} | jq -c)" >> "$GITHUB_OUTPUT"
+      
+      ## Высчитываем условие для загрузки assets
+      - name: Computed scope state
+        id: scope
+        uses: actions/github-script@v6
+        env:
+          CHANGED_STATE: ${{ toJSON(steps.lerna_ls.outputs.STATE) }}
+        with:
+          script: |
+            const processingScope = require('./.github/processing-scope.js');
+            
+            const state = processingScope();
+            
+            return state.HAS_ASSETS ?? false;
+
   publish:
     name: Publish RC version
-    needs: [ scope ]
+    needs: [ change-state ]
     if: ${{ github.actor == 'github-merge-queue[bot]' }}
     uses: ./.github/workflows/publish-common.yml
     with:
       with-update-package-lock: true
       commit-message: "Update package-lock.json files"
-      upload_assets: ${{ needs.scope.outputs.HAS_ASSETS == 'true' }}
+      upload_assets: ${{ needs.change-state.outputs.HAS_ASSETS == 'true' }}
     secrets:
       gh_token: ${{ secrets.GH_TOKEN }}
       npm_registry_token: ${{ secrets.NPM_REGISTRY_TOKEN }}


### PR DESCRIPTION
### Upload assets when publish RC

- добавлена логика получения `pull_request.base.sha` для правильного расчета условия загрузки assets

### What/why Changed

Когда мы находимся в dev ветки команда - `npx lerna la --json --since=$(git merge-base --fork-point origin/dev)` не видит изменений. 

Поэтому для publish RC решили изменить подход отслеживания изменений с момента последнего выпуска. 

#### Lerna changed ➖

В таком подходе есть уязвимость, например

В прошлом у нас были внесены изменения в `@salutejs/plasma-tokens-native` но с префиксом `chore` и соотвественно такие изменения **не сделали** bump версии пакета и **не было** выпуска, это ключевой момент. 

И поэтому вывод команды `npx lerna changed --all --json` учтет эти изменения, они не были опубликованы.   

И расчет условия загрузки для ваших изменений будет **некорректным**, потому что вывод `npx lerna changed` содержит запись о изменениях в `plasma-tokens`.

#### Получить корректный ref, sha для `--since` ✅

В момент выпуска RC у нас есть commit который запустил процесс публикации. 

На основе этого commit можно получить список связанных с ним pull requests (API listPullRequestsAssociatedWithCommit).

Из полученных данных вытаскиваем last commit (`base.sha`) для ветки dev на момент влития pull request.

Теперь lerna корректно может сравнить состояние изменений между внесенными и тем что уже есть в dev.

#### Lerna ls --since with correct sha

<img width="630" alt="Screenshot 2023-12-07 at 13 21 14" src="https://github.com/salute-developers/plasma/assets/2895992/10da982e-f14a-4b89-b9b7-cba8e0fa4b97">
               
#### last commit (base.sha) до влития изменений

<img width="1234" alt="Screenshot 2023-12-07 at 13 23 02" src="https://github.com/salute-developers/plasma/assets/2895992/1b8303a0-8f10-4859-aa4c-956a16c05774">
                
[пример из песочницы ](https://github.com/PoligonSa/plasma-sandbox/actions/runs/7114973837/job/19370098592)