### PR TITLE
plasma-infra: Use 18.16.1 node version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,2 @@
-lts/hydrogen
+v18.16.1
+


### PR DESCRIPTION
## Release Notes

- зафиксировали версию Node.js (18.16.1) для корректной работы CI 

### What/why Changed

https://nodejs.org/en/blog/release/v18.19.0 

TL;DR 

> After two months of baking time in Node.js 20, npm 10 is backported, so that all release lines include a supported version of npm. This release includes npm v10.2.3.

А у нас есть ограничение на версию npm 

```
"engines": {
   "npm": "^8.19.0 || ^9.5.1"
}
``` 

Поэтому решили зафиксировать точную версию Node.js, а не tag  

