### PR TITLE
plasma-hope: fix broken style for Upload button

### DIFF
--- a/packages/plasma-hope/src/components/Upload/UploadButton.tsx
+++ b/packages/plasma-hope/src/components/Upload/UploadButton.tsx
@@ -85,11 +85,9 @@ export const StyledButton = styled.button<StyledButtonProps>`
     ${({ isGrabbing }) =>
         isGrabbing &&
         css`
-             {
-                border-color: ${buttonAccent};
-                background-color: ${surfaceLiquid02};
-                transform: scale(1.04);
-            }
+            border-color: ${buttonAccent};
+            background-color: ${surfaceLiquid02};
+            transform: scale(1.04);
         `}
     ${({ paint }) => paints[paint]}
     ${({ status }) => status && statuses[status]}


### PR DESCRIPTION
### Upload

-   исправлены стили для StyledButton в состоянии isGrabbing



Из-за лишних скобок в стилях для состояния isGrabbing слетали все стили для styled-components.
**До** наведения мыши с файлом
![image](https://github.com/salute-developers/plasma/assets/40370966/3e63d80a-91a6-43f9-8c09-7066a717821d)
**После**
![image](https://github.com/salute-developers/plasma/assets/40370966/5c13fcc1-3ea8-445b-b60b-b28982df985b)

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.255.0-canary.926.7207896497.0
  npm install @salutejs/plasma-hope@1.249.0-canary.926.7207896497.0
  npm install @salutejs/plasma-web@1.255.0-canary.926.7207896497.0
  # or 
  yarn add @salutejs/plasma-b2c@1.255.0-canary.926.7207896497.0
  yarn add @salutejs/plasma-hope@1.249.0-canary.926.7207896497.0
  yarn add @salutejs/plasma-web@1.255.0-canary.926.7207896497.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
