### PR TITLE
fix(plasma-new-hope): Add support children props to `Tooltip` component

### DIFF
--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
@@ -46,6 +46,7 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                 placement = 'bottom',
                 usePortal = true,
                 target,
+                children,
                 onDismiss,
                 view,
                 size,
@@ -79,13 +80,13 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                     placement={placement}
                     offset={offset}
                     zIndex={zIndex}
-                    target={target}
+                    target={target || children}
                     usePortal={usePortal}
                     hasArrow={hasArrow}
                     aria-hidden={!isOpen}
                     aria-live="polite"
                     role="tooltip"
-                    className={cx(ref?.classList.toString())} // прокидываем стили для Popover из Root Tooltip-а
+                    className={cx(ref?.classList.toString())} // INFO: Прокидываем стили для Popover из Root Tooltip-а
                     {...rest}
                 >
                     <Root view={view} size={size} ref={setRef}>

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.types.ts
@@ -70,4 +70,9 @@ export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
      * Вид тултипа.
      */
     view?: string;
+    /**
+     * Свойство устарело, вместо этого нужно использовать target
+     * @deprecated
+     */
+    children?: ReactNode;
 }


### PR DESCRIPTION
### Tooltip

- для сохранения обратной совместимости  вернули поддержку prop `children`

### What/why changed

При использовании компонента `Tooltip` children не отображается



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.16.1-canary.937.7274120598.0
  npm install @salutejs/plasma-b2c@1.257.1-canary.937.7274120598.0
  npm install @salutejs/plasma-new-hope@0.23.1-canary.937.7274120598.0
  npm install @salutejs/plasma-temple@1.191.1-canary.937.7274120598.0
  npm install @salutejs/plasma-ui@1.223.1-canary.937.7274120598.0
  npm install @salutejs/plasma-web@1.257.1-canary.937.7274120598.0
  # or 
  yarn add @salutejs/plasma-asdk@0.16.1-canary.937.7274120598.0
  yarn add @salutejs/plasma-b2c@1.257.1-canary.937.7274120598.0
  yarn add @salutejs/plasma-new-hope@0.23.1-canary.937.7274120598.0
  yarn add @salutejs/plasma-temple@1.191.1-canary.937.7274120598.0
  yarn add @salutejs/plasma-ui@1.223.1-canary.937.7274120598.0
  yarn add @salutejs/plasma-web@1.257.1-canary.937.7274120598.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
