### PR TITLE
feat(plasma-new-hope): remove useEffect from typography

### DIFF
--- a/packages/plasma-new-hope/src/components/Typography/Body/Body.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Body/Body.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const bodyRoot = (Root: RootProps<HTMLDivElement, BodyProps>) =>
         const { children, breakWord, bold, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Dspl/Dspl.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Dspl/Dspl.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const dsplRoot = (Root: RootProps<HTMLDivElement, DsplProps>) =>
         const { children, breakWord, bold = true, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Heading/Heading.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Heading/Heading.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const headingRoot = (Root: RootProps<HTMLDivElement, HeadingProps>) =>
         const { children, breakWord, bold = true, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Body/Body.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Body/Body.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const oldBodyRoot = (Root: RootProps<HTMLDivElement, OldBodyProps>) =>
         const { children, breakWord, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Button/Button.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const buttonTypographyRoot = (Root: RootProps<HTMLDivElement, ButtonProps
         const { children, breakWord, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Caption/Caption.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Caption/Caption.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const captionRoot = (Root: RootProps<HTMLDivElement, CaptionProps>) =>
         const { children, breakWord, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Display/Display.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Display/Display.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const displayRoot = (Root: RootProps<HTMLDivElement, DisplayProps>) =>
         const { children, breakWord, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Footnote/Footnote.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Footnote/Footnote.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const footnoteRoot = (Root: RootProps<HTMLDivElement, FootnoteProps>) =>
         const { children, breakWord, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Headline/Headline.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Headline/Headline.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const headlineRoot = (Root: RootProps<HTMLDivElement, HeadlineProps>) =>
         const { children, breakWord, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Paragraph/Paragraph.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Paragraph/Paragraph.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -42,10 +42,6 @@ export const paragraphRoot = (Root: RootProps<HTMLDivElement, ParagraphProps>) =
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
         const withResetMargin = resetMargin ? { margin: 0 } : {};
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/ParagraphText/ParagraphText.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/ParagraphText/ParagraphText.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -37,10 +37,6 @@ export const paragraphTextRoot = (Root: RootProps<HTMLDivElement, ParagraphTextP
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
         const withResetMargin = resetMargin ? { margin: 0 } : {};
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Subtitle/Subtitle.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Subtitle/Subtitle.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -26,11 +26,6 @@ export const Subtitle = styled.div<SubtitleProps>`
 export const subtitleRoot = (Root: RootProps<HTMLDivElement, SubtitleProps>) =>
     forwardRef<HTMLDivElement, SubtitleProps>((props, ref) => {
         const { children, ...rest } = props;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Old/Underline/Underline.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Old/Underline/Underline.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -36,11 +36,6 @@ export const underlineRoot = (Root: RootProps<HTMLDivElement, UnderlineProps>) =
         const { children, breakWord, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>

--- a/packages/plasma-new-hope/src/components/Typography/Text/Text.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
@@ -34,11 +34,6 @@ export const textRoot = (Root: RootProps<HTMLDivElement, TextProps>) =>
         const { children, breakWord, bold, ...rest } = props;
 
         const withBreakWord = breakWord ? classes.typoWithBreakWord : undefined;
-
-        /*
-         * Хак, который фиксит применение applySpacing для linaria
-         */
-        useEffect(() => {}, []);
 
         return (
             <Root ref={ref} {...rest}>


### PR DESCRIPTION
### Typography

-   удален пустой useEffect из компонент типографики

### What/why changed

Раньше была бага связанная с линарией (без useEffect крашилась сборка new-hope). Сейчас баг исправился -> useEffect больше не нужен.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.20.0-canary.946.7298430960.0
  npm install @salutejs/plasma-b2c@1.261.0-canary.946.7298430960.0
  npm install @salutejs/plasma-new-hope@0.27.0-canary.946.7298430960.0
  npm install @salutejs/plasma-web@1.261.0-canary.946.7298430960.0
  # or 
  yarn add @salutejs/plasma-asdk@0.20.0-canary.946.7298430960.0
  yarn add @salutejs/plasma-b2c@1.261.0-canary.946.7298430960.0
  yarn add @salutejs/plasma-new-hope@0.27.0-canary.946.7298430960.0
  yarn add @salutejs/plasma-web@1.261.0-canary.946.7298430960.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
