### PR TITLE
fix(plasma-hope/plasma-web): Turn onDragScroll off by default in accessibility mode in Carousel. Fix storybook control panel in it.

### DIFF
--- a/packages/plasma-b2c/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-b2c/src/components/Carousel/Carousel.stories.tsx
@@ -21,6 +21,9 @@ const meta: Meta<typeof Carousel> = {
                 type: 'inline-radio',
             },
         },
+        isDragScrollDisabled: {
+            control: 'boolean',
+        },
         ...disableProps([
             'onScroll',
             'index',
@@ -88,7 +91,7 @@ const defaultCarouselStyle = { margin: '0 -0.5rem' };
 
 const defaultCarouselItemStyle = { width: 550, padding: '0 0.5rem' };
 
-const StoryDefault = ({ align }: { align: alignType }) => {
+const StoryDefault = ({ align, isDragScrollDisabled }: { align: alignType; isDragScrollDisabled: boolean }) => {
     const [index, setIndex] = useState(0);
 
     const changeIndexDown = useCallback(() => {
@@ -107,6 +110,7 @@ const StoryDefault = ({ align }: { align: alignType }) => {
                 detectActive
                 onIndexChange={setIndex}
                 scrollAlign={align}
+                isDragScrollDisabled={isDragScrollDisabled}
             >
                 {items.map((item) => (
                     <CarouselItem key={item.id} style={defaultCarouselItemStyle} scrollSnapAlign={align}>
@@ -130,9 +134,10 @@ const StoryDefault = ({ align }: { align: alignType }) => {
     );
 };
 
-export const Default: StoryObj<{ align: alignType }> = {
+export const Default: StoryObj<{ align: alignType; isDragScrollDisabled: boolean }> = {
     args: {
         align: 'center',
+        isDragScrollDisabled: false,
     },
     render: (args) => <StoryDefault {...args} />,
 };

--- a/packages/plasma-hope/api/plasma-hope.api.md
+++ b/packages/plasma-hope/api/plasma-hope.api.md
@@ -385,6 +385,7 @@ export type CardProps = CardProps_2 & RoundnessProps & BackgroundProps;
 // @public
 export const Carousel: React_2.ForwardRefExoticComponent<Omit<CarouselProps_2, "axis" | "animatedScrollByIndex" | "throttleMs" | "debounceMs"> & {
     ariaLive?: "off" | "polite" | undefined;
+    isDragScrollDisabled?: boolean | undefined;
 } & React_2.RefAttributes<HTMLDivElement>>;
 
 export { CarouselGridWrapper }
@@ -396,6 +397,7 @@ export { CarouselItemProps }
 // @public (undocumented)
 export type CarouselProps = Omit<CarouselProps_2, 'axis' | 'animatedScrollByIndex' | 'throttleMs' | 'debounceMs'> & {
     ariaLive?: 'off' | 'polite';
+    isDragScrollDisabled?: boolean;
 };
 
 // @public

--- a/packages/plasma-hope/src/components/Carousel/Carousel.tsx
+++ b/packages/plasma-hope/src/components/Carousel/Carousel.tsx
@@ -17,6 +17,7 @@ export type CarouselProps = Omit<BaseProps, 'axis' | 'animatedScrollByIndex' | '
      * При значении `polite` скринридер будет объявлять переключаемые слайды.
      */
     ariaLive?: 'off' | 'polite';
+    // Выключает драг скролл (только для десктопа). False по дефолту.
     isDragScrollDisabled?: boolean;
 };
 

--- a/packages/plasma-hope/src/components/Carousel/Carousel.tsx
+++ b/packages/plasma-hope/src/components/Carousel/Carousel.tsx
@@ -17,6 +17,7 @@ export type CarouselProps = Omit<BaseProps, 'axis' | 'animatedScrollByIndex' | '
      * При значении `polite` скринридер будет объявлять переключаемые слайды.
      */
     ariaLive?: 'off' | 'polite';
+    isDragScrollDisabled?: boolean;
 };
 
 const StyledCarousel = styled(CarouselCore)`
@@ -41,6 +42,7 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(function
         paddingEnd,
         children,
         ariaLive = 'off',
+        isDragScrollDisabled = false,
         ...rest
     },
     ref,
@@ -59,7 +61,7 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(function
     });
     const handleRef = useForkRef(scrollRef, ref);
 
-    useDragScroll(scrollRef);
+    useDragScroll(scrollRef, isDragScrollDisabled);
 
     return (
         <StyledCarousel ref={handleRef} axis={axis} scrollSnapType={scrollSnapType} {...rest}>

--- a/packages/plasma-hope/src/components/Carousel/hooks.tsx
+++ b/packages/plasma-hope/src/components/Carousel/hooks.tsx
@@ -4,7 +4,7 @@ const SCROLL_SPEED = 2;
 
 export const useDragScroll = <T extends HTMLElement>(
     scrollRef: React.MutableRefObject<T | null>,
-    isDragScrollDisabled: boolean | null = false,
+    isDragScrollDisabled?: boolean,
 ) => {
     const [isDragging, setDragging] = useState(false);
     const [startX, setStartX] = useState(0);

--- a/packages/plasma-hope/src/components/Carousel/hooks.tsx
+++ b/packages/plasma-hope/src/components/Carousel/hooks.tsx
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 
 const SCROLL_SPEED = 2;
 
-export const useDragScroll = <T extends HTMLElement>(scrollRef: React.MutableRefObject<T | null>) => {
+export const useDragScroll = <T extends HTMLElement>(
+    scrollRef: React.MutableRefObject<T | null>,
+    isDragScrollDisabled: boolean | null = false,
+) => {
     const [isDragging, setDragging] = useState(false);
     const [startX, setStartX] = useState(0);
     const [scrollLeft, setScrollLeft] = useState(0);
@@ -40,7 +43,7 @@ export const useDragScroll = <T extends HTMLElement>(scrollRef: React.MutableRef
     );
 
     useEffect(() => {
-        if (scrollRef && scrollRef.current) {
+        if (scrollRef && scrollRef.current && !isDragScrollDisabled) {
             scrollRef.current.style.userSelect = 'none';
             scrollRef.current.addEventListener('mousedown', handleMouseDown);
             scrollRef.current.addEventListener('mouseup', handleMouseUp);
@@ -49,12 +52,12 @@ export const useDragScroll = <T extends HTMLElement>(scrollRef: React.MutableRef
         }
 
         return () => {
-            if (scrollRef && scrollRef.current) {
+            if (scrollRef && scrollRef.current && !isDragScrollDisabled) {
                 scrollRef.current.removeEventListener('mousedown', handleMouseDown);
                 scrollRef.current.removeEventListener('mouseup', handleMouseUp);
                 scrollRef.current.removeEventListener('mouseleave', handleMouseUp);
                 scrollRef.current.removeEventListener('mousemove', handleMouseMove);
             }
         };
-    }, [scrollRef, handleMouseDown, handleMouseUp, handleMouseMove]);
+    }, [scrollRef, handleMouseDown, handleMouseUp, handleMouseMove, isDragScrollDisabled]);
 };

--- a/packages/plasma-web/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-web/src/components/Carousel/Carousel.stories.tsx
@@ -88,6 +88,7 @@ const StyledControls = styled.div`
 const StyledCarousel = styled(Carousel)`
     display: flex;
     padding: 0.5rem 0;
+    overflow: hidden;
 `;
 const StyledCarouselItem = styled(CarouselItem)`
     width: 32.5rem;
@@ -152,7 +153,7 @@ const StoryAccessibilityDemo = () => {
                         view="clear"
                     />
                 </StyledControls>
-                <StyledCarousel index={index} scrollSnapType="none" ariaLive={ariaLive}>
+                <StyledCarousel index={index} scrollSnapType="none" ariaLive={ariaLive} isDragScrollDisabled>
                     {items.map((item, i) => (
                         <StyledCarouselItem key={item.id} aria-label={`${i + 1} из ${items.length}`}>
                             <CarouselCard

--- a/packages/plasma-web/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-web/src/components/Carousel/Carousel.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof Carousel> = {
     component: Carousel,
     decorators: [InSpacingDecorator],
     argTypes: {
-        align: {
+        scrollAlign: {
             options: ['center', 'start', 'end'],
             control: {
                 type: 'inline-radio',
@@ -49,11 +49,14 @@ const defaultCarouselStyle = { margin: '0 -0.5rem' };
 const defaultCarouselItemStyle = { width: '20rem', padding: '0 0.5rem' };
 
 export const Default: StoryObj<CarouselProps> = {
-    render: () => {
+    args: {
+        scrollAlign: 'start',
+    },
+    render: ({ scrollAlign }) => {
         return (
-            <Carousel index={0} style={defaultCarouselStyle}>
+            <Carousel index={0} style={defaultCarouselStyle} scrollAlign={scrollAlign}>
                 {items.map((item) => (
-                    <CarouselItem key={item.id} style={defaultCarouselItemStyle}>
+                    <CarouselItem key={item.id} style={defaultCarouselItemStyle} scrollSnapAlign={scrollAlign}>
                         <CarouselCard
                             id={item.id}
                             title={item.title}

--- a/packages/plasma-web/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-web/src/components/Carousel/Carousel.stories.tsx
@@ -51,10 +51,16 @@ const defaultCarouselItemStyle = { width: '20rem', padding: '0 0.5rem' };
 export const Default: StoryObj<CarouselProps> = {
     args: {
         scrollAlign: 'start',
+        isDragScrollDisabled: false,
     },
-    render: ({ scrollAlign }) => {
+    render: ({ scrollAlign, isDragScrollDisabled }) => {
         return (
-            <Carousel index={0} style={defaultCarouselStyle} scrollAlign={scrollAlign}>
+            <Carousel
+                index={0}
+                style={defaultCarouselStyle}
+                scrollAlign={scrollAlign}
+                isDragScrollDisabled={isDragScrollDisabled}
+            >
                 {items.map((item) => (
                     <CarouselItem key={item.id} style={defaultCarouselItemStyle} scrollSnapAlign={scrollAlign}>
                         <CarouselCard


### PR DESCRIPTION
### Carousel

Решен баг с пролистыванием (onDragScroll) в accessible mode - mobile & desktop.
Control panel в карусели работает корректно (можно выбрать scrollAlign).

### What/why changed

Добавил проп isDragScrollDisabled, чтобы дать возможность отключать скролл через drag event. 
Фикс control panel в Carousel в plasma-web.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.263.1-canary.957.7345838046.0
  npm install @salutejs/plasma-hope@1.251.1-canary.957.7345838046.0
  npm install @salutejs/plasma-web@1.263.1-canary.957.7345838046.0
  # or 
  yarn add @salutejs/plasma-b2c@1.263.1-canary.957.7345838046.0
  yarn add @salutejs/plasma-hope@1.251.1-canary.957.7345838046.0
  yarn add @salutejs/plasma-web@1.263.1-canary.957.7345838046.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
