### PR TITLE
feat(plasma-new-hope): fix CalendarDouble ref

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
@@ -16,7 +16,7 @@ export type CalendarDoubleProps = HTMLAttributes<HTMLDivElement> & Calendar;
  */
 export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttributes<HTMLDivElement>>) =>
     forwardRef<HTMLDivElement, CalendarDoubleProps>(
-        ({ value: externalValue, min, max, eventList, disabledList, onChangeValue, ...rest }) => {
+        ({ value: externalValue, min, max, eventList, disabledList, onChangeValue, ...rest }, outerRootRef) => {
             const [firstValue, secondValue] = useMemo(
                 () => (Array.isArray(externalValue) ? externalValue : [externalValue]),
                 [externalValue],
@@ -117,7 +117,7 @@ export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttribute
             }
 
             return (
-                <Root aria-label="Выбор даты" {...rest}>
+                <Root ref={outerRootRef} aria-label="Выбор даты" {...rest}>
                     <CalendarHeader
                         isDouble
                         firstDate={firstDate}


### PR DESCRIPTION
### Calendar

-   добавлен ref в forwardRef вторым аргументом

### What/why changed

В CalendarDouble в forwardRef не было ref как пропса, из-за чего в консоль падал ворнинг об этом.
forwardRef должен принимать два аргумента

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.23.0-canary.959.7347249945.0
  npm install @salutejs/plasma-b2c@1.264.0-canary.959.7347249945.0
  npm install @salutejs/plasma-new-hope@0.30.0-canary.959.7347249945.0
  npm install @salutejs/plasma-web@1.264.0-canary.959.7347249945.0
  # or 
  yarn add @salutejs/plasma-asdk@0.23.0-canary.959.7347249945.0
  yarn add @salutejs/plasma-b2c@1.264.0-canary.959.7347249945.0
  yarn add @salutejs/plasma-new-hope@0.30.0-canary.959.7347249945.0
  yarn add @salutejs/plasma-web@1.264.0-canary.959.7347249945.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
