### PR TITLE
fix(plasma-web): fix Popover arrow in Safari, Firefox

### DIFF
--- a/.github/workflows/required-primary-checks.yml
+++ b/.github/workflows/required-primary-checks.yml
@@ -62,7 +62,7 @@ jobs:
           npm i --no-progress --no-audit react@17 react-dom@17 @types/react@17.0.40 @types/react-dom@17 --prefix="./packages/plasma-web"
 
       - name: Lerna bootstrap by scope
-        run: npx lerna bootstrap --scope=@salutejs/plasma-{ui,web,b2c,temple,hope,new-hope,core}
+        run: npx lerna bootstrap --scope=@salutejs/plasma-{ui,web,b2c,temple,hope,new-hope,core,icons}
 
       - name: Unit tests for React 17
         run: npm run test -- --scope=@salutejs/plasma-{ui,web,b2c,temple}

--- a/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
@@ -14,19 +14,16 @@ export const StyledRoot = styled.div`
 `;
 
 export const StyledArrow = styled.div`
-    visibility: hidden;
+    width: var(${String(tokens.arrowMaskWidth)});
+    height: var(${String(tokens.arrowMaskHeight)});
 
-    &,
     &::before {
         position: absolute;
         width: var(${String(tokens.arrowMaskWidth)});
         height: var(${String(tokens.arrowMaskHeight)});
         mask-image: var(${String(tokens.arrowMaskImage)});
         background: var(${String(tokens.arrowBackground)});
-    }
 
-    &::before {
-        visibility: visible;
         content: '';
         transform: rotate(0deg);
     }


### PR DESCRIPTION
### Popover arrow

-   Поправлено отображение Popover arrow в Safari, Firefox

### What/why changed

В safari не отображалась стрелка, а в Firefox не срабатывал rotate.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.25.1-canary.963.7501084786.0
  npm install @salutejs/plasma-b2c@1.266.1-canary.963.7501084786.0
  npm install @salutejs/plasma-new-hope@0.31.1-canary.963.7501084786.0
  npm install @salutejs/plasma-web@1.266.1-canary.963.7501084786.0
  # or 
  yarn add @salutejs/plasma-asdk@0.25.1-canary.963.7501084786.0
  yarn add @salutejs/plasma-b2c@1.266.1-canary.963.7501084786.0
  yarn add @salutejs/plasma-new-hope@0.31.1-canary.963.7501084786.0
  yarn add @salutejs/plasma-web@1.266.1-canary.963.7501084786.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
