### PR TITLE
fix(plasma-new-hope): Fix size for `Spinner` component

### DIFF
--- a/packages/plasma-new-hope/src/components/Spinner/Spinner.tsx
+++ b/packages/plasma-new-hope/src/components/Spinner/Spinner.tsx
@@ -15,6 +15,8 @@ const base = css`
 `;
 
 const SpinnerWrapper = styled.div<{ width: string; height: string }>`
+    display: flex;
+
     width: ${(props) => props.width};
     height: ${(props) => props.height};
 


### PR DESCRIPTION
### Spinner

Исправлено отображение компонента `Spinner` при размере 8px

### What/why changed

Если указать значение size='8' у компонента `Spinner`, то он будет крутиться не во круг своей оси, а со смещением


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.25.2-canary.966.7538300022.0
  npm install @salutejs/plasma-b2c@1.267.2-canary.966.7538300022.0
  npm install @salutejs/plasma-new-hope@0.31.2-canary.966.7538300022.0
  npm install @salutejs/plasma-web@1.267.2-canary.966.7538300022.0
  # or 
  yarn add @salutejs/plasma-asdk@0.25.2-canary.966.7538300022.0
  yarn add @salutejs/plasma-b2c@1.267.2-canary.966.7538300022.0
  yarn add @salutejs/plasma-new-hope@0.31.2-canary.966.7538300022.0
  yarn add @salutejs/plasma-web@1.267.2-canary.966.7538300022.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
