### PR TITLE
plasma-infra: Handle plasma-icons as dep 

### DIFF
--- a/.github/workflows/required-primary-checks.yml
+++ b/.github/workflows/required-primary-checks.yml
@@ -23,9 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          show-progress: false
 
       - name: Prepare environment
         uses: ./.github/actions/prepare-environment
@@ -41,15 +42,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          show-progress: false
 
       - name: Prepare environment
         uses: ./.github/actions/prepare-environment
 
       - name: Lerna bootstrap
-        run: npx lerna bootstrap --since=$(git merge-base --fork-point origin/dev) --ignore=${{env.LERNA_IGNORE_LIST}}
+        run: npx lerna bootstrap --ignore=${{env.LERNA_IGNORE_LIST}}
 
       - name: Unit tests
         run: npm run test

--- a/.github/workflows/typescript-coverage.yml
+++ b/.github/workflows/typescript-coverage.yml
@@ -28,11 +28,13 @@ jobs:
       # INFO: Игнорируем пакеты связанные с plasma-tokens, документацией и утилитами, т.к. в них не запускается typescript-coverage
       LERNA_IGNORE_LIST: "@salutejs/plasma-{tokens*,temple-docs,ui-docs,docs-ui,web-docs,website,theme-builder,cy-utils,sb-utils}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - uses: ./.github/actions/prepare-environment
+          show-progress: false
+  
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Computed scope
         id: scope
@@ -48,6 +50,10 @@ jobs:
             
             if (!enumeration.includes('plasma-core')) {
               enumeration.push('plasma-core')
+            }
+            
+            if (!enumeration.includes('plasma-icons')) {
+              enumeration.push('plasma-icons')
             }
             
             return enumeration.join(',');     


### PR DESCRIPTION
### Unit test

- выключили флаг `since` чтобы корректно обрабатывать/устанавливать зависимости    

### Typescript coverage

- добавлен пакет `plasma-icons` для корректной работы  

### What/why changed

Пакет `plasma-icons` идет как `peerDep` и не ставится с флагом `--since` (в этом пакете не было изменений и ставиться latest версия из npm) в которой нет нужных изменений. 

#968 - именно тут столкнулись с проблемой, которая решается этим PR  
#970 - тут проверили эти изменения
