### PR TITLE
fix(plasma-icons): fix package publish

### DIFF
--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -59,7 +59,8 @@
     "Icon.js",
     "IconRoot.d.ts",
     "IconRoot.js",
-    "es"
+    "es",
+    "scalable"
   ],
   "contributors": [
     "Vasiliy Loginevskiy",


### PR DESCRIPTION
### Icons

-   поправлена публикация пакета со всем содержимым билда

### What/why changed

В пакете не было папки scalable, в которой находились новые иконки.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.29.1-canary.988.7582907685.0
  npm install @salutejs/plasma-b2c@1.271.1-canary.988.7582907685.0
  npm install @salutejs/plasma-hope@1.255.1-canary.988.7582907685.0
  npm install @salutejs/plasma-icons@1.177.1-canary.988.7582907685.0
  npm install @salutejs/plasma-temple@1.196.1-canary.988.7582907685.0
  npm install @salutejs/plasma-ui@1.228.1-canary.988.7582907685.0
  npm install @salutejs/plasma-web@1.271.1-canary.988.7582907685.0
  # or 
  yarn add @salutejs/plasma-asdk@0.29.1-canary.988.7582907685.0
  yarn add @salutejs/plasma-b2c@1.271.1-canary.988.7582907685.0
  yarn add @salutejs/plasma-hope@1.255.1-canary.988.7582907685.0
  yarn add @salutejs/plasma-icons@1.177.1-canary.988.7582907685.0
  yarn add @salutejs/plasma-temple@1.196.1-canary.988.7582907685.0
  yarn add @salutejs/plasma-ui@1.228.1-canary.988.7582907685.0
  yarn add @salutejs/plasma-web@1.271.1-canary.988.7582907685.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
