### PR TITLE
plasma-infra: Override `lerna ls` config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,6 +10,9 @@
         },
         "publish": {
             "verifyAccess": false
+        },
+        "list": {
+            "ignoreChanges": ["*.md", "package-lock.json"]
         }
     },
     "$schema": "node_modules/lerna/schemas/lerna-schema.json"


### PR DESCRIPTION
### Override `lerna ls`

- переопределили логику `ignoreChanges` для команды `lerna ls` чтобы изменения файлов `*.component-test.tsx` тоже учитывалось      

### What/why changed

Чтобы правильно понять "а какие пакеты у нас изменились?" переопределили свойство `ignoreChanges` для команды `lerna ls`. 

Теперь когда у нас запускается worfklow " ./.github/workflows/change-detection.yml" он учитывает в себе и измененые `*.component-test.tsx` файлы.      

Например мы изменили компонент `Badge` и нам пришлось адаптировать под новый API и визуал тесты - `Badge.component-test.tsx`

Прямые изменения были только в пакетах `plasma-{b2c,web}`, а измененные тесты лежат в `plasma-core`. 

А так как **ранее** мы **не учитывали** в своих расчетах файлы тестов, то CI не запустил тесты для plasma-ui, которые тоже раньше ссылались на тесты в plasma-core, а там ошибка. 

Как итог, после merge  в dev ветку у нас всегда падающий cypress для plasm-ui.           


### Примечания

При этом эти изменения не затрагивают другие команды lerna.

Пример для команды когда мы внесли изменения в `Badge.component-test.tsx`

```
lerna run api-report --since=$(git merge-base --fork-point origin/dev) --no-bail --stream
``` 

```
lerna notice cli v6.5.1
lerna verb rootPath /Users/workspace/plasma
lerna info versioning independent
lerna notice filter changed since "67df0d451e17b4d31d35d61243db5a9af2119479"
lerna verb hasTags true
lerna info Looking for changed packages since 67df0d451e17b4d31d35d61243db5a9af2119479
lerna info ignoring diff in paths matching [ '*.md', '*.component-test.tsx', 'package-lock.json' ]
lerna verb no diff found in @salutejs/plasma-core (after filtering)
lerna success run No packages found with the lifecycle script 'api-report'
```
