### PR TITLE
chore: fix Popup storybook example

### DIFF
--- a/packages/plasma-b2c/src/components/PopupBase/PopupBase.stories.tsx
+++ b/packages/plasma-b2c/src/components/PopupBase/PopupBase.stories.tsx
@@ -48,9 +48,8 @@ const StyledWrapper = styled.div`
 `;
 
 const OtherContent = styled.div`
-    margin-top: 1rem;
-    width: 400px;
-    height: 500px;
+    width: 50%;
+    height: 50%;
     background: ${surfaceSolid03};
     position: absolute;
 
@@ -59,7 +58,7 @@ const OtherContent = styled.div`
     justify-content: center;
     padding: 1rem;
 
-    top: 0;
+    top: 10rem;
     right: 0;
 `;
 

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Popup/Popup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Popup/Popup.stories.tsx
@@ -59,9 +59,8 @@ const StyledWrapper = styled.div`
 `;
 
 const OtherContent = styled.div`
-    margin-top: 1rem;
-    width: 400px;
-    height: 500px;
+    width: 50%;
+    height: 50%;
     background: var(--plasma-colors-surface-solid03);
     position: absolute;
 
@@ -70,7 +69,7 @@ const OtherContent = styled.div`
     justify-content: center;
     padding: 1rem;
 
-    top: 0;
+    top: 10rem;
     right: 0;
 `;
 

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Popup/Popup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Popup/Popup.stories.tsx
@@ -59,9 +59,8 @@ const StyledWrapper = styled.div`
 `;
 
 const OtherContent = styled.div`
-    margin-top: 1rem;
-    width: 400px;
-    height: 500px;
+    width: 50%;
+    height: 50%;
     background: var(--plasma-colors-surface-solid03);
     position: absolute;
 
@@ -70,7 +69,7 @@ const OtherContent = styled.div`
     justify-content: center;
     padding: 1rem;
 
-    top: 0;
+    top: 10rem;
     right: 0;
 `;
 

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/Popup/Popup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/Popup/Popup.stories.tsx
@@ -59,9 +59,8 @@ const StyledWrapper = styled.div`
 `;
 
 const OtherContent = styled.div`
-    margin-top: 1rem;
-    width: 400px;
-    height: 500px;
+    width: 50%;
+    height: 50%;
     background: var(--plasma-colors-surface-solid03);
     position: absolute;
 
@@ -70,7 +69,7 @@ const OtherContent = styled.div`
     justify-content: center;
     padding: 1rem;
 
-    top: 0;
+    top: 10rem;
     right: 0;
 `;
 

--- a/packages/plasma-web/src/components/PopupBase/PopupBase.stories.tsx
+++ b/packages/plasma-web/src/components/PopupBase/PopupBase.stories.tsx
@@ -48,9 +48,8 @@ const StyledWrapper = styled.div`
 `;
 
 const OtherContent = styled.div`
-    margin-top: 1rem;
-    width: 400px;
-    height: 500px;
+    width: 50%;
+    height: 50%;
     background: ${surfaceSolid03};
     position: absolute;
 
@@ -59,7 +58,7 @@ const OtherContent = styled.div`
     justify-content: center;
     padding: 1rem;
 
-    top: 0;
+    top: 10rem;
     right: 0;
 `;
 


### PR DESCRIPTION
### Storybook example

-   поправлено отображение примера Popup в storybook

### What/why changed

Невозможно было проверить работу Popup на мобилках из-за некорректной верстки примера.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.30.3-canary.997.7655379448.0
  npm install @salutejs/plasma-b2c@1.272.3-canary.997.7655379448.0
  npm install @salutejs/plasma-new-hope@0.36.2-canary.997.7655379448.0
  npm install @salutejs/plasma-web@1.272.3-canary.997.7655379448.0
  # or 
  yarn add @salutejs/plasma-asdk@0.30.3-canary.997.7655379448.0
  yarn add @salutejs/plasma-b2c@1.272.3-canary.997.7655379448.0
  yarn add @salutejs/plasma-new-hope@0.36.2-canary.997.7655379448.0
  yarn add @salutejs/plasma-web@1.272.3-canary.997.7655379448.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
