### PR TITLE
plasma-web: Add `onChangeStartOfRange` prop into Calendar

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -434,7 +434,7 @@ type?: "Days" | "Months" | "Years" | undefined;
 export { CalendarBaseProps }
 
 // @public (undocumented)
-export const CalendarBaseRange: ({ value, disabledList, eventList, min, max, onChangeValue, ...rest }: CalendarRange<CalendarBaseProps>) => ReactElement<CalendarBaseProps, string | JSXElementConstructor<any>>;
+export const CalendarBaseRange: ({ value, disabledList, eventList, min, max, onChangeValue, onChangeStartOfRange, ...rest }: CalendarRange<CalendarBaseProps>) => ReactElement<CalendarBaseProps, string | JSXElementConstructor<any>>;
 
 // @public (undocumented)
 export const CalendarDouble: FunctionComponent<PropsType<    {
@@ -449,7 +449,7 @@ m: string;
 export { CalendarDoubleProps }
 
 // @public (undocumented)
-export const CalendarDoubleRange: ({ value, disabledList, eventList, min, max, onChangeValue, ...rest }: CalendarRange<CalendarDoubleProps>) => ReactElement<CalendarDoubleProps, string | JSXElementConstructor<any>>;
+export const CalendarDoubleRange: ({ value, disabledList, eventList, min, max, onChangeValue, onChangeStartOfRange, ...rest }: CalendarRange<CalendarDoubleProps>) => ReactElement<CalendarDoubleProps, string | JSXElementConstructor<any>>;
 
 export { CalendarProps }
 

--- a/packages/plasma-b2c/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-b2c/src/components/Calendar/Calendar.stories.tsx
@@ -12,6 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 import type { CalendarProps, CalendarBaseProps, CalendarDoubleProps } from '.';
 
 const onChangeValue = action('onChangeValue');
+const onChangeStartOfRange = action('onChangeStartOfRange');
 
 const meta: Meta<CalendarProps> = {
     title: 'Controls/Calendar',
@@ -228,6 +229,7 @@ const StoryCalendarRange = ({ min, max, type }: ComponentProps<typeof CalendarBa
             max={max}
             type={type}
             onChangeValue={handleOnChange}
+            onChangeStartOfRange={onChangeStartOfRange}
         />
     );
 };
@@ -276,6 +278,7 @@ const StoryDoubleRange = ({ min, max }: ComponentProps<typeof CalendarDoubleRang
             min={min}
             max={max}
             onChangeValue={handleOnChange}
+            onChangeStartOfRange={onChangeStartOfRange}
         />
     );
 };

--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.types.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.types.ts
@@ -120,6 +120,10 @@ export type CalendarRange<T> = Omit<T, 'value' | 'onChangeValue'> & {
      * Обработчик изменения значения.
      */
     onChangeValue: (values: [Date, Date?]) => void;
+    /**
+     * Обработчик для выбора стартового значения в диапазоне.
+     */
+    onChangeStartOfRange?: (value: Date) => void;
 };
 
 export interface DaysMetaDescription {

--- a/packages/plasma-new-hope/src/components/Calendar/hoc/withRange.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/hoc/withRange.tsx
@@ -13,6 +13,7 @@ export const withRange = <T extends Calendar>(Component: React.FC<Calendar>) => 
     min,
     max,
     onChangeValue,
+    onChangeStartOfRange,
     ...rest
 }: CalendarRange<T>): ReactElement<T> => {
     const [startExternalValue, endExternalValue] = useMemo(() => value, [value]);
@@ -29,6 +30,9 @@ export const withRange = <T extends Calendar>(Component: React.FC<Calendar>) => 
         (newDay: Date) => {
             if (endValue) {
                 setValues([newDay, undefined]);
+
+                onChangeStartOfRange?.(newDay);
+
                 return;
             }
 
@@ -40,7 +44,7 @@ export const withRange = <T extends Calendar>(Component: React.FC<Calendar>) => 
                 onChangeValue([first, second]);
             }
         },
-        [onChangeValue, startValue, endValue],
+        [onChangeValue, onChangeStartOfRange, startValue, endValue],
     );
 
     return (

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -434,7 +434,7 @@ type?: "Days" | "Months" | "Years" | undefined;
 export { CalendarBaseProps }
 
 // @public (undocumented)
-export const CalendarBaseRange: ({ value, disabledList, eventList, min, max, onChangeValue, ...rest }: CalendarRange<CalendarBaseProps>) => ReactElement<CalendarBaseProps, string | JSXElementConstructor<any>>;
+export const CalendarBaseRange: ({ value, disabledList, eventList, min, max, onChangeValue, onChangeStartOfRange, ...rest }: CalendarRange<CalendarBaseProps>) => ReactElement<CalendarBaseProps, string | JSXElementConstructor<any>>;
 
 // @public (undocumented)
 export const CalendarDouble: FunctionComponent<PropsType<    {
@@ -449,7 +449,7 @@ m: string;
 export { CalendarDoubleProps }
 
 // @public (undocumented)
-export const CalendarDoubleRange: ({ value, disabledList, eventList, min, max, onChangeValue, ...rest }: CalendarRange<CalendarDoubleProps>) => ReactElement<CalendarDoubleProps, string | JSXElementConstructor<any>>;
+export const CalendarDoubleRange: ({ value, disabledList, eventList, min, max, onChangeValue, onChangeStartOfRange, ...rest }: CalendarRange<CalendarDoubleProps>) => ReactElement<CalendarDoubleProps, string | JSXElementConstructor<any>>;
 
 export { CalendarProps }
 

--- a/packages/plasma-web/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-web/src/components/Calendar/Calendar.stories.tsx
@@ -12,6 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 import type { CalendarProps, CalendarBaseProps, CalendarDoubleProps } from '.';
 
 const onChangeValue = action('onChangeValue');
+const onChangeStartOfRange = action('onChangeStartOfRange');
 
 const meta: Meta<CalendarProps> = {
     title: 'Controls/Calendar',
@@ -237,6 +238,7 @@ const StoryRange = ({ min, max, type }: ComponentProps<typeof CalendarBaseRange>
             max={max}
             type={type}
             onChangeValue={handleOnChange}
+            onChangeStartOfRange={onChangeStartOfRange}
         />
     );
 };
@@ -285,6 +287,7 @@ const StoryDoubleRange = ({ min, max }: ComponentProps<typeof CalendarDoubleRang
             min={min}
             max={max}
             onChangeValue={handleOnChange}
+            onChangeStartOfRange={onChangeStartOfRange}
         />
     );
 };


### PR DESCRIPTION
### Calendar

- добавлено новое свойство `onChangeStartOfRange` в библиотеки `plasma-{web,b2c}`

### After 

<img width="600" alt="prop onChangeStartOfRange" src="https://github.com/salute-developers/plasma/assets/2895992/a2e01d6e-01f1-4041-b57f-57bb7d3de54e" />

### What/why changed

Возник такой кейс 

> есть календари, в которых есть ограничения диапазона, который пользователь может выбрать, например не больше недели, и при выборе первой даты нужно `disable` даты все, кроме дат за неделю и после первой выбранной

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.4.0-canary.1014.7840120119.0
  npm install @salutejs/caldera@0.4.0-canary.1014.7840120119.0
  npm install @salutejs/plasma-asdk@0.39.0-canary.1014.7840120119.0
  npm install @salutejs/plasma-b2c@1.281.0-canary.1014.7840120119.0
  npm install @salutejs/plasma-new-hope@0.45.0-canary.1014.7840120119.0
  npm install @salutejs/plasma-web@1.281.0-canary.1014.7840120119.0
  npm install @salutejs/sdds-srvc@0.5.0-canary.1014.7840120119.0
  # or 
  yarn add @salutejs/caldera-online@0.4.0-canary.1014.7840120119.0
  yarn add @salutejs/caldera@0.4.0-canary.1014.7840120119.0
  yarn add @salutejs/plasma-asdk@0.39.0-canary.1014.7840120119.0
  yarn add @salutejs/plasma-b2c@1.281.0-canary.1014.7840120119.0
  yarn add @salutejs/plasma-new-hope@0.45.0-canary.1014.7840120119.0
  yarn add @salutejs/plasma-web@1.281.0-canary.1014.7840120119.0
  yarn add @salutejs/sdds-srvc@0.5.0-canary.1014.7840120119.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
