### PR TITLE
fix(plasma-hope): Add value deps for `Select` component with multiselect mode

### DIFF
--- a/packages/plasma-b2c/src/components/Select/Select.stories.tsx
+++ b/packages/plasma-b2c/src/components/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
@@ -68,16 +68,18 @@ const items = [
 const StoryDefault = ({ status, ...rest }: SelectProps) => {
     const [value, setValue] = useState<string | Array<string>>(null);
 
+    const onChangeHandle = useCallback((v) => {
+        setValue(v);
+        onChange(v);
+    }, []);
+
     return (
         <div style={{ display: 'grid', gap: '1rem', width: '20rem', gridTemplateColumns: '100%' }}>
             <Select
                 value={value as string}
                 items={items}
                 status={status || undefined}
-                onChange={(v) => {
-                    setValue(v);
-                    onChange(v);
-                }}
+                onChange={onChangeHandle}
                 onFocus={onFocus}
                 onBlur={onBlur}
                 {...rest}
@@ -105,16 +107,18 @@ export const Default: Story = {
 const StoryGroup = ({ status, ...rest }: SelectProps) => {
     const [value, setValue] = useState<string | Array<string>>(null);
 
+    const onChangeHandle = useCallback((v) => {
+        setValue(v);
+        onChange(v);
+    }, []);
+
     return (
         <SelectGroup>
             <Select
                 value={value as string}
                 items={items}
                 status={status || undefined}
-                onChange={(v) => {
-                    setValue(v);
-                    onChange(v);
-                }}
+                onChange={onChangeHandle}
                 onFocus={onFocus}
                 onBlur={onBlur}
                 {...rest}

--- a/packages/plasma-hope/src/components/Select/withMultiSelect.tsx
+++ b/packages/plasma-hope/src/components/Select/withMultiSelect.tsx
@@ -54,7 +54,7 @@ export const withMultiSelect = (View: ComponentType<SelectViewProps & RefAttribu
 
                     onChange?.(Array.from(set));
                 },
-                [onChange],
+                [value, onChange],
             );
 
             return <View {...rest} ref={ref} value={viewValue} items={viewItems} onItemSelect={onItemSelect} />;

--- a/packages/plasma-web/src/components/Select/Select.stories.tsx
+++ b/packages/plasma-web/src/components/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
@@ -57,16 +57,18 @@ const items = [
 const StoryDefault = ({ status, ...rest }: SelectProps) => {
     const [value, setValue] = useState<string | Array<string>>(null);
 
+    const onChangeHandle = useCallback((v) => {
+        setValue(v);
+        onChange(v);
+    }, []);
+
     return (
         <div style={{ display: 'grid', gap: '1rem', width: '20rem', gridTemplateColumns: '100%' }}>
             <Select
                 value={value as string}
                 items={items}
                 status={status || undefined}
-                onChange={(v) => {
-                    setValue(v);
-                    onChange(v);
-                }}
+                onChange={onChangeHandle}
                 onFocus={onFocus}
                 onBlur={onBlur}
                 {...rest}


### PR DESCRIPTION
### Select

- Обновлены зависимости у колбэка, который вызывался при выборе элемента в `multiselect` режиме для библиотеки `@salutejs/plasma-hope`

### What/why changed

- Необходимо было добавить зависимость `value`, т.к. иначе при оборачивании обработчика `onChangeValue` в `useCallback` выбиралось только одно значение.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.282.1-canary.1040.7883094690.0
  npm install @salutejs/plasma-hope@1.261.1-canary.1040.7883094690.0
  npm install @salutejs/plasma-web@1.282.1-canary.1040.7883094690.0
  # or 
  yarn add @salutejs/plasma-b2c@1.282.1-canary.1040.7883094690.0
  yarn add @salutejs/plasma-hope@1.261.1-canary.1040.7883094690.0
  yarn add @salutejs/plasma-web@1.282.1-canary.1040.7883094690.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
