### PR TITLE
plasma-infra: Upload assets for target package(-s)

### DIFF
--- a/.github/workflows/publish-common.yml
+++ b/.github/workflows/publish-common.yml
@@ -65,7 +65,7 @@ jobs:
         run: npm whoami && npx lerna info && npx auto info || echo 'auto info returned 1'
       
       - name: Create Release
-        run: upload_assets="${{ inputs.upload_assets }}" npm run release -- ${{ inputs.auto-options }}
+        run: upload_assets="${{ inputs.upload_assets }}" upload_assets_targets=${{ toJSON(vars.UPLOAD_ASSETS_TARGET) }} npm run release -- ${{ inputs.auto-options }}
       
       - name: Update package-lock files
         if: ${{ inputs.with-update-package-lock }}

--- a/auto.config.js
+++ b/auto.config.js
@@ -17,11 +17,17 @@ const uploadAssetsPluginOptions = {
 
 /** Auto configuration */
 module.exports = function rc() {
-    const { upload_assets: uploadAssets = 'false' } = process.env || {};
+    const { upload_assets: uploadAssets = 'false', upload_assets_targets = [] } = process.env || {};
     const plugins = [['released', releasedOptions], ['npm', npmOptions], 'conventional-commits'];
 
     if (uploadAssets === 'true') {
-        plugins.unshift(['./auto-plugins/dist/upload-assets-extend.js', uploadAssetsPluginOptions]);
+        plugins.unshift([
+            './auto-plugins/dist/upload-assets-extend.js',
+            {
+                ...uploadAssetsPluginOptions,
+                uploadAssetsTargets: JSON.parse(upload_assets_targets),
+            },
+        ]);
     }
 
     return {

--- a/patches/@auto-it+upload-assets+10.46.0.patch
+++ b/patches/@auto-it+upload-assets+10.46.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@auto-it/upload-assets/dist/index.js b/node_modules/@auto-it/upload-assets/dist/index.js
+index dd2f5b9..e4d6689 100644
+--- a/node_modules/@auto-it/upload-assets/dist/index.js
++++ b/node_modules/@auto-it/upload-assets/dist/index.js
+@@ -130,6 +130,7 @@ class UploadAssetsPlugin {
+             if (Array.isArray(release)) {
+                 await Promise.all(release.map(async (r) => {
+                     const { data: releaseAsset, } = await auto.git.github.repos.uploadReleaseAsset(Object.assign(Object.assign({}, options), { release_id: r.data.id }));
++                    auto.logger.log.success(`Uploaded asset to package: ${r.data.name}`);
+                     assetResponses.push(releaseAsset);
+                 }));
+             }


### PR DESCRIPTION
### Upload assets

- добавлена возможность указать пакет/релиз к которому нужно прикрепить assets  

### What/why changed

С увеличением кол-ва assets и пакетов появилась угроза выхода за выданные API rate лимиты. 

По сути в текущей ситуации нам нужно грузить assets **только** для пакета - `@salutejs/plasma-tokens`.    

