### PR TITLE
plasma-infra:  Refactoring upload assets by package

### DIFF
--- a/auto-plugins/src/upload-assets-extend.ts
+++ b/auto-plugins/src/upload-assets-extend.ts
@@ -62,7 +62,7 @@ export default class UploadAssetsExtendPlugin extends UploadAssetsPlugin impleme
 
     // @ts-ignore
     apply(auto: Auto) {
-        const { headerMessage, filter, includeBotPrs, group, compact } = this.options;
+        const { headerMessage, filter, includeBotPrs, group, compact, uploadAssetsTargets } = this.options;
 
         auto.hooks.validateConfig.tapPromise(this.name, async (name, options) => {
             if (name === this.name || name === `@auto-it/${this.name}`) {
@@ -115,12 +115,14 @@ export default class UploadAssetsExtendPlugin extends UploadAssetsPlugin impleme
 
             let releases = response;
 
-            if (!!this.options.uploadAssetsTargets.length && Array.isArray(response)) {
-                releases = response.filter((releaseData: any) =>
-                    this.options.uploadAssetsTargets.some((uploadAssetsTarget) =>
-                        releaseData.data.name.includes(uploadAssetsTarget),
-                    ),
-                );
+            if (uploadAssetsTargets.length && Array.isArray(response)) {
+                releases = response.filter((releaseData: any) => {
+                    // name ==> @salutejs/plasma-tokens@1.72.0
+                    // after split ==> ['', 'salutejs/plasma-tokens', '1.72.0']
+                    const [, name, version] = releaseData.data.name.split('@');
+
+                    return uploadAssetsTargets.includes(`@${name}`);
+                });
             }
 
             // @ts-ignore

--- a/auto.config.js
+++ b/auto.config.js
@@ -18,7 +18,7 @@ const uploadAssetsPluginOptions = {
 /** Auto configuration */
 module.exports = function rc() {
     const { upload_assets: uploadAssets = 'false', upload_assets_targets = [] } = process.env || {};
-    const plugins = [['released', releasedOptions], ['npm', npmOptions], 'conventional-commits'];
+    const plugins = [['npm', npmOptions], 'conventional-commits'];
 
     if (uploadAssets === 'true') {
         plugins.unshift([


### PR DESCRIPTION
### What/why changed

исправил условие фильтрации пакетов. Теперь работает строгое сравнение по названию пакета. 

Сделано, чтобы исключить попадание случаев когда match по "@salutejs/plasma-tokens" в:
 
```js
[
{ name: "@salutejs/plasma-tokens@1.72.0", ... }
{ name: "@salutejs/plasma-tokens-native@1.23.0", ...}
]
```

В фильтр попадали оба пакета.   

Теперь строгое сравнение вернет **только** пакет - `@salutejs/plasma-tokens`
   