### PR TITLE
plasma-infra: Simplify code

### DIFF
--- a/.github/workflows/documentation-pr.yml
+++ b/.github/workflows/documentation-pr.yml
@@ -125,6 +125,12 @@ jobs:
           export NODE_OPTIONS=--openssl-legacy-provider
           npm run build --prefix="./website/plasma-web-docs"
           cp -R ./website/plasma-web-docs/build ./s3_build/${PR_NAME}/web
+          
+      - name: Plasma "SDDS SERV" Docs
+        if: ${{ needs.scope.outputs.HAS_SDDS_SERV == 'true' }}
+        run: |
+          npm run build --prefix="./website/sdds-serv-docs"
+          cp -R ./website/sdds-serv-docs/build ./s3_build/${PR_NAME}/sdds-serv
       
       - name: Plasma UI Storybook
         if: ${{ needs.scope.outputs.HAS_PLASMA_UI == 'true' }}

--- a/.github/workflows/required-primary-checks.yml
+++ b/.github/workflows/required-primary-checks.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-  LERNA_IGNORE_LIST: "@salutejs/plasma-{ui-docs,docs-ui,web-docs,website,cy-utils,sb-utils,tokens-native}"
+  LERNA_IGNORE_LIST: "@salutejs/plasma-{cy-utils,sb-utils}"
 
 jobs:
   lint:
@@ -51,7 +51,7 @@ jobs:
         uses: ./.github/actions/prepare-environment
 
       - name: Lerna bootstrap
-        run: npx lerna bootstrap --ignore=${{env.LERNA_IGNORE_LIST}}
+        run: npx lerna bootstrap --no-private --ignore=${{env.LERNA_IGNORE_LIST}}
 
       - name: Unit tests
         run: npm run test

--- a/.github/workflows/typescript-coverage.yml
+++ b/.github/workflows/typescript-coverage.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       # INFO: Игнорируем пакеты связанные с plasma-tokens, документацией и утилитами, т.к. в них не запускается typescript-coverage
-      LERNA_IGNORE_LIST: "@salutejs/plasma-{tokens*,ui-docs,docs-ui,web-docs,website,theme-builder,cy-utils,sb-utils}"
+      LERNA_IGNORE_LIST: "@salutejs/plasma-{tokens*,cy-utils,sb-utils}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,7 +59,7 @@ jobs:
             return enumeration.join(',');     
 
       - name: Lerna bootstrap
-        run: npx lerna bootstrap --scope=@salutejs/{${{steps.scope.outputs.result}}} --ignore=${{env.LERNA_IGNORE_LIST}}
+        run: npx lerna bootstrap --scope=@salutejs/{${{steps.scope.outputs.result}}} --no-private --ignore=${{env.LERNA_IGNORE_LIST}}
 
       - name: Run Typescript Coverage
         if: ${{ always() }}


### PR DESCRIPTION
### Typescript coverage workflow

- добавлен filter флаг `--no-private`

### Unit Tests workflow

- добавлен filter флаг `--no-private`


### PR Documentation and Storybook workflow

- добавлена сборка документации для вертикали "SDDS SERV"

### What/why changed

Чтобы не добавлять каждый новый пакет в `LERNA_IGNORE_LIST`, 

мы используем **filter** флаг `--no-private` с помощью которого и исключим из сборки не нужные для этого процесса приватные пакеты.  

Изменения сделаны по мотивам #1062 - где мы добавляем новый приватный пакет документации для вертикали sdds serv