### PR TITLE
fix(sdds-serv): package rename

### DIFF
--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -25,6 +25,7 @@ import { bodyXXS } from '@salutejs/plasma-new-hope';
 import { bodyXXSBold } from '@salutejs/plasma-new-hope';
 import { BoldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Typography.types';
 import { ButtonHTMLAttributes } from 'react';
+import { ButtonProps as ButtonProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { ComboboxProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ComponentClass } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -248,8 +249,8 @@ export { bodyXXSBold }
 // @public
 export const Button: FunctionComponent<PropsType<    {
 view: {
-default: string;
 primary: string;
+accent: string;
 secondary: string;
 clear: string;
 success: string;
@@ -273,19 +274,12 @@ true: string;
 focused: {
 true: string;
 };
-}> & ButtonHTMLAttributes<HTMLButtonElement> & {
-text?: string | undefined;
-contentLeft?: ReactNode;
-contentRight?: ReactNode;
-isLoading?: boolean | undefined;
-loader?: ReactNode;
-stretch?: boolean | undefined;
-square?: boolean | undefined;
-focused?: boolean | undefined;
-pin?: "square-square" | "square-clear" | "clear-square" | "clear-clear" | "clear-circle" | "circle-clear" | "circle-circle" | undefined;
-view?: string | undefined;
-size?: string | undefined;
-} & RefAttributes<HTMLButtonElement>>;
+stretching: {
+auto: string;
+filled: string;
+fixed: string;
+};
+}> & ButtonProps_2<HTMLElement> & RefAttributes<HTMLButtonElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "ButtonComponent" needs to be exported by the entry point index.d.ts
 //
@@ -670,7 +664,9 @@ view?: string | undefined;
 } & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
 width: number;
 height: number;
-size?: undefined;
+size?: undefined; /**
+* @deprecated
+*/
 view?: string | undefined;
 } & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
 width: string;

--- a/packages/sdds-serv/package-lock.json
+++ b/packages/sdds-serv/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@salutejs/sdds-srvc",
+  "name": "@salutejs/sdds-serv",
   "version": "0.12.0-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@salutejs/sdds-srvc",
+      "name": "@salutejs/sdds-serv",
       "version": "0.12.0-dev.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/sdds-serv/package.json
+++ b/packages/sdds-serv/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@salutejs/sdds-srvc",
+  "name": "@salutejs/sdds-serv",
   "version": "0.12.0-dev.0",
-  "description": "Salute Design System / React UI kit for SDDS SRVC web applications",
+  "description": "Salute Design System / React UI kit for SDDS SERV web applications",
   "author": "Salute Frontend Team <salute.developers@gmail.com>",
   "license": "MIT",
   "keywords": [
@@ -16,7 +16,7 @@
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:salute-developers/plasma.git",
-    "directory": "packages/sdds-srvc"
+    "directory": "packages/sdds-serv"
   },
   "dependencies": {
     "@salutejs/plasma-new-hope": "0.52.0-dev.0",
@@ -92,8 +92,7 @@
   },
   "contributors": [
     "Vasiliy Loginevskiy",
-    "Anton Vinogradov",
-    "Fanil Zubairov"
+    "Anton Vinogradov"
   ],
   "sideEffects": false
 }


### PR DESCRIPTION
### Пакет sdds-srvc переименнован в sdds-serv


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-serv@0.12.1-canary.1072.8077092341.0
  # or 
  yarn add @salutejs/sdds-serv@0.12.1-canary.1072.8077092341.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
