### PR TITLE
chore(new-hope): fix overlay stories

### DIFF
--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Overlay/Overlay.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Overlay/Overlay.stories.tsx
@@ -11,7 +11,9 @@ import { Overlay } from '../../../../components/Overlay';
 
 const onOverlayClick = action('onOverlayClick');
 
-export default {
+type StoryOverlayProps = ComponentProps<typeof Overlay>;
+
+const meta: Meta<StoryOverlayProps> = {
     title: 'plasma_b2c/Overlay',
     decorators: [WithTheme],
     argTypes: {
@@ -29,9 +31,10 @@ export default {
         },
         ...disableProps(['onOverlayClick', 'zIndex']),
     },
-} as Meta;
+    component: Overlay,
+};
 
-type StoryOverlayProps = ComponentProps<typeof Overlay>;
+export default meta;
 
 const StyledButton = styled(Button)`
     margin: 1rem;

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Overlay/Overlay.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Overlay/Overlay.stories.tsx
@@ -11,7 +11,9 @@ import { Overlay } from '../../../../components/Overlay';
 
 const onOverlayClick = action('onOverlayClick');
 
-export default {
+type StoryOverlayProps = ComponentProps<typeof Overlay>;
+
+const meta: Meta<StoryOverlayProps> = {
     title: 'plasma_web/Overlay',
     decorators: [WithTheme],
     argTypes: {
@@ -29,9 +31,10 @@ export default {
         },
         ...disableProps(['onOverlayClick', 'zIndex']),
     },
-} as Meta;
+    component: Overlay,
+};
 
-type StoryOverlayProps = ComponentProps<typeof Overlay>;
+export default meta;
 
 const StyledButton = styled(Button)`
     margin: 1rem;

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/Overlay/Overlay.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/Overlay/Overlay.stories.tsx
@@ -11,7 +11,9 @@ import { Overlay } from '../../../../components/Overlay';
 
 const onOverlayClick = action('onOverlayClick');
 
-export default {
+type StoryOverlayProps = ComponentProps<typeof Overlay>;
+
+const meta: Meta<StoryOverlayProps> = {
     title: 'sds_engineer/Overlay',
     decorators: [WithTheme],
     argTypes: {
@@ -29,9 +31,10 @@ export default {
         },
         ...disableProps(['onOverlayClick', 'zIndex']),
     },
-} as Meta;
+    component: Overlay,
+};
 
-type StoryOverlayProps = ComponentProps<typeof Overlay>;
+export default meta;
 
 const StyledButton = styled(Button)`
     margin: 1rem;


### PR DESCRIPTION
### What/why changed

Исправлены на **новый формат** stories для компонента `Overlay`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.11.1-canary.1075.8092130882.0
  npm install @salutejs/caldera@0.11.1-canary.1075.8092130882.0
  npm install @salutejs/plasma-asdk@0.46.1-canary.1075.8092130882.0
  npm install @salutejs/plasma-b2c@1.288.1-canary.1075.8092130882.0
  npm install @salutejs/plasma-new-hope@0.52.1-canary.1075.8092130882.0
  npm install @salutejs/plasma-web@1.288.1-canary.1075.8092130882.0
  npm install @salutejs/sdds-serv@0.12.2-canary.1075.8092130882.0
  # or 
  yarn add @salutejs/caldera-online@0.11.1-canary.1075.8092130882.0
  yarn add @salutejs/caldera@0.11.1-canary.1075.8092130882.0
  yarn add @salutejs/plasma-asdk@0.46.1-canary.1075.8092130882.0
  yarn add @salutejs/plasma-b2c@1.288.1-canary.1075.8092130882.0
  yarn add @salutejs/plasma-new-hope@0.52.1-canary.1075.8092130882.0
  yarn add @salutejs/plasma-web@1.288.1-canary.1075.8092130882.0
  yarn add @salutejs/sdds-serv@0.12.2-canary.1075.8092130882.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
