### PR TITLE
feat(plasma-tokens-*): Add re-export fallback tokens

### DIFF
--- a/packages/plasma-tokens-b2b/generate.ts
+++ b/packages/plasma-tokens-b2b/generate.ts
@@ -37,9 +37,9 @@ fs.existsSync(OUT_DIR) || fs.mkdirSync(OUT_DIR);
 // Генерация цветов
 writeGeneratedToFS(COLORS_DIR, [
     // Файл с токенами CSS-Variables (с дефолтными значениями)
-    { file: 'index.ts', content: generateTokens(colorThemes.light, 'css', 'colors') },
+    { file: 'index.ts', content: generateTokens({ ...colorThemes.light, ...fallbackThemeLight }, 'css', 'colors') },
     // Файл с токенами (JS-переменными) для инъекции значения напрямую
-    { file: 'values.ts', content: generateTokens(colorThemes.light) },
+    { file: 'values.ts', content: generateTokens({ ...colorThemes.light, ...fallbackThemeLight }) },
 ]);
 
 // Генерация и запись файлов тем для создания глобальных стилей

--- a/packages/plasma-tokens-b2c/generate.ts
+++ b/packages/plasma-tokens-b2c/generate.ts
@@ -37,9 +37,9 @@ fs.existsSync(OUT_DIR) || fs.mkdirSync(OUT_DIR);
 // Генерация цветов
 writeGeneratedToFS(COLORS_DIR, [
     // Файл с токенами CSS-Variables (с дефолтными значениями)
-    { file: 'index.ts', content: generateTokens(colorThemes.light, 'css', 'colors') },
+    { file: 'index.ts', content: generateTokens({ ...colorThemes.light, ...fallbackThemeLight }, 'css', 'colors') },
     // Файл с токенами (JS-переменными) для инъекции значения напрямую
-    { file: 'values.ts', content: generateTokens(colorThemes.light) },
+    { file: 'values.ts', content: generateTokens({ ...colorThemes.light, ...fallbackThemeLight }) },
 ]);
 
 // Генерация и запись файлов тем для создания глобальных стилей

--- a/packages/plasma-tokens-web/generate.ts
+++ b/packages/plasma-tokens-web/generate.ts
@@ -37,9 +37,9 @@ fs.existsSync(OUT_DIR) || fs.mkdirSync(OUT_DIR);
 // Генерация цветов
 writeGeneratedToFS(COLORS_DIR, [
     // Файл с токенами CSS-Variables (с дефолтными значениями)
-    { file: 'index.ts', content: generateTokens(colorThemes.light, 'css', 'colors') },
+    { file: 'index.ts', content: generateTokens({ ...colorThemes.light, ...fallbackThemeLight }, 'css', 'colors') },
     // Файл с токенами (JS-переменными) для инъекции значения напрямую
-    { file: 'values.ts', content: generateTokens(colorThemes.light) },
+    { file: 'values.ts', content: generateTokens({ ...colorThemes.light, ...fallbackThemeLight }) },
 ]);
 
 // Генерация и запись файлов тем для создания глобальных стилей


### PR DESCRIPTION
### Tokens

* Добавлены ре-экспорты актуальных токенов в библиотеки `@salutejs/plasma-tokens-b2b`, `@salutejs/plasma-tokens-b2c`, `@salutejs/plasma-tokens-web`

### What/why changed

У пользователей появилась необходимость забирать токены напрямую по пути `import { textPrimary } from "@salutejs/plasma-tokens-b2b"` и т.д.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.13.0-canary.1078.8095147029.0
  npm install @salutejs/caldera@0.13.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-asdk@0.48.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-b2c@1.290.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-core@1.152.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-hope@1.266.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-icons@1.185.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-new-hope@0.54.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-tokens-b2b@1.34.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-tokens-b2c@0.44.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-tokens-web@1.49.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-ui@1.236.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-web@1.290.0-canary.1078.8095147029.0
  npm install @salutejs/sdds-serv@0.14.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-cy-utils@0.84.0-canary.1078.8095147029.0
  npm install @salutejs/plasma-sb-utils@0.150.0-canary.1078.8095147029.0
  # or 
  yarn add @salutejs/caldera-online@0.13.0-canary.1078.8095147029.0
  yarn add @salutejs/caldera@0.13.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-asdk@0.48.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-b2c@1.290.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-core@1.152.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-hope@1.266.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-icons@1.185.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-new-hope@0.54.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-tokens-b2b@1.34.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-tokens-b2c@0.44.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-tokens-web@1.49.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-ui@1.236.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-web@1.290.0-canary.1078.8095147029.0
  yarn add @salutejs/sdds-serv@0.14.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-cy-utils@0.84.0-canary.1078.8095147029.0
  yarn add @salutejs/plasma-sb-utils@0.150.0-canary.1078.8095147029.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
