### PR TITLE
feat(plasma-new-hope, b2c): ButtonBase

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -38,6 +38,7 @@ import { blurs } from '@salutejs/plasma-core';
 import { BoldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Typography.types';
 import { Breakpoint } from '@salutejs/plasma-hope';
 import { BreakWordProps } from '@salutejs/plasma-core';
+import { ButtonBase } from '@salutejs/plasma-new-hope/styled-components';
 import { ButtonGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ButtonHTMLAttributes } from 'react';
 import { ButtonProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -492,6 +493,8 @@ size: {
 button2: string;
 };
 }> & TypographyOldProps & RefAttributes<HTMLDivElement>>;
+
+export { ButtonBase }
 
 // @public
 export const ButtonGroup: FunctionComponent<PropsType<    {

--- a/packages/plasma-b2c/src/components/ButtonBase/index.ts
+++ b/packages/plasma-b2c/src/components/ButtonBase/index.ts
@@ -1,0 +1,1 @@
+export { ButtonBase } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/plasma-b2c/src/index.ts
+++ b/packages/plasma-b2c/src/index.ts
@@ -54,3 +54,4 @@ export * from './utils';
 export * from './components/Avatar';
 export * from './components/AvatarGroup';
 export * from './components/Indicator';
+export * from './components/ButtonBase';

--- a/packages/plasma-new-hope/src/components/ButtonBase/index.ts
+++ b/packages/plasma-new-hope/src/components/ButtonBase/index.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+import { addFocus } from '../../mixins';
+
+export const ButtonBase = styled.button`
+    width: 100%;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    background-color: transparent;
+    box-sizing: border-box;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: background-color 0.3s ease-in-out;
+    cursor: pointer;
+    border-radius: 0.25rem;
+    &:disabled {
+        background-color: transparent;
+    }
+    &:focus {
+        outline: none;
+    }
+    ${addFocus({
+        outlineRadius: 'inherit',
+    })}
+`;

--- a/packages/plasma-new-hope/src/index.ts
+++ b/packages/plasma-new-hope/src/index.ts
@@ -37,4 +37,5 @@ export * from './components/Overlay';
 export * from './components/SSRProvider';
 export * from './components/Combobox';
 export * from './components/Indicator';
+export * from './components/ButtonBase';
 export * from './components/Grid';

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -38,6 +38,7 @@ import { blurs } from '@salutejs/plasma-core';
 import { BoldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Typography.types';
 import { Breakpoint } from '@salutejs/plasma-hope';
 import { BreakWordProps } from '@salutejs/plasma-core';
+import { ButtonBase } from '@salutejs/plasma-new-hope/styled-components';
 import { ButtonGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ButtonHTMLAttributes } from 'react';
 import { ButtonProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -492,6 +493,8 @@ size: {
 button2: string;
 };
 }> & TypographyOldProps & RefAttributes<HTMLDivElement>>;
+
+export { ButtonBase }
 
 // @public
 export const ButtonGroup: FunctionComponent<PropsType<    {

--- a/packages/plasma-web/src/components/ButtonBase/index.ts
+++ b/packages/plasma-web/src/components/ButtonBase/index.ts
@@ -1,0 +1,1 @@
+export { ButtonBase } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/plasma-web/src/index.ts
+++ b/packages/plasma-web/src/index.ts
@@ -54,3 +54,4 @@ export * from './utils';
 export * from './components/Avatar';
 export * from './components/AvatarGroup';
 export * from './components/Indicator';
+export * from './components/ButtonBase';


### PR DESCRIPTION
### ButtonBase

-   добавлен styled-элемент ButtonBase в new-hope и b2c
-   он служит базой для создания кастомных кнопок

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.20.1-canary.1080.8261082592.0
  npm install @salutejs/caldera@0.20.1-canary.1080.8261082592.0
  npm install @salutejs/plasma-asdk@0.56.1-canary.1080.8261082592.0
  npm install @salutejs/plasma-b2c@1.298.1-canary.1080.8261082592.0
  npm install @salutejs/plasma-new-hope@0.60.1-canary.1080.8261082592.0
  npm install @salutejs/plasma-web@1.298.1-canary.1080.8261082592.0
  npm install @salutejs/sdds-serv@0.23.1-canary.1080.8261082592.0
  # or 
  yarn add @salutejs/caldera-online@0.20.1-canary.1080.8261082592.0
  yarn add @salutejs/caldera@0.20.1-canary.1080.8261082592.0
  yarn add @salutejs/plasma-asdk@0.56.1-canary.1080.8261082592.0
  yarn add @salutejs/plasma-b2c@1.298.1-canary.1080.8261082592.0
  yarn add @salutejs/plasma-new-hope@0.60.1-canary.1080.8261082592.0
  yarn add @salutejs/plasma-web@1.298.1-canary.1080.8261082592.0
  yarn add @salutejs/sdds-serv@0.23.1-canary.1080.8261082592.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
