### PR TITLE
plasma new-hope: extended range logic for calenar

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/utils/index.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/utils/index.ts
@@ -116,7 +116,7 @@ export const isDayInRage = (
     }
 
     const day = new Date(year, monthIndex, currentDay);
-    return startValue && startValue <= day && day <= endValue;
+    return startValue && startValue < day && day <= endValue;
 };
 
 export const isSameDay = (firstDate: DateObject, secondDate?: DateObject) =>
@@ -243,9 +243,11 @@ export const canSelectDate = (
     const hoverDate = new Date(year, monthIndex, day);
     const [startDate] = value;
 
-    if (hoverDate?.getTime() === startDate?.getTime()) {
-        return false;
-    }
+    // if (hoverDate?.getTime() === startDate?.getTime()) {
+    //     return false;
+    // }
+
+    // Закоментировано, для возможности в Range режиме выбрать один и тот же день
 
     if (!disabledList?.length) {
         return true;

--- a/packages/plasma-new-hope/src/components/Calendar/utils/index.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/utils/index.ts
@@ -243,12 +243,6 @@ export const canSelectDate = (
     const hoverDate = new Date(year, monthIndex, day);
     const [startDate] = value;
 
-    // if (hoverDate?.getTime() === startDate?.getTime()) {
-    //     return false;
-    // }
-
-    // Закоментировано, для возможности в Range режиме выбрать один и тот же день
-
     if (!disabledList?.length) {
         return true;
     }


### PR DESCRIPTION
### Calendar

-  добавлено возможность выбрать 1 дня в типе range

### What/why changed

Возможность выбор 1 дня в типе range, закомментировал проверку на hoverDate со startDate


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.16.0-canary.1081.8112366460.0
  npm install @salutejs/caldera@0.16.0-canary.1081.8112366460.0
  npm install @salutejs/plasma-asdk@0.51.0-canary.1081.8112366460.0
  npm install @salutejs/plasma-b2c@1.293.0-canary.1081.8112366460.0
  npm install @salutejs/plasma-new-hope@0.57.0-canary.1081.8112366460.0
  npm install @salutejs/plasma-web@1.293.0-canary.1081.8112366460.0
  npm install @salutejs/sdds-serv@0.17.0-canary.1081.8112366460.0
  # or 
  yarn add @salutejs/caldera-online@0.16.0-canary.1081.8112366460.0
  yarn add @salutejs/caldera@0.16.0-canary.1081.8112366460.0
  yarn add @salutejs/plasma-asdk@0.51.0-canary.1081.8112366460.0
  yarn add @salutejs/plasma-b2c@1.293.0-canary.1081.8112366460.0
  yarn add @salutejs/plasma-new-hope@0.57.0-canary.1081.8112366460.0
  yarn add @salutejs/plasma-web@1.293.0-canary.1081.8112366460.0
  yarn add @salutejs/sdds-serv@0.17.0-canary.1081.8112366460.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
