### PR TITLE
feat(plasma-new-hope): TextField issue with opacity

### DIFF
--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -13,6 +13,7 @@ import { base as labelPlacement } from './_label-placement/base';
 import { Input, LeftHelper, Label, InputWrapper, InputLabelWrapper } from './TextField.styles';
 
 const base = css`
+    /* NOTE: Webkit не применяет opacity к inline тегам */
     display: block;
 `;
 

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -12,7 +12,9 @@ import { base as disabled } from './_disabled/base';
 import { base as labelPlacement } from './_label-placement/base';
 import { Input, LeftHelper, Label, InputWrapper, InputLabelWrapper } from './TextField.styles';
 
-const base = css``;
+const base = css`
+    display: block;
+`;
 
 export const textFieldRoot = (
     Root: RootProps<HTMLInputElement, TextFieldProps & LabelHTMLAttributes<HTMLLabelElement>>,


### PR DESCRIPTION
### Баг с прозрачностью в TextField

Исправлен баг с прозрачностью в компоненте TextField. Проблема была только в сафари, т.к. вебкит не применяет opacity к inline тегам. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.17.0-canary.1082.8157187677.0
  npm install @salutejs/caldera@0.17.0-canary.1082.8157187677.0
  npm install @salutejs/plasma-asdk@0.51.0-canary.1082.8157187677.0
  npm install @salutejs/plasma-b2c@1.293.0-canary.1082.8157187677.0
  npm install @salutejs/plasma-new-hope@0.57.0-canary.1082.8157187677.0
  npm install @salutejs/plasma-web@1.293.0-canary.1082.8157187677.0
  npm install @salutejs/sdds-serv@0.18.0-canary.1082.8157187677.0
  # or 
  yarn add @salutejs/caldera-online@0.17.0-canary.1082.8157187677.0
  yarn add @salutejs/caldera@0.17.0-canary.1082.8157187677.0
  yarn add @salutejs/plasma-asdk@0.51.0-canary.1082.8157187677.0
  yarn add @salutejs/plasma-b2c@1.293.0-canary.1082.8157187677.0
  yarn add @salutejs/plasma-new-hope@0.57.0-canary.1082.8157187677.0
  yarn add @salutejs/plasma-web@1.293.0-canary.1082.8157187677.0
  yarn add @salutejs/sdds-serv@0.18.0-canary.1082.8157187677.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
