### PR TITLE
fix(new-hope): remove wrapper from popover

### DIFF
--- a/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
@@ -5,12 +5,11 @@ import { DEFAULT_Z_INDEX } from '../Popup/utils';
 import { classes, tokens } from './Popover.tokens';
 import { PopoverProps } from './Popover.types';
 
-export const Wrapper = styled.div``;
-
+export const StyledWrapper = styled.div``;
 export const StyledRoot = styled.div`
-    position: relative;
-    box-sizing: border-box;
     display: inline-flex;
+    box-sizing: border-box;
+    position: relative;
 `;
 
 export const StyledArrow = styled.div`

--- a/packages/plasma-new-hope/src/components/Popover/Popover.tsx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.tsx
@@ -8,7 +8,7 @@ import { cx } from '../../utils';
 
 import { base as viewCSS } from './variations/_view/base';
 import type { PopoverPlacement, PopoverProps } from './Popover.types';
-import { StyledArrow, StyledPopover, StyledRoot, Wrapper } from './Popover.styles';
+import { StyledArrow, StyledPopover, StyledRoot, StyledWrapper } from './Popover.styles';
 import { classes } from './Popover.tokens';
 
 export const ESCAPE_KEYCODE = 27;
@@ -214,7 +214,7 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
             }, [isOpen, children, forceUpdate]);
 
             return (
-                <Wrapper className={classes.wrapper}>
+                <StyledWrapper className={classes.wrapper}>
                     <StyledRoot
                         ref={handleRef}
                         onClick={onClick}
@@ -250,7 +250,7 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
                             </Root>,
                             portalRef.current,
                         )}
-                </Wrapper>
+                </StyledWrapper>
             );
         },
     );

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
@@ -52,6 +52,7 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                 size,
                 contentLeft,
                 zIndex = '9200',
+                className,
                 ...rest
             },
             outerRef,
@@ -86,7 +87,9 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                     aria-hidden={!isOpen}
                     aria-live="polite"
                     role="tooltip"
-                    className={cx(ref?.classList.toString())} // INFO: Прокидываем стили для Popover из Root Tooltip-а
+                    className={cx(ref?.classList.toString(), className)}
+                    // INFO: Прокидываем стили для Popover из Root Tooltip-а
+
                     {...rest}
                 >
                     <Root view={view} size={size} ref={setRef}>


### PR DESCRIPTION
### Tooltip

-   Classname добавляется в tooltip

### What/why changed

Теперь не ломается стрелка при добавлении стилей

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.16.1-canary.1083.8155986695.0
  npm install @salutejs/caldera@0.16.1-canary.1083.8155986695.0
  npm install @salutejs/plasma-asdk@0.50.1-canary.1083.8155986695.0
  npm install @salutejs/plasma-b2c@1.292.1-canary.1083.8155986695.0
  npm install @salutejs/plasma-new-hope@0.56.1-canary.1083.8155986695.0
  npm install @salutejs/plasma-web@1.292.1-canary.1083.8155986695.0
  npm install @salutejs/sdds-serv@0.17.1-canary.1083.8155986695.0
  # or 
  yarn add @salutejs/caldera-online@0.16.1-canary.1083.8155986695.0
  yarn add @salutejs/caldera@0.16.1-canary.1083.8155986695.0
  yarn add @salutejs/plasma-asdk@0.50.1-canary.1083.8155986695.0
  yarn add @salutejs/plasma-b2c@1.292.1-canary.1083.8155986695.0
  yarn add @salutejs/plasma-new-hope@0.56.1-canary.1083.8155986695.0
  yarn add @salutejs/plasma-web@1.292.1-canary.1083.8155986695.0
  yarn add @salutejs/sdds-serv@0.17.1-canary.1083.8155986695.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
