### PR TITLE
feat(new-hope): edit calendar range logic and fix name

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/hooks/useDays.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/hooks/useDays.ts
@@ -8,7 +8,7 @@ import {
     getOffsetDayInWeek,
     getPrevDate,
     IsCurrentDay,
-    isDayInRage,
+    isDayInRange,
     isSelectedDay,
 } from '../utils';
 import type { CalendarValueType, DateItem, DateObject, DisabledDay, EventDay } from '../Calendar.types';
@@ -25,7 +25,7 @@ const getDaysInPrevMonth = (date: DateObject, offsetDayInWeek: number, value: Ca
         isSelected: false,
         isDayInCurrentMonth: false,
         inRange: Array.isArray(value)
-            ? isDayInRage(prevYear, prevMonth, daysInPrevMonth - (offsetDayInWeek - i) + 1, value)
+            ? isDayInRange(prevYear, prevMonth, daysInPrevMonth - (offsetDayInWeek - i) + 1, value)
             : false,
         date: {
             day: daysInPrevMonth - (offsetDayInWeek - i) + 1,
@@ -45,7 +45,7 @@ const getDaysInCurrentMonth = (date: DateObject, daysInMonth: number, value: Cal
             ? Boolean(value.find((v) => isSelectedDay(date, i + 1, v)))
             : isSelectedDay(date, i + 1, value),
         isDayInCurrentMonth: true,
-        inRange: Array.isArray(value) ? isDayInRage(date.year, date.monthIndex, i + 1, value) : false,
+        inRange: Array.isArray(value) ? isDayInRange(date.year, date.monthIndex, i + 1, value) : false,
         date: {
             day: i + 1,
             monthIndex: date.monthIndex,
@@ -71,7 +71,7 @@ const getDaysInNextMonth = (
         isCurrent: false,
         isSelected: false,
         isDayInCurrentMonth: false,
-        inRange: Array.isArray(value) ? isDayInRage(nextYear, nextMonthIndex, i + 1, value) : false,
+        inRange: Array.isArray(value) ? isDayInRange(nextYear, nextMonthIndex, i + 1, value) : false,
         date: {
             day: i + 1,
             monthIndex: nextMonthIndex,

--- a/packages/plasma-new-hope/src/components/Calendar/utils/index.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/utils/index.ts
@@ -103,7 +103,7 @@ export const getSortedValues = (values: [Date | undefined, (Date | undefined)?])
         return start.getTime() - end.getTime();
     });
 
-export const isDayInRage = (
+export const isDayInRange = (
     year: number,
     monthIndex: number,
     currentDay: number,
@@ -111,12 +111,12 @@ export const isDayInRage = (
 ) => {
     const [startValue, endValue] = getSortedValues(values);
 
-    if (!endValue) {
+    if (!endValue || !startValue) {
         return false;
     }
 
     const day = new Date(year, monthIndex, currentDay);
-    return startValue && startValue <= day && day <= endValue;
+    return startValue < day && day <= endValue;
 };
 
 export const isSameDay = (firstDate: DateObject, secondDate?: DateObject) =>
@@ -242,10 +242,6 @@ export const canSelectDate = (
 
     const hoverDate = new Date(year, monthIndex, day);
     const [startDate] = value;
-
-    if (hoverDate?.getTime() === startDate?.getTime()) {
-        return false;
-    }
 
     if (!disabledList?.length) {
         return true;


### PR DESCRIPTION
### Calendar

-   добавлено возможность выбрать 1 дня в типе range

### What/why changed

Возможность выбор 1 дня в типе range, убрал проверку на hoverDate со startDate. И изменил название функции, которая была написана неправильно 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.17.0-canary.1084.8168958226.0
  npm install @salutejs/caldera@0.17.0-canary.1084.8168958226.0
  npm install @salutejs/plasma-asdk@0.51.0-canary.1084.8168958226.0
  npm install @salutejs/plasma-b2c@1.293.0-canary.1084.8168958226.0
  npm install @salutejs/plasma-new-hope@0.57.0-canary.1084.8168958226.0
  npm install @salutejs/plasma-web@1.293.0-canary.1084.8168958226.0
  npm install @salutejs/sdds-serv@0.18.0-canary.1084.8168958226.0
  # or 
  yarn add @salutejs/caldera-online@0.17.0-canary.1084.8168958226.0
  yarn add @salutejs/caldera@0.17.0-canary.1084.8168958226.0
  yarn add @salutejs/plasma-asdk@0.51.0-canary.1084.8168958226.0
  yarn add @salutejs/plasma-b2c@1.293.0-canary.1084.8168958226.0
  yarn add @salutejs/plasma-new-hope@0.57.0-canary.1084.8168958226.0
  yarn add @salutejs/plasma-web@1.293.0-canary.1084.8168958226.0
  yarn add @salutejs/sdds-serv@0.18.0-canary.1084.8168958226.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
