### PR TITLE
fix(ui): fix pickers documentation bug with overflow

### DIFF
--- a/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
+++ b/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
@@ -34,7 +34,6 @@ interface StyledSizeProps {
 export const StyledPickerItem = styled.div<StyledSizeProps>`
     position: relative;
     box-sizing: border-box;
-    overflow: hidden;
     display: flex;
     align-items: center;
     text-align: center;


### PR DESCRIPTION
### Pickers

-   fix бага в документации 

### What/why changed

Убрал свойство "overflow: hidden", чтобы исправить баг. Визуализация на рабочих компонентах никак не пострадала 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.17.1-canary.1089.8186819754.0
  npm install @salutejs/caldera@0.17.1-canary.1089.8186819754.0
  npm install @salutejs/plasma-asdk@0.51.1-canary.1089.8186819754.0
  npm install @salutejs/plasma-b2c@1.293.1-canary.1089.8186819754.0
  npm install @salutejs/plasma-new-hope@0.57.1-canary.1089.8186819754.0
  npm install @salutejs/plasma-ui@1.237.3-canary.1089.8186819754.0
  npm install @salutejs/plasma-web@1.293.1-canary.1089.8186819754.0
  npm install @salutejs/sdds-serv@0.18.1-canary.1089.8186819754.0
  # or 
  yarn add @salutejs/caldera-online@0.17.1-canary.1089.8186819754.0
  yarn add @salutejs/caldera@0.17.1-canary.1089.8186819754.0
  yarn add @salutejs/plasma-asdk@0.51.1-canary.1089.8186819754.0
  yarn add @salutejs/plasma-b2c@1.293.1-canary.1089.8186819754.0
  yarn add @salutejs/plasma-new-hope@0.57.1-canary.1089.8186819754.0
  yarn add @salutejs/plasma-ui@1.237.3-canary.1089.8186819754.0
  yarn add @salutejs/plasma-web@1.293.1-canary.1089.8186819754.0
  yarn add @salutejs/sdds-serv@0.18.1-canary.1089.8186819754.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
