### PR TITLE
feat(plasma-new-hope): Added ellipsis at the end of long TextField

### DIFF
--- a/packages/plasma-new-hope/src/components/TextField/TextField.styles.ts
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.styles.ts
@@ -1,5 +1,7 @@
 import { styled } from '@linaria/react';
 
+import { applyEllipsis } from '../../mixins';
+
 export const Input = styled.input`
     box-sizing: border-box;
     appearance: none;
@@ -7,6 +9,8 @@ export const Input = styled.input`
     padding: 0;
     background-color: transparent;
     outline: none;
+
+    ${applyEllipsis()};
 `;
 
 export const InputLabelWrapper = styled.div`


### PR DESCRIPTION
### Троеточие в конце TextField

- Добавлено троеточие в конце длинной строки
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.16.0-canary.1091.8138016017.0
  npm install @salutejs/caldera@0.16.0-canary.1091.8138016017.0
  npm install @salutejs/plasma-asdk@0.51.0-canary.1091.8138016017.0
  npm install @salutejs/plasma-b2c@1.293.0-canary.1091.8138016017.0
  npm install @salutejs/plasma-new-hope@0.57.0-canary.1091.8138016017.0
  npm install @salutejs/plasma-web@1.293.0-canary.1091.8138016017.0
  npm install @salutejs/sdds-serv@0.17.0-canary.1091.8138016017.0
  # or 
  yarn add @salutejs/caldera-online@0.16.0-canary.1091.8138016017.0
  yarn add @salutejs/caldera@0.16.0-canary.1091.8138016017.0
  yarn add @salutejs/plasma-asdk@0.51.0-canary.1091.8138016017.0
  yarn add @salutejs/plasma-b2c@1.293.0-canary.1091.8138016017.0
  yarn add @salutejs/plasma-new-hope@0.57.0-canary.1091.8138016017.0
  yarn add @salutejs/plasma-web@1.293.0-canary.1091.8138016017.0
  yarn add @salutejs/sdds-serv@0.17.0-canary.1091.8138016017.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
