### PR TITLE
fix(sdds-serv): add components to sdds-serv

### DIFF
--- a/packages/caldera-online/api/caldera-online.api.md
+++ b/packages/caldera-online/api/caldera-online.api.md
@@ -22,6 +22,7 @@ import { bodyXXSBold } from '@salutejs/caldera-online-themes/tokens';
 import { BoldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Typography.types';
 import { ButtonHTMLAttributes } from 'react';
 import { ButtonProps as ButtonProps_2 } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentClass } from 'react';
 import { CustomDropdownProps } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
 import { CustomToastProps } from '@salutejs/plasma-new-hope/types/components/Toast/Toast.types';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/styled-components';
@@ -49,6 +50,7 @@ import { h5 } from '@salutejs/caldera-online-themes/tokens';
 import { h5Bold } from '@salutejs/caldera-online-themes/tokens';
 import { HTMLAttributes } from 'react';
 import type { InputHTMLAttributes } from 'react';
+import { JSXElementConstructor } from 'react';
 import { LinkCustomProps } from '@salutejs/plasma-new-hope/types/components/Link/Link';
 import { mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 import { modalClasses } from '@salutejs/plasma-new-hope/styled-components';
@@ -61,7 +63,10 @@ import { PopupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
+import { ReactElement } from 'react';
+import { ReactFragment } from 'react';
 import { ReactNode } from 'react';
+import { ReactPortal } from 'react';
 import { RefAttributes } from 'react';
 import { SegmentGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -85,6 +90,7 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
+import { Variants } from '@salutejs/plasma-new-hope/types/engines/types';
 
 export { addFocus }
 
@@ -213,6 +219,25 @@ view: {
 primary: string;
 };
 }> & HTMLAttributes<HTMLDivElement> & CustomDropdownProps & RefAttributes<HTMLDivElement>>;
+
+// @public
+export const DropdownItem: FunctionComponent<PropsType<Variants> & Omit<HTMLAttributes<HTMLDivElement>, "onSelect"> & {
+id?: string | undefined;
+disabled?: boolean | undefined;
+label?: ReactNode;
+role?: string | undefined;
+contentLeft?: string | number | boolean | ReactElement<any, string | JSXElementConstructor<any>> | FunctionComponent<any> | ReactFragment | ReactPortal | ComponentClass<any, any> | null | undefined;
+contentRight?: string | number | boolean | ReactElement<any, string | JSXElementConstructor<any>> | FunctionComponent<any> | ReactFragment | ReactPortal | ComponentClass<any, any> | null | undefined;
+name?: string | undefined;
+checked?: boolean | undefined;
+text?: string | undefined;
+value?: string | number | boolean | undefined;
+isSelected?: boolean | undefined;
+onClick?: ((event: MouseEvent_2<HTMLDivElement, MouseEvent>) => void) | undefined;
+onSelect?: ((value?: any, text?: any) => void) | undefined;
+size?: string | undefined;
+view?: string | undefined;
+} & RefAttributes<HTMLDivElement>>;
 
 export { DropdownPlacement }
 

--- a/packages/caldera-online/src/components/Dropdown/index.ts
+++ b/packages/caldera-online/src/components/Dropdown/index.ts
@@ -1,2 +1,2 @@
-export { Dropdown } from './Dropdown';
+export { Dropdown, DropdownItem } from './Dropdown';
 export type { DropdownProps, DropdownPlacement, DropdownTrigger } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/caldera/api/caldera.api.md
+++ b/packages/caldera/api/caldera.api.md
@@ -22,6 +22,7 @@ import { bodyXXSBold } from '@salutejs/caldera-online-themes/tokens';
 import { BoldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Typography.types';
 import { ButtonHTMLAttributes } from 'react';
 import { ButtonProps as ButtonProps_2 } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentClass } from 'react';
 import { CustomDropdownProps } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
 import { CustomToastProps } from '@salutejs/plasma-new-hope/types/components/Toast/Toast.types';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/styled-components';
@@ -49,6 +50,7 @@ import { h5 } from '@salutejs/caldera-online-themes/tokens';
 import { h5Bold } from '@salutejs/caldera-online-themes/tokens';
 import { HTMLAttributes } from 'react';
 import type { InputHTMLAttributes } from 'react';
+import { JSXElementConstructor } from 'react';
 import { LinkCustomProps } from '@salutejs/plasma-new-hope/types/components/Link/Link';
 import { mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 import { modalClasses } from '@salutejs/plasma-new-hope/styled-components';
@@ -61,7 +63,10 @@ import { PopupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
+import { ReactElement } from 'react';
+import { ReactFragment } from 'react';
 import { ReactNode } from 'react';
+import { ReactPortal } from 'react';
 import { RefAttributes } from 'react';
 import { SegmentGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -85,6 +90,7 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
+import { Variants } from '@salutejs/plasma-new-hope/types/engines/types';
 
 export { addFocus }
 
@@ -213,6 +219,25 @@ view: {
 primary: string;
 };
 }> & HTMLAttributes<HTMLDivElement> & CustomDropdownProps & RefAttributes<HTMLDivElement>>;
+
+// @public
+export const DropdownItem: FunctionComponent<PropsType<Variants> & Omit<HTMLAttributes<HTMLDivElement>, "onSelect"> & {
+id?: string | undefined;
+disabled?: boolean | undefined;
+label?: ReactNode;
+role?: string | undefined;
+contentLeft?: string | number | boolean | ReactElement<any, string | JSXElementConstructor<any>> | FunctionComponent<any> | ReactFragment | ReactPortal | ComponentClass<any, any> | null | undefined;
+contentRight?: string | number | boolean | ReactElement<any, string | JSXElementConstructor<any>> | FunctionComponent<any> | ReactFragment | ReactPortal | ComponentClass<any, any> | null | undefined;
+name?: string | undefined;
+checked?: boolean | undefined;
+text?: string | undefined;
+value?: string | number | boolean | undefined;
+isSelected?: boolean | undefined;
+onClick?: ((event: MouseEvent_2<HTMLDivElement, MouseEvent>) => void) | undefined;
+onSelect?: ((value?: any, text?: any) => void) | undefined;
+size?: string | undefined;
+view?: string | undefined;
+} & RefAttributes<HTMLDivElement>>;
 
 export { DropdownPlacement }
 

--- a/packages/caldera/src/components/Dropdown/index.ts
+++ b/packages/caldera/src/components/Dropdown/index.ts
@@ -1,2 +1,2 @@
-export { Dropdown } from './Dropdown';
+export { Dropdown, DropdownItem } from './Dropdown';
 export type { DropdownProps, DropdownPlacement, DropdownTrigger } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -24,6 +24,7 @@ import { bodyXSBold } from '@salutejs/sdds-themes/tokens';
 import { bodyXXS } from '@salutejs/sdds-themes/tokens';
 import { bodyXXSBold } from '@salutejs/sdds-themes/tokens';
 import { BoldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Typography.types';
+import { ButtonGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ButtonHTMLAttributes } from 'react';
 import { ButtonProps as ButtonProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { ClosePlacementType } from '@salutejs/plasma-new-hope/styled-components';
@@ -288,6 +289,49 @@ fixed: string;
 };
 }> & ButtonProps_2<HTMLElement> & RefAttributes<HTMLButtonElement>>;
 
+// @public
+export const ButtonGroup: FunctionComponent<PropsType<    {
+view: {
+primary: string;
+accent: string;
+secondary: string;
+clear: string;
+success: string;
+warning: string;
+critical: string;
+};
+size: {
+l: string;
+lr: string;
+m: string;
+mr: string;
+s: string;
+sr: string;
+xs: string;
+xsr: string;
+xxs: string;
+};
+orientation: {
+horizontal: string;
+vertical: string;
+};
+gap: {
+none: string;
+dense: string;
+wide: string;
+};
+shape: {
+segmented: string;
+default: string;
+};
+stretching: {
+auto: string;
+filled: string;
+};
+}> & ButtonGroupProps & RefAttributes<HTMLDivElement>>;
+
+export { ButtonGroupProps }
+
 // Warning: (ae-forgotten-export) The symbol "ButtonComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -449,6 +493,25 @@ view: {
 primary: string;
 };
 }> & HTMLAttributes<HTMLDivElement> & CustomDropdownProps & RefAttributes<HTMLDivElement>>;
+
+// @public
+export const DropdownItem: FunctionComponent<PropsType<Variants> & Omit<HTMLAttributes<HTMLDivElement>, "onSelect"> & {
+id?: string | undefined;
+disabled?: boolean | undefined;
+label?: ReactNode;
+role?: string | undefined;
+contentLeft?: string | number | boolean | ReactElement<any, string | JSXElementConstructor<any>> | FunctionComponent<any> | ReactFragment | ReactPortal | ComponentClass<any, any> | null | undefined;
+contentRight?: string | number | boolean | ReactElement<any, string | JSXElementConstructor<any>> | FunctionComponent<any> | ReactFragment | ReactPortal | ComponentClass<any, any> | null | undefined;
+name?: string | undefined;
+checked?: boolean | undefined;
+text?: string | undefined;
+value?: string | number | boolean | undefined;
+isSelected?: boolean | undefined;
+onClick?: ((event: MouseEvent_2<HTMLDivElement, MouseEvent>) => void) | undefined;
+onSelect?: ((value?: any, text?: any) => void) | undefined;
+size?: string | undefined;
+view?: string | undefined;
+} & RefAttributes<HTMLDivElement>>;
 
 export { DropdownPlacement }
 

--- a/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.config.ts
+++ b/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.config.ts
@@ -1,0 +1,267 @@
+import { css, buttonGroupTokens, buttonGroupClasses } from '@salutejs/plasma-new-hope/styled-components';
+
+export const config = {
+    defaults: {
+        view: 'primary',
+        size: 'm',
+    },
+    variations: {
+        view: {
+            primary: css`
+                ${buttonGroupTokens.buttonColor}: var(--inverse-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColor}: var(--surface-solid-default);
+                ${buttonGroupTokens.buttonColorHover}: var(--inverse-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorHover}: color-mix(
+                    in srgb,
+                    var(--inverse-text-primary),
+                    var(--surface-solid-default) 85%
+                );
+                ${buttonGroupTokens.buttonColorActive}: var(--inverse-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorActive}: color-mix(
+                    in srgb,
+                    var(--inverse-text-primary),
+                    var(--surface-solid-default) 80%
+                );
+            `,
+            accent: css`
+                ${buttonGroupTokens.buttonColor}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColor}: var(--surface-accent);
+                ${buttonGroupTokens.buttonColorHover}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorHover}: color-mix(in srgb, var(--text-primary), var(--surface-accent) 85%);
+                ${buttonGroupTokens.buttonColorActive}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorActive}: color-mix(in srgb, var(--text-primary), var(--surface-accent) 80%);
+            `,
+            secondary: css`
+                ${buttonGroupTokens.buttonColor}: var(--text-primary);
+                ${buttonGroupTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
+                ${buttonGroupTokens.buttonColorHover}: var(--text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorHover}: color-mix(
+                    in srgb,
+                    var(--inverse-text-primary),
+                    var(--surface-transparent-secondary) 85%
+                );
+                ${buttonGroupTokens.buttonColorActive}: var(--text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorActive}: color-mix(
+                    in srgb,
+                    var(--inverse-text-primary),
+                    var(--surface-transparent-secondary) 80%
+                );
+            `,
+            clear: css`
+                ${buttonGroupTokens.buttonColor}: var(--text-primary);
+                ${buttonGroupTokens.buttonBackgroundColor}: var(--surface-clear);
+                ${buttonGroupTokens.buttonColorHover}: var(--text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorHover}: color-mix(in srgb, var(--text-primary), var(--surface-clear) 95%);
+                ${buttonGroupTokens.buttonColorActive}: var(--text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorActive}: color-mix(in srgb, var(--text-primary), var(--surface-clear) 90%);
+            `,
+            success: css`
+                ${buttonGroupTokens.buttonColor}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColor}: var(--surface-positive);
+                ${buttonGroupTokens.buttonColorHover}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorHover}: color-mix(
+                    in srgb,
+                    var(--inverse-text-primary),
+                    var(--surface-positive) 85%
+                );
+                ${buttonGroupTokens.buttonColorActive}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorActive}: color-mix(in srgb, var(--text-primary), var(--surface-positive) 85%);
+            `,
+            warning: css`
+                ${buttonGroupTokens.buttonColor}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColor}: var(--surface-warning);
+                ${buttonGroupTokens.buttonColorHover}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorHover}: color-mix(
+                    in srgb,
+                    var(--inverse-text-primary),
+                    var(--surface-warning) 85%
+                );
+                ${buttonGroupTokens.buttonColorActive}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorActive}: color-mix(in srgb, var(--text-primary), var(--surface-warning) 85%);
+            `,
+            critical: css`
+                ${buttonGroupTokens.buttonColor}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColor}: var(--surface-negative);
+                ${buttonGroupTokens.buttonColorHover}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorHover}: color-mix(
+                    in srgb,
+                    var(--inverse-text-primary),
+                    var(--surface-negative) 85%
+                );
+                ${buttonGroupTokens.buttonColorActive}: var(--on-dark-text-primary);
+                ${buttonGroupTokens.buttonBackgroundColorActive}: color-mix(in srgb, var(--text-primary), var(--surface-negative) 85%);
+            `,
+        },
+        size: {
+            l: css`
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.875rem;
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.375rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.875rem;
+
+                ${buttonGroupTokens.buttonHeight}: 3.5rem;
+                ${buttonGroupTokens.buttonPadding}: 1.5rem;
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-l-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-l-line-height);
+            `,
+            lr: css`
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.875rem;
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.375rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.875rem;
+
+                ${buttonGroupTokens.buttonHeight}: 3.5rem;
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-l-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-l-line-height);
+            `,
+            m: css`
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.25rem;
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.75rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.75rem;
+
+                ${buttonGroupTokens.buttonHeight}: 3rem;
+                ${buttonGroupTokens.buttonPadding}: 1.25rem;
+
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-m-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-m-line-height);
+            `,
+            mr: css`
+                &.${buttonGroupClasses.segmented} {
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.25rem;
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.75rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.75rem;
+
+                ${buttonGroupTokens.buttonHeight}: 3rem;
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-m-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-m-line-height);
+            `,
+            s: css`
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.25rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.625rem;
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.625rem;
+
+                ${buttonGroupTokens.buttonHeight}: 2.5rem;
+                ${buttonGroupTokens.buttonPadding}: 1rem;
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-s-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-s-line-height);
+            `,
+            sr: css`
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.25rem;
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.625rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.625rem;
+
+                ${buttonGroupTokens.buttonHeight}: 2.5rem;
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-s-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-s-line-height);
+            `,
+            xs: css`
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.125rem;
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.5rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.5rem;
+
+                ${buttonGroupTokens.buttonHeight}: 2rem;
+                ${buttonGroupTokens.buttonPadding}: 0.75rem;
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-xs-line-height);
+            `,
+            xsr: css`
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.125rem;
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.5rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.5rem;
+
+                ${buttonGroupTokens.buttonHeight}: 2rem;
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-xs-line-height);
+            `,
+            xxs: css`
+                ${buttonGroupTokens.buttonSegmentedRadius}: 0.125rem;
+                ${buttonGroupTokens.buttonDefaultRadius}: 0.375rem;
+                ${buttonGroupTokens.buttonSideRadius}: 0.375rem;
+
+                ${buttonGroupTokens.buttonHeight}: 1.5rem;
+                ${buttonGroupTokens.buttonPadding}: 0.625rem;
+                ${buttonGroupTokens.buttonScaleActive}: 0.98;
+                ${buttonGroupTokens.buttonScaleHover}: 1.02;
+                ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
+                ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
+                ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
+                ${buttonGroupTokens.buttonFontWeight}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${buttonGroupTokens.buttonLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
+                ${buttonGroupTokens.buttonLineHeight}: var(--plasma-typo-body-xs-line-height);
+            `,
+        },
+        orientation: {
+            horizontal: css`
+                ${buttonGroupTokens.buttonGroupOrientation}: row;
+            `,
+            vertical: css`
+                ${buttonGroupTokens.buttonGroupOrientation}: column;
+            `,
+        },
+        gap: {
+            none: css`
+                ${buttonGroupTokens.buttonGroupItemsGap}: 0;
+            `,
+            dense: css`
+                ${buttonGroupTokens.buttonGroupItemsGap}: 0.125rem;
+            `,
+            wide: css`
+                ${buttonGroupTokens.buttonGroupItemsGap}: 0.5rem;
+            `,
+        },
+        shape: {
+            segmented: css``,
+            default: css``,
+        },
+        stretching: {
+            auto: css``,
+            filled: css``,
+        },
+    },
+};

--- a/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,16 +1,117 @@
 import React from 'react';
+import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
+import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
-import { InSpacingDecorator } from '../../helpers';
-import { H3 } from '../Typography';
+import { Button } from '../Button/Button';
 
-const meta: Meta = {
-    title: 'Layout/ButtonGroup',
+import { ButtonGroup } from './ButtonGroup';
+
+type StoryProps = ComponentProps<typeof ButtonGroup> & { itemsCount?: number };
+type Story = StoryObj<StoryProps>;
+
+const views = ['accent', 'primary', 'secondary', 'success', 'warning', 'critical', 'clear'];
+const sizes = ['l', 'm', 's', 'xs', 'xxs'];
+const orientationValues = ['horizontal', 'vertical'];
+const gapValues = ['none', 'dense', 'wide'];
+const shapeValues = ['segmented', 'default'];
+const stretchingValues = ['auto', 'filled'];
+
+const meta: Meta<typeof ButtonGroup> = {
+    title: 'Controls/ButtonGroup',
     decorators: [InSpacingDecorator],
+    argTypes: {
+        size: {
+            options: sizes,
+            control: {
+                type: 'select',
+            },
+        },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
+        orientation: {
+            options: orientationValues,
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        gap: {
+            options: gapValues,
+            control: {
+                type: 'select',
+            },
+        },
+        shape: {
+            options: shapeValues,
+            control: {
+                type: 'select',
+            },
+        },
+        stretching: {
+            options: stretchingValues,
+            control: {
+                type: 'select',
+            },
+        },
+    },
 };
 
 export default meta;
 
-export const Default: StoryObj = {
-    render: () => <H3>Компонент в разработке; Срок — 2024:Q1</H3>,
+export const Default: Story = {
+    args: {
+        view: 'primary',
+        size: 'm',
+        gap: 'dense',
+        orientation: 'horizontal',
+        shape: 'default',
+        itemsCount: 5,
+        stretching: 'auto',
+    },
+    render: ({ itemsCount, ...args }: StoryProps) => {
+        return (
+            <ButtonGroup {...args}>
+                {Array(itemsCount)
+                    .fill(true)
+                    .map((_, i) => (
+                        <Button text={`Button ${i}`} />
+                    ))}
+            </ButtonGroup>
+        );
+    },
+};
+
+export const CustomButtons: Story = {
+    args: {
+        ...Default.args,
+        isCommonButtonStyles: false,
+    },
+    argTypes: {
+        ...disableProps(['itemsCount']),
+    },
+    render: (args: StoryProps) => {
+        return (
+            <>
+                <h3>Группа кнопок с разными темами</h3>
+                <ButtonGroup {...args}>
+                    <Button text="Primary" view="primary" />
+                    <Button text="Negative" view="success" />
+                    <Button text="Positive" view="warning" />
+                    <Button text="Clear" view="clear" />
+                </ButtonGroup>
+
+                <h3>Группа кнопок с разными размерами</h3>
+                <ButtonGroup {...args}>
+                    <Button text="Primary" view="primary" size="l" />
+                    <Button text="Negative" view="success" size="m" />
+                    <Button text="Positive" view="warning" size="s" />
+                    <Button text="Clear" view="clear" size="l" />
+                </ButtonGroup>
+            </>
+        );
+    },
 };

--- a/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,10 @@
+import { buttonGroupConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+
+import { config } from './ButtonGroup.config';
+
+const mergedConfig = mergeConfig(buttonGroupConfig, config);
+
+/**
+ * Группа кнопок.
+ */
+export const ButtonGroup = component(mergedConfig);

--- a/packages/sdds-serv/src/components/ButtonGroup/index.tsx
+++ b/packages/sdds-serv/src/components/ButtonGroup/index.tsx
@@ -1,0 +1,3 @@
+export { ButtonGroup } from './ButtonGroup';
+
+export type { ButtonGroupProps } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/sdds-serv/src/components/Dropdown/index.ts
+++ b/packages/sdds-serv/src/components/Dropdown/index.ts
@@ -1,2 +1,2 @@
-export { Dropdown } from './Dropdown';
+export { Dropdown, DropdownItem } from './Dropdown';
 export type { DropdownProps, DropdownPlacement, DropdownTrigger } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/sdds-serv/src/index.ts
+++ b/packages/sdds-serv/src/index.ts
@@ -2,6 +2,7 @@ export * from './components/Avatar';
 export * from './components/AvatarGroup';
 export * from './components/Badge';
 export * from './components/Button';
+export * from './components/ButtonGroup';
 export * from './components/Drawer';
 export * from './components/Checkbox';
 export * from './components/Combobox';


### PR DESCRIPTION
### SDDS

- добавлен `ButtonGroup`
- добавлен экспорт `DropdownItem` (а так же в caldera, caldera-online)

### What/why changed

Стабилизация пакета sdds-serv.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.16.0-canary.1092.8152262621.0
  npm install @salutejs/caldera@0.16.0-canary.1092.8152262621.0
  npm install @salutejs/sdds-serv@0.17.0-canary.1092.8152262621.0
  # or 
  yarn add @salutejs/caldera-online@0.16.0-canary.1092.8152262621.0
  yarn add @salutejs/caldera@0.16.0-canary.1092.8152262621.0
  yarn add @salutejs/sdds-serv@0.17.0-canary.1092.8152262621.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
