### PR TITLE
plasma-infra: Refactoring "Deploy documentation and storybook artefacts to `/dev`"

### DIFF
--- a/.github/workflows/documentation-deploy-dev-subdir.yml
+++ b/.github/workflows/documentation-deploy-dev-subdir.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      PREFIX: 'dev'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,12 +21,12 @@ jobs:
 
       - name: Prepare directories
         run: |
-          mkdir -p s3_build s3_build_sb
+          mkdir -p s3_build
 
       - name: Plasma Website
         run: |
           npm run build --prefix="./website/plasma-website"
-          cp -R ./website/plasma-website/build ./s3_build
+          cp -R ./website/plasma-website/build ./s3_build/index
 
       - name: Plasma UI Docs
         run: |
@@ -44,37 +46,37 @@ jobs:
       - name: Plasma UI Storybook
         run: |
           npm run storybook:build --prefix="./packages/plasma-ui"
-          cp -R ./packages/plasma-ui/build-sb ./s3_build_sb/ui-storybook
+          cp -R ./packages/plasma-ui/build-sb ./s3_build/ui-storybook
 
       - name: Plasma Web Storybook
         run: |
           npm run storybook:build --prefix="./packages/plasma-web"
-          cp -R ./packages/plasma-web/build-sb ./s3_build_sb/web-storybook
+          cp -R ./packages/plasma-web/build-sb ./s3_build/web-storybook
 
       - name: Plasma B2C Storybook
         run: |
           npm run storybook:build --prefix="./packages/plasma-b2c"
-          cp -R ./packages/plasma-b2c/build-sb ./s3_build_sb/b2c-storybook
+          cp -R ./packages/plasma-b2c/build-sb ./s3_build/b2c-storybook
           
       - name: Plasma "ASDK" Storybook
         run: |
           npm run storybook:build --prefix="./packages/plasma-asdk"
-          cp -R ./packages/plasma-asdk/build-sb ./s3_build_sb/asdk-storybook
+          cp -R ./packages/plasma-asdk/build-sb ./s3_build/asdk-storybook
           
       - name: Plasma "New-hope" Storybook
         run: |
           npm run storybook:build --prefix="./packages/plasma-new-hope"
-          cp -R ./packages/plasma-new-hope/build-sb ./s3_build_sb/new-hope-storybook
+          cp -R ./packages/plasma-new-hope/build-sb ./s3_build/new-hope-storybook
         
       - name: Plasma "Caldera-online" Storybook
         run: |
           npm run storybook:build --prefix="./packages/caldera-online"
-          cp -R ./packages/caldera-online/build-sb ./s3_build_sb/caldera-online-storybook
+          cp -R ./packages/caldera-online/build-sb ./s3_build/caldera-online-storybook
       
       - name: Plasma "SDDS SERV" Storybook
         run: |
           npm run storybook:build --prefix="./packages/sdds-serv"
-          cp -R ./packages/sdds-serv/build-sb ./s3_build_sb/sdds-serv-storybook
+          cp -R ./packages/sdds-serv/build-sb ./s3_build/sdds-serv-storybook
 
       - name: Install s3cmd
         run: pip3 install s3cmd
@@ -92,19 +94,4 @@ jobs:
           --no-mime-magic
           sync
           ./s3_build/
-          s3://${{ secrets.AWS_S3_BUCKET_2 }}/dev/
-
-      - name: Upload artefacts
-        run: >
-          s3cmd
-          --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
-          --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          --host ${{ secrets.AWS_ENDPOINT }}
-          --host-bucket ${{ secrets.AWS_ENDPOINT }}
-          --bucket-location ${{ secrets.AWS_REGION }}
-          --signature-v2
-          --delete-removed
-          --no-mime-magic
-          sync
-          ./s3_build_sb/
           s3://${{ secrets.AWS_S3_BUCKET_2 }}/dev/

--- a/website/sdds-serv-docs/docusaurus.config.js
+++ b/website/sdds-serv-docs/docusaurus.config.js
@@ -13,8 +13,8 @@ const pckgJson = require('./package.json');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const versionsArchived = require('./versionsArchived.json');
 
-const { PR_NAME, VERSION_NAME } = process.env;
-const prefix = VERSION_NAME || !PR_NAME ? '' : `/pr/${PR_NAME}`;
+const { PR_NAME, VERSION_NAME, PREFIX } = process.env;
+const prefix = PREFIX || (VERSION_NAME || !PR_NAME ? '' : `/pr/${PR_NAME}`);
 const baseUrl = VERSION_NAME ? `/versions/${VERSION_NAME}/` : `${prefix}/sdds-serv/`;
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */


### PR DESCRIPTION
### What/why changed

- исправлена конфигурация для deploy в `/dev` директорию

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.17.1-canary.1102.8175322475.0
  npm install @salutejs/caldera@0.17.1-canary.1102.8175322475.0
  npm install @salutejs/plasma-asdk@0.51.1-canary.1102.8175322475.0
  npm install @salutejs/plasma-b2c@1.293.1-canary.1102.8175322475.0
  npm install @salutejs/plasma-new-hope@0.57.1-canary.1102.8175322475.0
  npm install @salutejs/plasma-ui@1.237.3-canary.1102.8175322475.0
  npm install @salutejs/plasma-web@1.293.1-canary.1102.8175322475.0
  npm install @salutejs/sdds-serv@0.18.1-canary.1102.8175322475.0
  # or 
  yarn add @salutejs/caldera-online@0.17.1-canary.1102.8175322475.0
  yarn add @salutejs/caldera@0.17.1-canary.1102.8175322475.0
  yarn add @salutejs/plasma-asdk@0.51.1-canary.1102.8175322475.0
  yarn add @salutejs/plasma-b2c@1.293.1-canary.1102.8175322475.0
  yarn add @salutejs/plasma-new-hope@0.57.1-canary.1102.8175322475.0
  yarn add @salutejs/plasma-ui@1.237.3-canary.1102.8175322475.0
  yarn add @salutejs/plasma-web@1.293.1-canary.1102.8175322475.0
  yarn add @salutejs/sdds-serv@0.18.1-canary.1102.8175322475.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
