### PR TITLE
feat: remove scale tokens from Button & ButtonGroup

### DIFF
--- a/packages/caldera-online/src/components/Button/Button.config.ts
+++ b/packages/caldera-online/src/components/Button/Button.config.ts
@@ -99,8 +99,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 12.5rem;
                 ${buttonTokens.buttonPadding}: 1.5rem;
                 ${buttonTokens.buttonRadius}: 0.875rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -114,8 +112,6 @@ export const config = {
             lr: css`
                 ${buttonTokens.buttonHeight}: 3.5rem;
                 ${buttonTokens.buttonWidth}: 12.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -131,8 +127,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1.25rem;
                 ${buttonTokens.buttonRadius}: 0.75rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -145,9 +139,7 @@ export const config = {
             `,
             mr: css`
                 ${buttonTokens.buttonHeight}: 3rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -163,8 +155,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1rem;
                 ${buttonTokens.buttonRadius}: 0.625rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -178,8 +168,6 @@ export const config = {
             sr: css`
                 ${buttonTokens.buttonHeight}: 2.5rem;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -195,8 +183,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 10rem;
                 ${buttonTokens.buttonPadding}: 0.75rem;
                 ${buttonTokens.buttonRadius}: 0.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -210,8 +196,6 @@ export const config = {
             xsr: css`
                 ${buttonTokens.buttonHeight}: 2rem;
                 ${buttonTokens.buttonWidth}: 10rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -227,8 +211,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 8.75rem;
                 ${buttonTokens.buttonPadding}: 0.625rem;
                 ${buttonTokens.buttonRadius}: 0.375rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/caldera/src/components/Button/Button.config.ts
+++ b/packages/caldera/src/components/Button/Button.config.ts
@@ -99,8 +99,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 12.5rem;
                 ${buttonTokens.buttonPadding}: 1.5rem;
                 ${buttonTokens.buttonRadius}: 0.875rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -114,8 +112,6 @@ export const config = {
             lr: css`
                 ${buttonTokens.buttonHeight}: 3.5rem;
                 ${buttonTokens.buttonWidth}: 12.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -131,8 +127,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1.25rem;
                 ${buttonTokens.buttonRadius}: 0.75rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -145,9 +139,7 @@ export const config = {
             `,
             mr: css`
                 ${buttonTokens.buttonHeight}: 3rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -163,8 +155,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1rem;
                 ${buttonTokens.buttonRadius}: 0.625rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -178,8 +168,6 @@ export const config = {
             sr: css`
                 ${buttonTokens.buttonHeight}: 2.5rem;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -195,8 +183,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 10rem;
                 ${buttonTokens.buttonPadding}: 0.75rem;
                 ${buttonTokens.buttonRadius}: 0.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -210,8 +196,6 @@ export const config = {
             xsr: css`
                 ${buttonTokens.buttonHeight}: 2rem;
                 ${buttonTokens.buttonWidth}: 10rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -227,8 +211,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 8.75rem;
                 ${buttonTokens.buttonPadding}: 0.625rem;
                 ${buttonTokens.buttonRadius}: 0.375rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-b2c/src/components/Button/Button.config.ts
+++ b/packages/plasma-b2c/src/components/Button/Button.config.ts
@@ -99,8 +99,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 12.5rem;
                 ${buttonTokens.buttonPadding}: 1.5rem;
                 ${buttonTokens.buttonRadius}: 0.875rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -114,8 +113,7 @@ export const config = {
             lr: css`
                 ${buttonTokens.buttonHeight}: 3.5rem;
                 ${buttonTokens.buttonWidth}: 12.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -131,8 +129,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1.25rem;
                 ${buttonTokens.buttonRadius}: 0.75rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -145,9 +142,7 @@ export const config = {
             `,
             mr: css`
                 ${buttonTokens.buttonHeight}: 3rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -163,8 +158,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1rem;
                 ${buttonTokens.buttonRadius}: 0.625rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -178,8 +172,7 @@ export const config = {
             sr: css`
                 ${buttonTokens.buttonHeight}: 2.5rem;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -195,8 +188,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 10rem;
                 ${buttonTokens.buttonPadding}: 0.75rem;
                 ${buttonTokens.buttonRadius}: 0.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -210,8 +202,7 @@ export const config = {
             xsr: css`
                 ${buttonTokens.buttonHeight}: 2rem;
                 ${buttonTokens.buttonWidth}: 10rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -227,8 +218,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 8.75rem;
                 ${buttonTokens.buttonPadding}: 0.625rem;
                 ${buttonTokens.buttonRadius}: 0.375rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-b2c/src/components/ButtonGroup/ButtonGroup.config.ts
+++ b/packages/plasma-b2c/src/components/ButtonGroup/ButtonGroup.config.ts
@@ -100,8 +100,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -115,8 +113,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.875rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -132,8 +128,6 @@ export const config = {
                 ${buttonGroupTokens.buttonHeight}: 3rem;
                 ${buttonGroupTokens.buttonPadding}: 1.25rem;
 
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -148,8 +142,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.75rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -164,8 +156,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -179,8 +169,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.625rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -195,8 +183,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
                 ${buttonGroupTokens.buttonPadding}: 0.75rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -210,8 +196,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.5rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -226,8 +210,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 1.5rem;
                 ${buttonGroupTokens.buttonPadding}: 0.625rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.config.ts
@@ -101,8 +101,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 12.5rem;
                 ${buttonTokens.buttonPadding}: 1.5rem;
                 ${buttonTokens.buttonRadius}: 0.875rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -116,8 +114,6 @@ export const config = {
             lr: css`
                 ${buttonTokens.buttonHeight}: 3.5rem;
                 ${buttonTokens.buttonWidth}: 12.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -133,8 +129,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1.25rem;
                 ${buttonTokens.buttonRadius}: 0.75rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -147,9 +141,7 @@ export const config = {
             `,
             mr: css`
                 ${buttonTokens.buttonHeight}: 3rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -165,8 +157,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1rem;
                 ${buttonTokens.buttonRadius}: 0.625rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -180,8 +170,6 @@ export const config = {
             sr: css`
                 ${buttonTokens.buttonHeight}: 2.5rem;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -197,8 +185,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 10rem;
                 ${buttonTokens.buttonPadding}: 0.75rem;
                 ${buttonTokens.buttonRadius}: 0.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -212,8 +198,6 @@ export const config = {
             xsr: css`
                 ${buttonTokens.buttonHeight}: 2rem;
                 ${buttonTokens.buttonWidth}: 10rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -229,8 +213,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 8.75rem;
                 ${buttonTokens.buttonPadding}: 0.625rem;
                 ${buttonTokens.buttonRadius}: 0.375rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/ButtonGroup/ButtonGroup.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/ButtonGroup/ButtonGroup.config.ts
@@ -102,8 +102,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -117,8 +115,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.875rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -134,8 +130,6 @@ export const config = {
                 ${buttonGroupTokens.buttonHeight}: 3rem;
                 ${buttonGroupTokens.buttonPadding}: 1.25rem;
 
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -149,8 +143,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.75rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -165,8 +157,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -180,8 +170,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.625rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -196,8 +184,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
                 ${buttonGroupTokens.buttonPadding}: 0.75rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -211,8 +197,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.5rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -227,8 +211,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 1.5rem;
                 ${buttonGroupTokens.buttonPadding}: 0.625rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.config.ts
@@ -101,8 +101,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 12.5rem;
                 ${buttonTokens.buttonPadding}: 1.5rem;
                 ${buttonTokens.buttonRadius}: 0.875rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -116,8 +114,6 @@ export const config = {
             lr: css`
                 ${buttonTokens.buttonHeight}: 3.5rem;
                 ${buttonTokens.buttonWidth}: 12.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -133,8 +129,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1.25rem;
                 ${buttonTokens.buttonRadius}: 0.75rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -147,9 +141,7 @@ export const config = {
             `,
             mr: css`
                 ${buttonTokens.buttonHeight}: 3rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -165,8 +157,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1rem;
                 ${buttonTokens.buttonRadius}: 0.625rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -180,8 +170,6 @@ export const config = {
             sr: css`
                 ${buttonTokens.buttonHeight}: 2.5rem;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -197,8 +185,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 10rem;
                 ${buttonTokens.buttonPadding}: 0.75rem;
                 ${buttonTokens.buttonRadius}: 0.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -212,8 +198,6 @@ export const config = {
             xsr: css`
                 ${buttonTokens.buttonHeight}: 2rem;
                 ${buttonTokens.buttonWidth}: 10rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -229,8 +213,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 8.75rem;
                 ${buttonTokens.buttonPadding}: 0.625rem;
                 ${buttonTokens.buttonRadius}: 0.375rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/ButtonGroup/ButtonGroup.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/ButtonGroup/ButtonGroup.config.ts
@@ -102,8 +102,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -117,8 +115,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.875rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -134,8 +130,6 @@ export const config = {
                 ${buttonGroupTokens.buttonHeight}: 3rem;
                 ${buttonGroupTokens.buttonPadding}: 1.25rem;
 
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -149,8 +143,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.75rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -165,8 +157,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -180,8 +170,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.625rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -196,8 +184,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
                 ${buttonGroupTokens.buttonPadding}: 0.75rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -211,8 +197,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.5rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -227,8 +211,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 1.5rem;
                 ${buttonGroupTokens.buttonPadding}: 0.625rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/Button/Button.config.ts
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/Button/Button.config.ts
@@ -101,8 +101,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 12.5rem;
                 ${buttonTokens.buttonPadding}: 1.5rem;
                 ${buttonTokens.buttonRadius}: 0.875rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -116,8 +114,6 @@ export const config = {
             lr: css`
                 ${buttonTokens.buttonHeight}: 3.5rem;
                 ${buttonTokens.buttonWidth}: 12.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -133,8 +129,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1.25rem;
                 ${buttonTokens.buttonRadius}: 0.75rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -147,9 +141,7 @@ export const config = {
             `,
             mr: css`
                 ${buttonTokens.buttonHeight}: 3rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -165,8 +157,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1rem;
                 ${buttonTokens.buttonRadius}: 0.625rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -180,8 +170,6 @@ export const config = {
             sr: css`
                 ${buttonTokens.buttonHeight}: 2.5rem;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -197,8 +185,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 10rem;
                 ${buttonTokens.buttonPadding}: 0.75rem;
                 ${buttonTokens.buttonRadius}: 0.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -212,8 +198,6 @@ export const config = {
             xsr: css`
                 ${buttonTokens.buttonHeight}: 2rem;
                 ${buttonTokens.buttonWidth}: 10rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -229,8 +213,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 8.75rem;
                 ${buttonTokens.buttonPadding}: 0.625rem;
                 ${buttonTokens.buttonRadius}: 0.375rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/ButtonGroup/ButtonGroup.config.ts
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/ButtonGroup/ButtonGroup.config.ts
@@ -102,8 +102,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -117,8 +115,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.875rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -134,8 +130,6 @@ export const config = {
                 ${buttonGroupTokens.buttonHeight}: 3rem;
                 ${buttonGroupTokens.buttonPadding}: 1.25rem;
 
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -149,8 +143,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.75rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -165,8 +157,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -180,8 +170,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.625rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -196,8 +184,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
                 ${buttonGroupTokens.buttonPadding}: 0.75rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -211,8 +197,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.5rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -227,8 +211,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 1.5rem;
                 ${buttonGroupTokens.buttonPadding}: 0.625rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-web/src/components/Button/Button.config.ts
+++ b/packages/plasma-web/src/components/Button/Button.config.ts
@@ -99,8 +99,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 12.5rem;
                 ${buttonTokens.buttonPadding}: 1.5rem;
                 ${buttonTokens.buttonRadius}: 0.875rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -114,8 +113,7 @@ export const config = {
             lr: css`
                 ${buttonTokens.buttonHeight}: 3.5rem;
                 ${buttonTokens.buttonWidth}: 12.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -131,8 +129,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1.25rem;
                 ${buttonTokens.buttonRadius}: 0.75rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -145,9 +142,7 @@ export const config = {
             `,
             mr: css`
                 ${buttonTokens.buttonHeight}: 3rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -163,8 +158,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1rem;
                 ${buttonTokens.buttonRadius}: 0.625rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -178,8 +172,7 @@ export const config = {
             sr: css`
                 ${buttonTokens.buttonHeight}: 2.5rem;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -195,8 +188,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 10rem;
                 ${buttonTokens.buttonPadding}: 0.75rem;
                 ${buttonTokens.buttonRadius}: 0.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -210,8 +202,7 @@ export const config = {
             xsr: css`
                 ${buttonTokens.buttonHeight}: 2rem;
                 ${buttonTokens.buttonWidth}: 10rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -227,8 +218,7 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 8.75rem;
                 ${buttonTokens.buttonPadding}: 0.625rem;
                 ${buttonTokens.buttonRadius}: 0.375rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
+
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/plasma-web/src/components/ButtonGroup/ButtonGroup.config.ts
+++ b/packages/plasma-web/src/components/ButtonGroup/ButtonGroup.config.ts
@@ -100,8 +100,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -115,8 +113,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.875rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -132,8 +128,6 @@ export const config = {
                 ${buttonGroupTokens.buttonHeight}: 3rem;
                 ${buttonGroupTokens.buttonPadding}: 1.25rem;
 
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -148,8 +142,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.75rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -164,8 +156,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -179,8 +169,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.625rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -195,8 +183,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
                 ${buttonGroupTokens.buttonPadding}: 0.75rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -210,8 +196,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.5rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -226,8 +210,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 1.5rem;
                 ${buttonGroupTokens.buttonPadding}: 0.625rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/sdds-serv/src/components/Button/Button.config.ts
+++ b/packages/sdds-serv/src/components/Button/Button.config.ts
@@ -99,8 +99,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 12.5rem;
                 ${buttonTokens.buttonPadding}: 1.5rem;
                 ${buttonTokens.buttonRadius}: 0.875rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -114,8 +112,6 @@ export const config = {
             lr: css`
                 ${buttonTokens.buttonHeight}: 3.5rem;
                 ${buttonTokens.buttonWidth}: 12.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -131,8 +127,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1.25rem;
                 ${buttonTokens.buttonRadius}: 0.75rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -145,9 +139,7 @@ export const config = {
             `,
             mr: css`
                 ${buttonTokens.buttonHeight}: 3rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -163,8 +155,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 11.25rem;
                 ${buttonTokens.buttonPadding}: 1rem;
                 ${buttonTokens.buttonRadius}: 0.625rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -178,8 +168,6 @@ export const config = {
             sr: css`
                 ${buttonTokens.buttonHeight}: 2.5rem;
                 ${buttonTokens.buttonWidth}: 11.25rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -195,8 +183,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 10rem;
                 ${buttonTokens.buttonPadding}: 0.75rem;
                 ${buttonTokens.buttonRadius}: 0.5rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -210,8 +196,6 @@ export const config = {
             xsr: css`
                 ${buttonTokens.buttonHeight}: 2rem;
                 ${buttonTokens.buttonWidth}: 10rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -227,8 +211,6 @@ export const config = {
                 ${buttonTokens.buttonWidth}: 8.75rem;
                 ${buttonTokens.buttonPadding}: 0.625rem;
                 ${buttonTokens.buttonRadius}: 0.375rem;
-                ${buttonTokens.buttonScaleActive}: 0.98;
-                ${buttonTokens.buttonScaleHover}: 1.02;
                 ${buttonTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.config.ts
+++ b/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.config.ts
@@ -100,8 +100,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -115,8 +113,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.875rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-l-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-l-font-style);
@@ -132,8 +128,6 @@ export const config = {
                 ${buttonGroupTokens.buttonHeight}: 3rem;
                 ${buttonGroupTokens.buttonPadding}: 1.25rem;
 
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -148,8 +142,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.75rem;
 
                 ${buttonGroupTokens.buttonHeight}: 3rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-m-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-m-font-style);
@@ -164,8 +156,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
                 ${buttonGroupTokens.buttonPadding}: 1rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -179,8 +169,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.625rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2.5rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-s-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -195,8 +183,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
                 ${buttonGroupTokens.buttonPadding}: 0.75rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -210,8 +196,6 @@ export const config = {
                 ${buttonGroupTokens.buttonSideRadius}: 0.5rem;
 
                 ${buttonGroupTokens.buttonHeight}: 2rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -226,8 +210,6 @@ export const config = {
 
                 ${buttonGroupTokens.buttonHeight}: 1.5rem;
                 ${buttonGroupTokens.buttonPadding}: 0.625rem;
-                ${buttonGroupTokens.buttonScaleActive}: 0.98;
-                ${buttonGroupTokens.buttonScaleHover}: 1.02;
                 ${buttonGroupTokens.buttonFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${buttonGroupTokens.buttonFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${buttonGroupTokens.buttonFontStyle}: var(--plasma-typo-body-xs-font-style);


### PR DESCRIPTION
### Button

- удалены токены scale из кнопки и группы кнопок в пакетах b2c, web, sdds-serv, caldera/-online
- удалены токены scale из example для plasma-new-hope

### What/why changed

Scale ошибочно применялся к кнопке при ховере и нажатии, поэтому были удалены токены, которые задавали значение scale.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.19.0-canary.1110.8254420470.0
  npm install @salutejs/caldera@0.19.0-canary.1110.8254420470.0
  npm install @salutejs/plasma-asdk@0.55.0-canary.1110.8254420470.0
  npm install @salutejs/plasma-b2c@1.297.0-canary.1110.8254420470.0
  npm install @salutejs/plasma-new-hope@0.59.0-canary.1110.8254420470.0
  npm install @salutejs/plasma-web@1.297.0-canary.1110.8254420470.0
  npm install @salutejs/sdds-serv@0.22.0-canary.1110.8254420470.0
  # or 
  yarn add @salutejs/caldera-online@0.19.0-canary.1110.8254420470.0
  yarn add @salutejs/caldera@0.19.0-canary.1110.8254420470.0
  yarn add @salutejs/plasma-asdk@0.55.0-canary.1110.8254420470.0
  yarn add @salutejs/plasma-b2c@1.297.0-canary.1110.8254420470.0
  yarn add @salutejs/plasma-new-hope@0.59.0-canary.1110.8254420470.0
  yarn add @salutejs/plasma-web@1.297.0-canary.1110.8254420470.0
  yarn add @salutejs/sdds-serv@0.22.0-canary.1110.8254420470.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
