### PR TITLE
fix: change height for Drawer stories

### DIFF
--- a/packages/plasma-b2c/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-b2c/src/components/Drawer/Drawer.stories.tsx
@@ -116,7 +116,7 @@ const StyledContentWrapper = styled.div`
 `;
 
 const StyledContent = styled.div`
-    background: #f5f5dc;
+    background: #a8a875;
     flex-grow: 1;
     height: 100%;
 `;
@@ -200,7 +200,7 @@ export const DrawerDemo: StoryObj<StoryDrawerProps> = {
         asModal: true,
         closePlacement: 'right',
         width: '50vw',
-        height: '100vh',
+        height: '100dvh',
         borderRadius: 'none',
     },
     render: (args) => <StoryDrawerDemo {...args} />,

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Drawer/Drawer.stories.tsx
@@ -116,7 +116,7 @@ const StyledContentWrapper = styled.div`
 `;
 
 const StyledContent = styled.div`
-    background: #f5f5dc;
+    background: #a8a875;
     flex-grow: 1;
     height: 100%;
 `;
@@ -211,7 +211,7 @@ export const DrawerDemo: StoryObj<StoryDrawerProps> = {
         asModal: true,
         closePlacement: 'right',
         width: '25vw',
-        height: '100vh',
+        height: '100dvh',
         borderRadius: 'none',
     },
     render: (args) => <StoryDrawerDemo {...args} />,

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Drawer/Drawer.stories.tsx
@@ -116,7 +116,7 @@ const StyledContentWrapper = styled.div`
 `;
 
 const StyledContent = styled.div`
-    background: #f5f5dc;
+    background: #a8a875;
     flex-grow: 1;
     height: 100%;
 `;
@@ -211,7 +211,7 @@ export const DrawerDemo: StoryObj<StoryDrawerProps> = {
         asModal: true,
         closePlacement: 'right',
         width: '25vw',
-        height: '100vh',
+        height: '100dvh',
         borderRadius: 'none',
     },
     render: (args) => <StoryDrawerDemo {...args} />,

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/Drawer/Drawer.stories.tsx
@@ -116,7 +116,7 @@ const StyledContentWrapper = styled.div`
 `;
 
 const StyledContent = styled.div`
-    background: #f5f5dc;
+    background: #a8a875;
     flex-grow: 1;
     height: 100%;
 `;
@@ -211,7 +211,7 @@ export const DrawerDemo: StoryObj<StoryDrawerProps> = {
         asModal: true,
         closePlacement: 'right',
         width: '25vw',
-        height: '100vh',
+        height: '100dvh',
         borderRadius: 'none',
     },
     render: (args) => <StoryDrawerDemo {...args} />,

--- a/packages/plasma-web/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-web/src/components/Drawer/Drawer.stories.tsx
@@ -116,7 +116,7 @@ const StyledContentWrapper = styled.div`
 `;
 
 const StyledContent = styled.div`
-    background: #f5f5dc;
+    background: #a8a875;
     flex-grow: 1;
     height: 100%;
 `;
@@ -200,7 +200,7 @@ export const DrawerDemo: StoryObj<StoryDrawerProps> = {
         asModal: true,
         closePlacement: 'right',
         width: '50vw',
-        height: '100vh',
+        height: '100dvh',
     },
     render: (args) => <StoryDrawerDemo {...args} />,
 };

--- a/packages/sdds-serv/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-serv/src/components/Drawer/Drawer.stories.tsx
@@ -115,7 +115,7 @@ const StyledContentWrapper = styled.div`
 `;
 
 const StyledContent = styled.div`
-    background: #f5f5dc;
+    background: #a8a875;
     flex-grow: 1;
     height: 100%;
 `;
@@ -189,7 +189,7 @@ export const DrawerDemo: StoryObj<StoryDrawerProps> = {
         asModal: true,
         closePlacement: 'right',
         width: '25vw',
-        height: '100vh',
+        height: '100dvh',
         borderRadius: 'none',
     },
     render: (args) => <StoryDrawerDemo {...args} />,


### PR DESCRIPTION
### Drawer

- изменили величину измерения высоты на dvh в storybook

### What/why changed

Так как в браузерах телефона появляется плашка, которая накладывается поверх контента - из-за высоты дровера не было видно скруглений.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.21.1-canary.1116.8323779850.0
  npm install @salutejs/caldera@0.21.1-canary.1116.8323779850.0
  npm install @salutejs/plasma-asdk@0.58.2-canary.1116.8323779850.0
  npm install @salutejs/plasma-b2c@1.300.3-canary.1116.8323779850.0
  npm install @salutejs/plasma-new-hope@0.61.1-canary.1116.8323779850.0
  npm install @salutejs/plasma-web@1.300.3-canary.1116.8323779850.0
  npm install @salutejs/sdds-serv@0.25.2-canary.1116.8323779850.0
  # or 
  yarn add @salutejs/caldera-online@0.21.1-canary.1116.8323779850.0
  yarn add @salutejs/caldera@0.21.1-canary.1116.8323779850.0
  yarn add @salutejs/plasma-asdk@0.58.2-canary.1116.8323779850.0
  yarn add @salutejs/plasma-b2c@1.300.3-canary.1116.8323779850.0
  yarn add @salutejs/plasma-new-hope@0.61.1-canary.1116.8323779850.0
  yarn add @salutejs/plasma-web@1.300.3-canary.1116.8323779850.0
  yarn add @salutejs/sdds-serv@0.25.2-canary.1116.8323779850.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
