### PR TITLE
fix: fix args for Image stories

### DIFF
--- a/packages/caldera-online/package-lock.json
+++ b/packages/caldera-online/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@salutejs/caldera-online",
-  "version": "0.21.0",
+  "version": "0.21.1-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@salutejs/caldera-online",
-      "version": "0.21.0",
+      "version": "0.21.1-dev.0",
       "license": "MIT",
       "dependencies": {
         "@salutejs/caldera-online-themes": "0.6.0",
-        "@salutejs/plasma-new-hope": "0.61.0"
+        "@salutejs/plasma-new-hope": "0.61.1-dev.0"
       },
       "devDependencies": {
         "@babel/cli": "7.15.4",
@@ -5538,9 +5538,9 @@
       }
     },
     "node_modules/@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "dependencies": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",
@@ -23896,9 +23896,9 @@
       "dev": true
     },
     "@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "requires": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",

--- a/packages/caldera/package-lock.json
+++ b/packages/caldera/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@salutejs/caldera",
-  "version": "0.21.0",
+  "version": "0.21.1-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@salutejs/caldera",
-      "version": "0.21.0",
+      "version": "0.21.1-dev.0",
       "license": "MIT",
       "dependencies": {
         "@salutejs/caldera-online-themes": "0.6.0",
-        "@salutejs/plasma-new-hope": "0.61.0"
+        "@salutejs/plasma-new-hope": "0.61.1-dev.0"
       },
       "devDependencies": {
         "@babel/cli": "7.15.4",
@@ -5815,9 +5815,9 @@
       }
     },
     "node_modules/@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "dependencies": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",
@@ -24355,9 +24355,9 @@
       "dev": true
     },
     "@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "requires": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",

--- a/packages/plasma-asdk/package-lock.json
+++ b/packages/plasma-asdk/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@salutejs/plasma-asdk",
-  "version": "0.58.1-dev.0",
+  "version": "0.58.2-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@salutejs/plasma-asdk",
-      "version": "0.58.1-dev.0",
+      "version": "0.58.2-dev.0",
       "license": "MIT",
       "dependencies": {
-        "@salutejs/plasma-new-hope": "0.61.0",
+        "@salutejs/plasma-new-hope": "0.61.1-dev.0",
         "@salutejs/plasma-tokens": "1.75.0",
         "@salutejs/plasma-tokens-b2b": "1.36.0",
         "@salutejs/plasma-typo": "0.40.0"
@@ -4712,9 +4712,9 @@
       }
     },
     "node_modules/@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "dependencies": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",
@@ -19950,9 +19950,9 @@
       "dev": true
     },
     "@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "requires": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",

--- a/packages/plasma-b2c/package-lock.json
+++ b/packages/plasma-b2c/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@salutejs/plasma-b2c",
-  "version": "1.300.2-dev.0",
+  "version": "1.300.3-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@salutejs/plasma-b2c",
-      "version": "1.300.2-dev.0",
+      "version": "1.300.3-dev.0",
       "license": "MIT",
       "dependencies": {
         "@salutejs/plasma-core": "1.154.0",
         "@salutejs/plasma-hope": "1.271.1-dev.0",
-        "@salutejs/plasma-new-hope": "0.61.0",
+        "@salutejs/plasma-new-hope": "0.61.1-dev.0",
         "@salutejs/plasma-tokens-b2c": "0.46.0",
         "@salutejs/plasma-tokens-web": "1.51.0",
         "@salutejs/plasma-typo": "0.40.0"
@@ -5669,9 +5669,9 @@
       }
     },
     "node_modules/@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "dependencies": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",
@@ -23401,9 +23401,9 @@
       "dev": true
     },
     "@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "requires": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",

--- a/packages/plasma-b2c/src/components/Image/Image.stories.tsx
+++ b/packages/plasma-b2c/src/components/Image/Image.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 
-import { Image, Ratio } from '.';
+import { Image } from '.';
 import type { ImageProps } from '.';
 
 const meta: Meta<ImageProps> = {
@@ -22,13 +22,13 @@ const meta: Meta<ImageProps> = {
                 type: 'select',
             },
         },
-        ...disableProps(['height', 'customRatio']),
+        ...disableProps(['src', 'alt', 'customRatio']),
     },
 };
 
 export default meta;
 
-export const Default: StoryObj<ImageProps & { ratio: Ratio }> = {
+export const Default: StoryObj<ImageProps> = {
     args: {
         base: 'div',
         src: './images/320_320_9.jpg',
@@ -36,9 +36,9 @@ export const Default: StoryObj<ImageProps & { ratio: Ratio }> = {
         width: '200px',
         height: '200px',
     },
-    render: ({ base, ratio, ...args }) => (
+    render: (args) => (
         <div style={{ maxWidth: '10rem' }}>
-            <Image style={{ position: 'relative' }} {...args} />
+            <Image {...args} />
         </div>
     ),
 };

--- a/packages/plasma-new-hope/package-lock.json
+++ b/packages/plasma-new-hope/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salutejs/plasma-new-hope",
-  "version": "0.61.0",
+  "version": "0.61.1-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@salutejs/plasma-new-hope",
-      "version": "0.61.0",
+      "version": "0.61.1-dev.0",
       "license": "MIT",
       "dependencies": {
         "@linaria/core": "5.0.2",

--- a/packages/plasma-new-hope/src/components/Image/Image.tsx
+++ b/packages/plasma-new-hope/src/components/Image/Image.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes } from 'react';
 
 import type { RootProps } from '../../engines';
 
-import { StyledDivImg, StyledImg, base } from './Image.styles';
+import { StyledDivImg, StyledImg, base as baseCSS } from './Image.styles';
 import type { ImageProps } from './Image.types';
 import { ratios } from './Image.utils';
 
@@ -51,7 +51,7 @@ export const imageConfig = {
     name: 'Image',
     tag: 'div',
     layout: imageRoot,
-    base,
+    base: baseCSS,
     variations: {},
     defaults: {},
 };

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Image/Image.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Image/Image.stories.tsx
@@ -3,7 +3,7 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
 import { Image } from './Image';
-import type { ImageProps, Ratio } from './Image';
+import type { ImageProps } from './Image';
 
 const bases = ['div', 'img'];
 
@@ -26,13 +26,13 @@ const meta: Meta<ImageProps> = {
                 type: 'select',
             },
         },
-        ...disableProps(['view', 'src', 'alt', 'customRatio']),
+        ...disableProps(['src', 'alt', 'customRatio']),
     },
 };
 
 export default meta;
 
-export const Default: StoryObj<ImageProps & { ratio: Ratio }> = {
+export const Default: StoryObj<typeof Image> = {
     args: {
         base: 'div',
         src: './images/320_320_9.jpg',
@@ -42,7 +42,7 @@ export const Default: StoryObj<ImageProps & { ratio: Ratio }> = {
     },
     render: (args) => (
         <div style={{ maxWidth: '10rem' }}>
-            <Image style={{ position: 'relative' }} {...args} />
+            <Image {...args} />
         </div>
     ),
 };

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Image/Image.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Image/Image.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<ImageProps> = {
                 type: 'select',
             },
         },
-        ...disableProps(['view', 'src', 'alt', 'customRatio']),
+        ...disableProps(['src', 'alt', 'customRatio']),
     },
 };
 
@@ -42,7 +42,7 @@ export const Default: StoryObj<ImageProps & { ratio: Ratio }> = {
     },
     render: (args) => (
         <div style={{ maxWidth: '10rem' }}>
-            <Image style={{ position: 'relative' }} {...args} />
+            <Image {...args} />
         </div>
     ),
 };

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/Image/Image.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/Image/Image.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<ImageProps> = {
                 type: 'select',
             },
         },
-        ...disableProps(['view', 'src', 'alt', 'customRatio']),
+        ...disableProps(['src', 'alt', 'customRatio']),
     },
 };
 
@@ -42,7 +42,7 @@ export const Default: StoryObj<ImageProps & { ratio: Ratio }> = {
     },
     render: (args) => (
         <div style={{ maxWidth: '10rem' }}>
-            <Image style={{ position: 'relative' }} {...args} />
+            <Image {...args} />
         </div>
     ),
 };

--- a/packages/plasma-web/package-lock.json
+++ b/packages/plasma-web/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@salutejs/plasma-web",
-  "version": "1.300.2-dev.0",
+  "version": "1.300.3-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@salutejs/plasma-web",
-      "version": "1.300.2-dev.0",
+      "version": "1.300.3-dev.0",
       "license": "MIT",
       "dependencies": {
         "@salutejs/plasma-core": "1.154.0",
         "@salutejs/plasma-hope": "1.271.1-dev.0",
-        "@salutejs/plasma-new-hope": "0.61.0",
+        "@salutejs/plasma-new-hope": "0.61.1-dev.0",
         "@salutejs/plasma-tokens-b2b": "1.36.0",
         "@salutejs/plasma-tokens-b2c": "0.46.0",
         "@salutejs/plasma-tokens-web": "1.51.0",
@@ -5464,9 +5464,9 @@
       }
     },
     "node_modules/@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "dependencies": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",
@@ -22480,9 +22480,9 @@
       "dev": true
     },
     "@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "requires": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",

--- a/packages/plasma-web/src/components/Image/Image.stories.tsx
+++ b/packages/plasma-web/src/components/Image/Image.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<ImageProps> = {
                 type: 'select',
             },
         },
-        ...disableProps(['height', 'customRatio']),
+        ...disableProps(['src', 'alt', 'customRatio']),
     },
 };
 
@@ -36,9 +36,9 @@ export const Default: StoryObj<ImageProps & { ratio: Ratio }> = {
         width: '200px',
         height: '200px',
     },
-    render: ({ base, ratio, ...args }) => (
+    render: (args) => (
         <div style={{ maxWidth: '10rem' }}>
-            <Image style={{ position: 'relative' }} {...args} />
+            <Image {...args} />
         </div>
     ),
 };

--- a/packages/sdds-serv/package-lock.json
+++ b/packages/sdds-serv/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@salutejs/sdds-serv",
-  "version": "0.25.1-dev.0",
+  "version": "0.25.2-dev.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@salutejs/sdds-serv",
-      "version": "0.25.1-dev.0",
+      "version": "0.25.2-dev.0",
       "license": "MIT",
       "dependencies": {
-        "@salutejs/plasma-new-hope": "0.61.0",
+        "@salutejs/plasma-new-hope": "0.61.1-dev.0",
         "@salutejs/sdds-themes": "0.6.0"
       },
       "devDependencies": {
@@ -5834,9 +5834,9 @@
       }
     },
     "node_modules/@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "dependencies": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",
@@ -24409,9 +24409,9 @@
       "dev": true
     },
     "@salutejs/plasma-new-hope": {
-      "version": "0.61.0",
-      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.0.tgz",
-      "integrity": "sha512-TsPkTbFrCR0HyBm9nUKSoO/MXtnDUxAKmuRAEnO9RNV6c/JtdWOnYUn38oBkrGoM6zqdOxxkBb9YfuKUQjvNQQ==",
+      "version": "0.61.1-dev.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-new-hope/-/plasma-new-hope-0.61.1-dev.0.tgz",
+      "integrity": "sha512-Hg9POic9eMROJ45Pvkrkf39WBoTdBrFsBroANjvIoLR0/O5t3B4IN/35maPO9MHPiz2H+sY7n6grHnFs7R8itg==",
       "requires": {
         "@linaria/core": "5.0.2",
         "@linaria/react": "5.0.3",

--- a/packages/sdds-serv/src/components/Image/Image.stories.tsx
+++ b/packages/sdds-serv/src/components/Image/Image.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<ImageProps> = {
                 type: 'select',
             },
         },
-        ...disableProps(['height', 'customRatio']),
+        ...disableProps(['src', 'alt', 'customRatio']),
     },
 };
 
@@ -36,9 +36,9 @@ export const Default: StoryObj<ImageProps & { ratio: Ratio }> = {
         width: '200px',
         height: '200px',
     },
-    render: ({ base, ratio, ...args }) => (
+    render: (args) => (
         <div style={{ maxWidth: '10rem' }}>
-            <Image style={{ position: 'relative' }} {...args} />
+            <Image {...args} />
         </div>
     ),
 };


### PR DESCRIPTION
### Image

- поправлена передача пропсов в Image сторях

### What/why changed

Поправлена передача пропсов в Image сторях.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.21.2-canary.1119.8324919346.0
  npm install @salutejs/caldera@0.21.2-canary.1119.8324919346.0
  npm install @salutejs/plasma-asdk@0.58.3-canary.1119.8324919346.0
  npm install @salutejs/plasma-b2c@1.300.4-canary.1119.8324919346.0
  npm install @salutejs/plasma-new-hope@0.61.2-canary.1119.8324919346.0
  npm install @salutejs/plasma-web@1.300.4-canary.1119.8324919346.0
  npm install @salutejs/sdds-serv@0.25.3-canary.1119.8324919346.0
  # or 
  yarn add @salutejs/caldera-online@0.21.2-canary.1119.8324919346.0
  yarn add @salutejs/caldera@0.21.2-canary.1119.8324919346.0
  yarn add @salutejs/plasma-asdk@0.58.3-canary.1119.8324919346.0
  yarn add @salutejs/plasma-b2c@1.300.4-canary.1119.8324919346.0
  yarn add @salutejs/plasma-new-hope@0.61.2-canary.1119.8324919346.0
  yarn add @salutejs/plasma-web@1.300.4-canary.1119.8324919346.0
  yarn add @salutejs/sdds-serv@0.25.3-canary.1119.8324919346.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
