### PR TITLE
plasma-infra: Refactoring deploy documentations artefacts [PR context] 

### DIFF
--- a/.github/config-ci.json
+++ b/.github/config-ci.json
@@ -1,0 +1,13 @@
+{
+    "PACKAGES_CYPRESS": ["plasma-web", "plasma-b2c", "plasma-ui"],
+    "PACKAGES_DS": [
+        "plasma-web",
+        "plasma-b2c",
+        "plasma-ui",
+        "plasma-new-hope",
+        "plasma-asdk",
+        "caldera",
+        "caldera-online",
+        "sdds-serv"
+    ]
+}

--- a/.github/create-links.js
+++ b/.github/create-links.js
@@ -1,0 +1,13 @@
+module.exports = () => {
+    const { PACKAGES_DS, BASE_URL } = process.env;
+
+    const links = JSON.parse(PACKAGES_DS)
+        .map((item) => {
+            const name = item.replace('plasma-', '');
+
+            return `${name} storybook: ${BASE_URL}/${name}-storybook/`;
+        })
+        .join('\n');
+
+    return 'Documentation preview deployed!' + '\n\n' + `website:${BASE_URL}/` + '\n' + `${links}`;
+};

--- a/.github/workflows/change-detection.yml
+++ b/.github/workflows/change-detection.yml
@@ -7,79 +7,19 @@ on:
         description: 'Lerna boostrap filter-option, exclude all transitive dependents when running a command with --since'
         default: false
         type: boolean
-      as-enumeration:
-        description: 'Get scope as "[plasma-core,plasma-ui]", etc'
-        default: false
-        type: boolean
       ref:
           type: string
           description: "Manual set repo ref"
           default: ''
     outputs:
-      SCOPE:
-        description: "scope collection"
-        value: ${{ jobs.run.outputs.SCOPE }}
-      HAS_SCOPE:
-        description: "has scope"
-        value: ${{ jobs.run.outputs.HAS_SCOPE }}
-      HAS_DOCUMENTATION_CHANGED:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_DOCUMENTATION_CHANGED }}
-      HAS_PLASMA_UI_DOCS:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_PLASMA_UI_DOCS }}
-      HAS_PLASMA_WEB_DOCS:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_PLASMA_WEB_DOCS }}
-      HAS_PLASMA_UI:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_PLASMA_UI }}
-      HAS_PLASMA_WEB:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_PLASMA_WEB }}
-      HAS_PLASMA_B2C:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_PLASMA_B2C }}
-      HAS_PLASMA_HOPE:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_PLASMA_HOPE }}
-      HAS_PLASMA_ASDK:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_PLASMA_ASDK }}
-      HAS_CALDERA:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_CALDERA }}
-      HAS_CALDERA_ONLINE:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_CALDERA_ONLINE }}
-      HAS_SDDS_SERV:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_SDDS_SERV }}
-      HAS_ASSETS:
-        description: ""
-        value: ${{ jobs.run.outputs.HAS_ASSETS }}
-      PACKAGES_ENUMERATION:
-        description: ""
-        value: ${{ jobs.run.outputs.PACKAGES_ENUMERATION }}
+      STATE:
+        description: "state based on changed state of lerna packages"
+        value: ${{ jobs.run.outputs.STATE }}
 jobs:
   run:
     runs-on: ubuntu-latest
     outputs:
-      SCOPE: ${{ steps.set-output.outputs.SCOPE }}
-      HAS_SCOPE: ${{ steps.set-output.outputs.HAS_SCOPE }}
-      HAS_DOCUMENTATION_CHANGED: ${{ steps.set-output.outputs.HAS_DOCUMENTATION_CHANGED }}
-      HAS_PLASMA_UI_DOCS: ${{ steps.set-output.outputs.HAS_PLASMA_UI_DOCS }}
-      HAS_PLASMA_WEB_DOCS: ${{ steps.set-output.outputs.HAS_PLASMA_WEB_DOCS }}
-      HAS_PLASMA_B2C: ${{ steps.set-output.outputs.HAS_PLASMA_B2C }}
-      HAS_PLASMA_WEB: ${{ steps.set-output.outputs.HAS_PLASMA_WEB }}
-      HAS_PLASMA_UI: ${{ steps.set-output.outputs.HAS_PLASMA_UI }}
-      HAS_PLASMA_HOPE: ${{ steps.set-output.outputs.HAS_PLASMA_HOPE }}
-      HAS_PLASMA_ASDK: ${{ steps.set-output.outputs.HAS_PLASMA_ASDK }}
-      HAS_CALDERA: ${{ steps.set-output.outputs.HAS_CALDERA }}
-      HAS_CALDERA_ONLINE: ${{ steps.set-output.outputs.HAS_CALDERA_ONLINE }}
-      HAS_SDDS_SERV: ${{ steps.set-output.outputs.HAS_SDDS_SERV }}
-      HAS_ASSETS: ${{ steps.set-output.outputs.HAS_ASSETS }}
-      PACKAGES_ENUMERATION: ${{ steps.set-output.outputs.PACKAGES_ENUMERATION }}
+      STATE: ${{ steps.set-output.outputs.STATE }}
 
     steps:
       - uses: actions/checkout@v4
@@ -96,18 +36,16 @@ jobs:
         run: echo "EXCLUDE_DEPENDENTS=--exclude-dependents" >> $GITHUB_ENV
 
       - name: Get lerna ls output
-        shell: bash
-        id: changed-state
+        id: lerna-state
         run: |
           #INFO: `jq -c` => Делаем вывод в одну JSON строку
-          echo "CHANGED_STATE=$(npx lerna la --json --since=$(git merge-base --fork-point origin/dev) ${{ env.EXCLUDE_DEPENDENTS }} | jq -c)" >> "$GITHUB_OUTPUT"
+          echo "RAW_DATA=$(npx lerna la --json --since=$(git merge-base --fork-point origin/dev) ${{ env.EXCLUDE_DEPENDENTS }} | jq -c)" >> "$GITHUB_OUTPUT"
 
       - name: Computed scope state
-        id: scope
-        uses: actions/github-script@v6
+        id: state
+        uses: actions/github-script@v7
         env:
-          CHANGED_STATE: ${{ toJSON(steps.changed-state.outputs.CHANGED_STATE) }}
-          AS_ENUMERATION: ${{ inputs.as-enumeration }}
+          RAW_DATA: ${{ steps.lerna-state.outputs.RAW_DATA }}
         with:
           script: |
             const processingScope = require('./.github/processing-scope.js');
@@ -117,19 +55,5 @@ jobs:
       - name: Set "GITHUB_OUTPUT"
         id: set-output
         run: |
-          echo "SCOPE=${{ fromJSON(steps.scope.outputs.result).SCOPE }}" >> $GITHUB_OUTPUT
-          echo "HAS_SCOPE=${{ fromJSON(steps.scope.outputs.result).HAS_SCOPE }}" >> $GITHUB_OUTPUT
-          echo "HAS_PLASMA_UI_DOCS=${{ fromJSON(steps.scope.outputs.result).HAS_PLASMA_UI_DOCS }}" >> $GITHUB_OUTPUT
-          echo "HAS_PLASMA_WEB_DOCS=${{ fromJSON(steps.scope.outputs.result).HAS_PLASMA_WEB_DOCS }}" >> $GITHUB_OUTPUT
-          echo "HAS_DOCUMENTATION_CHANGED=${{ fromJSON(steps.scope.outputs.result).HAS_DOCUMENTATION_CHANGED }}" >> $GITHUB_OUTPUT
-          echo "HAS_PLASMA_B2C=${{ fromJSON(steps.scope.outputs.result).HAS_PLASMA_B2C }}" >> $GITHUB_OUTPUT
-          echo "HAS_PLASMA_WEB=${{ fromJSON(steps.scope.outputs.result).HAS_PLASMA_WEB }}" >> $GITHUB_OUTPUT
-          echo "HAS_PLASMA_UI=${{ fromJSON(steps.scope.outputs.result).HAS_PLASMA_UI }}" >> $GITHUB_OUTPUT
-          echo "HAS_PLASMA_HOPE=${{ fromJSON(steps.scope.outputs.result).HAS_PLASMA_HOPE }}" >> $GITHUB_OUTPUT
-          echo "HAS_PLASMA_ASDK=${{ fromJSON(steps.scope.outputs.result).HAS_PLASMA_ASDK }}" >> $GITHUB_OUTPUT
-          echo "HAS_CALDERA=${{ fromJSON(steps.scope.outputs.result).HAS_CALDERA }}" >> $GITHUB_OUTPUT
-          echo "HAS_CALDERA_ONLINE=${{ fromJSON(steps.scope.outputs.result).HAS_CALDERA_ONLINE }}" >> $GITHUB_OUTPUT
-          echo "HAS_SDDS_SERV=${{ fromJSON(steps.scope.outputs.result).HAS_SDDS_SERV }}" >> $GITHUB_OUTPUT
-          echo "HAS_ASSETS=${{ fromJSON(steps.scope.outputs.result).HAS_ASSETS }}" >> $GITHUB_OUTPUT
-          echo "PACKAGES_ENUMERATION=${{ fromJSON(steps.scope.outputs.result).PACKAGES_ENUMERATION }}" >> $GITHUB_OUTPUT
+          echo "STATE=${{ steps.state.outputs.result }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,7 +1,6 @@
 name: Cypress component testing
 
 on:
-  merge_group:
   pull_request:
     branches:
       - master
@@ -13,26 +12,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  change-detection:
-      uses: ./.github/workflows/change-detection.yml
-      secrets: inherit
-
-  change-detection-temple:
+  state:
     uses: ./.github/workflows/change-detection.yml
-    with:
-      exclude-dependents: true
     secrets: inherit
 
   cypress:
-    needs: change-detection
-    if: ${{ needs.change-detection.outputs.HAS_SCOPE == 'true' }}
+    needs: state
+    if: ${{ fromJSON(needs.state.outputs.STATE).HAS_PACKAGES_CYPRESS_RUN }}
     strategy:
       fail-fast: false
       matrix:
         # [Note]
         # Важно что бы массив был со значениями, где `""` экранируются, например -> ["\"b2c\""]
         # Можно для этого использовать JSON.stringify()
-        scope: ${{fromJson(needs.change-detection.outputs.SCOPE)}}
+        scope: ${{ fromJson(needs.state.outputs.STATE).PACKAGES_CYPRESS_RUN }}
 
     uses: ./.github/workflows/cypress-common.yml
     with:
@@ -40,12 +33,12 @@ jobs:
     secrets: inherit
 
   cypress-react-17:
-    needs: change-detection
-    if: ${{ needs.change-detection.outputs.HAS_SCOPE == 'true' }}
+    needs: state
+    if: ${{ fromJSON(needs.state.outputs.STATE).HAS_PACKAGES_CYPRESS_RUN }}
     strategy:
       fail-fast: false
       matrix:
-        scope: ${{fromJson(needs.change-detection.outputs.SCOPE)}}
+        scope: ${{ fromJson(needs.state.outputs.STATE).PACKAGES_CYPRESS_RUN }}
 
     uses: ./.github/workflows/cypress-common.yml
     with:

--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -1,0 +1,271 @@
+name: Deploy documentations artefacts [PR]
+
+on:
+    pull_request_target:
+        branches:
+            - dev
+    pull_request:
+        branches:
+            - master
+
+concurrency:
+    # New commit on branch cancels running workflows of the same branch
+    group: ${{ github.workflow }}-${{ github.head_ref }}
+    cancel-in-progress: true
+
+jobs:
+    authorize:
+        name: Authorize external pull request
+        if: ${{ !startsWith(github.head_ref, 'release') }}
+        uses: ./.github/workflows/authorize-external-pr.yml
+
+    state:
+        name: Handle lerna changed state
+        needs: [authorize]
+        uses: ./.github/workflows/change-detection.yml
+        with:
+            ref: refs/pull/${{github.event.pull_request.number}}/merge
+        secrets: inherit
+
+    deploy-website:
+        name: Deploy website artifacts
+        needs: [ state ]
+        if: ${{ fromJSON(needs.state.outputs.STATE).HAS_PACKAGES_DS_CHANGES }}
+
+        runs-on: ubuntu-latest
+        env:
+            PR_NAME: pr-${{ github.event.number }}
+            PREFIX: pr/pr-${{ github.event.number }}
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    show-progress: false
+
+            -   name: Prepare environment
+                uses: ./.github/actions/prepare-environment
+
+            - name: Get lerna scope
+              id: lerna-scope
+              uses: actions/github-script@v7
+              env:
+                  PROCESSED_DATA: ${{ toJSON(fromJson(needs.state.outputs.STATE).PROCESSED_DATA) }}
+              with:
+                  result-encoding: string
+                  script: |
+                      const { PROCESSED_DATA } = process.env;
+
+                      const processedData = JSON.parse(PROCESSED_DATA);
+
+                      const requiredPackages = [
+                          'plasma-b2c',
+                          'plasma-tokens-b2c',
+                          'plasma-typo'
+                      ];
+
+                      // TODO: логика под рефакторинг под использование object
+                      const result = [
+                          ...processedData.filter((package) => requiredPackages.includes(package)),
+                          'plasma-website',
+                          'plasma-icons',
+                      ];
+
+
+                      // INFO: Пока не починили медленный css build for b2c/web ставим plasma-new-hope
+                      if (processedData.includes('plasma-b2c')) {
+                        result.push('plasma-new-hope');
+                      }
+
+                      console.log('Result =>', result);
+
+                      return `@salutejs/{${result.join(',')}}`;
+
+            -   name: Lerna bootstrap
+                run: npx lerna bootstrap --scope="${{ steps.lerna-scope.outputs.result }}"
+
+            -   name: Prepare directory
+                run: |
+                    mkdir -p s3_build/${PR_NAME}
+
+                # TODO: https://github.com/salute-developers/plasma/issues/603
+            -   name: Plasma Website
+                run: |
+                    export NODE_OPTIONS=--openssl-legacy-provider
+                    npm run build --prefix="./website/plasma-website"
+                    cp -R ./website/plasma-website/build/. ./s3_build/${PR_NAME}
+
+            -   name: Install s3cmd
+                run: pip3 install s3cmd
+
+            -   name: s3 Upload
+                run: >
+                    s3cmd
+                    --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+                    --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                    --host ${{ secrets.AWS_ENDPOINT }}
+                    --host-bucket ${{ secrets.AWS_ENDPOINT }}
+                    --bucket-location ${{ secrets.AWS_REGION }}
+                    --signature-v2
+                    --delete-removed
+                    --no-mime-magic
+                    sync
+                    ./s3_build/${PR_NAME}/
+                    s3://${{ secrets.AWS_S3_BUCKET_2 }}/pr/${PR_NAME}/
+
+    deploy-artifacts:
+        name: Deploy artifacts
+        needs: [ state,deploy-website ]
+        runs-on: ubuntu-latest
+        env:
+            PR_NAME: pr-${{ github.event.number }}
+            PREFIX: pr/pr-${{ github.event.number }}
+        strategy:
+            fail-fast: false
+            matrix:
+                package: ${{ fromJson(needs.state.outputs.STATE).PACKAGES_DOCUMENTATIONS_RUN }}
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    show-progress: false
+
+            -   name: Prepare environment
+                uses: ./.github/actions/prepare-environment
+
+            -   name: Set job environment variables
+                run: |
+                    echo "SHORT_NAME=$(echo ${{ matrix.package }} | sed -r 's/@salutejs\///g' | sed -r 's/plasma-//g')" >> $GITHUB_ENV
+                    echo "HAS_PACKAGE_DOCS=$([ -d "./website/${{ matrix.package }}-docs" ] && echo true || echo false)" >> $GITHUB_ENV
+
+            -   name: Get lerna scope
+                id: lerna-scope
+                uses: actions/github-script@v7
+                env:
+                    PROCESSED_DATA: ${{ toJSON(fromJson(needs.state.outputs.STATE).PROCESSED_DATA) }}
+                    PACKAGE: ${{ matrix.package }}
+                with:
+                    result-encoding: string
+                    script: |
+                        const { PROCESSED_DATA, PACKAGE } = process.env;
+
+                        const processedData = JSON.parse(PROCESSED_DATA);
+
+                        const [scopeDSName] = PACKAGE.split('-');
+
+                        // INFO: Пока нет устойчивого правила для формирования пакетов `themes`
+                        // и где то используется одно слово, типа `plasma`, а где-то два `caldera-online`
+                        const themes = ['caldera-online'].includes(PACKAGE) ? `${PACKAGE}-themes` : `${scopeDSName}-themes`;
+
+                        const packages = [
+                          'plasma-hope',
+                          'plasma-tokens',
+                          'plasma-tokens-native',
+                          'plasma-tokens-utils',
+                          'plasma-typo',
+                          themes,
+                          `${PACKAGE}-docs`,
+                        ];
+
+                        // TODO: рефакторинг - использовать объект для resolve required deps
+                        const result = [
+                            ...processedData.filter((package) => packages.includes(package)),
+                            PACKAGE,
+                            'plasma-core',
+                            'plasma-docs-ui',
+                            'plasma-icons',
+                        ];
+
+                        // INFO: Пока не починили медленный css build for b2c/web ставим plasma-new-hope
+                        if (processedData.includes('plasma-b2c') || processedData.includes('plasma-web')) {
+                            result.push('plasma-new-hope');
+                        }
+
+                        if (result.includes('plasma-tokens-native')) {
+                            result.push('plasma-tokens');
+                            result.push('plasma-tokens-utils');
+                        }
+
+                        if (result.includes(themes)) {
+                            result.push('plasma-typo');
+                            result.push('data-themes');
+                        }
+
+                        console.log('Result =>', result);
+
+                        return `@salutejs/{${result.join(',')}}`;
+
+            -   name: Lerna bootstrap
+                run: npx lerna bootstrap --scope="${{ steps.lerna-scope.outputs.result }}"
+
+            -   name: Prepare directory
+                run: mkdir -p s3_build/${PR_NAME}
+
+            -   name: Build documentation - "${{ matrix.package }}"
+                if: ${{ fromJSON(env.HAS_PACKAGE_DOCS) }}
+                run: |
+                    npm run build --prefix="./website/${{ matrix.package }}-docs" -- --no-minify
+                    cp -R ./website/${{ matrix.package }}-docs/build ./s3_build/${PR_NAME}/${{ env.SHORT_NAME }}
+
+            -   name: Build storybook - "${{ matrix.package }}"
+                run: |
+                    npm run storybook:build --prefix="./packages/${{ matrix.package }}"
+                    cp -R ./packages/${{ matrix.package }}/build-sb ./s3_build/${PR_NAME}/${{ env.SHORT_NAME }}-storybook
+
+            -   name: Install s3cmd
+                run: pip3 install s3cmd
+
+            -   name: s3 upload docs
+                if: ${{ fromJSON(env.HAS_PACKAGE_DOCS) }}
+                run: >
+                    s3cmd
+                    --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+                    --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                    --host ${{ secrets.AWS_ENDPOINT }}
+                    --host-bucket ${{ secrets.AWS_ENDPOINT }}
+                    --bucket-location ${{ secrets.AWS_REGION }}
+                    --signature-v2
+                    --delete-removed
+                    --no-mime-magic
+                    sync
+                    ./s3_build/${PR_NAME}/${{ env.SHORT_NAME }}/
+                    s3://${{ secrets.AWS_S3_BUCKET_2 }}/pr/${PR_NAME}/${{ env.SHORT_NAME }}/
+
+            -   name: s3 upload storybook
+                run: >
+                    s3cmd
+                    --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+                    --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                    --host ${{ secrets.AWS_ENDPOINT }}
+                    --host-bucket ${{ secrets.AWS_ENDPOINT }}
+                    --bucket-location ${{ secrets.AWS_REGION }}
+                    --signature-v2
+                    --delete-removed
+                    --no-mime-magic
+                    sync
+                    ./s3_build/${PR_NAME}/${{ env.SHORT_NAME }}-storybook/
+                    s3://${{ secrets.AWS_S3_BUCKET_2 }}/pr/${PR_NAME}/${{ env.SHORT_NAME }}-storybook/
+
+    attache-comment:
+        name: Attached comment
+        needs: [ state, deploy-artifacts ]
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v4
+                with:
+                    show-progress: false
+
+            -   name: Create comment
+                id: comment-link
+                uses: actions/github-script@v7
+                env:
+                    PACKAGES_DS: ${{ toJSON(fromJSON(needs.state.outputs.STATE).PACKAGES_DOCUMENTATIONS_RUN) }}
+                    BASE_URL: ${{ vars.STAGE_STABLE_URL }}/pr/pr-${{ github.event.number }}
+                with:
+                    result-encoding: string
+                    script: |
+                        const createLinks = require('./.github/create-links.js');
+
+                        return createLinks();
+
+            -   name: Attach comment
+                uses: marocchino/sticky-pull-request-comment@v2
+                with:
+                    message: ${{ steps.comment-link.outputs.result }}

--- a/.github/workflows/documentation-main.yml
+++ b/.github/workflows/documentation-main.yml
@@ -12,8 +12,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       # [NOTE]: В проекте default branch - dev, что бы правильно собрать
       # актуальную версию для branch master, нужно указать ref = 'master'

--- a/.github/workflows/documentation-pr.yml
+++ b/.github/workflows/documentation-pr.yml
@@ -1,12 +1,7 @@
 name: PR Documentation and Storybook [PR into DEV branch]
 
 on:
-  pull_request:
-    branches:
-      - master
-  pull_request_target:
-    branches:
-      - dev
+    workflow_dispatch:
 
 concurrency:
   # New commit on branch cancels running workflows of the same branch
@@ -18,7 +13,7 @@ jobs:
     name: Authorize external pull request
     if: ${{ !startsWith(github.head_ref, 'release') }}
     uses: ./.github/workflows/authorize-external-pr.yml
-  
+
   scope:
     needs: [ authorize ]
     uses: ./.github/workflows/change-detection.yml
@@ -26,7 +21,7 @@ jobs:
       as-enumeration: true
       ref: refs/pull/${{github.event.pull_request.number}}/merge
     secrets: inherit
-  
+
   build:
     name: Build
     needs: [ authorize, scope ]
@@ -41,10 +36,10 @@ jobs:
         with:
           show-progress: false
           ref: refs/pull/${{github.event.pull_request.number}}/merge
-      
+
       - name: Prepare environment
         uses: ./.github/actions/prepare-environment
-      
+
       - name: Computed scope
         id: scope
         uses: actions/github-script@v6
@@ -54,45 +49,45 @@ jobs:
           result-encoding: string
           script: |
             const { ENUMERATION } = process.env;
-            
+
             const enumeration = JSON.parse(JSON.parse(ENUMERATION));
-            
+
             if (!enumeration.includes('plasma-core')) {
               enumeration.push('plasma-core');
             }
-            
+
             if (!enumeration.includes('plasma-hope')) {
               enumeration.push('plasma-hope');
             }
-            
+
             if (!enumeration.includes('plasma-new-hope')) {
               enumeration.push('plasma-new-hope');
             }
-            
+
             if (!enumeration.includes('plasma-tokens-utils')) {
               enumeration.push('plasma-tokens-utils');
             }
-            
+
             if (enumeration.includes('plasma-tokens-native') && !enumeration.includes('plasma-tokens')) {
               enumeration.push('plasma-tokens');
             }
-            
+
             if (!enumeration.includes('plasma-icons')) {
               enumeration.push('plasma-icons');
             }
-            
+
             if (!enumeration.includes('plasma-docs-ui')) {
               enumeration.push('plasma-docs-ui');
             }
-            
+
             if (!enumeration.includes('plasma-website')) {
               enumeration.push('plasma-website');
             }
-            
-            if (enumeration.includes('plasma-website') && !enumeration.includes('plasma-b2c')) {
+
+            if(enumeration.includes('plasma-website') && !enumeration.includes('plasma-b2c')) {
               enumeration.push('plasma-b2c');
             }
-            
+
             if (enumeration.includes('plasma-ui-docs')) {
               enumeration.push('plasma-web');
             }
@@ -100,22 +95,22 @@ jobs:
             if (!enumeration.includes('plasma-typo')) {
               enumeration.push('plasma-typo');
             }
-            
+
             return enumeration.join(',');
-      
+
       - name: Lerna bootstrap
         run: npx lerna bootstrap --scope=@salutejs/{${{steps.scope.outputs.result}}}
-      
+
       - name: Prepare directory
         run: mkdir -p s3_build/${PR_NAME}
-      
+
       # TODO: https://github.com/salute-developers/plasma/issues/603
       - name: Plasma Website
         run: |
           export NODE_OPTIONS=--openssl-legacy-provider
           npm run build --prefix="./website/plasma-website"
           cp -R ./website/plasma-website/build/. ./s3_build/${PR_NAME}
-      
+
       - name: Plasma UI Docs
         if: ${{ needs.scope.outputs.HAS_PLASMA_UI_DOCS == 'true' && needs.scope.outputs.HAS_PLASMA_UI == 'true' }}
         run: |
@@ -133,58 +128,58 @@ jobs:
         run: |
           npm run build --prefix="./website/sdds-serv-docs"
           cp -R ./website/sdds-serv-docs/build ./s3_build/${PR_NAME}/sdds-serv
-      
+
       - name: Plasma UI Storybook
         if: ${{ needs.scope.outputs.HAS_PLASMA_UI == 'true' }}
         run: |
           npm run storybook:build --prefix="./packages/plasma-ui"
           cp -R ./packages/plasma-ui/build-sb ./s3_build/${PR_NAME}/ui-storybook
-      
+
       - name: Plasma Web Storybook
         if: ${{ needs.scope.outputs.HAS_PLASMA_WEB == 'true' }}
         run: |
           npm run storybook:build --prefix="./packages/plasma-web"
           cp -R ./packages/plasma-web/build-sb ./s3_build/${PR_NAME}/web-storybook
-      
+
       - name: Plasma B2C Storybook
         if: ${{ needs.scope.outputs.HAS_PLASMA_B2C == 'true' }}
         run: |
           npm run storybook:build --prefix="./packages/plasma-b2c"
           cp -R ./packages/plasma-b2c/build-sb ./s3_build/${PR_NAME}/b2c-storybook
-      
+
       - name: Plasma "New Hope" Storybook
         if: ${{ needs.scope.outputs.HAS_PLASMA_HOPE == 'true' }}
         run: |
           npm run storybook:build --prefix="./packages/plasma-new-hope"
           cp -R ./packages/plasma-new-hope/build-sb ./s3_build/${PR_NAME}/new-hope-storybook
-      
+
       - name: Plasma "ASDK" Storybook
         if: ${{ needs.scope.outputs.HAS_PLASMA_ASDK == 'true' }}
         run: |
           npm run storybook:build --prefix="./packages/plasma-asdk"
           cp -R ./packages/plasma-asdk/build-sb ./s3_build/${PR_NAME}/asdk-storybook
-      
+
       - name: Plasma "Caldera" Storybook
         if: ${{ needs.scope.outputs.HAS_CALDERA == 'true' }}
         run: |
           npm run storybook:build --prefix="./packages/caldera"
           cp -R ./packages/caldera/build-sb ./s3_build/${PR_NAME}/caldera-storybook
-      
+
       - name: Plasma "Caldera-online" Storybook
         if: ${{ needs.scope.outputs.HAS_CALDERA_ONLINE == 'true' }}
         run: |
           npm run storybook:build --prefix="./packages/caldera-online"
           cp -R ./packages/caldera-online/build-sb ./s3_build/${PR_NAME}/caldera-online-storybook
-      
+
       - name: Plasma "SDDS SERV" Storybook
         if: ${{ needs.scope.outputs.HAS_SDDS_SERV == 'true' }}
         run: |
           npm run storybook:build --prefix="./packages/sdds-serv"
           cp -R ./packages/sdds-serv/build-sb ./s3_build/${PR_NAME}/sdds-serv-storybook
-      
+
       - name: Install s3cmd
         run: pip3 install s3cmd
-      
+
       - name: s3 Upload builds
         run: >
           s3cmd
@@ -199,7 +194,7 @@ jobs:
           sync
           ./s3_build/${PR_NAME}/
           s3://${{ secrets.AWS_S3_BUCKET_2 }}/pr/${PR_NAME}/
-      
+
       - name: Post success comment
         uses: actions/github-script@v6
         env:
@@ -215,32 +210,32 @@ jobs:
           github-token: ${{secrets.GH_TOKEN}}
           script: |
             const { HAS_PLASMA_B2C, HAS_PLASMA_WEB, HAS_PLASMA_UI, HAS_PLASMA_HOPE, HAS_PLASMA_ASDK, HAS_CALDERA, HAS_CALDERA_ONLINE, HAS_SDDS_SERV } = process.env;
-            
+
             const {
               issue: { number },
               repo: { owner, repo }
             } = context;
-            
+
             const links = [
               `website: http://plasma.sberdevices.ru/pr/pr-${number}/`
             ];
-            
+
             if (HAS_PLASMA_B2C === 'true') {
               links.push(`b2c storybook: http://plasma.sberdevices.ru/pr/pr-${number}/b2c-storybook/`)
             }
-            
+
             if (HAS_PLASMA_WEB === 'true') {
               links.push(`web storybook: http://plasma.sberdevices.ru/pr/pr-${number}/web-storybook/`)
             }
-            
+
             if (HAS_PLASMA_UI === 'true') {
               links.push(`ui storybook: http://plasma.sberdevices.ru/pr/pr-${number}/ui-storybook/`)
             }
-            
+
             if (HAS_PLASMA_HOPE === 'true') {
               links.push(`new-hope storybook: http://plasma.sberdevices.ru/pr/pr-${number}/new-hope-storybook/`)
             }
-            
+
             if (HAS_PLASMA_ASDK === 'true') {
               links.push(`asdk storybook: http://plasma.sberdevices.ru/pr/pr-${number}/asdk-storybook/`)
             }
@@ -256,13 +251,13 @@ jobs:
             if (HAS_SDDS_SERV === 'true') {
               links.push(`sdds-serv storybook: http://plasma.sberdevices.ru/pr/pr-${number}/sdds-serv-storybook/`)
             }
-            
+
             github.rest.issues.createComment({
               issue_number: number,
               owner,
               repo,
               body: `Documentation preview deployed!
-            
+
               ${links.join('\n')}
               `
             });

--- a/.github/workflows/performance-test-base.yml
+++ b/.github/workflows/performance-test-base.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   perftest:
     runs-on: ubuntu-latest
-    env:
-      NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/performance-test-pr.yml
+++ b/.github/workflows/performance-test-pr.yml
@@ -11,162 +11,161 @@ on:
          - dev
 
 concurrency:
-  # New commit on branch cancels running workflows of the same branch
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
+    # New commit on branch cancels running workflows of the same branch
+    group: ${{ github.workflow }}-${{ github.head_ref }}
+    cancel-in-progress: true
 
 jobs:
-  authorize:
-    name: Authorize external pull request
-    uses: ./.github/workflows/authorize-external-pr.yml
+    authorize:
+        name: Authorize external pull request
+        uses: ./.github/workflows/authorize-external-pr.yml
 
-  scope:
-    needs: [authorize]
-    uses: ./.github/workflows/change-detection.yml
-    with:
-      exclude-dependents: true
-      ref: refs/pull/${{github.event.pull_request.number}}/merge
-    secrets: inherit
-
-  perftest:
-    needs: [authorize, scope]
-    if: ${{ needs.scope.outputs.HAS_SCOPE == 'true' }}
-    runs-on: ubuntu-latest
-    env:
-      NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-      PR_NAME: pr-${{ github.event.number }}
-    steps:
-      - name: Install s3cmd
-        run: pip3 install s3cmd
-
-      - uses: actions/checkout@v4
+    state:
+        needs: [ authorize ]
+        uses: ./.github/workflows/change-detection.yml
         with:
-          path: current
-          show-progress: false
-          ref: refs/pull/${{github.event.pull_request.number}}/merge
+            exclude-dependents: true
+            ref: refs/pull/${{github.event.pull_request.number}}/merge
+        secrets: inherit
 
-      - uses: actions/checkout@v4
-        with:
-          path: baseline
-          show-progress: false
-          ref: ${{ github.event.pull_request.base.ref }}
+    perftest:
+        needs: [ authorize, state ]
+        runs-on: ubuntu-latest
+        if: ${{ fromJSON(needs.state.outputs.STATE).HAS_PACKAGES_DS_CHANGES }}
+        env:
+            PR_NAME: pr-${{ github.event.number }}
+        steps:
+            -   name: Install s3cmd
+                run: pip3 install s3cmd
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: 'current/.nvmrc'
-          cache: 'npm'
-          cache-dependency-path: 'current/package-lock.json'
+            -   uses: actions/checkout@v4
+                with:
+                    path: current
+                    show-progress: false
+                    ref: refs/pull/${{github.event.pull_request.number}}/merge
 
-      - name: Cache node modules
-        id: node_modules_current
-        uses: actions/cache@v3
-        with:
-          path: current/node_modules
-          key: node-modules-${{ hashFiles('current/package-lock.json') }}
-          restore-keys: |
-            node-modules-${{ hashFiles('current/package-lock.json') }}
-            node-modules-
+            -   uses: actions/checkout@v4
+                with:
+                    path: baseline
+                    show-progress: false
+                    ref: ${{ github.event.pull_request.base.ref }}
 
-      - name: Cache node modules
-        id: node_modules_base
-        uses: actions/cache/restore@v3
-        with:
-          path: baseline/node_modules
-          key: node-modules-${{ hashFiles('baseline/package-lock.json') }}
-          restore-keys: |
-            node-modules-${{ hashFiles('baseline/package-lock.json') }}
-            node-modules-
+            -   name: Setup Node.js
+                uses: actions/setup-node@v3
+                with:
+                    node-version-file: 'current/.nvmrc'
+                    cache: 'npm'
+                    cache-dependency-path: 'current/package-lock.json'
 
-      - name: Cache dependencies
-        id: cache_deps
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache
-          key: cache-${{ hashFiles('current/package-lock.json') }}
-          restore-keys: |
-            cache-${{ hashFiles('current/package-lock.json') }}
-            cache-
+            -   name: Cache node modules
+                id: node_modules_current
+                uses: actions/cache@v3
+                with:
+                    path: current/node_modules
+                    key: node-modules-${{ hashFiles('current/package-lock.json') }}
+                    restore-keys: |
+                        node-modules-${{ hashFiles('current/package-lock.json') }}
+                        node-modules-
 
-      - name: Setup packages for PR
-        if: ${{ steps.cache_deps.outputs.cache-hit != 'true' || steps.node_modules_current.outputs.cache-hit != 'true' }}
-        run: |
-          cd current
-          npm ci --no-progress
+            -   name: Cache node modules
+                id: node_modules_base
+                uses: actions/cache/restore@v3
+                with:
+                    path: baseline/node_modules
+                    key: node-modules-${{ hashFiles('baseline/package-lock.json') }}
+                    restore-keys: |
+                        node-modules-${{ hashFiles('baseline/package-lock.json') }}
+                        node-modules-
 
-      - name: Lerna bootstrap for PR
-        run: |
-          cd current
-          npx lerna bootstrap --scope=@salutejs/plasma-{core,hope,new-hope,web,b2c,asdk,ui,icons} --scope=@salutejs/perftest-helpers
+            -   name: Cache dependencies
+                id: cache_deps
+                uses: actions/cache@v3
+                with:
+                    path: ~/.cache
+                    key: cache-${{ hashFiles('current/package-lock.json') }}
+                    restore-keys: |
+                        cache-${{ hashFiles('current/package-lock.json') }}
+                        cache-
 
-      - name: Setup packages for ${{ github.event.pull_request.base.ref }}
-        if: ${{ steps.cache_deps.outputs.cache-hit != 'true' || steps.node_modules_base.outputs.cache-hit != 'true' }}
-        run: |
-          cd baseline
-          npm ci --no-progress
+            -   name: Setup packages for PR
+                if: ${{ steps.cache_deps.outputs.cache-hit != 'true' || steps.node_modules_current.outputs.cache-hit != 'true' }}
+                run: |
+                    cd current
+                    npm ci --no-progress
 
-      - name: Lerna bootstrap for ${{ github.event.pull_request.base.ref }}
-        run: |
-          cd baseline
-          npx lerna bootstrap --scope=@salutejs/plasma-{core,hope,new-hope,web,b2c,asdk,ui,icons} --scope=@salutejs/perftest-helpers
+            -   name: Lerna bootstrap for PR
+                run: |
+                    cd current
+                    npx lerna bootstrap --scope=@salutejs/plasma-{core,hope,new-hope,web,b2c,asdk,ui,icons} --scope=@salutejs/perftest-helpers
 
-      - name: Restore perftool cache
-        run: >
-          s3cmd
-          --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
-          --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          --host ${{ secrets.AWS_ENDPOINT }}
-          --host-bucket ${{ secrets.AWS_ENDPOINT }}
-          --bucket-location ${{ secrets.AWS_REGION }}
-          --signature-v2
-          --no-mime-magic
-          --no-preserve
-          sync
-          s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
-          ./current/.perftool/cache/
+            -   name: Setup packages for ${{ github.event.pull_request.base.ref }}
+                if: ${{ steps.cache_deps.outputs.cache-hit != 'true' || steps.node_modules_base.outputs.cache-hit != 'true' }}
+                run: |
+                    cd baseline
+                    npm ci --no-progress
 
-      - name: Run performance test
-        run: |
-          cd current
-          npx perftool --baselineRefDir ../baseline -o perftest/pr-result.json --baselineOutputPath perftest/base-result.json --compareOutputPath perftest/comparison.json --baseBranchRef ${{ github.event.pull_request.base.sha }} --currentBranchRef ${{ github.event.pull_request.head.sha }}
+            -   name: Lerna bootstrap for ${{ github.event.pull_request.base.ref }}
+                run: |
+                    cd baseline
+                    npx lerna bootstrap --scope=@salutejs/plasma-{core,hope,new-hope,web,b2c,asdk,ui,icons} --scope=@salutejs/perftest-helpers
 
-      - name: Save perftool cache
-        run: >
-            s3cmd
-            --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
-            --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            --host ${{ secrets.AWS_ENDPOINT }}
-            --host-bucket ${{ secrets.AWS_ENDPOINT }}
-            --bucket-location ${{ secrets.AWS_REGION }}
-            --signature-v2
-            --no-mime-magic
-            --no-preserve
-            sync
-            ./current/.perftool/cache/
-            s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
+            -   name: Restore perftool cache
+                run: >
+                    s3cmd
+                    --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+                    --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                    --host ${{ secrets.AWS_ENDPOINT }}
+                    --host-bucket ${{ secrets.AWS_ENDPOINT }}
+                    --bucket-location ${{ secrets.AWS_REGION }}
+                    --signature-v2
+                    --no-mime-magic
+                    --no-preserve
+                    sync
+                    s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
+                    ./current/.perftool/cache/
 
-      - name: Save comparison result
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: Component performance comparison result
-          path: ${{ github.workspace }}/current/perftest/*.json
+            -   name: Run performance test
+                run: |
+                    cd current
+                    npx perftool --baselineRefDir ../baseline -o perftest/pr-result.json --baselineOutputPath perftest/base-result.json --compareOutputPath perftest/comparison.json --baseBranchRef ${{ github.event.pull_request.base.sha }} --currentBranchRef ${{ github.event.pull_request.head.sha }}
 
-      - name: Write report comment
-        if: always()
-        uses: ./current/actions/perftest-helpers/actions/write-comment
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          reportPath: ${{ github.workspace }}/current/perftest/comparison.json
-          prId: ${{ github.event.number }}
-          owner: ${{ github.repository_owner }}
-          repo: plasma
+            -   name: Save perftool cache
+                run: >
+                    s3cmd
+                    --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}
+                    --secret_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                    --host ${{ secrets.AWS_ENDPOINT }}
+                    --host-bucket ${{ secrets.AWS_ENDPOINT }}
+                    --bucket-location ${{ secrets.AWS_REGION }}
+                    --signature-v2
+                    --no-mime-magic
+                    --no-preserve
+                    sync
+                    ./current/.perftool/cache/
+                    s3://${{ secrets.AWS_S3_BUCKET_2 }}/perftool-cache/
 
-      - name: Send report
-        if: always()
-        uses: ./current/actions/perftest-helpers/actions/send-report
-        with:
-          reportPath: ${{ github.workspace }}/current/perftest/comparison.json
-          commitHash: ${{ github.sha }}
-          subject: packages/plasma
-          referrer: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            -   name: Save comparison result
+                if: always()
+                uses: actions/upload-artifact@v2
+                with:
+                    name: Component performance comparison result
+                    path: ${{ github.workspace }}/current/perftest/*.json
+
+            -   name: Write report comment
+                if: always()
+                uses: ./current/actions/perftest-helpers/actions/write-comment
+                with:
+                    token: ${{ secrets.GITHUB_TOKEN }}
+                    reportPath: ${{ github.workspace }}/current/perftest/comparison.json
+                    prId: ${{ github.event.number }}
+                    owner: ${{ github.repository_owner }}
+                    repo: plasma
+
+            -   name: Send report
+                if: always()
+                uses: ./current/actions/perftest-helpers/actions/send-report
+                with:
+                    reportPath: ${{ github.workspace }}/current/perftest/comparison.json
+                    commitHash: ${{ github.sha }}
+                    subject: packages/plasma
+                    referrer: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -17,22 +17,22 @@ jobs:
   authorize:
     name: Authorize external pull request
     uses: ./.github/workflows/authorize-external-pr.yml
-    
-  scope:
+
+  state:
     name: Computed changed state
     needs: [ authorize ]
     uses: ./.github/workflows/change-detection.yml
     with:
       ref: refs/pull/${{github.event.pull_request.number}}/merge
     secrets: inherit
-  
+
   publish:
     name: Publish canary version
-    needs: [ authorize, scope ]
+    needs: [ authorize, state ]
     uses: ./.github/workflows/publish-common.yml
     with:
       ref: refs/pull/${{github.event.pull_request.number}}/merge
-      upload_assets: ${{ needs.scope.outputs.HAS_ASSETS == 'true' }}
+      upload_assets: ${{ fromJSON(needs.state.outputs.STATE).HAS_ASSETS }}
       auto-options: '--no-changelog'
     secrets:
       gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/required-primary-checks.yml
+++ b/.github/workflows/required-primary-checks.yml
@@ -14,7 +14,6 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-  NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
   LERNA_IGNORE_LIST: "@salutejs/plasma-{cy-utils,sb-utils}"
 
 jobs:
@@ -25,7 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           show-progress: false
 
       - name: Prepare environment
@@ -44,7 +42,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           show-progress: false
 
       - name: Prepare environment

--- a/.github/workflows/theme-builder-pr.yml
+++ b/.github/workflows/theme-builder-pr.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: authorize
     env:
-      NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       PR_NAME: pr-${{ github.event.number }}
     steps:
       - uses: actions/checkout@v4
@@ -71,21 +70,20 @@ jobs:
           ./s3_build/plasma-theme-builder-${PR_NAME}/
           s3://${{ secrets.AWS_S3_BUCKET_2 }}/pr/plasma-theme-builder-${PR_NAME}/
 
-      - name: Post success comment
+      - name: Create success comment
+        id: success-comment
         uses: actions/github-script@v3
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          result-encoding: string
           script: |
             const branchName = context.payload.pull_request.head.ref;
             const themeName = branchName.split('theme-builder-')[1];
             const params = themeName ? `?theme=${themeName}&branch=${branchName}` : '';
+            const url = `${{ vars.STAGE_STABLE_URL }}/pr/plasma-theme-builder-pr-${context.issue.number}/${params}`
 
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Theme Builder app deployed!
+            return "Theme Builder app deployed!" + "\n\n" + url;
 
-              http://plasma.sberdevices.ru/pr/plasma-theme-builder-pr-${context.issue.number}/${params}
-              `
-            })
+      -   name: Attach comment
+          uses: marocchino/sticky-pull-request-comment@v2
+          with:
+              message: ${{ steps.success-comment.outputs.result }}

--- a/.github/workflows/theme-builder.yml
+++ b/.github/workflows/theme-builder.yml
@@ -9,8 +9,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/typescript-coverage.yml
+++ b/.github/workflows/typescript-coverage.yml
@@ -13,50 +13,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  scope:
-    uses: ./.github/workflows/change-detection.yml
-    with:
-      as-enumeration: true
-    secrets: inherit
-
   typescript-coverage:
-    needs: scope
-    if: ${{ needs.scope.outputs.HAS_SCOPE == 'true' }}
     runs-on: ubuntu-latest
     env:
-      NPM_REGISTRY_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
       # INFO: Игнорируем пакеты связанные с plasma-tokens, документацией и утилитами, т.к. в них не запускается typescript-coverage
       LERNA_IGNORE_LIST: "@salutejs/plasma-{tokens*,cy-utils,sb-utils}"
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           show-progress: false
-  
+
       - name: Prepare environment
         uses: ./.github/actions/prepare-environment
-
-      - name: Computed scope
-        id: scope
-        uses: actions/github-script@v6
-        env:
-          ENUMERATION: ${{ toJSON(needs.scope.outputs.PACKAGES_ENUMERATION) }}
-        with:
-          result-encoding: string
-          script: |
-            const { ENUMERATION } = process.env;
-            
-            const enumeration = JSON.parse(JSON.parse(ENUMERATION));
-            
-            if (!enumeration.includes('plasma-core')) {
-              enumeration.push('plasma-core')
-            }
-            
-            if (!enumeration.includes('plasma-icons')) {
-              enumeration.push('plasma-icons')
-            }
-            
-            return enumeration.join(',');     
 
       - name: Lerna bootstrap
         run: npx lerna bootstrap --no-private
@@ -64,11 +32,11 @@ jobs:
       - name: Run Typescript Coverage
         if: ${{ always() }}
         run: |
-          npm run typescript-coverage -- --ignore=${{env.LERNA_IGNORE_LIST}}
+          npm run typescript-coverage -- --no-private --ignore=${{env.LERNA_IGNORE_LIST}}
 
       - name: Save artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@master
         with:
           name: Typescript Coverage Report Artifacts
-          path: /home/runner/work/plasma/plasma/packages/*/coverage-ts/
+          path: packages/*/coverage-ts/

--- a/.github/workflows/typescript-coverage.yml
+++ b/.github/workflows/typescript-coverage.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Save artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4.1.0
         with:
           name: Typescript Coverage Report Artifacts
           path: packages/*/coverage-ts/


### PR DESCRIPTION
### Deploy documentations artefacts

- распараллели процесс создания и загрузки артефактов документации
- добавили `marocchino/sticky-pull-request-comment` для приклеивания сообщения к одному комментарию в pr
- добавлена конфигурация: `config-ci.json` 
- удалены неиспользуемые переменные

### What/why changed

При увеличении кол-ва клиентских пакетов будет расти время загрузки артефактов документации. 

Уже сейчас время на загрузку для всех пакетов составляет: от `20 min` до `30 min`.

Поэтом решили делать параллельные job сборки документации (нечто подобное делаем для запуска тестов Cypress)       

<img width="298" alt="Screenshot 2024-03-18 at 15 54 08" src="https://github.com/salute-developers/plasma/assets/2895992/76eff6a4-9a75-4112-8fc1-4819699a08c4">


### Плюсы:

- возможность перезапустить упавшую job для конкретного пакета (раньше весь процесс целиком)  
- ставится только то что нужно пакету который запустил pipeline
- возможность доп оптимизаций, что дадут ускорения выполнения (например включение cache)
- понятная конфигурация процесса
- единая точка входа для определения **для какого** запускать        

### Минусы: 

-  конечное кол-во ресурсов runner's, а значит будет спор за ресурсы между 2-мя pr's
-  время ожидание свободного runner суммируется с общим временем исполнения   
 
#### Файл конфигурации CI: `config-ci.json`

Описывает:

- какие клиентские пакеты имеют арфтекаты документация
- для каких пакетов запускать `cypress` тесты

#### Доводы **ЗА** файл конфигурации

- видно кто изменял (в отличие от  `vars. PACKAGES_DS `)
- можно изменить конфигурацию в разных pr's, **не вливая** код в default branch ( env мы меняем сразу на все jobs во всех ветках )
- его можно изменять роботом ( в отличии от env которые надо будет править через некое API если оно есть )
 
`Lerna` предоставляет состояние измененных пакетов на основе которого высчитывается для каких пакетов из конфигурации нужно собрать и загрузить артефакты документации. 
  
#### Сборка plasma-web (storybook + docs): 13m 31s 

<img width="1882" alt="Screenshot 2024-03-20 at 16 32 18" src="https://github.com/salute-developers/plasma/assets/2895992/10078c3c-247f-45f0-b2b6-a7376a15959b">

#### Сборка plasma-asdk (storybook): 8m 21s 

<img width="1539" alt="Screenshot 2024-03-20 at 15 58 40" src="https://github.com/salute-developers/plasma/assets/2895992/c8129a86-29ac-470d-b63d-0bc9ddea63e5">

#### Сборка всех пакетов (storybook + docs): 16m 52s

<img width="1538" alt="Screenshot 2024-03-20 at 16 18 27" src="https://github.com/salute-developers/plasma/assets/2895992/09bc6a7c-9ada-4bf1-a4f7-b12bdd29c872">
  
### Проверена сборка для: 

- [x] plasma-core
- [x] plasma-new-hope
- [x] plasma-web
- [x] plasma-b2c
- [x] plasma-asdk
- [x] sdds-serv 
- [x] plasma-native-tokens