### PR TITLE
fix: test new ci docs sdds-serv 

### DIFF
--- a/packages/sdds-serv/package.json
+++ b/packages/sdds-serv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salutejs/sdds-serv",
   "version": "0.25.3-dev.0",
-  "description": "Salute Design System / React UI kit for SDDS SERV web applications",
+  "description": "Salute Design System / React UI kit for SDDS SERV web applicationsasdas",
   "author": "Salute Frontend Team <salute.developers@gmail.com>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-serv@0.25.4-canary.1136.8369226092.0
  # or 
  yarn add @salutejs/sdds-serv@0.25.4-canary.1136.8369226092.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
