### PR TITLE
chore: test new-hope

### DIFF
--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -268,4 +268,5 @@ jobs:
             -   name: Attach comment
                 uses: marocchino/sticky-pull-request-comment@v2
                 with:
+                    header: Links
                     message: ${{ steps.comment-link.outputs.result }}

--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -156,6 +156,7 @@ jobs:
 
                         const packages = [
                           'plasma-hope',
+                          'plasma-new-hope',
                           'plasma-tokens',
                           'plasma-tokens-native',
                           'plasma-tokens-utils',

--- a/.github/workflows/theme-builder-pr.yml
+++ b/.github/workflows/theme-builder-pr.yml
@@ -86,4 +86,5 @@ jobs:
       -   name: Attach comment
           uses: marocchino/sticky-pull-request-comment@v2
           with:
+              header: Theme Builder
               message: ${{ steps.success-comment.outputs.result }}

--- a/packages/plasma-new-hope/package.json
+++ b/packages/plasma-new-hope/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salutejs/plasma-new-hope",
   "version": "0.61.2-dev.0",
-  "description": "Salute Design System blueprint",
+  "description": "Salute Design System blueprintasdas",
   "main": "cjs/index.js",
   "module": "es/index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.21.3-canary.1138.8369775446.0
  npm install @salutejs/caldera@0.21.3-canary.1138.8369775446.0
  npm install @salutejs/plasma-asdk@0.58.4-canary.1138.8369775446.0
  npm install @salutejs/plasma-b2c@1.300.5-canary.1138.8369775446.0
  npm install @salutejs/plasma-new-hope@0.61.3-canary.1138.8369775446.0
  npm install @salutejs/plasma-web@1.300.5-canary.1138.8369775446.0
  npm install @salutejs/sdds-serv@0.25.4-canary.1138.8369775446.0
  # or 
  yarn add @salutejs/caldera-online@0.21.3-canary.1138.8369775446.0
  yarn add @salutejs/caldera@0.21.3-canary.1138.8369775446.0
  yarn add @salutejs/plasma-asdk@0.58.4-canary.1138.8369775446.0
  yarn add @salutejs/plasma-b2c@1.300.5-canary.1138.8369775446.0
  yarn add @salutejs/plasma-new-hope@0.61.3-canary.1138.8369775446.0
  yarn add @salutejs/plasma-web@1.300.5-canary.1138.8369775446.0
  yarn add @salutejs/sdds-serv@0.25.4-canary.1138.8369775446.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
