### PR TITLE
fix(plasma-web,plasma-b2c,plasma-asdk): Replace tokens for background in storybook to new

### DIFF
--- a/packages/plasma-asdk/.storybook/decoratorThemes.tsx
+++ b/packages/plasma-asdk/.storybook/decoratorThemes.tsx
@@ -5,7 +5,9 @@ import {
     stylesSalute__dark as stylesSaluteDark,
     stylesSalute__light as stylesSaluteLight,
 } from '@salutejs/plasma-tokens';
-import { link, linkHover, linkActive, surfaceSolid01 } from '@salutejs/plasma-tokens-b2b';
+import { link, linkHover, linkActive } from '@salutejs/plasma-tokens-b2b';
+import { backgroundPrimary } from '@salutejs/plasma-tokens-b2b/new';
+
 import { standard as standardTypo, compatible as compatibleTypo } from '@salutejs/plasma-typo';
 import { b2b as b2bTypo } from '@salutejs/plasma-tokens-b2b';
 
@@ -17,7 +19,7 @@ const CompatibleTypoStyle = createGlobalStyle(compatibleTypo);
 const DocumentStyle = createGlobalStyle`
     html:root {
         min-height: 100vh;
-        background-color: ${surfaceSolid01};
+        background-color: ${backgroundPrimary};
     }
     a {
         color: ${link};

--- a/packages/plasma-asdk/.storybook/preview-head.html
+++ b/packages/plasma-asdk/.storybook/preview-head.html
@@ -20,7 +20,7 @@
     }
 
     .sbdocs-preview {
-        background: var(--plasma-colors-background) !important;
+        background: var(--background-primary) !important;
         box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.05) !important;
     }
 

--- a/packages/plasma-b2c/.storybook/decoratorThemes.tsx
+++ b/packages/plasma-b2c/.storybook/decoratorThemes.tsx
@@ -2,14 +2,15 @@ import React from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 import { b2c, dark, light } from '@salutejs/plasma-tokens-b2c';
-import { link, linkHover, linkActive, surfaceSolid01 } from '@salutejs/plasma-tokens-web';
+import { link, linkHover, linkActive } from '@salutejs/plasma-tokens-web';
+import { backgroundPrimary } from '@salutejs/plasma-tokens-web/new';
 import { standard as standardTypo, compatible as compatibleTypo } from '@salutejs/plasma-typo';
 
 /* stylelint-disable */
 const DocumentStyle = createGlobalStyle`
     html:root {
         min-height: 100vh;
-        background-color: ${surfaceSolid01};
+        background-color: ${backgroundPrimary};
     }
     a {
         color: ${link};

--- a/packages/plasma-b2c/.storybook/preview-head.html
+++ b/packages/plasma-b2c/.storybook/preview-head.html
@@ -26,7 +26,7 @@
     }
 
     .sbdocs-preview {
-        background: var(--plasma-colors-background) !important;
+        background: var(--background-primary) !important;
         box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.05) !important;
     }
 

--- a/packages/plasma-web/.storybook/decoratorThemes.tsx
+++ b/packages/plasma-web/.storybook/decoratorThemes.tsx
@@ -8,8 +8,8 @@ import {
     link,
     linkHover,
     linkActive,
-    surfaceSolid01,
 } from '@salutejs/plasma-tokens-b2b';
+import { backgroundPrimary } from '@salutejs/plasma-tokens-b2b/new';
 import { light as b2cLight, dark as b2cDark } from '@salutejs/plasma-tokens-b2c';
 import { light as legacyLight, dark as legacyDark } from '@salutejs/plasma-tokens-web';
 import { standard as standardTypo, compatible as compatibleTypo } from '@salutejs/plasma-typo';
@@ -18,7 +18,7 @@ import { standard as standardTypo, compatible as compatibleTypo } from '@salutej
 const DocumentStyle = createGlobalStyle`
     html:root {
         min-height: 100vh;
-        background-color: ${surfaceSolid01};
+        background-color: ${backgroundPrimary};
     }
     a {
         color: ${link};

--- a/packages/plasma-web/.storybook/preview-head.html
+++ b/packages/plasma-web/.storybook/preview-head.html
@@ -20,7 +20,7 @@
     }
 
     .sbdocs-preview {
-        background: var(--plasma-colors-background) !important;
+        background: var(--background-primary) !important;
         box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.05) !important;
     }
 


### PR DESCRIPTION
### Docs

* Исправлена ошибка примера путём обновления токенов бэграундов в сторибуке для библиотек `plasma-web`, `plasma-b2c`, `plasma-asdk`.

До:
<img width="412" alt="Screenshot 2024-03-21 at 12 28 41" src="https://github.com/salute-developers/plasma/assets/26903236/5814e04f-1425-403c-8e20-1151a12063c6">

После:
<img width="412" alt="Screenshot 2024-03-21 at 17 03 31" src="https://github.com/salute-developers/plasma/assets/26903236/259c6397-2e5c-4d82-a2a6-4d6fdcc31e79">

### What/why changed

Сейчас заливка некоторых новых компонент сливаются с фоном сторибука



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.58.4-canary.1139.8374382404.0
  npm install @salutejs/plasma-b2c@1.300.5-canary.1139.8374382404.0
  npm install @salutejs/plasma-web@1.300.5-canary.1139.8374382404.0
  # or 
  yarn add @salutejs/plasma-asdk@0.58.4-canary.1139.8374382404.0
  yarn add @salutejs/plasma-b2c@1.300.5-canary.1139.8374382404.0
  yarn add @salutejs/plasma-web@1.300.5-canary.1139.8374382404.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
