### PR TITLE
feat(plasma-new-hope): tooltip old api fallback

### DIFF
--- a/packages/plasma-b2c/src/components/Tooltip/Tooltip.config.ts
+++ b/packages/plasma-b2c/src/components/Tooltip/Tooltip.config.ts
@@ -59,6 +59,7 @@ export const config = {
             `,
         },
         view: {
+            // TODO заменить тень на токен https://github.com/salute-developers/plasma/issues/1131
             default: css`
                 ${tooltipTokens.backgroundColor}: var(--plasma-colors-background-primary);
                 ${tooltipTokens.boxShadow}: 0px 4px 12px 0px rgba(0, 0, 0, 0.16),0px 1px 4px 0px rgba(0, 0, 0, 0.08);

--- a/packages/plasma-b2c/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-b2c/src/components/Tooltip/Tooltip.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { IconDisclosureRight } from '@salutejs/plasma-icons';
 import type { StoryObj, Meta } from '@storybook/react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button/Button';
 import { PopoverPlacement } from '../Popover';
@@ -46,47 +46,28 @@ const StyledGrid = styled.div`
     padding: 3.5rem;
 `;
 
-const StoryDefault = ({ size }: TooltipProps) => {
+const StoryDefault = (props: Pick<TooltipProps, 'hasArrow' | 'size' | 'usePortal'>) => {
     return (
         <StyledGrid>
             <Tooltip
-                target={
-                    <Tooltip target={<Button>Btn</Button>} placement="left" size={size} isOpen hasArrow text="left" />
-                }
+                target={<Tooltip target={<Button>Btn</Button>} placement="left" isOpen text="left" {...props} />}
                 placement="top-start"
-                size={size}
                 isOpen
-                hasArrow
                 text="top-start"
+                view="default"
+                {...props}
             />
-            <Tooltip target={<Button>Btn</Button>} placement="top" size={size} isOpen hasArrow text="top" />
+            <Tooltip target={<Button>Btn</Button>} placement="top" isOpen text="top" {...props} />
             <Tooltip
-                target={
-                    <Tooltip target={<Button>Btn</Button>} placement="right" size={size} isOpen hasArrow text="right" />
-                }
+                target={<Tooltip target={<Button>Btn</Button>} placement="right" isOpen text="right" {...props} />}
                 placement="top-end"
-                size={size}
                 isOpen
-                hasArrow
                 text="top-end"
+                {...props}
             />
-            <Tooltip
-                target={<Button>Btn</Button>}
-                placement="bottom-start"
-                size={size}
-                isOpen
-                hasArrow
-                text="bottom-start"
-            />
-            <Tooltip target={<Button>Btn</Button>} placement="bottom" size={size} isOpen hasArrow text="bottom" />
-            <Tooltip
-                target={<Button>Btn</Button>}
-                placement="bottom-end"
-                size={size}
-                isOpen
-                hasArrow
-                text="bottom-end"
-            />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom-start" isOpen text="bottom-start" {...props} />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom" isOpen text="bottom" {...props} />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom-end" isOpen text="bottom-end" {...props} />
         </StyledGrid>
     );
 };
@@ -99,9 +80,27 @@ export const Default: StoryObj<TooltipProps> = {
                 type: 'select',
             },
         },
+        ...disableProps([
+            'target',
+            'children',
+            'text',
+            'isOpen',
+            'isVisible',
+            'placement',
+            'offset',
+            'frame',
+            'view',
+            'zIndex',
+            'minWidth',
+            'maxWidth',
+            'contentLeft',
+            'onDismiss',
+        ]),
     },
     args: {
         size: 'm',
+        hasArrow: true,
+        usePortal: false,
     },
     render: (args) => <StoryDefault {...args} />,
 };
@@ -153,12 +152,27 @@ export const Live: StoryObj<TooltipProps> = {
                 type: 'select',
             },
         },
+        ...disableProps([
+            'target',
+            'children',
+            'text',
+            'isOpen',
+            'isVisible',
+            'offset',
+            'frame',
+            'view',
+            'zIndex',
+            'contentLeft',
+            'onDismiss',
+        ]),
     },
     args: {
         placement: 'bottom',
         maxWidth: 10,
         minWidth: 3,
         hasArrow: true,
+        usePortal: false,
+        animated: true,
         size: 'm',
     },
     render: (args) => <StoryLive {...args} />,

--- a/packages/plasma-new-hope/src/components/Popover/Popover.tsx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.tsx
@@ -1,9 +1,10 @@
 import React, { useRef, useCallback, useEffect, useState, forwardRef } from 'react';
+import type { CSSProperties } from 'react';
 import ReactDOM from 'react-dom';
 import { usePopper } from 'react-popper';
 import { useFocusTrap, useForkRef } from '@salutejs/plasma-core';
 
-import { RootProps } from '../../engines/types';
+import type { RootProps } from '../../engines/types';
 import { cx } from '../../utils';
 
 import { base as viewCSS } from './variations/_view/base';
@@ -58,6 +59,11 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
 
             const isAutoArray = Array.isArray(placement);
             const isAuto = isAutoArray || (placement as PopoverPlacement).startsWith('auto');
+
+            const initialStyles = {
+                visibility: isOpen ? 'visible' : 'hidden',
+                opacity: isOpen ? 1 : 0,
+            } as CSSProperties;
 
             const { styles, attributes, forceUpdate } = usePopper(rootRef.current, popoverRef.current, {
                 placement: isAutoArray ? 'auto' : (placement as PopoverPlacement),
@@ -234,7 +240,7 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
                                     {...attributes.popper}
                                     className={classes.root}
                                     ref={popoverForkRef}
-                                    style={{ ...styles.popper, ...{ display: isOpen ? 'block' : 'none' } }}
+                                    style={{ ...styles.popper, ...initialStyles }}
                                     zIndex={zIndex}
                                 >
                                     {hasArrow && (

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tokens.ts
@@ -1,5 +1,6 @@
 export const classes = {
     hasContentLeft: 'has-content-left',
+    animated: 'tooltip-animated',
 };
 
 export const tokens = {

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, forwardRef, useState } from 'react';
 import { styled } from '@linaria/react';
 
 import { RootProps, component } from '../../engines';
-import { popoverConfig, popoverTokens } from '../Popover';
+import { popoverClasses, popoverConfig, popoverTokens } from '../Popover';
 import { cx } from '../../utils';
 
 import { TooltipProps } from './Tooltip.types';
@@ -26,6 +26,10 @@ const StyledPopover = styled(Popover)`
     ${popoverTokens.arrowBackground}: var(${tokens.arrowBackground});
     ${popoverTokens.arrowHeight}: var(${tokens.arrowHeight});
     ${popoverTokens.arrowEdgeMargin}: var(${tokens.arrowEdgeMargin});
+
+    &.${classes.animated} .${popoverClasses.root} {
+        transition: opacity 200ms ease-in-out, visibility 200ms ease-in-out;
+    }
 `;
 
 /**
@@ -39,7 +43,10 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                 id,
                 text,
                 isOpen,
+                isVisible,
                 hasArrow = true,
+                arrow,
+                animated,
                 offset = [0, 8],
                 minWidth,
                 maxWidth,
@@ -59,6 +66,13 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
         ) => {
             const [ref, setRef] = useState<HTMLDivElement | null>(null);
 
+            // TODO убрать после отказа от старого API
+            const innerIsOpen = isVisible || isOpen;
+            const innerHasArrow = arrow || hasArrow;
+            const showTooltip = innerIsOpen && Boolean(text?.length);
+
+            const animatedClass = animated ? classes.animated : undefined;
+
             useEffect(() => {
                 const onKeyDown = (event: KeyboardEvent) => {
                     if (event.keyCode === ESCAPE_KEYCODE) {
@@ -77,17 +91,17 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
 
             return (
                 <StyledPopover
-                    isOpen={isOpen && Boolean(text?.length)}
+                    isOpen={showTooltip}
                     placement={placement}
                     offset={offset}
                     zIndex={zIndex}
                     target={target || children}
                     usePortal={usePortal}
-                    hasArrow={hasArrow}
-                    aria-hidden={!isOpen}
+                    hasArrow={innerHasArrow}
+                    aria-hidden={!innerIsOpen}
                     aria-live="polite"
                     role="tooltip"
-                    className={cx(ref?.classList.toString(), className)}
+                    className={cx(ref?.classList.toString(), animatedClass, className)}
                     // INFO: Прокидываем стили для Popover из Root Tooltip-а
 
                     {...rest}

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.types.ts
@@ -12,6 +12,11 @@ export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
      */
     isOpen: boolean;
     /**
+     * Видимость тултипа.
+     * @deprecated
+     */
+    isVisible?: boolean;
+    /**
      * Элемент, рядом с которым произойдет вызов всплывающего окна.
      */
     target?: ReactNode;
@@ -23,6 +28,15 @@ export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
      * Видимость стрелки (хвоста).
      */
     hasArrow?: boolean;
+    /**
+     * Видимость стрелки (хвоста).
+     * @deprecated
+     */
+    arrow?: boolean;
+    /**
+     * Анимированное появление/сокрытие.
+     */
+    animated?: boolean;
     /**
      * Отступ окна относительно элемента, у которого оно вызвано.
      * @default

--- a/packages/plasma-web/src/components/Tooltip/Tooltip.config.ts
+++ b/packages/plasma-web/src/components/Tooltip/Tooltip.config.ts
@@ -59,6 +59,7 @@ export const config = {
             `,
         },
         view: {
+            // TODO заменить тень на токен https://github.com/salute-developers/plasma/issues/1131
             default: css`
                 ${tooltipTokens.backgroundColor}: var(--plasma-colors-background-primary);
                 ${tooltipTokens.boxShadow}: 0px 4px 12px 0px rgba(0, 0, 0, 0.16),0px 1px 4px 0px rgba(0, 0, 0, 0.08);

--- a/packages/plasma-web/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-web/src/components/Tooltip/Tooltip.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { IconDisclosureRight } from '@salutejs/plasma-icons';
 import type { StoryObj, Meta } from '@storybook/react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button/Button';
 import { PopoverPlacement } from '../Popover';
@@ -46,47 +46,28 @@ const StyledGrid = styled.div`
     padding: 3.5rem;
 `;
 
-const StoryDefault = ({ size }: TooltipProps) => {
+const StoryDefault = (props: Pick<TooltipProps, 'hasArrow' | 'size' | 'usePortal'>) => {
     return (
         <StyledGrid>
             <Tooltip
-                target={
-                    <Tooltip target={<Button>Btn</Button>} placement="left" size={size} isOpen hasArrow text="left" />
-                }
+                target={<Tooltip target={<Button>Btn</Button>} placement="left" isOpen text="left" {...props} />}
                 placement="top-start"
-                size={size}
                 isOpen
-                hasArrow
                 text="top-start"
+                view="default"
+                {...props}
             />
-            <Tooltip target={<Button>Btn</Button>} placement="top" size={size} isOpen hasArrow text="top" />
+            <Tooltip target={<Button>Btn</Button>} placement="top" isOpen text="top" {...props} />
             <Tooltip
-                target={
-                    <Tooltip target={<Button>Btn</Button>} placement="right" size={size} isOpen hasArrow text="right" />
-                }
+                target={<Tooltip target={<Button>Btn</Button>} placement="right" isOpen text="right" {...props} />}
                 placement="top-end"
-                size={size}
                 isOpen
-                hasArrow
                 text="top-end"
+                {...props}
             />
-            <Tooltip
-                target={<Button>Btn</Button>}
-                placement="bottom-start"
-                size={size}
-                isOpen
-                hasArrow
-                text="bottom-start"
-            />
-            <Tooltip target={<Button>Btn</Button>} placement="bottom" size={size} isOpen hasArrow text="bottom" />
-            <Tooltip
-                target={<Button>Btn</Button>}
-                placement="bottom-end"
-                size={size}
-                isOpen
-                hasArrow
-                text="bottom-end"
-            />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom-start" isOpen text="bottom-start" {...props} />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom" isOpen text="bottom" {...props} />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom-end" isOpen text="bottom-end" {...props} />
         </StyledGrid>
     );
 };
@@ -99,9 +80,27 @@ export const Default: StoryObj<TooltipProps> = {
                 type: 'select',
             },
         },
+        ...disableProps([
+            'target',
+            'children',
+            'text',
+            'isOpen',
+            'isVisible',
+            'placement',
+            'offset',
+            'frame',
+            'view',
+            'zIndex',
+            'minWidth',
+            'maxWidth',
+            'contentLeft',
+            'onDismiss',
+        ]),
     },
     args: {
         size: 'm',
+        hasArrow: true,
+        usePortal: false,
     },
     render: (args) => <StoryDefault {...args} />,
 };
@@ -153,12 +152,27 @@ export const Live: StoryObj<TooltipProps> = {
                 type: 'select',
             },
         },
+        ...disableProps([
+            'target',
+            'children',
+            'text',
+            'isOpen',
+            'isVisible',
+            'offset',
+            'frame',
+            'view',
+            'zIndex',
+            'contentLeft',
+            'onDismiss',
+        ]),
     },
     args: {
         placement: 'bottom',
         maxWidth: 10,
         minWidth: 3,
         hasArrow: true,
+        usePortal: false,
+        animated: true,
         size: 'm',
     },
     render: (args) => <StoryLive {...args} />,

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -123,6 +123,7 @@ import { textXSBold } from '@salutejs/sdds-themes/tokens';
 import { ToastPosition } from '@salutejs/plasma-new-hope/styled-components';
 import { ToastProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
+import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
@@ -1030,6 +1031,11 @@ export const ToastProvider: ({ children }: {
 }) => JSX.Element;
 
 export { ToastRole }
+
+// @public (undocumented)
+export const Tooltip: ForwardRefExoticComponent<TooltipProps & RefAttributes<HTMLDivElement>>;
+
+export { TooltipProps }
 
 export { usePopupContext }
 

--- a/packages/sdds-serv/src/components/Tooltip/Tooltip.config.ts
+++ b/packages/sdds-serv/src/components/Tooltip/Tooltip.config.ts
@@ -1,0 +1,70 @@
+import { css, tooltipTokens } from '@salutejs/plasma-new-hope/styled-components';
+
+export const config = {
+    defaults: {
+        view: 'default',
+        size: 'm',
+    },
+    variations: {
+        size: {
+            s: css`
+                ${tooltipTokens.paddingTop}: 0.5rem;
+                ${tooltipTokens.paddingRight}: 0.75rem;
+                ${tooltipTokens.paddingBottom}: 0.5rem;
+                ${tooltipTokens.paddingLeft}: 0.75rem;
+
+                ${tooltipTokens.minHeight}: 2rem;
+                ${tooltipTokens.borderRadius}: 0.5rem;
+
+                ${tooltipTokens.textFontFamily}: var(--plasma-typo-body-xs-font-family);
+                ${tooltipTokens.textFontSize}: var(--plasma-typo-body-xs-font-size);
+                ${tooltipTokens.textFontStyle}: var(--plasma-typo-body-xs-font-style);
+                ${tooltipTokens.textFontWeight}: var(--plasma-typo-body-xs-font-weight);
+                ${tooltipTokens.textFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
+                ${tooltipTokens.textFontLineHeight}: var(--plasma-typo-body-xs-line-height);
+
+                ${tooltipTokens.contentLeftMargin}: 0.25rem;
+
+                ${tooltipTokens.arrowMaskWidth}: 1rem;
+                ${tooltipTokens.arrowMaskHeight}: 1rem;
+                ${tooltipTokens.arrowMaskImage}: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtMCw5Ljg1bDE2LDBjLTQuNDEsMCAtOCwyLjY5IC04LDZjMCwtMy4zMSAtMy41OSwtNiAtOCwtNnoiIGZpbGw9IiMxNzE3MTciIGZpbGwtcnVsZT0iZXZlbm9kZCIgaWQ9IlRhaWwiLz4KPC9zdmc+");
+                ${tooltipTokens.arrowHeight}: 0.375rem;
+                ${tooltipTokens.arrowEdgeMargin}: 0.5625rem;
+                ${tooltipTokens.arrowBackground}: var(--surface-solid-card);
+            `,
+            m: css`
+                ${tooltipTokens.paddingTop}: 0.6875rem;
+                ${tooltipTokens.paddingRight}: 0.875rem;
+                ${tooltipTokens.paddingBottom}: 0.6875rem;
+                ${tooltipTokens.paddingLeft}: 0.875rem;
+
+                ${tooltipTokens.minHeight}: 2.5rem;
+                ${tooltipTokens.borderRadius}: 0.625rem;
+
+                ${tooltipTokens.textFontFamily}: var(--plasma-typo-body-s-font-family);
+                ${tooltipTokens.textFontSize}: var(--plasma-typo-body-s-font-size);
+                ${tooltipTokens.textFontStyle}: var(--plasma-typo-body-s-font-style);
+                ${tooltipTokens.textFontWeight}: var(--plasma-typo-body-s-font-weight);
+                ${tooltipTokens.textFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
+                ${tooltipTokens.textFontLineHeight}: var(--plasma-typo-body-s-line-height);
+
+                ${tooltipTokens.contentLeftMargin}: 0.375rem;
+
+                ${tooltipTokens.arrowMaskWidth}: 1.25rem;
+                ${tooltipTokens.arrowMaskHeight}: 1.25rem;
+                ${tooltipTokens.arrowMaskImage}: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtMC4xNywxMS44M2wyMCwwYy01LjUyLDAgLTEwLDMuNTkgLTEwLDhjMCwtNC40MSAtNC40OCwtOCAtMTAsLTh6IiBmaWxsPSIjMTcxNzE3IiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGlkPSJUYWlsIi8+Cjwvc3ZnPg==");
+                ${tooltipTokens.arrowHeight}: 0.5rem;
+                ${tooltipTokens.arrowEdgeMargin}: 0.625rem;
+                ${tooltipTokens.arrowBackground}: var(--surface-solid-card);
+            `,
+        },
+        view: {
+            // TODO заменить тень на токен https://github.com/salute-developers/plasma/issues/1131
+            default: css`
+                ${tooltipTokens.backgroundColor}: var(--surface-solid-card);
+                ${tooltipTokens.boxShadow}: 0px 4px 12px 0px rgba(0, 0, 0, 0.16),0px 1px 4px 0px rgba(0, 0, 0, 0.08);
+                ${tooltipTokens.color}: var(--plasma-colors-primary);
+            `,
+        },
+    },
+};

--- a/packages/sdds-serv/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-serv/src/components/Tooltip/Tooltip.stories.tsx
@@ -2,16 +2,14 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { IconDisclosureRight } from '@salutejs/plasma-icons';
 import type { StoryObj, Meta } from '@storybook/react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button/Button';
-import { PopoverPlacement } from '../Popover';
-import { TextField } from '../TextField';
 
 import { Tooltip } from '.';
 import type { TooltipProps } from '.';
 
-const placements: Array<PopoverPlacement> = [
+const placements: Array<string> = [
     'top',
     'top-start',
     'top-end',
@@ -46,47 +44,28 @@ const StyledGrid = styled.div`
     padding: 3.5rem;
 `;
 
-const StoryDefault = ({ size }: TooltipProps) => {
+const StoryDefault = (props: Pick<TooltipProps, 'hasArrow' | 'size' | 'usePortal'>) => {
     return (
         <StyledGrid>
             <Tooltip
-                target={
-                    <Tooltip target={<Button>Btn</Button>} placement="left" size={size} isOpen hasArrow text="left" />
-                }
+                target={<Tooltip target={<Button>Btn</Button>} placement="left" isOpen text="left" {...props} />}
                 placement="top-start"
-                size={size}
                 isOpen
-                hasArrow
                 text="top-start"
+                view="default"
+                {...props}
             />
-            <Tooltip target={<Button>Btn</Button>} placement="top" size={size} isOpen hasArrow text="top" />
+            <Tooltip target={<Button>Btn</Button>} placement="top" isOpen text="top" {...props} />
             <Tooltip
-                target={
-                    <Tooltip target={<Button>Btn</Button>} placement="right" size={size} isOpen hasArrow text="right" />
-                }
+                target={<Tooltip target={<Button>Btn</Button>} placement="right" isOpen text="right" {...props} />}
                 placement="top-end"
-                size={size}
                 isOpen
-                hasArrow
                 text="top-end"
+                {...props}
             />
-            <Tooltip
-                target={<Button>Btn</Button>}
-                placement="bottom-start"
-                size={size}
-                isOpen
-                hasArrow
-                text="bottom-start"
-            />
-            <Tooltip target={<Button>Btn</Button>} placement="bottom" size={size} isOpen hasArrow text="bottom" />
-            <Tooltip
-                target={<Button>Btn</Button>}
-                placement="bottom-end"
-                size={size}
-                isOpen
-                hasArrow
-                text="bottom-end"
-            />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom-start" isOpen text="bottom-start" {...props} />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom" isOpen text="bottom" {...props} />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom-end" isOpen text="bottom-end" {...props} />
         </StyledGrid>
     );
 };
@@ -99,9 +78,26 @@ export const Default: StoryObj<TooltipProps> = {
                 type: 'select',
             },
         },
+        ...disableProps([
+            'target',
+            'children',
+            'text',
+            'isOpen',
+            'placement',
+            'offset',
+            'frame',
+            'view',
+            'zIndex',
+            'minWidth',
+            'maxWidth',
+            'contentLeft',
+            'onDismiss',
+        ]),
     },
     args: {
         size: 'm',
+        hasArrow: true,
+        usePortal: false,
     },
     render: (args) => <StoryDefault {...args} />,
 };
@@ -146,12 +142,27 @@ export const Live: StoryObj<TooltipProps> = {
                 type: 'select',
             },
         },
+        ...disableProps([
+            'target',
+            'children',
+            'text',
+            'isOpen',
+            'isVisible',
+            'offset',
+            'frame',
+            'view',
+            'zIndex',
+            'contentLeft',
+            'onDismiss',
+        ]),
     },
     args: {
         placement: 'bottom',
         maxWidth: 10,
         minWidth: 3,
         hasArrow: true,
+        usePortal: false,
+        animated: true,
         size: 'm',
     },
     render: (args) => <StoryLive {...args} />,

--- a/packages/sdds-serv/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-serv/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { IconDisclosureRight } from '@salutejs/plasma-icons';
+import type { StoryObj, Meta } from '@storybook/react';
+import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+
+import { Button } from '../Button/Button';
+import { PopoverPlacement } from '../Popover';
+import { TextField } from '../TextField';
+
+import { Tooltip } from '.';
+import type { TooltipProps } from '.';
+
+const placements: Array<PopoverPlacement> = [
+    'top',
+    'top-start',
+    'top-end',
+
+    'bottom',
+    'bottom-start',
+    'bottom-end',
+
+    'left',
+    'left-start',
+    'left-end',
+
+    'right',
+    'right-start',
+    'right-end',
+
+    'auto',
+];
+
+const meta: Meta<TooltipProps> = {
+    title: 'Controls/Tooltip',
+    decorators: [InSpacingDecorator],
+    component: Tooltip,
+};
+
+export default meta;
+
+const StyledGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(3, max-content);
+    grid-gap: 1rem 3.5rem;
+    padding: 3.5rem;
+`;
+
+const StoryDefault = ({ size }: TooltipProps) => {
+    return (
+        <StyledGrid>
+            <Tooltip
+                target={
+                    <Tooltip target={<Button>Btn</Button>} placement="left" size={size} isOpen hasArrow text="left" />
+                }
+                placement="top-start"
+                size={size}
+                isOpen
+                hasArrow
+                text="top-start"
+            />
+            <Tooltip target={<Button>Btn</Button>} placement="top" size={size} isOpen hasArrow text="top" />
+            <Tooltip
+                target={
+                    <Tooltip target={<Button>Btn</Button>} placement="right" size={size} isOpen hasArrow text="right" />
+                }
+                placement="top-end"
+                size={size}
+                isOpen
+                hasArrow
+                text="top-end"
+            />
+            <Tooltip
+                target={<Button>Btn</Button>}
+                placement="bottom-start"
+                size={size}
+                isOpen
+                hasArrow
+                text="bottom-start"
+            />
+            <Tooltip target={<Button>Btn</Button>} placement="bottom" size={size} isOpen hasArrow text="bottom" />
+            <Tooltip
+                target={<Button>Btn</Button>}
+                placement="bottom-end"
+                size={size}
+                isOpen
+                hasArrow
+                text="bottom-end"
+            />
+        </StyledGrid>
+    );
+};
+
+export const Default: StoryObj<TooltipProps> = {
+    argTypes: {
+        size: {
+            options: ['m', 's'],
+            control: {
+                type: 'select',
+            },
+        },
+    },
+    args: {
+        size: 'm',
+    },
+    render: (args) => <StoryDefault {...args} />,
+};
+
+const StyledRow = styled.div`
+    display: flex;
+    width: 150vw;
+    height: 150vh;
+    padding: 10rem;
+`;
+
+const StoryLive = (args: TooltipProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+        <>
+            <StyledRow>
+                <Tooltip
+                    target={<Button onClick={() => setIsOpen(!isOpen)}>Show tooltip</Button>}
+                    contentLeft={<IconDisclosureRight size="xs" />}
+                    {...args}
+                    id="example-tooltip-firstname"
+                    text="Tooltip text"
+                    isOpen={isOpen}
+                />
+            </StyledRow>
+        </>
+    );
+};
+
+export const Live: StoryObj<TooltipProps> = {
+    argTypes: {
+        placement: {
+            options: placements,
+            control: {
+                type: 'select',
+            },
+        },
+        size: {
+            options: ['m', 's'],
+            control: {
+                type: 'select',
+            },
+        },
+    },
+    args: {
+        placement: 'bottom',
+        maxWidth: 10,
+        minWidth: 3,
+        hasArrow: true,
+        size: 'm',
+    },
+    render: (args) => <StoryLive {...args} />,
+};

--- a/packages/sdds-serv/src/components/Tooltip/Tooltip.tsx
+++ b/packages/sdds-serv/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,10 @@
+import { ForwardRefExoticComponent, RefAttributes } from 'react';
+import { TooltipProps, tooltipConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+
+import { config } from './Tooltip.config';
+
+const mergedConfig = mergeConfig(tooltipConfig, config);
+
+export const Tooltip = component(mergedConfig) as ForwardRefExoticComponent<
+    TooltipProps & RefAttributes<HTMLDivElement>
+>;

--- a/packages/sdds-serv/src/components/Tooltip/index.ts
+++ b/packages/sdds-serv/src/components/Tooltip/index.ts
@@ -1,0 +1,2 @@
+export { Tooltip } from './Tooltip';
+export type { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/sdds-serv/src/index.ts
+++ b/packages/sdds-serv/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/SSRProvider';
 export * from './components/Switch';
 export * from './components/Tabs';
 export * from './components/Toast';
+export * from './components/Tooltip';
 export * from './components/Typography';
 
 export * from './mixins';


### PR DESCRIPTION
### Tooltip

-  добавлены фолбэки на следующие свойства: isVisible, arrow, animated

### What/why changed

При рефакторинге тултипа потерялись некоторые пропсы из-за чего пропала обратная совместимость.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.23.0-canary.1140.8433944914.0
  npm install @salutejs/caldera@0.23.0-canary.1140.8433944914.0
  npm install @salutejs/plasma-asdk@0.60.0-canary.1140.8433944914.0
  npm install @salutejs/plasma-b2c@1.302.0-canary.1140.8433944914.0
  npm install @salutejs/plasma-new-hope@0.63.0-canary.1140.8433944914.0
  npm install @salutejs/plasma-web@1.302.0-canary.1140.8433944914.0
  npm install @salutejs/sdds-serv@0.27.0-canary.1140.8433944914.0
  # or 
  yarn add @salutejs/caldera-online@0.23.0-canary.1140.8433944914.0
  yarn add @salutejs/caldera@0.23.0-canary.1140.8433944914.0
  yarn add @salutejs/plasma-asdk@0.60.0-canary.1140.8433944914.0
  yarn add @salutejs/plasma-b2c@1.302.0-canary.1140.8433944914.0
  yarn add @salutejs/plasma-new-hope@0.63.0-canary.1140.8433944914.0
  yarn add @salutejs/plasma-web@1.302.0-canary.1140.8433944914.0
  yarn add @salutejs/sdds-serv@0.27.0-canary.1140.8433944914.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
