### PR TITLE
fix(plasma-web,plasma-b2c,plasma-asdk): Remove js token from import with nested directory

### DIFF
--- a/packages/plasma-asdk/.storybook/decoratorThemes.tsx
+++ b/packages/plasma-asdk/.storybook/decoratorThemes.tsx
@@ -6,7 +6,6 @@ import {
     stylesSalute__light as stylesSaluteLight,
 } from '@salutejs/plasma-tokens';
 import { link, linkHover, linkActive } from '@salutejs/plasma-tokens-b2b';
-import { backgroundPrimary } from '@salutejs/plasma-tokens-b2b/new';
 
 import { standard as standardTypo, compatible as compatibleTypo } from '@salutejs/plasma-typo';
 import { b2b as b2bTypo } from '@salutejs/plasma-tokens-b2b';
@@ -19,7 +18,7 @@ const CompatibleTypoStyle = createGlobalStyle(compatibleTypo);
 const DocumentStyle = createGlobalStyle`
     html:root {
         min-height: 100vh;
-        background-color: ${backgroundPrimary};
+        background-color: var(--background-primary);
     }
     a {
         color: ${link};

--- a/packages/plasma-b2c/.storybook/decoratorThemes.tsx
+++ b/packages/plasma-b2c/.storybook/decoratorThemes.tsx
@@ -3,14 +3,13 @@ import { createGlobalStyle } from 'styled-components';
 
 import { b2c, dark, light } from '@salutejs/plasma-tokens-b2c';
 import { link, linkHover, linkActive } from '@salutejs/plasma-tokens-web';
-import { backgroundPrimary } from '@salutejs/plasma-tokens-web/new';
 import { standard as standardTypo, compatible as compatibleTypo } from '@salutejs/plasma-typo';
 
 /* stylelint-disable */
 const DocumentStyle = createGlobalStyle`
     html:root {
         min-height: 100vh;
-        background-color: ${backgroundPrimary};
+        background-color: var(--background-primary);
     }
     a {
         color: ${link};

--- a/packages/plasma-web/.storybook/decoratorThemes.tsx
+++ b/packages/plasma-web/.storybook/decoratorThemes.tsx
@@ -9,7 +9,6 @@ import {
     linkHover,
     linkActive,
 } from '@salutejs/plasma-tokens-b2b';
-import { backgroundPrimary } from '@salutejs/plasma-tokens-b2b/new';
 import { light as b2cLight, dark as b2cDark } from '@salutejs/plasma-tokens-b2c';
 import { light as legacyLight, dark as legacyDark } from '@salutejs/plasma-tokens-web';
 import { standard as standardTypo, compatible as compatibleTypo } from '@salutejs/plasma-typo';
@@ -18,7 +17,7 @@ import { standard as standardTypo, compatible as compatibleTypo } from '@salutej
 const DocumentStyle = createGlobalStyle`
     html:root {
         min-height: 100vh;
-        background-color: ${backgroundPrimary};
+        background-color: var(--background-primary);
     }
     a {
         color: ${link};


### PR DESCRIPTION
### What/why changed

Во время сборки сторибука через vite в слинкованных пакетах происходит ошибка при попытке зарезволить вложенные пути

![telegram-cloud-photo-size-2-5471950079733650266-y](https://github.com/salute-developers/plasma/assets/26903236/cd333676-ddaa-420a-9f6b-2b4f7349a322)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.59.2-canary.1144.8391665037.0
  npm install @salutejs/plasma-b2c@1.301.2-canary.1144.8391665037.0
  npm install @salutejs/plasma-web@1.301.2-canary.1144.8391665037.0
  # or 
  yarn add @salutejs/plasma-asdk@0.59.2-canary.1144.8391665037.0
  yarn add @salutejs/plasma-b2c@1.301.2-canary.1144.8391665037.0
  yarn add @salutejs/plasma-web@1.301.2-canary.1144.8391665037.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
