### PR TITLE
plasma-infra: Dispatch build-icons event

### DIFF
--- a/.github/workflows/dispatch-custom-event.yml
+++ b/.github/workflows/dispatch-custom-event.yml
@@ -1,0 +1,50 @@
+# Создаем custom событие "build-icons" на это событие есть подписка в android repo
+name: Dispatch build-icons event
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        default: 'master'
+        description: ''
+        required: false
+      version:
+        description: 'Version plasma-icons package'
+        required: true
+  release:
+    types: [published]
+
+jobs:
+  dispatch-manual:
+    name: "Dispatch event by workflow_dispatch"
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch custom event
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/salute-developers/plasma-android/dispatches \
+            -d "{\"event_type\":\"build-icons\",\"client_payload\":{\"version\":\"${{github.event.inputs.version}}\", \"ref\": \"${{github.event.inputs.ref}}\"}}"
+  
+  dispatch-published:
+    name: "Dispatch event after release published"
+    if: ${{ github.event_name == 'release' && contains(github.event.release.name, 'plasma-icons@') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get package version
+        run: |
+          echo "VERSION=$(echo "${{ github.event.release.tag_name }}" | cut -d '@' -f 2)" >> "$GITHUB_ENV"
+
+      - name: Dispatch custom event
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/salute-developers/plasma-android/dispatches \
+            -d "{\"event_type\":\"build-icons\",\"client_payload\":{\"version\":\"$VERSION\", \"ref\": \"master\"}}"


### PR DESCRIPTION
### Build android icons plugin

- добавлен dispatch события для запуска `build icons` в `plasma-android`

### What/why changed

Вызывается или в ручном режиме с указанием версии пакета plasma-icons или после публикации релиза. 

Нужно чтобы процесс сборки иконок было в полу-автоматическом режиме.   

Черновик - https://github.com/salute-developers/plasma/issues/1129
