### PR TITLE
plasma-infra: Refactoring retry for sync package-lock files

### DIFF
--- a/.github/actions/update-package-lock/action.yml
+++ b/.github/actions/update-package-lock/action.yml
@@ -14,30 +14,41 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set options
+      shell: bash
+      run: |
+        echo "OPTIONS=--no-audit --no-progress --package-lock-only --lockfile-version 2 --legacy-peer-deps" >> "$GITHUB_ENV"
+    
+    - name: Sync package-lock's root  level
+      shell: bash
+      run: npm i --silent ${{ env.OPTIONS }}
+    
+    - name: Remove the node_modules directory from all packages
+      shell: bash
+      run: npx lerna clean -y
+    
     - name: Sync package-lock files
-      uses: nick-fields/retry@v2
-      env:
-        options: "--no-audit --no-progress --package-lock-only --lockfile-version 2 --legacy-peer-deps"
+      uses: nick-fields/retry@v2.9.0
       with:
-          shell: bash
-          timeout_minutes: 5
-          max_attempts: 3
-          retry_on: error
-          command: |
-            # (1) Sync package-lock's root  level
-            npm i ${{ env.options }}
-            # (2) Remove the node_modules directory from all packages
-            lerna clean -y
-            # (3) Sync package-lock files state
-            lerna exec --no-private -- npm i ${{ env.options }} --ignore-scripts
-            # (4) root deps don't update correctly on first regeneration
-            npm i ${{ env.options }}
-
+        shell: bash
+        timeout_minutes: 5
+        max_attempts: 3
+        on_retry_command: |
+          git reset --hard
+          npm i --silent ${{ env.OPTIONS }}
+        command: |
+          npx lerna exec --no-private -- npm i --silent ${{ env.OPTIONS }} --ignore-scripts
+    
+    - name: Root deps don't update correctly on first regeneration
+      shell: bash
+      run: |
+        npm i ${{ env.OPTIONS }}
+    
     - name: Extract branch name
       id: branch
       shell: bash
       run: echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-
+    
     - name: Commit & Push package-lock's
       uses: actions-js/push@master
       with:


### PR DESCRIPTION
### What/why changed

добавлена логика для `on_retry_command`. 

Теперь перед тем как повторить команду `sync package-lock files` сперва сделаем `git reset` для предсказуемости результата.      

### Retry сработал 

<img width="1533" alt="Screenshot 2024-03-25 at 11 30 12" src="https://github.com/salute-developers/plasma/assets/2895992/971605d0-02c4-4514-ad56-7160de54d3c9">

НО теперь проверяем что получилось: [29 package.json](https://github.com/salute-developers/plasma/commit/f39b23b14abbd830278302eace0ac3f602e9aa10)

И только [9 lock файлов обновлено](https://github.com/salute-developers/plasma/commit/92ccc499d71f0d1c5ca5046e751609c51f30fddc)

поэтому нам нужно перед retry сбросить результат полученный в момент ошибки и заново все прогнать.       


