### PR TITLE
plasma-infra: Refactoring deploy documentations artefacts

### DIFF
--- a/.github/get-lerna-scope.js
+++ b/.github/get-lerna-scope.js
@@ -1,0 +1,36 @@
+const META = require('./meta');
+
+module.exports = () => {
+    const { PACKAGE, PROCESSED_DATA } = process.env;
+
+    // INFO: результат команды `lerna la --since` - список пакетов в которых были изменения
+    // или они связаны в графе зависимостей lerna
+    const processedData = JSON.parse(PROCESSED_DATA);
+
+    // INFO: Список пакетов которые нужно поставить если они есть в списке processedData
+    const packageScope = META[PACKAGE].scope || [];
+    const packageTheme = META[PACKAGE].themes;
+
+    // INFO: Список обязательных пакетов без которых не будет работать сборка
+    // INFO: Например для корректной сборки storybook в `plasma-asdk` нужно ставить plasma-core
+    // INFO: Это workaround - временно позволяет обойти ошибки в инфре
+    const requiredDeps = META[PACKAGE].required || [];
+
+    // INFO: Пакет с документацией, например `plasma-web-docs` или `sdds-serv-docs`
+    const packageDocs = `${PACKAGE}-docs`;
+
+    const computedScope = processedData.filter((dep) => [...packageScope, packageDocs].includes(dep));
+
+    const scope = new Set([...computedScope, ...requiredDeps, PACKAGE]);
+
+    if (scope.has(packageDocs)) {
+        scope.add('plasma-docs-ui');
+    }
+
+    if (scope.has(packageTheme)) {
+        scope.add('data-themes');
+        scope.add('plasma-typo');
+    }
+
+    return `@salutejs/{${Array.from(scope).join(',')}}`;
+};

--- a/.github/meta.js
+++ b/.github/meta.js
@@ -1,0 +1,54 @@
+const commonScope = ['plasma-icons', 'plasma-sb-utils', 'plasma-tokens', 'plasma-tokens-utils'];
+
+module.exports = {
+    'caldera-online': {
+        scope: [...commonScope, 'caldera-online-themes', 'plasma-new-hope'],
+        themes: 'caldera-online-themes',
+    },
+    'plasma-asdk': {
+        scope: [...commonScope, 'plasma-tokens-b2b', 'plasma-typo', 'plasma-themes', 'plasma-new-hope'],
+        required: ['plasma-core'],
+        themes: 'plasma-themes',
+    },
+    'plasma-b2c': {
+        scope: [
+            ...commonScope,
+            'plasma-core',
+            'plasma-hope',
+            'plasma-new-hope',
+            'plasma-tokens-b2c',
+            'plasma-tokens-web',
+            'plasma-typo',
+        ],
+        required: ['plasma-new-hope'],
+        themes: '',
+    },
+    'plasma-new-hope': {
+        scope: [...commonScope, 'plasma-core'],
+        required: [],
+    },
+    'plasma-ui': {
+        scope: [...commonScope, 'plasma-core', 'plasma-typo'],
+        required: ['plasma-icons'],
+        themes: '',
+    },
+    'plasma-web': {
+        scope: [
+            ...commonScope,
+            'plasma-core',
+            'plasma-hope',
+            'plasma-new-hope',
+            'plasma-tokens-b2c',
+            'plasma-tokens-b2b',
+            'plasma-tokens-web',
+            'plasma-typo',
+        ],
+        required: ['plasma-new-hope'],
+        themes: '',
+    },
+    'sdds-serv': {
+        scope: [...commonScope, 'sdds-themes', 'plasma-new-hope'],
+        required: [],
+        themes: 'sdds-themes',
+    },
+};

--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -146,54 +146,9 @@ jobs:
                 with:
                     result-encoding: string
                     script: |
-                        const { PROCESSED_DATA, PACKAGE } = process.env;
+                        const getLernaScope = require('./.github/get-lerna-scope.js');
 
-                        const processedData = JSON.parse(PROCESSED_DATA);
-
-                        const [scopeDSName] = PACKAGE.split('-');
-
-                        // INFO: Пока нет устойчивого правила для формирования пакетов `themes`
-                        // и где то используется одно слово, типа `plasma`, а где-то два `caldera-online`
-                        const themes = ['caldera-online'].includes(PACKAGE) ? `${PACKAGE}-themes` : `${scopeDSName}-themes`;
-
-                        const packages = [
-                          'plasma-hope',
-                          'plasma-new-hope',
-                          'plasma-tokens',
-                          'plasma-tokens-native',
-                          'plasma-tokens-utils',
-                          'plasma-typo',
-                          themes,
-                          `${PACKAGE}-docs`,
-                        ];
-
-                        // TODO: рефакторинг - использовать объект для resolve required deps
-                        const result = [
-                            ...processedData.filter((package) => packages.includes(package)),
-                            PACKAGE,
-                            'plasma-core',
-                            'plasma-docs-ui',
-                            'plasma-icons',
-                        ];
-
-                        // INFO: Пока не починили медленный css build for b2c/web ставим plasma-new-hope
-                        if (processedData.includes('plasma-b2c') || processedData.includes('plasma-web')) {
-                            result.push('plasma-new-hope');
-                        }
-
-                        if (result.includes('plasma-tokens-native')) {
-                            result.push('plasma-tokens');
-                            result.push('plasma-tokens-utils');
-                        }
-
-                        if (result.includes(themes)) {
-                            result.push('plasma-typo');
-                            result.push('data-themes');
-                        }
-
-                        console.log('Result =>', result);
-
-                        return `@salutejs/{${result.join(',')}}`;
+                        return getLernaScope();
 
             -   name: Lerna bootstrap
                 run: npx lerna bootstrap --scope="${{ steps.lerna-scope.outputs.result }}"

--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -106,7 +106,6 @@ jobs:
                     --host-bucket ${{ secrets.AWS_ENDPOINT }}
                     --bucket-location ${{ secrets.AWS_REGION }}
                     --signature-v2
-                    --delete-removed
                     --no-mime-magic
                     sync
                     ./s3_build/${PR_NAME}/
@@ -134,7 +133,7 @@ jobs:
 
             -   name: Set job environment variables
                 run: |
-                    echo "SHORT_NAME=$(echo ${{ matrix.package }} | sed -r 's/@salutejs\///g' | sed -r 's/plasma-//g')" >> $GITHUB_ENV
+                    echo "SHORT_NAME=$(echo ${{ matrix.package }} | sed -r 's/plasma-//g')" >> $GITHUB_ENV
                     echo "HAS_PACKAGE_DOCS=$([ -d "./website/${{ matrix.package }}-docs" ] && echo true || echo false)" >> $GITHUB_ENV
 
             -   name: Get lerna scope
@@ -208,6 +207,7 @@ jobs:
         steps:
             -   uses: actions/checkout@v4
                 with:
+                    ref: refs/pull/${{github.event.pull_request.number}}/merge
                     show-progress: false
 
             -   name: Create comment


### PR DESCRIPTION
### What/why changed

Декларативно описали JSON структуру - это возможный состояние того, что нужно установить для корректной работы пакета и сборки документации. 

Главная задача уйти от большого кол-ва `if` для каждого пакета и сделать процесс максимально прозрачным.  

#### Тестовые прогон всех пакетов 

<img width="1554" alt="Screenshot 2024-04-02 at 14 35 36" src="https://github.com/salute-developers/plasma/assets/2895992/f61b9e67-75a6-44fc-9524-09df27e616dd">

#### Почему еще один граф зависимости? Есть ли другой способ? 

`Lerna` может предоставить список того что зависит от пакета и его транзитивные зависимости. 

```console
npx lerna la --json --include-dependencies --scope="package"
```    
В нашем случае в этот список будут попадать транзитивные зависимости зависимостей =(

<img width="1890" alt="Screenshot 2024-04-02 at 13 17 11" src="https://github.com/salute-developers/plasma/assets/2895992/7d94d0b3-f5ea-4460-b2db-b9d0ac77ced3">
     
и в итоге все равно придется писать фильтр лист только уже на базе ignore логики.

### Резюме: 

Как только наши пакеты и их зависимости будет приведены в порядок. Можно будет посмотреть в сторону комбинации `lerna la` и минимального конфига.         

