### PR TITLE
plasma-icons: Add `old` dir for publish

### DIFF
--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -62,7 +62,8 @@
     "IconRoot.d.ts",
     "IconRoot.js",
     "es",
-    "scalable"
+    "scalable",
+    "old"
   ],
   "contributors": [
     "Vasiliy Loginevskiy",


### PR DESCRIPTION
### Icons publish

- добавлена директория `old` для обратной совместимости  

### What/why changed

поломались пути до части иконок, например 

```console
Module not found: Can't resolve './old/Icons/IconClockFilled'
```
 
или

```console
unhandledRejection Error: Cannot find module './old/Icons/IconApps'
```
 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.26.1-canary.1149.8446846250.0
  npm install @salutejs/caldera@0.26.1-canary.1149.8446846250.0
  npm install @salutejs/plasma-asdk@0.63.1-canary.1149.8446846250.0
  npm install @salutejs/plasma-b2c@1.305.1-canary.1149.8446846250.0
  npm install @salutejs/plasma-hope@1.272.1-canary.1149.8446846250.0
  npm install @salutejs/plasma-icons@1.189.2-canary.1149.8446846250.0
  npm install @salutejs/plasma-new-hope@0.66.1-canary.1149.8446846250.0
  npm install @salutejs/plasma-ui@1.241.1-canary.1149.8446846250.0
  npm install @salutejs/plasma-web@1.305.1-canary.1149.8446846250.0
  npm install @salutejs/sdds-serv@0.30.1-canary.1149.8446846250.0
  # or 
  yarn add @salutejs/caldera-online@0.26.1-canary.1149.8446846250.0
  yarn add @salutejs/caldera@0.26.1-canary.1149.8446846250.0
  yarn add @salutejs/plasma-asdk@0.63.1-canary.1149.8446846250.0
  yarn add @salutejs/plasma-b2c@1.305.1-canary.1149.8446846250.0
  yarn add @salutejs/plasma-hope@1.272.1-canary.1149.8446846250.0
  yarn add @salutejs/plasma-icons@1.189.2-canary.1149.8446846250.0
  yarn add @salutejs/plasma-new-hope@0.66.1-canary.1149.8446846250.0
  yarn add @salutejs/plasma-ui@1.241.1-canary.1149.8446846250.0
  yarn add @salutejs/plasma-web@1.305.1-canary.1149.8446846250.0
  yarn add @salutejs/sdds-serv@0.30.1-canary.1149.8446846250.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
