### PR TITLE
fix(plasma-website): Fix Icons

### DIFF
--- a/packages/plasma-new-hope/src/components/Cell/Cell.tsx
+++ b/packages/plasma-new-hope/src/components/Cell/Cell.tsx
@@ -31,6 +31,8 @@ export const cellRoot = (Root: RootProps<HTMLDivElement, CellProps>) =>
             outerRootRef,
         ) => {
             const stretchingClass = classes[`${stretching}Stretching` as keyof typeof classes];
+
+            // Импорт  старых свойств
             const titleText = title || description;
             const contentLeftDeprecated = contentLeft || content;
 

--- a/website/plasma-website/components/roster/Grid.tsx
+++ b/website/plasma-website/components/roster/Grid.tsx
@@ -3,5 +3,5 @@ import styled from 'styled-components';
 export const Grid = styled.div`
     display: grid;
     grid-template-columns: repeat(8, calc(12.5% - 0.5rem + 0.5rem / 8));
-    gap: var(--plasma-grid-gutter);
+    gap: 0.5rem;
 `;

--- a/website/plasma-website/components/roster/IconsList.tsx
+++ b/website/plasma-website/components/roster/IconsList.tsx
@@ -82,7 +82,7 @@ export const IconsList: FC<IconsListProps> = ({ searchQuery, onItemClick }) => {
         if (!searchQuery) {
             return icons;
         }
-        const regExp = new RegExp(searchQuery.toLocaleLowerCase());
+        const regExp = new RegExp(searchQuery.toLocaleLowerCase().replace(/\W/g, ''));
         return icons
             .map((group) => ({
                 ...group,


### PR DESCRIPTION
### Fix website icons

Фикс ввода названий иконок

### What/why changed

Сделал так, что обрезал все кроме букв и цифр. А еще добавил отступы у блоков иконок 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.31.2-canary.1169.8614020591.0
  npm install @salutejs/plasma-asdk@0.69.1-canary.1169.8614020591.0
  npm install @salutejs/plasma-b2c@1.311.1-canary.1169.8614020591.0
  npm install @salutejs/plasma-new-hope@0.71.2-canary.1169.8614020591.0
  npm install @salutejs/plasma-web@1.311.1-canary.1169.8614020591.0
  npm install @salutejs/sdds-serv@0.36.1-canary.1169.8614020591.0
  # or 
  yarn add @salutejs/caldera-online@0.31.2-canary.1169.8614020591.0
  yarn add @salutejs/plasma-asdk@0.69.1-canary.1169.8614020591.0
  yarn add @salutejs/plasma-b2c@1.311.1-canary.1169.8614020591.0
  yarn add @salutejs/plasma-new-hope@0.71.2-canary.1169.8614020591.0
  yarn add @salutejs/plasma-web@1.311.1-canary.1169.8614020591.0
  yarn add @salutejs/sdds-serv@0.36.1-canary.1169.8614020591.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
