### PR TITLE
plasma-docs(web-docs): Fix symlink for `_changelog.md`

### DIFF
--- a/website/plasma-web-docs/docs/_changelog.md
+++ b/website/plasma-web-docs/docs/_changelog.md
@@ -1,1 +1,1 @@
-../../../packages/plasma-ui/CHANGELOG.md
+../../../packages/plasma-web/CHANGELOG.md


### PR DESCRIPTION
### What/why changed

ссылка `_changelog` указывала на файл из `plasma-ui`  

#### Before

<img width="1920" alt="Screenshot 2024-04-09 at 13 19 58" src="https://github.com/salute-developers/plasma/assets/2895992/adbe6118-5509-481c-9631-406990ad9cb0">


#### After

<img width="1920" alt="Screenshot 2024-04-09 at 13 18 07" src="https://github.com/salute-developers/plasma/assets/2895992/71b22483-f0c6-4041-ad5d-514e7326a7dc">
 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-web@1.311.1-canary.1173.8611058354.0
  # or 
  yarn add @salutejs/plasma-web@1.311.1-canary.1173.8611058354.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
