### PR TITLE
feat(plasma-new-hope, b2c, web, sdds): Fix storybook argTypes

### DIFF
--- a/packages/plasma-b2c/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-b2c/src/components/Dropdown/Dropdown.stories.tsx
@@ -99,6 +99,13 @@ export const Placements: StoryObj<DropdownProps> = {
             control: {
                 type: 'select',
             },
+            mapping: {
+                top: 'top',
+                bottom: 'bottom',
+                right: 'right',
+                left: 'left',
+                auto: 'auto',
+            },
         },
     },
     render: (args) => {

--- a/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
@@ -92,16 +92,11 @@ type StorePropsDefault = Omit<
     | 'minLength'
     | 'required'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryDemo = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    status,
-    ...rest
-}: StorePropsDefault) => {
+const StoryDemo = ({ enableContentLeft, enableContentRight, status, ...rest }: StorePropsDefault) => {
     const [value, setValue] = useState('Значение поля');
 
     const iconSize = rest.size === 'xs' ? 'xs' : 's';
@@ -137,8 +132,8 @@ export const Default: StoryObj<StorePropsDefault> = {
         status: '' as 'success',
         disabled: false,
         readOnly: false,
-        'storybook:contentLeft': true,
-        'storybook:contentRight': true,
+        enableContentLeft: true,
+        enableContentRight: true,
     },
     render: (args) => <StoryDemo {...args} />,
 };

--- a/packages/plasma-b2c/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-b2c/src/components/Tooltip/Tooltip.stories.tsx
@@ -146,6 +146,7 @@ export const Live: StoryObj<TooltipProps> = {
             control: {
                 type: 'select',
             },
+            mapping: placements,
         },
         size: {
             options: ['m', 's'],

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Divider/Divider.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Divider/Divider.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta<typeof Divider> = {
             },
             table: { defaultValue: { summary: 'default' } },
         },
+        length: { control: 'text' },
     },
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextField/TextField.stories.tsx
@@ -70,16 +70,11 @@ type StoryPropsDefault = Omit<
     | 'chips'
     | 'onChangeChips'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryDemo = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    view,
-    ...rest
-}: StoryPropsDefault) => {
+const StoryDemo = ({ enableContentLeft, enableContentRight, view, ...rest }: StoryPropsDefault) => {
     const [text, setText] = useState('Значение поля');
 
     const iconSize = rest.size === 'xs' ? 'xs' : 's';
@@ -114,8 +109,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         leftHelper: 'Подсказка к полю',
         disabled: false,
         readOnly: false,
-        'storybook:contentLeft': true,
-        'storybook:contentRight': true,
+        enableContentLeft: true,
+        enableContentRight: true,
     },
     render: (args) => <StoryDemo {...args} />,
 };
@@ -139,16 +134,11 @@ type StoryPropsChips = Omit<
     | 'required'
     | 'enumerationType'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryChips = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    view,
-    ...rest
-}: StoryPropsChips) => {
+const StoryChips = ({ enableContentLeft, enableContentRight, view, ...rest }: StoryPropsChips) => {
     const [text, setText] = useState('Значение поля');
 
     const iconSize = rest.size === 'xs' ? 'xs' : 's';

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tooltip/Tooltip.stories.tsx
@@ -185,6 +185,7 @@ export const Live: StoryObj<TooltipProps> = {
             control: {
                 type: 'select',
             },
+            mapping: placements,
         },
         size: {
             options: ['m', 's'],

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/TextField/TextField.stories.tsx
@@ -70,16 +70,11 @@ type StoryPropsDefault = Omit<
     | 'chips'
     | 'onChangeChips'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryDemo = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    view,
-    ...rest
-}: StoryPropsDefault) => {
+const StoryDemo = ({ enableContentLeft, enableContentRight, view, ...rest }: StoryPropsDefault) => {
     const [text, setText] = useState('Значение поля');
 
     const iconSize = rest.size === 'xs' ? 'xs' : 's';
@@ -114,8 +109,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         leftHelper: 'Подсказка к полю',
         disabled: false,
         readOnly: false,
-        'storybook:contentLeft': true,
-        'storybook:contentRight': true,
+        enableContentLeft: true,
+        enableContentRight: true,
     },
     render: (args) => <StoryDemo {...args} />,
 };
@@ -139,16 +134,11 @@ type StoryPropsChips = Omit<
     | 'required'
     | 'enumerationType'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryChips = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    view,
-    ...rest
-}: StoryPropsChips) => {
+const StoryChips = ({ enableContentLeft, enableContentRight, view, ...rest }: StoryPropsChips) => {
     const [text, setText] = useState('Значение поля');
 
     const iconSize = rest.size === 'xs' ? 'xs' : 's';

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Tooltip/Tooltip.stories.tsx
@@ -185,6 +185,7 @@ export const Live: StoryObj<TooltipProps> = {
             control: {
                 type: 'select',
             },
+            mapping: placements,
         },
         size: {
             options: ['m', 's'],

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/TextField/TextField.stories.tsx
@@ -70,16 +70,11 @@ type StoryPropsDefault = Omit<
     | 'chips'
     | 'onChangeChips'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryDemo = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    view,
-    ...rest
-}: StoryPropsDefault) => {
+const StoryDemo = ({ enableContentLeft, enableContentRight, view, ...rest }: StoryPropsDefault) => {
     const [text, setText] = useState('Значение поля');
 
     const iconSize = rest.size === 'xs' ? 'xs' : 's';
@@ -114,8 +109,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         leftHelper: 'Подсказка к полю',
         disabled: false,
         readOnly: false,
-        'storybook:contentLeft': true,
-        'storybook:contentRight': true,
+        enableContentLeft: true,
+        enableContentRight: true,
     },
     render: (args) => <StoryDemo {...args} />,
 };
@@ -139,16 +134,11 @@ type StoryPropsChips = Omit<
     | 'required'
     | 'enumerationType'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryChips = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    view,
-    ...rest
-}: StoryPropsChips) => {
+const StoryChips = ({ enableContentLeft, enableContentRight, view, ...rest }: StoryPropsChips) => {
     const [text, setText] = useState('Значение поля');
 
     const iconSize = rest.size === 'xs' ? 'xs' : 's';

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/Tooltip/Tooltip.stories.tsx
@@ -185,6 +185,7 @@ export const Live: StoryObj<TooltipProps> = {
             control: {
                 type: 'select',
             },
+            mapping: placements,
         },
         size: {
             options: ['m', 's'],

--- a/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
@@ -99,6 +99,13 @@ export const Placements: StoryObj<DropdownProps> = {
             control: {
                 type: 'select',
             },
+            mapping: {
+                top: 'top',
+                bottom: 'bottom',
+                right: 'right',
+                left: 'left',
+                auto: 'auto',
+            },
         },
     },
     render: (args) => {

--- a/packages/plasma-web/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.stories.tsx
@@ -87,16 +87,11 @@ type StorePropsDefault = Omit<
     | 'minLength'
     | 'required'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryDemo = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    status,
-    ...rest
-}: StorePropsDefault) => {
+const StoryDemo = ({ enableContentLeft, enableContentRight, status, ...rest }: StorePropsDefault) => {
     const [value, setValue] = useState('Значение поля');
 
     const iconSize = rest.size === 'xs' ? 'xs' : 's';
@@ -132,8 +127,8 @@ export const Default: StoryObj<StorePropsDefault> = {
         status: '' as 'success',
         disabled: false,
         readOnly: false,
-        'storybook:contentLeft': true,
-        'storybook:contentRight': true,
+        enableContentLeft: true,
+        enableContentRight: true,
     },
     render: (args) => <StoryDemo {...args} />,
 };

--- a/packages/plasma-web/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-web/src/components/Tooltip/Tooltip.stories.tsx
@@ -147,6 +147,7 @@ export const Live: StoryObj<TooltipProps> = {
             control: {
                 type: 'select',
             },
+            mapping: placements,
         },
         size: {
             options: ['m', 's'],

--- a/packages/sdds-serv/src/components/TextField/TextField.stories.tsx
+++ b/packages/sdds-serv/src/components/TextField/TextField.stories.tsx
@@ -73,8 +73,8 @@ type StoryPropsDefault = Omit<
     | 'chips'
     | 'onChangeChips'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
 const BellIcon = ({ size }) => {
@@ -95,12 +95,7 @@ const BellIcon = ({ size }) => {
     );
 };
 
-const StoryDemo = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    view,
-    ...rest
-}: StoryPropsDefault) => {
+const StoryDemo = ({ enableContentLeft, enableContentRight, view, ...rest }: StoryPropsDefault) => {
     const [text, setText] = useState('Значение поля');
 
     return (
@@ -132,8 +127,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         leftHelper: 'Подсказка к полю',
         disabled: false,
         readOnly: false,
-        'storybook:contentLeft': true,
-        'storybook:contentRight': true,
+        enableContentLeft: true,
+        enableContentRight: true,
     },
     render: (args) => <StoryDemo {...args} />,
 };
@@ -157,16 +152,11 @@ type StoryPropsChips = Omit<
     | 'required'
     | 'enumerationType'
 > & {
-    'storybook:contentLeft': boolean;
-    'storybook:contentRight': boolean;
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
 };
 
-const StoryChips = ({
-    'storybook:contentLeft': enableContentLeft,
-    'storybook:contentRight': enableContentRight,
-    view,
-    ...rest
-}: StoryPropsChips) => {
+const StoryChips = ({ enableContentLeft, enableContentRight, view, ...rest }: StoryPropsChips) => {
     const [text, setText] = useState('Значение поля');
 
     return (

--- a/packages/sdds-serv/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-serv/src/components/Tooltip/Tooltip.stories.tsx
@@ -135,6 +135,7 @@ export const Live: StoryObj<TooltipProps> = {
             control: {
                 type: 'select',
             },
+            mapping: placements,
         },
         size: {
             options: ['m', 's'],


### PR DESCRIPTION
- Исправлено некорректное поведение пропса placement
- Также исправлен проп enableContentLeft и enableContentRight в TextField
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.35.1-canary.1182.8691036704.0
  npm install @salutejs/plasma-asdk@0.73.1-canary.1182.8691036704.0
  npm install @salutejs/plasma-b2c@1.315.1-canary.1182.8691036704.0
  npm install @salutejs/plasma-new-hope@0.75.1-canary.1182.8691036704.0
  npm install @salutejs/plasma-web@1.315.1-canary.1182.8691036704.0
  npm install @salutejs/sdds-serv@0.41.1-canary.1182.8691036704.0
  # or 
  yarn add @salutejs/caldera-online@0.35.1-canary.1182.8691036704.0
  yarn add @salutejs/plasma-asdk@0.73.1-canary.1182.8691036704.0
  yarn add @salutejs/plasma-b2c@1.315.1-canary.1182.8691036704.0
  yarn add @salutejs/plasma-new-hope@0.75.1-canary.1182.8691036704.0
  yarn add @salutejs/plasma-web@1.315.1-canary.1182.8691036704.0
  yarn add @salutejs/sdds-serv@0.41.1-canary.1182.8691036704.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
