### PR TITLE
plasma-new-hope(Button): Add complex accessibility story

### DIFF
--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.stories.tsx
@@ -1,6 +1,9 @@
-import { ComponentProps } from 'react';
+import * as React from 'react';
+import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
+import { disableProps } from '@salutejs/plasma-sb-utils';
 
+import { IconMic } from '../../../../components/_Icon';
 import { buttonConfig } from '../../../../components/Button';
 import { mergeConfig } from '../../../../engines';
 import { WithTheme, argTypesFromConfig } from '../../../_helpers';
@@ -12,6 +15,16 @@ const meta: Meta<typeof Button> = {
     title: 'plasma_b2c/Button',
     decorators: [WithTheme],
     component: Button,
+    args: {
+        text: 'Hello',
+        view: 'default',
+        size: 'm',
+        disabled: false,
+        focused: true,
+        square: false,
+        stretching: 'auto',
+        isLoading: false,
+    },
     argTypes: {
         ...argTypesFromConfig(mergeConfig(buttonConfig, config)),
         pin: {
@@ -41,15 +54,18 @@ const meta: Meta<typeof Button> = {
 
 export default meta;
 
-export const Default: StoryObj<ComponentProps<typeof Button>> = {
-    args: {
-        children: 'Hello',
-        view: 'default',
-        size: 'm',
-        disabled: false,
-        focused: true,
-        square: false,
-        stretching: 'auto',
-        isLoading: false,
+export const Default: StoryObj<ComponentProps<typeof Button>> = {};
+
+export const AccessibilityWithChildren: StoryObj<ComponentProps<typeof Button>> = {
+    argTypes: { ...disableProps(['text']) },
+    render: (props: ComponentProps<typeof Button>) => {
+        const args = { ...props, text: undefined };
+
+        return (
+            <Button {...args}>
+                <IconMic color="inherit" />
+                <span>Включить микрофон</span>
+            </Button>
+        );
     },
 };


### PR DESCRIPTION
### Button

- добавлен story для проверки доступности 

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.36.6-canary.1183.8752730341.0
  npm install @salutejs/plasma-asdk@0.74.6-canary.1183.8752730341.0
  npm install @salutejs/plasma-b2c@1.316.6-canary.1183.8752730341.0
  npm install @salutejs/plasma-new-hope@0.76.6-canary.1183.8752730341.0
  npm install @salutejs/plasma-web@1.317.2-canary.1183.8752730341.0
  npm install @salutejs/sdds-serv@0.42.6-canary.1183.8752730341.0
  # or 
  yarn add @salutejs/caldera-online@0.36.6-canary.1183.8752730341.0
  yarn add @salutejs/plasma-asdk@0.74.6-canary.1183.8752730341.0
  yarn add @salutejs/plasma-b2c@1.316.6-canary.1183.8752730341.0
  yarn add @salutejs/plasma-new-hope@0.76.6-canary.1183.8752730341.0
  yarn add @salutejs/plasma-web@1.317.2-canary.1183.8752730341.0
  yarn add @salutejs/sdds-serv@0.42.6-canary.1183.8752730341.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
