### PR TITLE
fix(plasma-web): add default size to Textfield interlayer

### DIFF
--- a/packages/plasma-web/src/components/TextField/TextField.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.tsx
@@ -28,7 +28,6 @@ const animatedHintToLabelPlacement: Record<
  */
 export const TextField = forwardRef<HTMLDivElement, CustomTextFieldProps>((props, ref) => {
     const {
-        size,
         status,
 
         label,
@@ -40,6 +39,8 @@ export const TextField = forwardRef<HTMLDivElement, CustomTextFieldProps>((props
         chips,
         onSearch,
         onChangeChips,
+
+        size = 'l',
 
         ...rest
     } = props;


### PR DESCRIPTION
### Textfield

- добавлен дефолтный size в прослойку textfield в plasma-web

### What/why changed

В прослойке textfield в plasma-web значение size переопределялось, из-за чего не применялись дефолтные значения конфига.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-web@1.317.0-canary.1187.8736914506.0
  # or 
  yarn add @salutejs/plasma-web@1.317.0-canary.1187.8736914506.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
