### PR TITLE
plasma-*: Fix textfield ref 

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -1694,7 +1694,7 @@ true: string;
     onChangeChips?: undefined;
     enumerationType?: "plain" | undefined;
     onSearch?: ((value: string, event?: React_2.KeyboardEvent<HTMLInputElement> | undefined) => void) | undefined;
-} & Omit<React_2.InputHTMLAttributes<HTMLInputElement>, "size"> & React_2.RefAttributes<HTMLDivElement>) | ({
+} & Omit<React_2.InputHTMLAttributes<HTMLInputElement>, "size"> & React_2.RefAttributes<HTMLInputElement>) | ({
     size?: string | undefined;
     view?: string | undefined;
     readOnly?: boolean | undefined;
@@ -1711,7 +1711,7 @@ true: string;
     onSearch?: undefined;
     chips?: TextFieldPrimitiveValue[] | undefined;
     onChangeChips?: ((value: TextFieldPrimitiveValue[]) => void) | undefined;
-} & Omit<React_2.InputHTMLAttributes<HTMLInputElement>, "size"> & React_2.RefAttributes<HTMLDivElement>)), "enumerationType" | "chips" | "onChangeChips"> & React_2.RefAttributes<HTMLInputElement>>;
+} & Omit<React_2.InputHTMLAttributes<HTMLInputElement>, "size"> & React_2.RefAttributes<HTMLInputElement>)), "enumerationType" | "chips" | "onChangeChips"> & React_2.RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "newHopeTextFieldProps" needs to be exported by the entry point index.d.ts
 //

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import type { ChangeEventHandler } from 'react';
-import { safeUseId } from '@salutejs/plasma-core';
+import { safeUseId, useForkRef } from '@salutejs/plasma-core';
 import { css } from '@linaria/core';
 
 import type { RootProps } from '../../engines';
@@ -24,7 +24,7 @@ import {
 } from './TextField.styles';
 import { classes } from './TextField.tokens';
 import { TextFieldChip } from './ui';
-import { useKeyNavigation } from './hooks/useKeyNavigation';
+import { useKeyNavigation } from './hooks';
 
 export const base = css`
     /* NOTE: Webkit не применяет opacity к inline тегам */
@@ -33,7 +33,7 @@ export const base = css`
 `;
 
 export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldProps>) =>
-    forwardRef<HTMLDivElement, TextFieldProps>(
+    forwardRef<HTMLInputElement, TextFieldProps>(
         (
             {
                 id,
@@ -67,6 +67,7 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldProps>) =
         ) => {
             const contentRef = useRef<HTMLDivElement>(null);
             const inputRef = useRef<HTMLInputElement>(null);
+            const inputForkRef = useForkRef(inputRef, ref);
             const chipsRefs = useRef<Array<HTMLButtonElement>>([]);
 
             const controlledRefs = { contentRef, inputRef, chipsRefs };
@@ -133,6 +134,7 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldProps>) =
                     block: 'center',
                     inline: 'center',
                 });
+
                 inputRef.current.focus({ preventScroll: true });
             };
 
@@ -158,7 +160,6 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldProps>) =
 
             return (
                 <Root
-                    ref={ref}
                     view={view}
                     size={size}
                     disabled={disabled}
@@ -202,7 +203,7 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldProps>) =
                             )}
                             <Input
                                 {...rest}
-                                ref={inputRef}
+                                ref={inputForkRef}
                                 id={innerId}
                                 aria-labelledby={labelId}
                                 aria-describedby={helperTextId}

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -1696,7 +1696,7 @@ true: string;
     onChangeChips?: undefined;
     enumerationType?: "plain" | undefined;
     onSearch?: ((value: string, event?: React_2.KeyboardEvent<HTMLInputElement> | undefined) => void) | undefined;
-} & Omit<React_2.InputHTMLAttributes<HTMLInputElement>, "size"> & React_2.RefAttributes<HTMLDivElement>) | ({
+} & Omit<React_2.InputHTMLAttributes<HTMLInputElement>, "size"> & React_2.RefAttributes<HTMLInputElement>) | ({
     size?: string | undefined;
     view?: string | undefined;
     readOnly?: boolean | undefined;
@@ -1713,7 +1713,7 @@ true: string;
     onSearch?: undefined;
     chips?: TextFieldPrimitiveValue[] | undefined;
     onChangeChips?: ((value: TextFieldPrimitiveValue[]) => void) | undefined;
-} & Omit<React_2.InputHTMLAttributes<HTMLInputElement>, "size"> & React_2.RefAttributes<HTMLDivElement>)), "enumerationType" | "chips" | "onChangeChips"> & React_2.RefAttributes<HTMLDivElement>>;
+} & Omit<React_2.InputHTMLAttributes<HTMLInputElement>, "size"> & React_2.RefAttributes<HTMLInputElement>)), "enumerationType" | "chips" | "onChangeChips"> & React_2.RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "newHopeTextFieldProps" needs to be exported by the entry point index.d.ts
 //

--- a/packages/plasma-web/src/components/TextField/TextField.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.tsx
@@ -26,7 +26,7 @@ const animatedHintToLabelPlacement: Record<
 /**
  * Поле ввода текста.
  */
-export const TextField = forwardRef<HTMLDivElement, CustomTextFieldProps>((props, ref) => {
+export const TextField = forwardRef<HTMLInputElement, CustomTextFieldProps>((props, ref) => {
     const {
         status,
 

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -1178,7 +1178,7 @@ chips?: undefined;
 onChangeChips?: undefined;
 enumerationType?: "plain" | undefined;
 onSearch?: ((value: string, event?: KeyboardEvent_2<HTMLInputElement> | undefined) => void) | undefined;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, "size"> & RefAttributes<HTMLDivElement>) | ({
+} & Omit<InputHTMLAttributes<HTMLInputElement>, "size"> & RefAttributes<HTMLInputElement>) | ({
 size?: string | undefined;
 view?: string | undefined;
 readOnly?: boolean | undefined;
@@ -1195,7 +1195,7 @@ enumerationType: "chip";
 onSearch?: undefined;
 chips?: TextFieldPrimitiveValue[] | undefined;
 onChangeChips?: ((value: TextFieldPrimitiveValue[]) => void) | undefined;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, "size"> & RefAttributes<HTMLDivElement>))>;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, "size"> & RefAttributes<HTMLInputElement>))>;
 
 export { TextFieldProps }
 


### PR DESCRIPTION
### TextField

- исправлен target для `ref` (теперь указывает на input tag) 

### What/why changed

#### After: 

<img width="480" alt="Screenshot 2024-04-25 at 16 31 00" src="https://github.com/salute-developers/plasma/assets/2895992/640bdd73-7848-4209-b25a-263da501eb1e">


