### PR TITLE
feat: add calendar edge dates control

### DIFF
--- a/packages/plasma-b2c/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-b2c/src/components/Calendar/Calendar.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
@@ -71,19 +71,20 @@ const StyledCalendar = styled(Calendar)`
 const CommonStoryProps = {
     min: new Date(2022, 4, 0),
     max: new Date(2022, 6, 15),
+    includeEdgeDates: false,
 };
 
 const StoryCalendarDefault = (props: CalendarProps) => {
-    const { isRange, isDouble, min, max, date } = props;
-    const [value, setValue] = React.useState(new Date(2022, 5, 6));
-    const [valueRange, setValueRange] = React.useState<[Date, Date?]>([new Date(2022, 5, 6), new Date(2022, 5, 10)]);
+    const { isRange, isDouble, min, max, date, includeEdgeDates } = props;
+    const [value, setValue] = useState(new Date(2022, 5, 6));
+    const [valueRange, setValueRange] = useState<[Date, Date?]>([new Date(2022, 5, 6), new Date(2022, 5, 10)]);
 
-    const handleOnChange = React.useCallback((newValue: Date) => {
+    const handleOnChange = useCallback((newValue: Date) => {
         setValue(newValue);
         onChangeValue(newValue);
     }, []);
 
-    const handleOnRangeChange = React.useCallback((newValue: [Date, Date?]) => {
+    const handleOnRangeChange = useCallback((newValue: [Date, Date?]) => {
         setValueRange(newValue);
     }, []);
 
@@ -104,6 +105,7 @@ const StoryCalendarDefault = (props: CalendarProps) => {
             value={(isRange ? valueRange : value) as Date & [Date, Date?]}
             eventList={[...baseEvents, ...eventsRange]}
             disabledList={disabledDays}
+            includeEdgeDates={includeEdgeDates}
             min={min}
             max={max}
             onChangeValue={(isRange ? handleOnRangeChange : handleOnChange) as (value: Date | [Date, Date?]) => void}
@@ -120,10 +122,10 @@ export const Default: Story = {
     render: (args) => <StoryCalendarDefault {...args} />,
 };
 
-const StoryCalendarBase = ({ min, max, type }: CalendarBaseProps) => {
-    const [value, setValue] = React.useState(new Date(2022, 5, 6));
+const StoryCalendarBase = ({ min, max, type, includeEdgeDates }: CalendarBaseProps) => {
+    const [value, setValue] = useState(new Date(2022, 5, 6));
 
-    const handleOnChange = React.useCallback((newValue: Date) => {
+    const handleOnChange = useCallback((newValue: Date) => {
         setValue(newValue);
         onChangeValue(newValue);
     }, []);
@@ -144,6 +146,7 @@ const StoryCalendarBase = ({ min, max, type }: CalendarBaseProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             type={type}
             onChangeValue={handleOnChange}
         />
@@ -166,9 +169,9 @@ export const Base: StoryObj<CalendarBaseProps> = {
     render: (args) => <StoryCalendarBase {...args} />,
 };
 
-const StoryCalendarDouble = ({ min, max }: CalendarDoubleProps) => {
-    const [value, setValue] = React.useState(new Date(2022, 5, 6));
-    const handleOnChange = React.useCallback((newValue: Date) => {
+const StoryCalendarDouble = ({ min, max, includeEdgeDates }: CalendarDoubleProps) => {
+    const [value, setValue] = useState(new Date(2022, 5, 6));
+    const handleOnChange = useCallback((newValue: Date) => {
         setValue(newValue);
         onChangeValue(newValue);
     }, []);
@@ -189,6 +192,7 @@ const StoryCalendarDouble = ({ min, max }: CalendarDoubleProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={handleOnChange}
         />
     );
@@ -201,9 +205,9 @@ export const Double: StoryObj<CalendarDoubleProps> = {
     render: (args) => <StoryCalendarDouble {...args} />,
 };
 
-const StoryCalendarRange = ({ min, max, type }: ComponentProps<typeof CalendarBaseRange>) => {
-    const [values, setValue] = React.useState<[Date, Date?]>([new Date(2022, 5, 16), new Date(2022, 5, 25)]);
-    const handleOnChange = React.useCallback((newValue: [Date, Date?]) => {
+const StoryCalendarRange = ({ min, max, type, includeEdgeDates }: ComponentProps<typeof CalendarBaseRange>) => {
+    const [values, setValue] = useState<[Date, Date?]>([new Date(2022, 5, 16), new Date(2022, 5, 25)]);
+    const handleOnChange = useCallback((newValue: [Date, Date?]) => {
         onChangeValue(newValue);
         setValue(newValue);
     }, []);
@@ -217,8 +221,8 @@ const StoryCalendarRange = ({ min, max, type }: ComponentProps<typeof CalendarBa
         date: new Date(2022, 5, 11 + day),
     }));
 
-    const eventList = React.useMemo(() => [...baseEvents, ...eventsRange], [eventsRange]);
-    const disabledList = React.useMemo(() => [{ date: new Date(2022, 5, 4) }, ...disabledDays], [disabledDays]);
+    const eventList = useMemo(() => [...baseEvents, ...eventsRange], [eventsRange]);
+    const disabledList = useMemo(() => [{ date: new Date(2022, 5, 4) }, ...disabledDays], [disabledDays]);
 
     return (
         <CalendarBaseRange
@@ -227,6 +231,7 @@ const StoryCalendarRange = ({ min, max, type }: ComponentProps<typeof CalendarBa
             disabledList={disabledList}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             type={type}
             onChangeValue={handleOnChange}
             onChangeStartOfRange={onChangeStartOfRange}
@@ -246,14 +251,15 @@ export const Range: StoryObj<ComponentProps<typeof CalendarBaseRange>> = {
     args: {
         min: new Date(2022, 4, 0),
         max: new Date(2022, 7, 15),
+        includeEdgeDates: false,
         type: 'Days',
     },
     render: (args) => <StoryCalendarRange {...args} />,
 };
 
-const StoryDoubleRange = ({ min, max }: ComponentProps<typeof CalendarDoubleRange>) => {
-    const [values, setValue] = React.useState<[Date, Date?]>([new Date(2022, 5, 7), new Date(2022, 6, 9)]);
-    const handleOnChange = React.useCallback((newValue: [Date, Date?]) => {
+const StoryDoubleRange = ({ min, max, includeEdgeDates }: ComponentProps<typeof CalendarDoubleRange>) => {
+    const [values, setValue] = useState<[Date, Date?]>([new Date(2022, 5, 7), new Date(2022, 6, 9)]);
+    const handleOnChange = useCallback((newValue: [Date, Date?]) => {
         onChangeValue(newValue);
         setValue(newValue);
     }, []);
@@ -267,8 +273,8 @@ const StoryDoubleRange = ({ min, max }: ComponentProps<typeof CalendarDoubleRang
         date: new Date(2022, 6, 10 + day),
     }));
 
-    const eventList = React.useMemo(() => [...baseEvents, ...eventsRange], [eventsRange]);
-    const disabledList = React.useMemo(() => [{ date: new Date(2022, 5, 4) }, ...disabledDays], [disabledDays]);
+    const eventList = useMemo(() => [...baseEvents, ...eventsRange], [eventsRange]);
+    const disabledList = useMemo(() => [{ date: new Date(2022, 5, 4) }, ...disabledDays], [disabledDays]);
 
     return (
         <CalendarDoubleRange
@@ -277,6 +283,7 @@ const StoryDoubleRange = ({ min, max }: ComponentProps<typeof CalendarDoubleRang
             disabledList={disabledList}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={handleOnChange}
             onChangeStartOfRange={onChangeStartOfRange}
         />
@@ -287,29 +294,30 @@ export const DoubleRange: StoryObj<ComponentProps<typeof CalendarDoubleRange>> =
     args: {
         min: new Date(2022, 4, 0),
         max: new Date(2022, 7, 15),
+        includeEdgeDates: false,
     },
     render: (args) => <StoryDoubleRange {...args} />,
 };
 
-const StoryCalendarWithPopup = ({ min, max, isDouble }: CalendarProps) => {
-    const [textValue, setTextValue] = React.useState('2022-06-06');
-    const [value, setValue] = React.useState(new Date(textValue));
-    const [isOpen, setIsOpen] = React.useState(false);
+const StoryCalendarWithPopup = ({ min, max, isDouble, includeEdgeDates }: CalendarProps) => {
+    const [textValue, setTextValue] = useState('2022-06-06');
+    const [value, setValue] = useState(new Date(textValue));
+    const [isOpen, setIsOpen] = useState(false);
 
-    const handleOnTextChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const handleOnTextChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
         const newValue = event.target.value;
         setTextValue(newValue);
         setValue(new Date(newValue));
     }, []);
 
-    const handleOnChange = React.useCallback((newValue: Date) => {
+    const handleOnChange = useCallback((newValue: Date) => {
         setValue(newValue);
         setTextValue(new Date(newValue).toLocaleDateString('en-CA'));
         setIsOpen(false);
         onChangeValue(newValue);
     }, []);
 
-    const onToggle = React.useCallback((newIsOpen) => {
+    const onToggle = useCallback((newIsOpen) => {
         setIsOpen(newIsOpen);
     }, []);
 
@@ -336,6 +344,7 @@ const StoryCalendarWithPopup = ({ min, max, isDouble }: CalendarProps) => {
                 disabledList={disabledDays}
                 min={min}
                 max={max}
+                includeEdgeDates={includeEdgeDates}
                 isDouble={isDouble}
                 onChangeValue={handleOnChange}
             />

--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.types.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.types.ts
@@ -98,6 +98,10 @@ export interface Calendar extends HTMLAttributes<HTMLDivElement> {
      */
     max?: Date;
     /**
+     * Должны ли значения минимального и максимального дня включаться в диапазон.
+     */
+    includeEdgeDates?: boolean;
+    /**
      * Список событий.
      */
     eventList?: EventDay[];

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
@@ -27,7 +27,17 @@ export type CalendarBaseProps = HTMLAttributes<HTMLDivElement> &
 export const calendarBaseRoot = (Root: RootProps<HTMLDivElement, HTMLAttributes<HTMLDivElement>>) =>
     forwardRef<HTMLDivElement, CalendarBaseProps>(
         (
-            { value: externalValue, min, max, type = 'Days', eventList, disabledList, onChangeValue, ...rest },
+            {
+                value: externalValue,
+                min,
+                max,
+                includeEdgeDates,
+                type = 'Days',
+                eventList,
+                disabledList,
+                onChangeValue,
+                ...rest
+            },
             outerRootRef,
         ) => {
             const [firstValue, secondValue] = useMemo(
@@ -207,6 +217,7 @@ export const calendarBaseRoot = (Root: RootProps<HTMLDivElement, HTMLAttributes<
                             disabledList={disabledList}
                             min={min}
                             max={max}
+                            includeEdgeDates={includeEdgeDates}
                             value={externalValue}
                             date={date}
                             hoveredDay={hoveredDay}

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
@@ -16,7 +16,10 @@ export type CalendarDoubleProps = HTMLAttributes<HTMLDivElement> & Calendar;
  */
 export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttributes<HTMLDivElement>>) =>
     forwardRef<HTMLDivElement, CalendarDoubleProps>(
-        ({ value: externalValue, min, max, eventList, disabledList, onChangeValue, ...rest }, outerRootRef) => {
+        (
+            { value: externalValue, min, max, includeEdgeDates, eventList, disabledList, onChangeValue, ...rest },
+            outerRootRef,
+        ) => {
             const [firstValue, secondValue] = useMemo(
                 () => (Array.isArray(externalValue) ? externalValue : [externalValue]),
                 [externalValue],
@@ -133,6 +136,7 @@ export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttribute
                             disabledList={disabledList}
                             min={min}
                             max={max}
+                            includeEdgeDates={includeEdgeDates}
                             value={externalValue}
                             date={firstDate}
                             hoveredDay={hoveredDay}
@@ -151,6 +155,7 @@ export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttribute
                             disabledList={disabledList}
                             min={min}
                             max={max}
+                            includeEdgeDates={includeEdgeDates}
                             value={externalValue}
                             date={secondDate}
                             hoveredDay={hoveredDay}

--- a/packages/plasma-new-hope/src/components/Calendar/hooks/useDays.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/hooks/useDays.ts
@@ -212,6 +212,7 @@ const getDaysWithModifications = (
     disabledList: DisabledDay[] = [],
     min?: Date,
     max?: Date,
+    includeEdgeDates?: boolean,
 ) => {
     const eventsMap = getPropsMap(eventList);
     const disabledDaysMap = getPropsMap(disabledList);
@@ -227,7 +228,9 @@ const getDaysWithModifications = (
         const keyDay = `${year}-${monthIndex}-${day}`;
         const currentDate = new Date(year, monthIndex, day);
 
-        const isOutOfMinMaxRange = (min && min >= currentDate) || (max && max <= currentDate);
+        const minValue = min && (includeEdgeDates ? min > currentDate : min >= currentDate);
+        const maxValue = max && (includeEdgeDates ? max < currentDate : max <= currentDate);
+        const isOutOfMinMaxRange = minValue || maxValue;
 
         dayItem.events = eventsMap.get(keyDay);
         dayItem.disabled = disabledDaysMap.has(keyDay) || isOutOfMinMaxRange;
@@ -250,6 +253,7 @@ export const useDays = (
     disabledList?: DisabledDay[],
     min?: Date,
     max?: Date,
+    includeEdgeDates?: boolean,
 ) =>
     useMemo(() => {
         const { monthIndex, year } = date;
@@ -263,7 +267,7 @@ export const useDays = (
         ];
 
         if (eventList?.length || disabledList?.length || max || min) {
-            const modifiedDays = getDaysWithModifications(days, eventList, disabledList, min, max);
+            const modifiedDays = getDaysWithModifications(days, eventList, disabledList, min, max, includeEdgeDates);
             return getMatrix<DateItem>(modifiedDays);
         }
 

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarDays/CalendarDays.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarDays/CalendarDays.tsx
@@ -27,6 +27,7 @@ export const CalendarDays: React.FC<CalendarDaysProps> = ({
     disabledList,
     min,
     max,
+    includeEdgeDates,
     hoveredDay,
     selectIndexes,
     isDouble,
@@ -37,7 +38,7 @@ export const CalendarDays: React.FC<CalendarDaysProps> = ({
     onSetSelected,
     onKeyDown,
 }) => {
-    const [days, selected] = useDays(currentDate, value, eventList, disabledList, min, max);
+    const [days, selected] = useDays(currentDate, value, eventList, disabledList, min, max, includeEdgeDates);
     const selectedRef = useRef(selected);
     const onSetSelectedRef = useRef(onSetSelected);
 

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarDays/CalendarDays.types.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarDays/CalendarDays.types.ts
@@ -7,6 +7,7 @@ export interface CalendarDaysProps extends HTMLAttributes<HTMLDivElement> {
     value: CalendarValueType;
     min?: Date;
     max?: Date;
+    includeEdgeDates?: boolean;
     eventList?: EventDay[];
     disabledList?: DisabledDay[];
     isDouble?: boolean;

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/Calendar.stories.tsx
@@ -79,7 +79,7 @@ const baseEvents = [
 ];
 
 const StoryDefault = (args: CalendarProps) => {
-    const { isRange, isDouble, min, max, date } = args;
+    const { isRange, isDouble, min, max, date, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
     const [valueRange, setValueRange] = useState<[Date, Date?]>([new Date(2023, 10, 16), new Date(2023, 10, 23)]);
 
@@ -110,6 +110,7 @@ const StoryDefault = (args: CalendarProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={(isRange ? handleOnRangeChange : handleOnChange) as (value: Date | [Date, Date?]) => void}
         />
     );
@@ -121,12 +122,13 @@ export const Default: StoryObj<CalendarProps> = {
         max: new Date(2023, 11, 24),
         isDouble: false,
         isRange: false,
+        includeEdgeDates: false,
     },
     render: (args) => <StoryDefault {...args} />,
 };
 
 const StoryBase = (args: CalendarBaseProps) => {
-    const { min, max, type } = args;
+    const { min, max, type, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
 
     const handleOnChange = useCallback((newValue: Date) => {
@@ -150,6 +152,7 @@ const StoryBase = (args: CalendarBaseProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             type={type}
             onChangeValue={handleOnChange}
         />
@@ -168,13 +171,14 @@ export const Base: StoryObj<CalendarBaseProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
         type: 'Days',
     },
     render: (args) => <StoryBase {...args} />,
 };
 
 const StoryDouble = (args: CalendarDoubleProps) => {
-    const { min, max } = args;
+    const { min, max, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
     const handleOnChange = useCallback((newValue: Date) => {
         setValue(newValue);
@@ -197,6 +201,7 @@ const StoryDouble = (args: CalendarDoubleProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={handleOnChange}
         />
     );
@@ -206,12 +211,13 @@ export const Double: StoryObj<CalendarDoubleProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
     },
     render: (args) => <StoryDouble {...args} />,
 };
 
 const StoryRange = (args: CalendarBaseRangeProps) => {
-    const { min, max, type } = args;
+    const { min, max, type, includeEdgeDates } = args;
     const [values, setValue] = useState<[Date, Date?]>([new Date(2023, 10, 15), new Date(2023, 10, 24)]);
     const handleOnChange = useCallback((newValue: [Date, Date?]) => {
         onChangeValue(newValue);
@@ -237,6 +243,7 @@ const StoryRange = (args: CalendarBaseRangeProps) => {
             disabledList={disabledList}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             type={type}
             onChangeValue={handleOnChange}
         />
@@ -255,13 +262,14 @@ export const Range: StoryObj<CalendarBaseRangeProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
         type: 'Days',
     },
     render: (args) => <StoryRange {...args} />,
 };
 
 const StoryRangeDouble = (args: CalendarBaseRangeProps) => {
-    const { min, max } = args;
+    const { min, max, includeEdgeDates } = args;
     const [values, setValue] = useState<[Date, Date?]>([new Date(2023, 10, 15), new Date(2023, 10, 24)]);
     const handleOnChange = useCallback((newValue: [Date, Date?]) => {
         onChangeValue(newValue);
@@ -287,6 +295,7 @@ const StoryRangeDouble = (args: CalendarBaseRangeProps) => {
             disabledList={disabledList}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={handleOnChange}
         />
     );
@@ -296,12 +305,13 @@ export const RangeDouble: StoryObj<CalendarBaseRangeProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
     },
     render: (args) => <StoryRangeDouble {...args} />,
 };
 
 const StoryWithPopover = (args: CalendarProps) => {
-    const { isDouble, min, max } = args;
+    const { isDouble, min, max, includeEdgeDates } = args;
     const [isOpen, setIsOpen] = useState(false);
     const [textValue, setTextValue] = useState('2023-10-16');
     const [value, setValue] = useState(new Date(textValue));
@@ -340,6 +350,7 @@ const StoryWithPopover = (args: CalendarProps) => {
                 disabledList={disabledDays}
                 min={min}
                 max={max}
+                includeEdgeDates={includeEdgeDates}
                 isDouble={isDouble}
                 isRange={false}
                 onChangeValue={handleOnChange}
@@ -353,6 +364,7 @@ export const WithPopover: StoryObj<CalendarProps> = {
         min: new Date(2023, 9, 1),
         max: new Date(2023, 11, 24),
         isDouble: false,
+        includeEdgeDates: false,
     },
     render: (args) => <StoryWithPopover {...args} />,
 };

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/Calendar.stories.tsx
@@ -79,7 +79,7 @@ const baseEvents = [
 ];
 
 const StoryDefault = (args: CalendarProps) => {
-    const { isRange, isDouble, min, max, date } = args;
+    const { isRange, isDouble, min, max, date, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
     const [valueRange, setValueRange] = useState<[Date, Date?]>([new Date(2023, 10, 16), new Date(2023, 10, 23)]);
 
@@ -110,6 +110,7 @@ const StoryDefault = (args: CalendarProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={(isRange ? handleOnRangeChange : handleOnChange) as (value: Date | [Date, Date?]) => void}
         />
     );
@@ -121,12 +122,13 @@ export const Default: StoryObj<CalendarProps> = {
         max: new Date(2023, 11, 24),
         isDouble: false,
         isRange: false,
+        includeEdgeDates: false,
     },
     render: (args) => <StoryDefault {...args} />,
 };
 
 const StoryBase = (args: CalendarBaseProps) => {
-    const { min, max, type } = args;
+    const { min, max, type, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
 
     const handleOnChange = useCallback((newValue: Date) => {
@@ -150,6 +152,7 @@ const StoryBase = (args: CalendarBaseProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             type={type}
             onChangeValue={handleOnChange}
         />
@@ -168,13 +171,14 @@ export const Base: StoryObj<CalendarBaseProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
         type: 'Days',
     },
     render: (args) => <StoryBase {...args} />,
 };
 
 const StoryDouble = (args: CalendarDoubleProps) => {
-    const { min, max } = args;
+    const { min, max, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
     const handleOnChange = useCallback((newValue: Date) => {
         setValue(newValue);
@@ -197,6 +201,7 @@ const StoryDouble = (args: CalendarDoubleProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={handleOnChange}
         />
     );
@@ -206,12 +211,13 @@ export const Double: StoryObj<CalendarDoubleProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
     },
     render: (args) => <StoryDouble {...args} />,
 };
 
 const StoryRange = (args: CalendarBaseRangeProps) => {
-    const { min, max, type } = args;
+    const { min, max, type, includeEdgeDates } = args;
     const [values, setValue] = useState<[Date, Date?]>([new Date(2023, 10, 15), new Date(2023, 10, 24)]);
     const handleOnChange = useCallback((newValue: [Date, Date?]) => {
         onChangeValue(newValue);
@@ -237,6 +243,7 @@ const StoryRange = (args: CalendarBaseRangeProps) => {
             disabledList={disabledList}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             type={type}
             onChangeValue={handleOnChange}
         />
@@ -255,13 +262,14 @@ export const Range: StoryObj<CalendarBaseRangeProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
         type: 'Days',
     },
     render: (args) => <StoryRange {...args} />,
 };
 
 const StoryRangeDouble = (args: CalendarBaseRangeProps) => {
-    const { min, max } = args;
+    const { min, max, includeEdgeDates } = args;
     const [values, setValue] = useState<[Date, Date?]>([new Date(2023, 10, 15), new Date(2023, 10, 24)]);
     const handleOnChange = useCallback((newValue: [Date, Date?]) => {
         onChangeValue(newValue);
@@ -287,6 +295,7 @@ const StoryRangeDouble = (args: CalendarBaseRangeProps) => {
             disabledList={disabledList}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={handleOnChange}
         />
     );
@@ -296,12 +305,13 @@ export const RangeDouble: StoryObj<CalendarBaseRangeProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
     },
     render: (args) => <StoryRangeDouble {...args} />,
 };
 
 const StoryWithPopover = (args: CalendarProps) => {
-    const { isDouble, min, max } = args;
+    const { isDouble, min, max, includeEdgeDates } = args;
     const [isOpen, setIsOpen] = useState(false);
     const [textValue, setTextValue] = useState('2023-10-16');
     const [value, setValue] = useState(new Date(textValue));
@@ -340,6 +350,7 @@ const StoryWithPopover = (args: CalendarProps) => {
                 disabledList={disabledDays}
                 min={min}
                 max={max}
+                includeEdgeDates={includeEdgeDates}
                 isDouble={isDouble}
                 isRange={false}
                 onChangeValue={handleOnChange}
@@ -353,6 +364,7 @@ export const WithPopover: StoryObj<CalendarProps> = {
         min: new Date(2023, 9, 1),
         max: new Date(2023, 11, 24),
         isDouble: false,
+        includeEdgeDates: false,
     },
     render: (args) => <StoryWithPopover {...args} />,
 };

--- a/packages/plasma-new-hope/src/examples/sds_engineer/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/sds_engineer/components/Calendar/Calendar.stories.tsx
@@ -79,7 +79,7 @@ const baseEvents = [
 ];
 
 const StoryDefault = (args: CalendarProps) => {
-    const { isRange, isDouble, min, max, date } = args;
+    const { isRange, isDouble, min, max, date, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
     const [valueRange, setValueRange] = useState<[Date, Date?]>([new Date(2023, 10, 16), new Date(2023, 10, 23)]);
 
@@ -110,6 +110,7 @@ const StoryDefault = (args: CalendarProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={(isRange ? handleOnRangeChange : handleOnChange) as (value: Date | [Date, Date?]) => void}
         />
     );
@@ -121,12 +122,13 @@ export const Default: StoryObj<CalendarProps> = {
         max: new Date(2023, 11, 24),
         isDouble: false,
         isRange: false,
+        includeEdgeDates: false,
     },
     render: (args) => <StoryDefault {...args} />,
 };
 
 const StoryBase = (args: CalendarBaseProps) => {
-    const { min, max, type } = args;
+    const { min, max, type, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
 
     const handleOnChange = useCallback((newValue: Date) => {
@@ -150,6 +152,7 @@ const StoryBase = (args: CalendarBaseProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             type={type}
             onChangeValue={handleOnChange}
         />
@@ -168,13 +171,14 @@ export const Base: StoryObj<CalendarBaseProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
         type: 'Days',
     },
     render: (args) => <StoryBase {...args} />,
 };
 
 const StoryDouble = (args: CalendarDoubleProps) => {
-    const { min, max } = args;
+    const { min, max, includeEdgeDates } = args;
     const [value, setValue] = useState(new Date(2023, 10, 16));
     const handleOnChange = useCallback((newValue: Date) => {
         setValue(newValue);
@@ -197,6 +201,7 @@ const StoryDouble = (args: CalendarDoubleProps) => {
             disabledList={disabledDays}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={handleOnChange}
         />
     );
@@ -206,12 +211,13 @@ export const Double: StoryObj<CalendarDoubleProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
     },
     render: (args) => <StoryDouble {...args} />,
 };
 
 const StoryRange = (args: CalendarBaseRangeProps) => {
-    const { min, max, type } = args;
+    const { min, max, type, includeEdgeDates } = args;
     const [values, setValue] = useState<[Date, Date?]>([new Date(2023, 10, 15), new Date(2023, 10, 24)]);
     const handleOnChange = useCallback((newValue: [Date, Date?]) => {
         onChangeValue(newValue);
@@ -237,6 +243,7 @@ const StoryRange = (args: CalendarBaseRangeProps) => {
             disabledList={disabledList}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             type={type}
             onChangeValue={handleOnChange}
         />
@@ -255,13 +262,14 @@ export const Range: StoryObj<CalendarBaseRangeProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
         type: 'Days',
     },
     render: (args) => <StoryRange {...args} />,
 };
 
 const StoryRangeDouble = (args: CalendarBaseRangeProps) => {
-    const { min, max } = args;
+    const { min, max, includeEdgeDates } = args;
     const [values, setValue] = useState<[Date, Date?]>([new Date(2023, 10, 15), new Date(2023, 10, 24)]);
     const handleOnChange = useCallback((newValue: [Date, Date?]) => {
         onChangeValue(newValue);
@@ -287,6 +295,7 @@ const StoryRangeDouble = (args: CalendarBaseRangeProps) => {
             disabledList={disabledList}
             min={min}
             max={max}
+            includeEdgeDates={includeEdgeDates}
             onChangeValue={handleOnChange}
         />
     );
@@ -296,12 +305,13 @@ export const RangeDouble: StoryObj<CalendarBaseRangeProps> = {
     args: {
         min: new Date(2023, 10, 1),
         max: new Date(2023, 11, 24),
+        includeEdgeDates: false,
     },
     render: (args) => <StoryRangeDouble {...args} />,
 };
 
 const StoryWithPopover = (args: CalendarProps) => {
-    const { isDouble, min, max } = args;
+    const { isDouble, min, max, includeEdgeDates } = args;
     const [isOpen, setIsOpen] = useState(false);
     const [textValue, setTextValue] = useState('2023-10-16');
     const [value, setValue] = useState(new Date(textValue));
@@ -340,6 +350,7 @@ const StoryWithPopover = (args: CalendarProps) => {
                 disabledList={disabledDays}
                 min={min}
                 max={max}
+                includeEdgeDates={includeEdgeDates}
                 isDouble={isDouble}
                 isRange={false}
                 onChangeValue={handleOnChange}
@@ -353,6 +364,7 @@ export const WithPopover: StoryObj<CalendarProps> = {
         min: new Date(2023, 9, 1),
         max: new Date(2023, 11, 24),
         isDouble: false,
+        includeEdgeDates: false,
     },
     render: (args) => <StoryWithPopover {...args} />,
 };


### PR DESCRIPTION
### Calendar

- добавлен пропс для включения/исключения минимума и максимума диапазона дат

### What/why changed

Появился запрос на выбор крайних дат диапазона. Изначально было нестрогое сравнение на выход за границы периода из-за чего крайние значения были недоступны. Пример: min=7 max=15, при этом числа доступные для выбора 7 < x < 15

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.42.0-canary.1203.9113315762.0
  npm install @salutejs/plasma-asdk@0.80.0-canary.1203.9113315762.0
  npm install @salutejs/plasma-b2c@1.322.0-canary.1203.9113315762.0
  npm install @salutejs/plasma-new-hope@0.82.0-canary.1203.9113315762.0
  npm install @salutejs/plasma-web@1.323.0-canary.1203.9113315762.0
  npm install @salutejs/sdds-serv@0.49.0-canary.1203.9113315762.0
  # or 
  yarn add @salutejs/caldera-online@0.42.0-canary.1203.9113315762.0
  yarn add @salutejs/plasma-asdk@0.80.0-canary.1203.9113315762.0
  yarn add @salutejs/plasma-b2c@1.322.0-canary.1203.9113315762.0
  yarn add @salutejs/plasma-new-hope@0.82.0-canary.1203.9113315762.0
  yarn add @salutejs/plasma-web@1.323.0-canary.1203.9113315762.0
  yarn add @salutejs/sdds-serv@0.49.0-canary.1203.9113315762.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
