### PR TITLE
Fix checkbox types

### DIFF
--- a/packages/caldera-online/api/caldera-online.api.md
+++ b/packages/caldera-online/api/caldera-online.api.md
@@ -8,7 +8,7 @@
 
 import { addFocus } from '@salutejs/plasma-new-hope/styled-components';
 import { AnchorHTMLAttributes } from 'react';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
 import { bodyL } from '@salutejs/caldera-online-themes/tokens';
 import { bodyLBold } from '@salutejs/caldera-online-themes/tokens';
 import { bodyM } from '@salutejs/caldera-online-themes/tokens';
@@ -22,6 +22,8 @@ import { bodyXXSBold } from '@salutejs/caldera-online-themes/tokens';
 import { BoldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Typography.types';
 import { ButtonHTMLAttributes } from 'react';
 import { ButtonProps as ButtonProps_2 } from '@salutejs/plasma-new-hope/styled-components';
+import { CheckboxProps as CheckboxProps_2 } from '@salutejs/plasma-new-hope/types/components/Checkbox/Checkbox.types';
+import { ComponentProps } from 'react';
 import { CustomToastProps } from '@salutejs/plasma-new-hope/types/components/Toast/Toast.types';
 import { DropdownProps } from '@salutejs/plasma-new-hope/styled-components';
 import { dsplL } from '@salutejs/caldera-online-themes/tokens';
@@ -45,7 +47,8 @@ import { h4Bold } from '@salutejs/caldera-online-themes/tokens';
 import { h5 } from '@salutejs/caldera-online-themes/tokens';
 import { h5Bold } from '@salutejs/caldera-online-themes/tokens';
 import { HTMLAttributes } from 'react';
-import type { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/types/types';
+import type { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import { LinkCustomProps } from '@salutejs/plasma-new-hope/types/components/Link/Link';
 import { mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 import { modalClasses } from '@salutejs/plasma-new-hope/styled-components';
@@ -195,12 +198,34 @@ fixed: string;
 export type ButtonProps = typeof ButtonComponent;
 
 // @public
-export const Checkbox: FunctionComponent<BaseboxProps>;
+export const Checkbox: FunctionComponent<PropsType<    {
+size: {
+s: string;
+m: string;
+};
+view: {
+default: string;
+primary: string;
+secondary: string;
+tertiary: string;
+paragraph: string;
+accent: string;
+positive: string;
+warning: string;
+negative: string;
+};
+disabled: {
+true: string;
+};
+focused: {
+true: string;
+};
+}> & CheckboxProps_2 & RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "CheckboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 // @public (undocumented)
 export const Dropdown: FunctionComponent<PropsType<    {
@@ -371,12 +396,34 @@ export { PopupProps }
 export { PopupProvider }
 
 // @public
-export const Radiobox: FunctionComponent<Omit<BaseboxProps, "indeterminate">>;
+export const Radiobox: FunctionComponent<PropsType<    {
+size: {
+s: string;
+m: string;
+};
+view: {
+default: string;
+primary: string;
+secondary: string;
+tertiary: string;
+paragraph: string;
+accent: string;
+positive: string;
+warning: string;
+negative: string;
+};
+disabled: {
+true: string;
+};
+focused: {
+true: string;
+};
+}> & Filter<InputHTMLAttributes<HTMLInputElement>, "size"> & Omit<BaseboxProps, "indeterminate"> & RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "RadioboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type RadioboxProps = typeof RadioboxComponent;
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 
 export { RadioGroup }
 
@@ -511,7 +558,7 @@ true: string;
 focused: {
 true: string;
 };
-}> & Filter<InputHTMLAttributes<HTMLInputElement>, "size"> & SwitchPropsVariations & RefAttributes<HTMLInputElement>>;
+}> & Filter<InputHTMLAttributes_2<HTMLInputElement>, "size"> & SwitchPropsVariations & RefAttributes<HTMLInputElement>>;
 
 // @public (undocumented)
 export type SwitchProps = {
@@ -525,7 +572,7 @@ export type SwitchProps = {
     pressed?: boolean;
     focused?: boolean;
     outlined?: boolean;
-} & FocusProps & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'onChange' | 'onFocus' | 'onBlur'> & Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'value' | 'checked' | 'disabled' | 'readOnly' | 'onChange' | 'onFocus' | 'onBlur'>;
+} & FocusProps & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'onChange' | 'onFocus' | 'onBlur'> & Pick<InputHTMLAttributes_2<HTMLInputElement>, 'name' | 'value' | 'checked' | 'disabled' | 'readOnly' | 'onChange' | 'onFocus' | 'onBlur'>;
 
 // @public (undocumented)
 export const TextL: FunctionComponent<PropsType<    {

--- a/packages/caldera-online/src/components/Checkbox/Checkbox.tsx
+++ b/packages/caldera-online/src/components/Checkbox/Checkbox.tsx
@@ -1,12 +1,12 @@
 import { checkboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Checkbox.config';
 
 const mergedConfig = mergeConfig(checkboxConfig, config);
-const CheckboxComponent = component(mergedConfig) as React.FunctionComponent<BaseboxProps>;
+const CheckboxComponent = component(mergedConfig);
 
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 /**
  * Флажок или чекбокс. Позволяет пользователю управлять параметром с двумя состояниями — ☑ включено и ☐ отключено.

--- a/packages/caldera-online/src/components/Radiobox/Radiobox.ts
+++ b/packages/caldera-online/src/components/Radiobox/Radiobox.ts
@@ -1,12 +1,12 @@
 import { radioboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Radiobox.config';
 
 const mergedConfig = mergeConfig(radioboxConfig, config);
-const RadioboxComponent = component(mergedConfig) as React.FunctionComponent<Omit<BaseboxProps, 'indeterminate'>>;
+const RadioboxComponent = component(mergedConfig);
 
-export type RadioboxProps = typeof RadioboxComponent;
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 
 /**
  * Переключатель, или *радиокнопка*.

--- a/packages/plasma-asdk/api/plasma-asdk.api.md
+++ b/packages/plasma-asdk/api/plasma-asdk.api.md
@@ -7,14 +7,17 @@
 /// <reference types="react" />
 
 import { AnchorHTMLAttributes } from 'react';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
 import { BoldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Typography.types';
 import { ButtonProps as ButtonProps_2 } from '@salutejs/plasma-new-hope/styled-components';
+import { CheckboxProps as CheckboxProps_2 } from '@salutejs/plasma-new-hope/types/components/Checkbox/Checkbox.types';
+import { ComponentProps } from 'react';
 import { Filter } from '@salutejs/plasma-new-hope/types/engines/types';
 import { FocusProps } from '@salutejs/plasma-new-hope/styled-components';
 import { FunctionComponent } from 'react';
 import { HTMLAttributes } from 'react';
-import type { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/types/types';
+import type { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import { LinkCustomProps } from '@salutejs/plasma-new-hope/types/components/Link/Link';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
@@ -155,12 +158,26 @@ m: string;
 }> & TypographyOldProps & RefAttributes<HTMLDivElement>>;
 
 // @public
-export const Checkbox: FunctionComponent<BaseboxProps>;
+export const Checkbox: FunctionComponent<PropsType<    {
+size: {
+s: string;
+m: string;
+};
+view: {
+accent: string;
+};
+disabled: {
+true: string;
+};
+focused: {
+true: string;
+};
+}> & CheckboxProps_2 & RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "CheckboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 // @public (undocumented)
 export const DsplL: FunctionComponent<PropsType<    {
@@ -312,12 +329,26 @@ paragraph2: string;
 }> & TypographyOldProps & RefAttributes<HTMLDivElement>>;
 
 // @public
-export const Radiobox: FunctionComponent<Omit<BaseboxProps, "indeterminate">>;
+export const Radiobox: FunctionComponent<PropsType<    {
+size: {
+s: string;
+m: string;
+};
+view: {
+accent: string;
+};
+disabled: {
+true: string;
+};
+focused: {
+true: string;
+};
+}> & Filter<InputHTMLAttributes<HTMLInputElement>, "size"> & Omit<BaseboxProps, "indeterminate"> & RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "RadioboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type RadioboxProps = typeof RadioboxComponent;
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 
 export { RadioGroup }
 
@@ -380,7 +411,7 @@ true: string;
 focused: {
 true: string;
 };
-}> & Filter<InputHTMLAttributes<HTMLInputElement>, "size"> & SwitchPropsVariations & RefAttributes<HTMLInputElement>>;
+}> & Filter<InputHTMLAttributes_2<HTMLInputElement>, "size"> & SwitchPropsVariations & RefAttributes<HTMLInputElement>>;
 
 // @public (undocumented)
 export type SwitchProps = {
@@ -394,7 +425,7 @@ export type SwitchProps = {
     pressed?: boolean;
     focused?: boolean;
     outlined?: boolean;
-} & FocusProps & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'onChange' | 'onFocus' | 'onBlur'> & Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'value' | 'checked' | 'disabled' | 'readOnly' | 'onChange' | 'onFocus' | 'onBlur'>;
+} & FocusProps & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'onChange' | 'onFocus' | 'onBlur'> & Pick<InputHTMLAttributes_2<HTMLInputElement>, 'name' | 'value' | 'checked' | 'disabled' | 'readOnly' | 'onChange' | 'onFocus' | 'onBlur'>;
 
 // @public (undocumented)
 export const TextL: FunctionComponent<PropsType<    {

--- a/packages/plasma-asdk/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-asdk/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -33,7 +32,7 @@ const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
-type CheckboxProps = ComponentProps<Base>;
+type CheckboxProps = Base;
 
 const meta: Meta<CheckboxProps> = {
     title: 'Controls/Checkbox',

--- a/packages/plasma-asdk/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plasma-asdk/src/components/Checkbox/Checkbox.tsx
@@ -1,12 +1,12 @@
 import { checkboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Checkbox.config';
 
 const mergedConfig = mergeConfig(checkboxConfig, config);
-const CheckboxComponent = component(mergedConfig) as React.FunctionComponent<BaseboxProps>;
+const CheckboxComponent = component(mergedConfig);
 
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 /**
  * Флажок или чекбокс. Позволяет пользователю управлять параметром с двумя состояниями — ☑ включено и ☐ отключено.

--- a/packages/plasma-asdk/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-asdk/src/components/Radiobox/Radiobox.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -14,7 +13,7 @@ const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
-type RadioboxProps = ComponentProps<Base>;
+type RadioboxProps = Base;
 
 const meta: Meta<RadioboxProps> = {
     title: 'Controls/Radiobox',

--- a/packages/plasma-asdk/src/components/Radiobox/Radiobox.ts
+++ b/packages/plasma-asdk/src/components/Radiobox/Radiobox.ts
@@ -1,13 +1,12 @@
 import { radioboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Radiobox.config';
 
 const mergedConfig = mergeConfig(radioboxConfig, config);
-const RadioboxComponent = component(mergedConfig) as React.FunctionComponent<Omit<BaseboxProps, 'indeterminate'>>;
+const RadioboxComponent = component(mergedConfig);
 
-export type RadioboxProps = typeof RadioboxComponent;
-
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 /**
  * Переключатель, или *радиокнопка*.
  */

--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -85,6 +85,7 @@ import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ComboboxPrimitiveValue } from '@salutejs/plasma-new-hope/styled-components';
 import { ComboboxProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ComponentClass } from 'react';
+import { ComponentProps } from 'react';
 import { GridProps as ContainerProps } from '@salutejs/plasma-new-hope/styled-components';
 import { convertRoundnessMatrix } from '@salutejs/plasma-core';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -127,6 +128,7 @@ import { ImageProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-core';
+import { InputHTMLAttributes as InputHTMLAttributes_2 } from '@salutejs/plasma-new-hope/types/types';
 import { JSXElementConstructor } from 'react';
 import { LineSkeletonProps } from '@salutejs/plasma-new-hope/styled-components';
 import { LinkCustomProps } from '@salutejs/plasma-new-hope/types/components/Link/Link';
@@ -724,7 +726,7 @@ true: string;
 // Warning: (ae-forgotten-export) The symbol "CheckboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 // @public
 export const Chip: FunctionComponent<PropsType<    {
@@ -781,11 +783,11 @@ l: string;
 view: {
 default: string;
 };
-}> & ((Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "type" | "target" | "size" | "value" | "checked" | "maxLength" | "minLength"> & CustomComboboxProps & {
+}> & ((Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "type" | "target" | "size" | "value" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
 valueType?: "single" | undefined;
 value?: ComboboxPrimitiveValue | undefined;
 onChangeValue?: ((value?: ComboboxPrimitiveValue | undefined) => void) | undefined;
-} & RefAttributes<HTMLInputElement>) | (Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "type" | "target" | "size" | "value" | "checked" | "maxLength" | "minLength"> & CustomComboboxProps & {
+} & RefAttributes<HTMLInputElement>) | (Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "type" | "target" | "size" | "value" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
 valueType: "multiple";
 value?: ComboboxPrimitiveValue[] | undefined;
 onChangeValue?: ((value?: ComboboxPrimitiveValue[] | undefined) => void) | undefined;
@@ -1484,12 +1486,12 @@ true: string;
 focused: {
 true: string;
 };
-}> & Filter<InputHTMLAttributes<HTMLInputElement>, "size"> & Omit<BaseboxProps, "indeterminate"> & RefAttributes<HTMLInputElement>>;
+}> & Filter<InputHTMLAttributes_2<HTMLInputElement>, "size"> & Omit<BaseboxProps, "indeterminate"> & RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "RadioboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type RadioboxProps = typeof RadioboxComponent;
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 
 export { RadioGroup }
 

--- a/packages/plasma-b2c/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plasma-b2c/src/components/Checkbox/Checkbox.tsx
@@ -1,11 +1,12 @@
 import { checkboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Checkbox.config';
 
 const mergedConfig = mergeConfig(checkboxConfig, config);
 const CheckboxComponent = component(mergedConfig);
 
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 /**
  * Флажок или чекбокс. Позволяет пользователю управлять параметром с двумя состояниями — ☑ включено и ☐ отключено.

--- a/packages/plasma-b2c/src/components/Radiobox/Radiobox.ts
+++ b/packages/plasma-b2c/src/components/Radiobox/Radiobox.ts
@@ -1,12 +1,12 @@
 import { radioboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Radiobox.config';
 
 const mergedConfig = mergeConfig(radioboxConfig, config);
 const RadioboxComponent = component(mergedConfig);
 
-export type RadioboxProps = typeof RadioboxComponent;
-
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 /**
  * Переключатель, или *радиокнопка*.
  */

--- a/packages/plasma-new-hope/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/plasma-new-hope/src/components/Checkbox/Checkbox.types.ts
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes } from 'react';
+import type { InputHTMLAttributes } from '../../types';
 
 export interface BaseboxProps {
     /**

--- a/packages/plasma-new-hope/src/components/Radiobox/Radiobox.tsx
+++ b/packages/plasma-new-hope/src/components/Radiobox/Radiobox.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useMemo } from 'react';
 import { safeUseId, extractTextFrom } from '@salutejs/plasma-core';
-import type { InputHTMLAttributes } from '@salutejs/plasma-core';
 
+import type { InputHTMLAttributes } from '../../types';
 import type { Filter, RootProps } from '../../engines/types';
 import {
     StyledContentWrapper,

--- a/packages/plasma-new-hope/src/mixins/applyDisabled.ts
+++ b/packages/plasma-new-hope/src/mixins/applyDisabled.ts
@@ -1,0 +1,33 @@
+import { css, InterpolationFunction } from 'styled-components';
+
+export interface DisabledProps {
+    /**
+     * Компонент неактивен
+     */
+    disabled?: boolean;
+}
+
+const disabledCss = css`
+    opacity: 0.4;
+    cursor: not-allowed;
+
+    /* stylelint-disable-next-line selector-nested-pattern */
+    &:hover,
+    &:active {
+        transform: none;
+    }
+`;
+
+/**
+ * Миксин неактивной кнопки
+ */
+export const applyDisabled: InterpolationFunction<DisabledProps & { $disabled?: boolean }> = ({
+    disabled,
+    $disabled,
+}) => css`
+    &:disabled {
+        ${disabledCss}
+    }
+
+    ${(disabled || $disabled) && disabledCss}
+`;

--- a/packages/plasma-new-hope/src/mixins/index.ts
+++ b/packages/plasma-new-hope/src/mixins/index.ts
@@ -8,3 +8,4 @@ export * from './addFocus';
 export * from './typography';
 export * from './applyRoundness';
 export * from './applySkeletonGradient';
+export * from './applyDisabled';

--- a/packages/plasma-new-hope/src/types/InputHTMLAttributes.ts
+++ b/packages/plasma-new-hope/src/types/InputHTMLAttributes.ts
@@ -1,0 +1,56 @@
+// INFO: Issue об этом решении - https://github.com/salute-developers/plasma/issues/1219
+
+import React from 'react';
+
+import { DisabledProps } from '../mixins';
+
+export interface InputHTMLAttributes<T> extends DisabledProps, React.InputHTMLAttributes<T> {
+    /**
+     * Тип элемента формы
+     */
+    type?: string;
+    /**
+     * Определяет уникальное имя элемента формы
+     */
+    name?: string;
+    /**
+     * Определяет значение элемента формы
+     */
+    value?: string | ReadonlyArray<string> | number;
+    /**
+     * Помечен ли заранее такой элемент формы, как флажок или переключатель
+     */
+    checked?: boolean;
+    /**
+     * Элемент формы не может изменяться пользователем
+     */
+    readOnly?: boolean;
+    /**
+     * Выводит текст внутри поля формы, который исчезает при получении фокуса
+     */
+    placeholder?: string;
+    /**
+     * Флаг обязательности поля
+     */
+    required?: boolean;
+    /**
+     * Минимальная длина значения поля
+     */
+    minLength?: number;
+    /**
+     * Максимальная длина значения поля
+     */
+    maxLength?: number;
+    /**
+     * Обработчик изменения элемента формы
+     */
+    onChange?: React.InputHTMLAttributes<T>['onChange'];
+    /**
+     * Обработчик фокуса на элементе формы
+     */
+    onFocus?: React.InputHTMLAttributes<T>['onFocus'];
+    /**
+     * Обработчик блюра на элементе формы
+     */
+    onBlur?: React.InputHTMLAttributes<T>['onBlur'];
+}

--- a/packages/plasma-new-hope/src/types/index.ts
+++ b/packages/plasma-new-hope/src/types/index.ts
@@ -1,2 +1,3 @@
 export type { AsProps } from './AsProps';
 export type { NumericRange, CreateArrayWithLengthX } from './Range';
+export type { InputHTMLAttributes } from './InputHTMLAttributes';

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -85,6 +85,7 @@ import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ComboboxPrimitiveValue } from '@salutejs/plasma-new-hope/styled-components';
 import { ComboboxProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ComponentClass } from 'react';
+import { ComponentProps } from 'react';
 import { GridProps as ContainerProps } from '@salutejs/plasma-new-hope/styled-components';
 import { convertRoundnessMatrix } from '@salutejs/plasma-core';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -127,6 +128,7 @@ import { ImageProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-core';
+import { InputHTMLAttributes as InputHTMLAttributes_2 } from '@salutejs/plasma-new-hope/types/types';
 import { JSXElementConstructor } from 'react';
 import { LineSkeletonProps } from '@salutejs/plasma-new-hope/styled-components';
 import { LinkCustomProps } from '@salutejs/plasma-new-hope/types/components/Link/Link';
@@ -725,7 +727,7 @@ true: string;
 // Warning: (ae-forgotten-export) The symbol "CheckboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 // @public
 export const Chip: FunctionComponent<PropsType<    {
@@ -782,11 +784,11 @@ l: string;
 view: {
 default: string;
 };
-}> & ((Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "type" | "target" | "size" | "value" | "checked" | "maxLength" | "minLength"> & CustomComboboxProps & {
+}> & ((Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "type" | "target" | "size" | "value" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
 valueType?: "single" | undefined;
 value?: ComboboxPrimitiveValue | undefined;
 onChangeValue?: ((value?: ComboboxPrimitiveValue | undefined) => void) | undefined;
-} & RefAttributes<HTMLInputElement>) | (Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "type" | "target" | "size" | "value" | "checked" | "maxLength" | "minLength"> & CustomComboboxProps & {
+} & RefAttributes<HTMLInputElement>) | (Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "type" | "target" | "size" | "value" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
 valueType: "multiple";
 value?: ComboboxPrimitiveValue[] | undefined;
 onChangeValue?: ((value?: ComboboxPrimitiveValue[] | undefined) => void) | undefined;
@@ -1486,12 +1488,12 @@ true: string;
 focused: {
 true: string;
 };
-}> & Filter<InputHTMLAttributes<HTMLInputElement>, "size"> & Omit<BaseboxProps, "indeterminate"> & RefAttributes<HTMLInputElement>>;
+}> & Filter<InputHTMLAttributes_2<HTMLInputElement>, "size"> & Omit<BaseboxProps, "indeterminate"> & RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "RadioboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type RadioboxProps = typeof RadioboxComponent;
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 
 export { RadioGroup }
 

--- a/packages/plasma-web/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plasma-web/src/components/Checkbox/Checkbox.tsx
@@ -1,11 +1,12 @@
 import { checkboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Checkbox.config';
 
 const mergedConfig = mergeConfig(checkboxConfig, config);
 const CheckboxComponent = component(mergedConfig);
 
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 /**
  * Флажок или чекбокс. Позволяет пользователю управлять параметром с двумя состояниями — ☑ включено и ☐ отключено.

--- a/packages/plasma-web/src/components/Radiobox/Radiobox.ts
+++ b/packages/plasma-web/src/components/Radiobox/Radiobox.ts
@@ -1,12 +1,12 @@
 import { radioboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Radiobox.config';
 
 const mergedConfig = mergeConfig(radioboxConfig, config);
 const RadioboxComponent = component(mergedConfig);
 
-export type RadioboxProps = typeof RadioboxComponent;
-
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 /**
  * Переключатель, или *радиокнопка*.
  */

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -13,7 +13,7 @@ import { AsProps } from '@salutejs/plasma-new-hope/types/types';
 import { AvatarGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { AvatarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { BadgeProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
 import { BaseCallbackChangeInstance } from '@salutejs/plasma-new-hope/types/components/Range/Range.types';
 import { BaseCallbackKeyboardInstance } from '@salutejs/plasma-new-hope/types/components/Range/Range.types';
 import { bodyL } from '@salutejs/sdds-themes/tokens';
@@ -36,6 +36,7 @@ import { CellTextboxLabel } from '@salutejs/plasma-new-hope/styled-components';
 import { CellTextboxSubtitle } from '@salutejs/plasma-new-hope/styled-components';
 import { CellTextboxTitle } from '@salutejs/plasma-new-hope/styled-components';
 import { ChangeEvent } from 'react';
+import { CheckboxProps as CheckboxProps_2 } from '@salutejs/plasma-new-hope/types/components/Checkbox/Checkbox.types';
 import { ChipProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ClosePlacementType } from '@salutejs/plasma-new-hope/styled-components';
 import { Col } from '@salutejs/plasma-new-hope/styled-components';
@@ -45,6 +46,7 @@ import { ColProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ComboboxProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ComponentClass } from 'react';
+import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { counterTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { CustomPopoverProps } from '@salutejs/plasma-new-hope/types/components/Popover/Popover.types';
@@ -82,7 +84,8 @@ import { HTMLAttributes } from 'react';
 import { ImageProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
-import { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/types/types';
+import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LinkCustomProps } from '@salutejs/plasma-new-hope/types/components/Link/Link';
@@ -440,12 +443,33 @@ export { CellTextboxSubtitle }
 export { CellTextboxTitle }
 
 // @public
-export const Checkbox: FunctionComponent<BaseboxProps>;
+export const Checkbox: FunctionComponent<PropsType<    {
+size: {
+s: string;
+m: string;
+};
+view: {
+default: string;
+secondary: string;
+tertiary: string;
+paragraph: string;
+accent: string;
+positive: string;
+warning: string;
+negative: string;
+};
+disabled: {
+true: string;
+};
+focused: {
+true: string;
+};
+}> & CheckboxProps_2 & RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "CheckboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 // @public
 export const Chip: FunctionComponent<PropsType<    {
@@ -944,12 +968,33 @@ m: string;
 export { ProgressProps }
 
 // @public
-export const Radiobox: FunctionComponent<Omit<BaseboxProps, "indeterminate">>;
+export const Radiobox: FunctionComponent<PropsType<    {
+size: {
+s: string;
+m: string;
+};
+view: {
+default: string;
+secondary: string;
+tertiary: string;
+paragraph: string;
+accent: string;
+positive: string;
+warning: string;
+negative: string;
+};
+disabled: {
+true: string;
+};
+focused: {
+true: string;
+};
+}> & Filter<InputHTMLAttributes<HTMLInputElement>, "size"> & Omit<BaseboxProps, "indeterminate"> & RefAttributes<HTMLInputElement>>;
 
 // Warning: (ae-forgotten-export) The symbol "RadioboxComponent" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export type RadioboxProps = typeof RadioboxComponent;
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 
 export { RadioGroup }
 
@@ -1277,7 +1322,7 @@ true: string;
 focused: {
 true: string;
 };
-}> & Filter<InputHTMLAttributes<HTMLInputElement>, "size"> & SwitchPropsVariations & RefAttributes<HTMLInputElement>>;
+}> & Filter<InputHTMLAttributes_2<HTMLInputElement>, "size"> & SwitchPropsVariations & RefAttributes<HTMLInputElement>>;
 
 // @public (undocumented)
 export type SwitchProps = {
@@ -1291,7 +1336,7 @@ export type SwitchProps = {
     pressed?: boolean;
     focused?: boolean;
     outlined?: boolean;
-} & FocusProps & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'onChange' | 'onFocus' | 'onBlur'> & Pick<InputHTMLAttributes<HTMLInputElement>, 'name' | 'value' | 'checked' | 'disabled' | 'readOnly' | 'onChange' | 'onFocus' | 'onBlur'>;
+} & FocusProps & Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'onChange' | 'onFocus' | 'onBlur'> & Pick<InputHTMLAttributes_2<HTMLInputElement>, 'name' | 'value' | 'checked' | 'disabled' | 'readOnly' | 'onChange' | 'onFocus' | 'onBlur'>;
 
 // @public
 export const TabItem: FunctionComponent<PropsType<    {
@@ -1390,7 +1435,7 @@ chips?: undefined;
 onChangeChips?: undefined;
 enumerationType?: "plain" | undefined;
 onSearch?: ((value: string, event?: KeyboardEvent_2<HTMLInputElement> | undefined) => void) | undefined;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, "size"> & RefAttributes<HTMLInputElement>) | ({
+} & Omit<InputHTMLAttributes_2<HTMLInputElement>, "size"> & RefAttributes<HTMLInputElement>) | ({
 size?: string | undefined;
 view?: string | undefined;
 readOnly?: boolean | undefined;
@@ -1409,7 +1454,7 @@ enumerationType: "chip";
 onSearch?: undefined;
 chips?: TextFieldPrimitiveValue[] | undefined;
 onChangeChips?: ((value: TextFieldPrimitiveValue[]) => void) | undefined;
-} & Omit<InputHTMLAttributes<HTMLInputElement>, "size"> & RefAttributes<HTMLInputElement>))>;
+} & Omit<InputHTMLAttributes_2<HTMLInputElement>, "size"> & RefAttributes<HTMLInputElement>))>;
 
 export { TextFieldProps }
 

--- a/packages/sdds-serv/src/components/Checkbox/Checkbox.tsx
+++ b/packages/sdds-serv/src/components/Checkbox/Checkbox.tsx
@@ -1,12 +1,12 @@
 import { checkboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Checkbox.config';
 
 const mergedConfig = mergeConfig(checkboxConfig, config);
-const CheckboxComponent = component(mergedConfig) as React.FunctionComponent<BaseboxProps>;
+const CheckboxComponent = component(mergedConfig);
 
-export type CheckboxProps = typeof CheckboxComponent;
+export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
 /**
  * Флажок или чекбокс. Позволяет пользователю управлять параметром с двумя состояниями — ☑ включено и ☐ отключено.

--- a/packages/sdds-serv/src/components/Radiobox/Radiobox.ts
+++ b/packages/sdds-serv/src/components/Radiobox/Radiobox.ts
@@ -1,13 +1,12 @@
 import { radioboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
-import type { BaseboxProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ComponentProps } from 'react';
 
 import { config } from './Radiobox.config';
 
 const mergedConfig = mergeConfig(radioboxConfig, config);
-const RadioboxComponent = component(mergedConfig) as React.FunctionComponent<Omit<BaseboxProps, 'indeterminate'>>;
+const RadioboxComponent = component(mergedConfig);
 
-export type RadioboxProps = typeof RadioboxComponent;
-
+export type RadioboxProps = ComponentProps<typeof RadioboxComponent>;
 /**
  * Переключатель, или *радиокнопка*.
  */


### PR DESCRIPTION
Поправил типы в checkbox для библиотек plasma-asdk, sdds-serv и caldera-online  

### What/why changed

Убрал принудительно поставленный тип в этих библиотеках. Теперь код аналогичен web и b2c

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.46.1-canary.1217.9271710675.0
  npm install @salutejs/plasma-asdk@0.84.1-canary.1217.9271710675.0
  npm install @salutejs/plasma-b2c@1.326.1-canary.1217.9271710675.0
  npm install @salutejs/plasma-new-hope@0.86.1-canary.1217.9271710675.0
  npm install @salutejs/plasma-web@1.327.1-canary.1217.9271710675.0
  npm install @salutejs/sdds-serv@0.54.1-canary.1217.9271710675.0
  # or 
  yarn add @salutejs/caldera-online@0.46.1-canary.1217.9271710675.0
  yarn add @salutejs/plasma-asdk@0.84.1-canary.1217.9271710675.0
  yarn add @salutejs/plasma-b2c@1.326.1-canary.1217.9271710675.0
  yarn add @salutejs/plasma-new-hope@0.86.1-canary.1217.9271710675.0
  yarn add @salutejs/plasma-web@1.327.1-canary.1217.9271710675.0
  yarn add @salutejs/sdds-serv@0.54.1-canary.1217.9271710675.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
