### PR TITLE
feat(plasma-new-hope): fix tabs styles

### DIFF
--- a/packages/plasma-new-hope/src/components/Segment/Segment.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Segment/Segment.template-doc.mdx
@@ -53,9 +53,11 @@ export function App() {
     }
 
     return (
-        <SegmentProvider>
-            <SegmentTemplate/>
-        </SegmentProvider>
+        <div style={{ display: "block" }} >
+            <SegmentProvider>
+                <SegmentTemplate/>
+            </SegmentProvider>
+        </div>
     );
 }
 ```

--- a/packages/plasma-new-hope/src/components/Tabs/Tabs.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Tabs/Tabs.template-doc.mdx
@@ -39,21 +39,23 @@ export function App() {
     const [index, setIndex] = useState(0);
 
     return (
-        <Tabs view="filled" stretch size="xs">
-            {items.map((_, i) => (
-                <TabItem
-                    view="secondary"
-                    key={`item:${i}`}
-                    size="xs"
-                    selected={i === index}
-                    tabIndex={0}
-                    contentLeft={<IconClock size="xs" color="inherit" />}
-                    onClick={() => setIndex(i)}
-                >
-                    Label
-                </TabItem>
-            ))}
-        </Tabs>
+        <div>
+            <Tabs view="filled" stretch size="xs">
+                {items.map((_, i) => (
+                    <TabItem
+                        view="secondary"
+                        key={`item:${i}`}
+                        size="xs"
+                        selected={i === index}
+                        tabIndex={0}
+                        contentLeft={<IconClock size="xs" color="inherit" />}
+                        onClick={() => setIndex(i)}
+                    >
+                        Label
+                    </TabItem>
+                ))}
+            </Tabs>
+        </div>
     );
 }
 ```
@@ -72,23 +74,25 @@ export function App() {
     const [index, setIndex] = useState(0);
 
     return (
-        <Tabs view="filled" stretch size="xs" index={index}>
-            {items.map((_, i) => (
-                <TabItem
-                    view="secondary"
-                    key={`item:${i}`}
-                    size="xs"
-                    itemIndex={i}
-                    onIndexChange={(i) => setIndex(i)}
-                    selected={i === index}
-                    tabIndex={0}
-                    contentLeft={<IconClock size="xs" color="inherit" />}
-                    onClick={() => setIndex(i)}
-                >
-                    Label
-                </TabItem>
-            ))}
-        </Tabs>
+        <div>
+            <Tabs view="filled" stretch size="xs" index={index}>
+                {items.map((_, i) => (
+                    <TabItem
+                        view="secondary"
+                        key={`item:${i}`}
+                        size="xs"
+                        itemIndex={i}
+                        onIndexChange={(i) => setIndex(i)}
+                        selected={i === index}
+                        tabIndex={0}
+                        contentLeft={<IconClock size="xs" color="inherit" />}
+                        onClick={() => setIndex(i)}
+                    >
+                        Label
+                    </TabItem>
+                ))}
+            </Tabs>
+        </div>
     );
 }
 ```

--- a/packages/plasma-new-hope/src/components/Tabs/ui/TabItem/TabItem.tsx
+++ b/packages/plasma-new-hope/src/components/Tabs/ui/TabItem/TabItem.tsx
@@ -29,6 +29,7 @@ export const tabItemRoot = (Root: RootProps<HTMLDivElement, TabItemProps>) =>
             onIndexChange,
             itemIndex,
             tabIndex,
+            className,
             ...rest
         } = props;
 
@@ -57,10 +58,10 @@ export const tabItemRoot = (Root: RootProps<HTMLDivElement, TabItemProps>) =>
 
         const onItemFocus = useCallback<React.FocusEventHandler>(
             (event) => {
-                if (!hasKeyNavigation) {
-                    event.target.scrollIntoView({
-                        block: 'center',
-                        inline: 'center',
+                if (!hasKeyNavigation && innerRef?.current) {
+                    innerRef.current.scrollTo({
+                        top: 0,
+                        left: innerRef.current.offsetLeft,
                         behavior: 'smooth',
                     });
 
@@ -93,7 +94,7 @@ export const tabItemRoot = (Root: RootProps<HTMLDivElement, TabItemProps>) =>
                 size={size}
                 onFocus={onItemFocus}
                 tabIndex={hasKeyNavigation ? navigationTabIndex : tabIndex}
-                className={cx(pilledClass, selectedClass, animatedClass)}
+                className={cx(pilledClass, selectedClass, animatedClass, className)}
                 {...rest}
             >
                 <>

--- a/packages/plasma-new-hope/src/components/Tabs/ui/Tabs/Tabs.styles.ts
+++ b/packages/plasma-new-hope/src/components/Tabs/ui/Tabs/Tabs.styles.ts
@@ -21,6 +21,7 @@ export const StyledContentWrapper = styled.div`
     margin: -0.125rem;
     padding: 0.25rem;
 
+    box-sizing: content-box;
     overflow: scroll;
     position: relative;
     height: 100%;
@@ -28,6 +29,7 @@ export const StyledContentWrapper = styled.div`
     display: flex;
     align-items: center;
 
+    scrollbar-width: none;
     ::-webkit-scrollbar {
         display: none;
     }

--- a/packages/plasma-new-hope/src/components/Tabs/ui/Tabs/Tabs.tsx
+++ b/packages/plasma-new-hope/src/components/Tabs/ui/Tabs/Tabs.tsx
@@ -25,7 +25,18 @@ enum Keys {
 
 export const tabsRoot = (Root: RootProps<HTMLDivElement, TabsProps>) =>
     forwardRef<HTMLDivElement, TabsProps>((props, outerRef) => {
-        const { id, stretch = false, disabled = false, size, view, children, pilled, index, ...rest } = props;
+        const {
+            id,
+            stretch = false,
+            disabled = false,
+            size,
+            view,
+            children,
+            pilled,
+            index,
+            className,
+            ...rest
+        } = props;
 
         const [firstItemVisible, setFirstItemVisible] = useState(true);
         const [lastItemVisible, setLastItemVisible] = useState(true);
@@ -156,7 +167,7 @@ export const tabsRoot = (Root: RootProps<HTMLDivElement, TabsProps>) =>
                     id={tabsId}
                     ref={outerRef}
                     disabled={disabled}
-                    className={cx(pilledClass, stretchClass, hasLeftArrowClass, hasRightArrowClass)}
+                    className={cx(pilledClass, stretchClass, hasLeftArrowClass, hasRightArrowClass, className)}
                     onKeyDown={onKeyDown}
                     {...rest}
                 >

--- a/website/plasma-web-docs/docs/components/Segment.mdx
+++ b/website/plasma-web-docs/docs/components/Segment.mdx
@@ -55,9 +55,11 @@ export function App() {
     }
 
     return (
-        <SegmentProvider>
-            <SegmentTemplate/>
-        </SegmentProvider>
+        <div style={{ display: "block" }} >
+            <SegmentProvider>
+                <SegmentTemplate/>
+            </SegmentProvider>
+        </div>
     );
 }
 ```

--- a/website/plasma-web-docs/docs/components/Tabs.mdx
+++ b/website/plasma-web-docs/docs/components/Tabs.mdx
@@ -41,21 +41,23 @@ export function App() {
     const [index, setIndex] = useState(0);
 
     return (
-        <Tabs view="filled" stretch size="xs">
-            {items.map((_, i) => (
-                <TabItem
-                    view="secondary"
-                    key={`item:${i}`}
-                    size="xs"
-                    selected={i === index}
-                    tabIndex={0}
-                    contentLeft={<IconClock size="xs" color="inherit" />}
-                    onClick={() => setIndex(i)}
-                >
-                    Label
-                </TabItem>
-            ))}
-        </Tabs>
+        <div>
+            <Tabs view="filled" stretch size="xs">
+                {items.map((_, i) => (
+                    <TabItem
+                        view="secondary"
+                        key={`item:${i}`}
+                        size="xs"
+                        selected={i === index}
+                        tabIndex={0}
+                        contentLeft={<IconClock size="xs" color="inherit" />}
+                        onClick={() => setIndex(i)}
+                    >
+                        Label
+                    </TabItem>
+                ))}
+            </Tabs>
+        </div>
     );
 }
 ```
@@ -74,23 +76,25 @@ export function App() {
     const [index, setIndex] = useState(0);
 
     return (
-        <Tabs view="filled" stretch size="xs" index={index}>
-            {items.map((_, i) => (
-                <TabItem
-                    view="secondary"
-                    key={`item:${i}`}
-                    size="xs"
-                    itemIndex={i}
-                    onIndexChange={(i) => setIndex(i)}
-                    selected={i === index}
-                    tabIndex={0}
-                    contentLeft={<IconClock size="xs" color="inherit" />}
-                    onClick={() => setIndex(i)}
-                >
-                    Label
-                </TabItem>
-            ))}
-        </Tabs>
+        <div>
+            <Tabs view="filled" stretch size="xs" index={index}>
+                {items.map((_, i) => (
+                    <TabItem
+                        view="secondary"
+                        key={`item:${i}`}
+                        size="xs"
+                        itemIndex={i}
+                        onIndexChange={(i) => setIndex(i)}
+                        selected={i === index}
+                        tabIndex={0}
+                        contentLeft={<IconClock size="xs" color="inherit" />}
+                        onClick={() => setIndex(i)}
+                    >
+                        Label
+                    </TabItem>
+                ))}
+            </Tabs>
+        </div>
     );
 }
 ```

--- a/website/sdds-serv-docs/docs/components/Segment.mdx
+++ b/website/sdds-serv-docs/docs/components/Segment.mdx
@@ -53,9 +53,11 @@ export function App() {
     }
 
     return (
-        <SegmentProvider>
-            <SegmentTemplate/>
-        </SegmentProvider>
+        <div style={{ display: "block" }} >
+            <SegmentProvider>
+                <SegmentTemplate/>
+            </SegmentProvider>
+        </div>
     );
 }
 ```

--- a/website/sdds-serv-docs/docs/components/Tabs.mdx
+++ b/website/sdds-serv-docs/docs/components/Tabs.mdx
@@ -39,21 +39,23 @@ export function App() {
     const [index, setIndex] = useState(0);
 
     return (
-        <Tabs view="filled" stretch size="xs">
-            {items.map((_, i) => (
-                <TabItem
-                    view="secondary"
-                    key={`item:${i}`}
-                    size="xs"
-                    selected={i === index}
-                    tabIndex={0}
-                    contentLeft={<IconClock size="xs" color="inherit" />}
-                    onClick={() => setIndex(i)}
-                >
-                    Label
-                </TabItem>
-            ))}
-        </Tabs>
+        <div>
+            <Tabs view="filled" stretch size="xs">
+                {items.map((_, i) => (
+                    <TabItem
+                        view="secondary"
+                        key={`item:${i}`}
+                        size="xs"
+                        selected={i === index}
+                        tabIndex={0}
+                        contentLeft={<IconClock size="xs" color="inherit" />}
+                        onClick={() => setIndex(i)}
+                    >
+                        Label
+                    </TabItem>
+                ))}
+            </Tabs>
+        </div>
     );
 }
 ```
@@ -72,23 +74,25 @@ export function App() {
     const [index, setIndex] = useState(0);
 
     return (
-        <Tabs view="filled" stretch size="xs" index={index}>
-            {items.map((_, i) => (
-                <TabItem
-                    view="secondary"
-                    key={`item:${i}`}
-                    size="xs"
-                    itemIndex={i}
-                    onIndexChange={(i) => setIndex(i)}
-                    selected={i === index}
-                    tabIndex={0}
-                    contentLeft={<IconClock size="xs" color="inherit" />}
-                    onClick={() => setIndex(i)}
-                >
-                    Label
-                </TabItem>
-            ))}
-        </Tabs>
+        <div>
+            <Tabs view="filled" stretch size="xs" index={index}>
+                {items.map((_, i) => (
+                    <TabItem
+                        view="secondary"
+                        key={`item:${i}`}
+                        size="xs"
+                        itemIndex={i}
+                        onIndexChange={(i) => setIndex(i)}
+                        selected={i === index}
+                        tabIndex={0}
+                        contentLeft={<IconClock size="xs" color="inherit" />}
+                        onClick={() => setIndex(i)}
+                    >
+                        Label
+                    </TabItem>
+                ))}
+            </Tabs>
+        </div>
     );
 }
 ```


### PR DESCRIPTION
### Tabs

- добавлен корректный проброс className в Tab и TabItem
- поправлена документация для Tab и Segment

ДО:
![image](https://github.com/salute-developers/plasma/assets/40370966/797f897d-95cc-4114-b54a-8629b281b2c7)
![image](https://github.com/salute-developers/plasma/assets/40370966/8a0e6de3-f6cd-4e7b-b87b-a1a26b5dd4e7)

ПОСЛЕ:
![image](https://github.com/salute-developers/plasma/assets/40370966/9dd690cc-e8ed-4623-baa0-52e1f22cf71c)
![image](https://github.com/salute-developers/plasma/assets/40370966/0c8bb69e-b2d3-4ae9-aed4-2fd4c4b5bd9b)

### What/why changed

В Tab и TabItem некорректно пробрасывался className, поэтому нельзя было оборачивать компонент в styled. Помимо этого в документации некорректно визуально отображались табы и сегменты

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.46.0-canary.1220.9266427683.0
  npm install @salutejs/plasma-asdk@0.84.0-canary.1220.9266427683.0
  npm install @salutejs/plasma-b2c@1.326.0-canary.1220.9266427683.0
  npm install @salutejs/plasma-new-hope@0.86.0-canary.1220.9266427683.0
  npm install @salutejs/plasma-web@1.327.0-canary.1220.9266427683.0
  npm install @salutejs/sdds-serv@0.54.0-canary.1220.9266427683.0
  # or 
  yarn add @salutejs/caldera-online@0.46.0-canary.1220.9266427683.0
  yarn add @salutejs/plasma-asdk@0.84.0-canary.1220.9266427683.0
  yarn add @salutejs/plasma-b2c@1.326.0-canary.1220.9266427683.0
  yarn add @salutejs/plasma-new-hope@0.86.0-canary.1220.9266427683.0
  yarn add @salutejs/plasma-web@1.327.0-canary.1220.9266427683.0
  yarn add @salutejs/sdds-serv@0.54.0-canary.1220.9266427683.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
