### PR TITLE
plasma-icons: Replace stroke value to "currentColor"

### DIFF
--- a/packages/plasma-icons/scripts/utils.ts
+++ b/packages/plasma-icons/scripts/utils.ts
@@ -10,6 +10,8 @@ const removeFillOpacity = (source: string) => source.replace(/fill-opacity="(.*?
 
 const setFillCurrentColor = (source: string) => source.replace(/fill="(.*?)"/gm, 'fill="currentColor"');
 
+const setStrokeCurrentColor = (source: string) => source.replace(/stroke="(.*?)"/gm, 'stroke="currentColor"');
+
 const convertCSSProperty = (source: string) =>
     source.replace(
         /([a-zA-Z-]*):(.*)/g,
@@ -33,6 +35,7 @@ export const getIconAsset = (source: string, iconName: string) => {
         removeLineBreak,
         getSvgContent,
         setFillCurrentColor,
+        setStrokeCurrentColor,
         removeFillOpacity,
         convertInlineStyleToObject,
         camelizeAttributes,


### PR DESCRIPTION
### Stroke

- заменили значение свойства `stroke` на `currentColor`

#### Before

<img width="1919" alt="Screenshot 2024-06-03 at 18 35 35" src="https://github.com/salute-developers/plasma/assets/2895992/85e34f50-5ed6-4d92-93b9-f430f36d5b2d">


#### After

<img width="1909" alt="Screenshot 2024-06-03 at 18 33 57" src="https://github.com/salute-developers/plasma/assets/2895992/ec5e440e-bd71-474a-b971-883f83b7bf9c">

### What/why changed

Цвет для свойства `stroke` не наследовался, потому что значение были константой (захардкожены внутри самого svg). Теперь используем `currentColor` чтобы была возможность управлять цветом из вне.  

#### codesandbox

https://codesandbox.io/p/sandbox/plasma-web-example-forked-6w8vvp?file=%2Fpackage.json%3A3%2C64


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.85.1-canary.1226.9349089565.0
  npm install @salutejs/plasma-b2c@1.327.1-canary.1226.9349089565.0
  npm install @salutejs/plasma-hope@1.280.1-canary.1226.9349089565.0
  npm install @salutejs/plasma-icons@1.193.1-canary.1226.9349089565.0
  npm install @salutejs/plasma-ui@1.249.1-canary.1226.9349089565.0
  npm install @salutejs/plasma-web@1.328.1-canary.1226.9349089565.0
  npm install @salutejs/sdds-serv@0.55.1-canary.1226.9349089565.0
  # or 
  yarn add @salutejs/plasma-asdk@0.85.1-canary.1226.9349089565.0
  yarn add @salutejs/plasma-b2c@1.327.1-canary.1226.9349089565.0
  yarn add @salutejs/plasma-hope@1.280.1-canary.1226.9349089565.0
  yarn add @salutejs/plasma-icons@1.193.1-canary.1226.9349089565.0
  yarn add @salutejs/plasma-ui@1.249.1-canary.1226.9349089565.0
  yarn add @salutejs/plasma-web@1.328.1-canary.1226.9349089565.0
  yarn add @salutejs/sdds-serv@0.55.1-canary.1226.9349089565.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
