### PR TITLE
plasma-infra: Cypress checks on release branch

### DIFF
--- a/.github/workflows/cypress-release-branch.yml
+++ b/.github/workflows/cypress-release-branch.yml
@@ -1,0 +1,40 @@
+# Run cypress tests in release branch without conditions for all packages
+name: Cypress component testing on release branch
+
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  # New commit on branch cancels running workflows of the same branch
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  cypress:
+    if: ${{ startsWith(github.head_ref, 'release') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: [web,b2c,ui]
+    
+    uses: ./.github/workflows/cypress-common.yml
+    with:
+      scope: ${{ matrix.scope }}
+      with-artifacts: true
+    secrets: inherit
+  
+  cypress-react-17:
+    if: ${{ startsWith(github.head_ref, 'release') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: [web,b2c,ui]
+    
+    uses: ./.github/workflows/cypress-common.yml
+    with:
+      scope: ${{ matrix.scope }}
+      with-react-17: true
+      with-artifacts: true
+    secrets: inherit

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -13,6 +13,8 @@ concurrency:
 
 jobs:
   state:
+    # cypress checks for "release branch" run in cypress-release-branch.yml file
+    if: ${{ !startsWith(github.head_ref, 'release') }}
     uses: ./.github/workflows/change-detection.yml
     secrets: inherit
 


### PR DESCRIPTION
### Cypress

- запуск `workflow` **только** в релизной ветки и без условий ( для всех библиотек ) 

### What/why changed

Один из шагов автоматизации регресса.  
