### PR TITLE
plasma-icons: handle all icons size [Android]

### DIFF
--- a/packages/plasma-icons/scripts/generateAndroidArchive.ts
+++ b/packages/plasma-icons/scripts/generateAndroidArchive.ts
@@ -2,12 +2,15 @@ import fs from 'fs';
 import path from 'path';
 import svg2vectordrawable from 'svg2vectordrawable';
 
-const sourceDirectory = `./src/scalable/Icon.svg.24`;
+const sourceDirectorySVG16 = `./src/scalable/Icon.svg.16`;
+const sourceDirectorySVG24 = `./src/scalable/Icon.svg.24`;
+const sourceDirectorySVG36 = `./src/scalable/Icon.svg.36`;
+
 const androidIconsDirectory = `./android-icons`;
 
 const destinations = [androidIconsDirectory];
 
-const files = fs.readdirSync(sourceDirectory);
+const files = fs.readdirSync(sourceDirectorySVG24);
 
 // Создаем директории, если нет
 destinations.forEach((destination) => {
@@ -16,8 +19,6 @@ destinations.forEach((destination) => {
     }
 });
 
-const names: Array<string> = [];
-
 const camelToSnakeCase = (str: string) => str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 
 const options = {
@@ -25,25 +26,30 @@ const options = {
     fillBlack: true, // заполняем черным
 };
 
+const getPath = (dir: string, name: string, size: string) => {
+    // INFO: по соглашению имя файла в camel_case
+    return path.join(dir, `ic${camelToSnakeCase(name)}_${size}.xml`);
+};
+
 files.forEach((file) => {
-    const sourceFilePath = path.join(sourceDirectory, file);
     const extension = path.extname(file);
 
     if (extension !== '.svg') {
         return;
     }
 
-    const data = fs.readFileSync(sourceFilePath, 'utf8');
-
-    const componentName = path.parse(file).name;
-    names.push(componentName);
-
-    const getPath = (dir: string, name: string) => {
-        return path.join(dir, `ic${camelToSnakeCase(name)}_24.xml`); // по соглашению имя файла в camel_case
+    const data = {
+        16: fs.readFileSync(path.join(sourceDirectorySVG16, file), 'utf8'),
+        24: fs.readFileSync(path.join(sourceDirectorySVG24, file), 'utf8'),
+        36: fs.readFileSync(path.join(sourceDirectorySVG36, file), 'utf8'),
     };
 
-    // генерируем xml файлы
-    svg2vectordrawable(data, options).then((xmlCode: string) => {
-        fs.writeFileSync(getPath(androidIconsDirectory, componentName), xmlCode, 'utf8');
+    const componentName = path.parse(file).name;
+
+    Object.entries(data).forEach(([size, data]) => {
+        // INFO: генерируем xml файлы
+        svg2vectordrawable(data, options).then((xmlCode: string) => {
+            fs.writeFileSync(getPath(androidIconsDirectory, componentName, size), xmlCode, 'utf8');
+        });
     });
 });


### PR DESCRIPTION
### Android

- добавлены `.xml` иконки для всех имеющихся размеров: 16, 24, 36

#### After

<img width="672" alt="Screenshot 2024-06-19 at 13 44 22" src="https://github.com/salute-developers/plasma/assets/2895992/878745f3-9f20-4224-826d-c0d898d1a94d" />

<img width="1920" alt="Screenshot 2024-06-19 at 13 46 09" src="https://github.com/salute-developers/plasma/assets/2895992/dca1102a-abbc-4a65-a628-f5acf40f80d8" />

### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.93.0-canary.1259.9613931890.0
  npm install @salutejs/plasma-b2c@1.335.0-canary.1259.9613931890.0
  npm install @salutejs/plasma-hope@1.285.0-canary.1259.9613931890.0
  npm install @salutejs/plasma-icons@1.198.0-canary.1259.9613931890.0
  npm install @salutejs/plasma-ui@1.255.0-canary.1259.9613931890.0
  npm install @salutejs/plasma-web@1.336.0-canary.1259.9613931890.0
  npm install @salutejs/sdds-serv@0.63.0-canary.1259.9613931890.0
  # or 
  yarn add @salutejs/plasma-asdk@0.93.0-canary.1259.9613931890.0
  yarn add @salutejs/plasma-b2c@1.335.0-canary.1259.9613931890.0
  yarn add @salutejs/plasma-hope@1.285.0-canary.1259.9613931890.0
  yarn add @salutejs/plasma-icons@1.198.0-canary.1259.9613931890.0
  yarn add @salutejs/plasma-ui@1.255.0-canary.1259.9613931890.0
  yarn add @salutejs/plasma-web@1.336.0-canary.1259.9613931890.0
  yarn add @salutejs/sdds-serv@0.63.0-canary.1259.9613931890.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
