### PR TITLE
feat(plasma-new-hope): Added prop 'portal' into Dropdown component

### DIFF
--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tsx
@@ -18,7 +18,7 @@ import { useHashMaps } from './hooks/useHashMaps';
 /**
  * Выпадающий список.
  */
-export const dropdownRoot = (Root: RootProps<HTMLDivElement, DropdownProps>) =>
+export const dropdownRoot = (Root: RootProps<HTMLDivElement, Omit<DropdownProps, 'items'>>) =>
     forwardRef<HTMLDivElement, DropdownProps>(
         (
             {
@@ -42,6 +42,7 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, DropdownProps>) =>
                 trigger = 'click',
                 variant = 'normal',
                 hasArrow = true,
+                portal,
                 ...rest
             },
             ref,
@@ -85,32 +86,26 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, DropdownProps>) =>
             };
 
             return (
-                <Root
-                    className={cx(className, classes.dropdownRoot)}
-                    ref={ref}
-                    view={view}
-                    size={size}
-                    items={items}
-                    {...rest}
+                <StyledPopover
+                    isOpen={isCurrentListOpen}
+                    onToggle={handleGlobalToggle}
+                    offset={offset}
+                    placement={getPlacements(placement)}
+                    trigger={trigger}
+                    closeOnOverlayClick={closeOnOverlayClick}
+                    isFocusTrapped={false}
+                    target={childrenWithProps(children, {
+                        role: 'combobox',
+                        'aria-controls': 'tree_level_1',
+                        'aria-expanded': isCurrentListOpen,
+                        'aria-activedescendant': getActiveDescendant(),
+                        onKeyDown,
+                    })}
+                    preventOverflow={false}
+                    usePortal={Boolean(portal)}
+                    frame={portal}
                 >
-                    <StyledPopover
-                        isOpen={isCurrentListOpen}
-                        usePortal={false}
-                        onToggle={handleGlobalToggle}
-                        offset={offset}
-                        placement={getPlacements(placement)}
-                        trigger={trigger}
-                        closeOnOverlayClick={closeOnOverlayClick}
-                        isFocusTrapped={false}
-                        target={childrenWithProps(children, {
-                            role: 'combobox',
-                            'aria-controls': 'tree_level_1',
-                            'aria-expanded': isCurrentListOpen,
-                            'aria-activedescendant': getActiveDescendant(),
-                            onKeyDown,
-                        })}
-                        preventOverflow={false}
-                    >
+                    <Root className={cx(className, classes.dropdownRoot)} ref={ref} view={view} size={size} {...rest}>
                         <Ul
                             listHeight={listHeight}
                             listOverflow={listOverflow}
@@ -142,8 +137,8 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, DropdownProps>) =>
                                 />
                             ))}
                         </Ul>
-                    </StyledPopover>
-                </Root>
+                    </Root>
+                </StyledPopover>
             );
         },
     );

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
@@ -76,6 +76,11 @@ export interface DropdownProps extends HTMLAttributes<HTMLDivElement> {
      */
     variant?: 'normal' | 'tight';
     /**
+     * Портал для выпадающего списка. Принимает id контейнера или ref.
+     */
+    portal?: string | React.RefObject<HTMLElement>;
+
+    /**
      * Обработчик клика по item.
      * @deprecated использовать onItemSelect.
      */

--- a/packages/plasma-new-hope/src/components/Popover/Popover.tsx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.tsx
@@ -111,8 +111,9 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
                     if (isOpen && closeOnOverlayClick && onToggle) {
                         const targetIsRoot = event.target === rootRef.current;
                         const rootHasTarget = rootRef.current?.contains(event.target as Element);
+                        const popoverRootHasTarget = popoverRef.current?.contains(event.target as Element);
 
-                        if (!targetIsRoot && !rootHasTarget) {
+                        if (!targetIsRoot && !rootHasTarget && !popoverRootHasTarget) {
                             onToggle(false, event);
                         }
                     }

--- a/website/plasma-web-docs/docs/components/Dropdown.mdx
+++ b/website/plasma-web-docs/docs/components/Dropdown.mdx
@@ -306,13 +306,65 @@ type Items = Array<{
                 },
             ];
 
-
             return (
                 <div style={{ height:"300px" }}>
                     <Dropdown
                         items={items}
                         trigger="hover"
                     >
+                        <Button text="Список стран" />
+                    </Dropdown>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+
+    <TabItem value="portal" label="Portal">
+        Иногда возникает необходимость вынесения выпадающего списка на уровни выше в DOM. К примеру, когда у родительского блока имеется скролл, и список будет обрезаться, чего хотелось бы избежать.\
+        Для такой реализации имеется пропс `portal`, который принимает либо `ref` либо `id` html-тега.
+
+        ```tsx live
+        import React, { useRef } from 'react';
+        import { Select } from '@salutejs/plasma-web';
+
+        export function App() {
+            const items = [
+                {
+                    value: 'north_america',
+                    label: 'Северная Америка',
+                },
+                {
+                    value: 'south_america',
+                    label: 'Южная Америка',
+                    items: [
+                        {
+                            value: 'brazil',
+                            label: 'Бразилия',
+                            items: [
+                                {
+                                    value: 'rio_de_janeiro',
+                                    label: 'Рио-де-Жанейро',
+                                },
+                                {
+                                    value: 'sao_paulo',
+                                    label: 'Сан-Паулу',
+                                },
+                            ],
+                        },
+                        {
+                            value: 'argentina',
+                            label: 'Аргентина',
+                        },
+                    ],
+                },
+            ];
+
+            const ref = useRef(null)
+
+            return (
+                <div style={{ height: '300px' }} ref={ref}>
+                    <Dropdown items={items} portal={ref}>
                         <Button text="Список стран" />
                     </Dropdown>
                 </div>

--- a/website/sdds-serv-docs/docs/components/Dropdown.mdx
+++ b/website/sdds-serv-docs/docs/components/Dropdown.mdx
@@ -318,6 +318,59 @@ type Items = Array<{
         }
         ```
     </TabItem>
+
+    <TabItem value="portal" label="Portal">
+        Иногда возникает необходимость вынесения выпадающего списка на уровни выше в DOM. К примеру, когда у родительского блока имеется скролл, и список будет обрезаться, чего хотелось бы избежать.\
+        Для такой реализации имеется пропс `portal`, который принимает либо `ref` либо `id` html-тега.
+
+        ```tsx live
+        import React, { useRef } from 'react';
+        import { Select } from '@salutejs/sdds-serv';
+
+        export function App() {
+            const items = [
+                {
+                    value: 'north_america',
+                    label: 'Северная Америка',
+                },
+                {
+                    value: 'south_america',
+                    label: 'Южная Америка',
+                    items: [
+                        {
+                            value: 'brazil',
+                            label: 'Бразилия',
+                            items: [
+                                {
+                                    value: 'rio_de_janeiro',
+                                    label: 'Рио-де-Жанейро',
+                                },
+                                {
+                                    value: 'sao_paulo',
+                                    label: 'Сан-Паулу',
+                                },
+                            ],
+                        },
+                        {
+                            value: 'argentina',
+                            label: 'Аргентина',
+                        },
+                    ],
+                },
+            ];
+
+            const ref = useRef(null)
+
+            return (
+                <div style={{ height: '300px' }} ref={ref}>
+                    <Dropdown items={items} portal={ref}>
+                        <Button text="Список стран" />
+                    </Dropdown>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация


### PR DESCRIPTION
### Dropdown

- добавлено новое свойство `portal`

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.57.0-canary.1260.9777960646.0
  npm install @salutejs/plasma-asdk@0.100.0-canary.1260.9777960646.0
  npm install @salutejs/plasma-b2c@1.342.0-canary.1260.9777960646.0
  npm install @salutejs/plasma-new-hope@0.97.0-canary.1260.9777960646.0
  npm install @salutejs/plasma-web@1.343.0-canary.1260.9777960646.0
  npm install @salutejs/sdds-serv@0.70.0-canary.1260.9777960646.0
  # or 
  yarn add @salutejs/caldera-online@0.57.0-canary.1260.9777960646.0
  yarn add @salutejs/plasma-asdk@0.100.0-canary.1260.9777960646.0
  yarn add @salutejs/plasma-b2c@1.342.0-canary.1260.9777960646.0
  yarn add @salutejs/plasma-new-hope@0.97.0-canary.1260.9777960646.0
  yarn add @salutejs/plasma-web@1.343.0-canary.1260.9777960646.0
  yarn add @salutejs/sdds-serv@0.70.0-canary.1260.9777960646.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
