### PR TITLE
plasma-docs: Fix intro.mdx

### DIFF
--- a/scaffold/template-docs/docs/intro.mdx
+++ b/scaffold/template-docs/docs/intro.mdx
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
 ```bash
 $ npm install --save react react-dom
 $ npm install --save styled-components
-$ npm install --save @salutejs/{{ name }} @salutejs/plasma-typo @salutejs/plasma-tokens
+$ npm install --save @salutejs/{{ name }} @salutejs/plasma-typo @salutejs/{{ vertical }}
 ```
 
 ## Настройка
@@ -39,7 +39,7 @@ $ npm install --save @salutejs/{{ name }} @salutejs/plasma-typo @salutejs/plasma
 ```jsx title="GlobalStyle.tsx"
 import { createGlobalStyle } from 'styled-components';
 import { standard } from '@salutejs/plasma-typo';
-import { {{ theme }}__light } from '@salutejs/plasma-tokens';
+import { {{ theme }}__light } from '@salutejs/{{ vertical }}';
 
 const ThemeStyle = createGlobalStyle({{ theme }}__light);
 const TypoStyle = createGlobalStyle(standard);

--- a/website/caldera-online-docs/docs/intro.mdx
+++ b/website/caldera-online-docs/docs/intro.mdx
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
 ```bash
 $ npm install --save react react-dom
 $ npm install --save styled-components
-$ npm install --save @salutejs/caldera-online @salutejs/plasma-typo @salutejs/plasma-tokens
+$ npm install --save @salutejs/caldera-online @salutejs/plasma-typo @salutejs/caldera-online-themes
 ```
 
 ## Настройка
@@ -39,7 +39,7 @@ $ npm install --save @salutejs/caldera-online @salutejs/plasma-typo @salutejs/pl
 ```jsx title="GlobalStyle.tsx"
 import { createGlobalStyle } from 'styled-components';
 import { standard } from '@salutejs/plasma-typo';
-import { caldera_online__light } from '@salutejs/plasma-tokens';
+import { caldera_online__light } from '@salutejs/caldera-online-themes';
 
 const ThemeStyle = createGlobalStyle(caldera_online__light);
 const TypoStyle = createGlobalStyle(standard);

--- a/website/sdds-serv-docs/docs/intro.mdx
+++ b/website/sdds-serv-docs/docs/intro.mdx
@@ -27,7 +27,7 @@ import TabItem from '@theme/TabItem';
 ```bash
 $ npm install --save react react-dom
 $ npm install --save styled-components
-$ npm install --save @salutejs/sdds-serv @salutejs/plasma-typo @salutejs/plasma-tokens
+$ npm install --save @salutejs/sdds-serv @salutejs/plasma-typo @salutejs/sdds-themes
 ```
 
 ## Настройка
@@ -37,7 +37,7 @@ $ npm install --save @salutejs/sdds-serv @salutejs/plasma-typo @salutejs/plasma-
 ```jsx title="GlobalStyle.tsx"
 import { createGlobalStyle } from 'styled-components';
 import { standard } from '@salutejs/plasma-typo';
-import { sdds_serv__light } from '@salutejs/plasma-tokens';
+import { sdds_serv__light } from '@salutejs/sdds-themes';
 
 const ThemeStyle = createGlobalStyle(sdds_serv__light);
 const TypoStyle = createGlobalStyle(standard);


### PR DESCRIPTION
### What/why changed

Исправлен шаблон для `intro.mdx`.

В документации указывался пакет `@salutejs/plasma-tokens`, а нужно было целевой. 

Например для `caldera-online` необходимо установить и использовать `@salutejs/caldera-online-themes`.   
