### PR TITLE
plasma-website: Add icons filter menu

### DIFF
--- a/website/plasma-website/components/roster/AbstractIcon.tsx
+++ b/website/plasma-website/components/roster/AbstractIcon.tsx
@@ -1,0 +1,26 @@
+import React, { useContext } from 'react';
+import type { FC } from 'react';
+import { IconRoot } from '@salutejs/plasma-icons';
+import type { IconProps } from '@salutejs/plasma-icons';
+
+import { Context } from '../../store';
+
+type AbstractIconProps = {
+    name: string;
+    component: FC<IconProps>;
+    isDeprecate: boolean;
+};
+
+export const AbstractIcon = ({ name, component: Component, isDeprecate }: AbstractIconProps) => {
+    const { state } = useContext(Context);
+
+    const props = {
+        size: name === state.wizardItemName ? state.size.value : state.gridItemsSize.value,
+        color: name === state.wizardItemName ? state.color.value : 'inherit',
+    };
+
+    // INFO: В том случае когда у нас иконка из старого набора (нет фактического файла для нужного размера),
+    // INFO: используем обертку IconRoot.
+    // INFO: В противном случае используем компонент иконки.
+    return isDeprecate ? <IconRoot icon={Component} {...props} /> : <Component {...props} />;
+};

--- a/website/plasma-website/components/roster/IconFilterMenu.tsx
+++ b/website/plasma-website/components/roster/IconFilterMenu.tsx
@@ -1,0 +1,65 @@
+import React, { useContext } from 'react';
+import styled, { css } from 'styled-components';
+
+import { Context, setIconGridSize, setIconSize } from '../../store';
+import { listSizes } from '../../utils/listSizes';
+
+const StyledFilterMenu = styled.div`
+    position: sticky;
+    top: 3rem;
+    display: inline-flex;
+    row-gap: 0.75rem;
+    flex-direction: column;
+    align-self: self-end;
+`;
+
+const StyledFilterMenuItem = styled.div<{ isActive?: boolean }>`
+    display: inline-flex;
+    align-items: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    font-size: 0.75rem;
+    line-height: 0.875rem;
+    color: rgba(255, 255, 255, 0.28);
+
+    cursor: pointer;
+
+    transition: color 120ms ease-in;
+
+    &:hover {
+        color: rgba(255, 255, 255, 1);
+    }
+
+    ${({ isActive }) =>
+        isActive &&
+        css`
+            color: rgba(255, 255, 255, 1);
+
+            cursor: default;
+
+            &:hover {
+                color: rgba(255, 255, 255, 1);
+            }
+        `}
+`;
+
+export const IconFilterMenu = () => {
+    const { state, dispatch } = useContext(Context);
+
+    return (
+        <StyledFilterMenu>
+            {listSizes.map(({ value, label }) => (
+                <StyledFilterMenuItem
+                    key={label}
+                    isActive={label === state.gridItemsSize.label}
+                    onClick={() => {
+                        dispatch(setIconGridSize({ value, label }));
+                        dispatch(setIconSize({ value, label }));
+                    }}
+                >
+                    {label}
+                </StyledFilterMenuItem>
+            ))}
+        </StyledFilterMenu>
+    );
+};

--- a/website/plasma-website/components/roster/IconOptionsColors.tsx
+++ b/website/plasma-website/components/roster/IconOptionsColors.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react';
 import styled, { css } from 'styled-components';
-import { accent, primary, secondary, tertiary } from '@salutejs/plasma-tokens-b2c';
+import { textPrimary, textAccent, textSecondary, textTertiary } from '@salutejs/plasma-tokens/brands';
 
 import { Context, setIconColor, initColorState } from '../../store';
 
 import { AnimationSlideUp } from './AnimationSlideUp';
 
-const colorsList = Object.entries({ accent, primary, secondary, tertiary }).map(([key, value]) => ({
+const colorsList = Object.entries({ textPrimary, textAccent, textSecondary, textTertiary }).map(([key, value]) => ({
     value,
     label: key,
 }));

--- a/website/plasma-website/components/roster/IconOptionsSize.tsx
+++ b/website/plasma-website/components/roster/IconOptionsSize.tsx
@@ -2,15 +2,9 @@ import React, { useContext } from 'react';
 import styled, { css } from 'styled-components';
 
 import { Context, setIconSize } from '../../store';
-import type { State } from '../../store';
+import { listSizes } from '../../utils/listSizes';
 
 import { AnimationSlideUp } from './AnimationSlideUp';
-
-const options: Array<State['size']> = [
-    { value: 'xs', label: '16' },
-    { value: 's', label: '24' },
-    { value: 'm', label: '36' },
-];
 
 const StyledOptions = styled.div`
     display: flex;
@@ -94,7 +88,7 @@ export const IconOptionsSize = () => {
 
     return (
         <StyledOptions>
-            {options.map(({ value, label }) => {
+            {listSizes.map(({ value, label }) => {
                 return (
                     <StyledOption
                         key={label}

--- a/website/plasma-website/components/roster/IconsList.tsx
+++ b/website/plasma-website/components/roster/IconsList.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useContext, useRef, useState, useEffect } from 'react';
 import type { FC } from 'react';
 import styled, { css } from 'styled-components';
 import { Headline4, applyNoSelect } from '@salutejs/plasma-b2c';
-import { IconRoot } from '@salutejs/plasma-icons';
 import { secondary } from '@salutejs/plasma-tokens-b2c';
 
 import { Context, setWizardItem, setIconColor, setIconSize, initColorState, initSizeState } from '../../store';
@@ -12,6 +11,7 @@ import { IconGroupHeading } from './IconGroupHeading';
 import { IconHoverDetails } from './IconHoverDetails';
 import { IconExtendedInfo } from './IconExtendedInfo';
 import { AnimationSlideUp } from './AnimationSlideUp';
+import { AbstractIcon } from './AbstractIcon';
 import { Grid } from './Grid';
 
 export interface IconsListProps {
@@ -21,8 +21,6 @@ export interface IconsListProps {
      */
     onItemClick?: React.HTMLAttributes<HTMLElement>['onClick'];
 }
-
-const size = 's';
 
 const getGridCellPosition = (grid: HTMLDivElement, index: number) => {
     if (!grid) {
@@ -75,7 +73,7 @@ const StyledIconHoverDetails = styled.div`
     ${AnimationSlideUp};
 `;
 
-const StyledIcon = styled.div<{ isActive?: boolean; hasOpacity?: boolean; isDeprecate: boolean }>`
+const StyledIcon = styled.div<{ isDeprecate: boolean; isActive?: boolean; hasOpacity?: boolean }>`
     ${applyNoSelect};
 
     display: flex;
@@ -216,7 +214,7 @@ export const IconsList: FC<IconsListProps> = ({ searchQuery, onItemClick }) => {
 
         dispatch(setIconColor(initColorState));
 
-        dispatch(setIconSize(initSizeState));
+        dispatch(setIconSize({ ...state.gridItemsSize }));
 
         setCurrentGridRowLabel('');
     };
@@ -239,13 +237,12 @@ export const IconsList: FC<IconsListProps> = ({ searchQuery, onItemClick }) => {
                         count={group.items.length}
                     />
                     <Grid ref={(el) => el && handleRefInit(el, indexGroup)}>
-                        {group.items.map(({ name, component: Component, groupName, version }, index) => (
+                        {group.items.map(({ name, component, groupName, isDeprecate = false }, index) => (
                             <StyledCell key={name}>
                                 <StyledIcon
-                                    key={name}
                                     hasOpacity={groupName === currentGridRowLabel && name !== state.wizardItemName}
                                     isActive={name === state.wizardItemName}
-                                    isDeprecate={version === 'legacy'}
+                                    isDeprecate={isDeprecate}
                                     onClick={(event) => {
                                         event.stopPropagation();
 
@@ -257,7 +254,7 @@ export const IconsList: FC<IconsListProps> = ({ searchQuery, onItemClick }) => {
 
                                         dispatch(setIconColor(initColorState));
 
-                                        dispatch(setIconSize(initSizeState));
+                                        dispatch(setIconSize({ ...state.gridItemsSize }));
 
                                         const currentIndex = index + 1;
 
@@ -273,26 +270,15 @@ export const IconsList: FC<IconsListProps> = ({ searchQuery, onItemClick }) => {
                                         }
                                     }}
                                 >
-                                    {version === 'legacy' ? (
-                                        <IconRoot
-                                            icon={Component}
-                                            size={name === state.wizardItemName ? state.size.value : size}
-                                            color={name === state.wizardItemName ? state.color.value : 'inherit'}
-                                        />
-                                    ) : (
-                                        <Component
-                                            size={name === state.wizardItemName ? state.size.value : size}
-                                            color={name === state.wizardItemName ? state.color.value : 'inherit'}
-                                        />
-                                    )}
+                                    <AbstractIcon isDeprecate={isDeprecate} component={component} name={name} />
                                 </StyledIcon>
                                 <StyledIconHoverDetails>
-                                    <IconHoverDetails name={name} sizes={{ 36: false, 24: true, 16: false }} />
+                                    <IconHoverDetails name={name} sizes={{ 36: true, 24: true, 16: true }} />
                                 </StyledIconHoverDetails>
                                 {name === state.wizardItemName && (
                                     <IconExtendedInfo
                                         onClose={handleCloseExtendInfo}
-                                        isDeprecate={version === 'legacy'}
+                                        isDeprecate={isDeprecate}
                                         offset={offset}
                                     />
                                 )}

--- a/website/plasma-website/components/roster/index.ts
+++ b/website/plasma-website/components/roster/index.ts
@@ -7,3 +7,4 @@ export { RadioGroup } from './RadioGroup';
 export { SearchForm } from './SearchForm';
 export { ThemeSwitcher } from './ThemeSwitcher';
 export { Footer } from './Footer';
+export { IconFilterMenu } from './IconFilterMenu';

--- a/website/plasma-website/package-lock.json
+++ b/website/plasma-website/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@salutejs/plasma-b2c": "1.335.0-dev.0",
         "@salutejs/plasma-icons": "1.198.0-dev.0",
+        "@salutejs/plasma-tokens": "1.81.0",
         "@salutejs/plasma-tokens-b2c": "0.50.0",
         "@salutejs/plasma-typo": "0.40.0",
         "next": "^12.3.4",
@@ -1112,6 +1113,14 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@salutejs/plasma-tokens": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-tokens/-/plasma-tokens-1.81.0.tgz",
+      "integrity": "sha512-IK9RK3eC4hIES9+bZ3lzq5x0M0vyX7zpsWmIYUIx2PIE8j/E7heQvqJQAW6d3O5RtpgKFoyDomeVX2nr78ffdA==",
+      "peerDependencies": {
+        "styled-components": "^5.1.1"
       }
     },
     "node_modules/@salutejs/plasma-tokens-b2c": {
@@ -5655,6 +5664,11 @@
           "integrity": "sha512-VuW4GQr3LGQr+gqscqsOz2c9asK9N+B+8+sWs7Pj4OqU7bngYIqsPF3IYpkbmccKNWjs7wwxUAlR+gtL9cEMEg=="
         }
       }
+    },
+    "@salutejs/plasma-tokens": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@salutejs/plasma-tokens/-/plasma-tokens-1.81.0.tgz",
+      "integrity": "sha512-IK9RK3eC4hIES9+bZ3lzq5x0M0vyX7zpsWmIYUIx2PIE8j/E7heQvqJQAW6d3O5RtpgKFoyDomeVX2nr78ffdA=="
     },
     "@salutejs/plasma-tokens-b2c": {
       "version": "0.50.0",

--- a/website/plasma-website/package.json
+++ b/website/plasma-website/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@salutejs/plasma-b2c": "1.337.1-dev.0",
     "@salutejs/plasma-icons": "1.198.0-dev.0",
+    "@salutejs/plasma-tokens": "1.81.0",
     "@salutejs/plasma-tokens-b2c": "0.50.0",
     "@salutejs/plasma-typo": "0.40.0",
     "next": "^12.3.4",

--- a/website/plasma-website/pages/icons.tsx
+++ b/website/plasma-website/pages/icons.tsx
@@ -1,16 +1,31 @@
 import React, { useState, useCallback } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { ToastProvider } from '@salutejs/plasma-b2c';
 import Head from 'next/head';
 
-import { Header, Main, SearchForm, IconsList, Footer } from '../components/roster';
+import { multipleMediaQuery } from '../mixins';
+import { Header, Main, SearchForm, IconsList, Footer, IconFilterMenu } from '../components/roster';
 
 const StyledSection = styled.section`
+    position: relative;
     display: grid;
     grid-template-rows: auto 1fr auto;
     grid-template-columns: 100%;
 
     min-height: 100vh;
+`;
+
+const StyledFilterWrapper = styled.div`
+    position: absolute;
+    top: 7.125rem;
+    right: 1.375rem;
+
+    min-height: calc(100% - 7.125rem);
+    max-width: 1.25rem;
+
+    ${multipleMediaQuery(['S'])(css`
+        right: 0;
+    `)}
 `;
 
 const StyledMain = styled(Main)`
@@ -40,6 +55,9 @@ export default function Home() {
             </Head>
             <StyledSection>
                 <Header />
+                <StyledFilterWrapper>
+                    <IconFilterMenu />
+                </StyledFilterWrapper>
                 <StyledMain>
                     <SearchForm onInput={onSearchInput} />
                     <IconsList searchQuery={searchQuery} />

--- a/website/plasma-website/store/actions.ts
+++ b/website/plasma-website/store/actions.ts
@@ -5,6 +5,7 @@ export enum ActionTypes {
     SET_ITEM = 'SET_ITEM',
     SET_ITEM_COLOR = 'SET_ITEM_COLOR',
     SET_ITEM_SIZE = 'SET_ITEM_SIZE',
+    SET_GRID_ITEM_SIZE = 'SET_GRID_ITEM_SIZE',
 }
 
 export type Action =
@@ -23,6 +24,10 @@ export type Action =
     | {
           type: ActionTypes.SET_ITEM_SIZE;
           payload: State['size'];
+      }
+    | {
+          type: ActionTypes.SET_GRID_ITEM_SIZE;
+          payload: State['size'];
       };
 
 export const setTheme = (theme: Theme): Action => ({ type: ActionTypes.SET_THEME, payload: { theme } });
@@ -39,5 +44,10 @@ export const setIconColor = (payload: State['color']): Action => ({
 
 export const setIconSize = (payload: State['size']): Action => ({
     type: ActionTypes.SET_ITEM_SIZE,
+    payload,
+});
+
+export const setIconGridSize = (payload: State['size']): Action => ({
+    type: ActionTypes.SET_GRID_ITEM_SIZE,
     payload,
 });

--- a/website/plasma-website/store/index.tsx
+++ b/website/plasma-website/store/index.tsx
@@ -18,6 +18,6 @@ export const ContextProvider: FC<{ children: React.ReactNode }> = ({ children })
     return <Context.Provider value={{ state, dispatch }}>{children}</Context.Provider>;
 };
 
-export { setTheme, setWizardItem, setIconColor, setIconSize } from './actions';
+export { setTheme, setWizardItem, setIconColor, setIconSize, setIconGridSize } from './actions';
 
 export type { State };

--- a/website/plasma-website/store/reducer.ts
+++ b/website/plasma-website/store/reducer.ts
@@ -10,6 +10,7 @@ export const initialState: State = {
     theme: 'dark',
     color: { ...initColorState },
     size: { ...initSizeState },
+    gridItemsSize: { ...initSizeState },
 };
 
 export const reducer: Reducer<State, Action> = (state, action) => {
@@ -31,6 +32,11 @@ export const reducer: Reducer<State, Action> = (state, action) => {
             return {
                 ...state,
                 size: { ...action.payload },
+            };
+        case ActionTypes.SET_GRID_ITEM_SIZE:
+            return {
+                ...state,
+                gridItemsSize: { ...action.payload },
             };
         default:
             return state;

--- a/website/plasma-website/store/types.ts
+++ b/website/plasma-website/store/types.ts
@@ -10,4 +10,8 @@ export interface State {
         value: 'xs' | 's' | 'm';
         label: '16' | '24' | '36';
     };
+    gridItemsSize: {
+        value: 'xs' | 's' | 'm';
+        label: '16' | '24' | '36';
+    };
 }

--- a/website/plasma-website/types/Data.ts
+++ b/website/plasma-website/types/Data.ts
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import type { IconProps } from '@salutejs/plasma-icons';
 
-export type Item = { name: string; component: FC<IconProps>; groupName?: string; version?: 'legacy' | 'new' };
+export type Item = { name: string; component: FC<IconProps>; groupName?: string; isDeprecate?: boolean };
 
 export type IconGroup = {
     title: string;

--- a/website/plasma-website/utils/iconsList.ts
+++ b/website/plasma-website/utils/iconsList.ts
@@ -64,7 +64,7 @@ const transformIconsSet = (iconSet: IconSectionsSet) => {
                 Object.entries((iconSectionsSet as IconSectionsSet)[key])
                     .sort()
                     .reduce((a, [iconName, component]) => {
-                        a.push({ name: iconName, component, groupName: iconGroup.subtitle, version: 'legacy' });
+                        a.push({ name: iconName, component, groupName: iconGroup.subtitle, isDeprecate: true });
 
                         return a;
                     }, IconsLegacyList);
@@ -73,7 +73,7 @@ const transformIconsSet = (iconSet: IconSectionsSet) => {
             const icons = Object.entries(group)
                 .sort()
                 .reduce((a, [iconName, component]) => {
-                    a.push({ name: iconName, component, groupName: iconGroup.subtitle, version: 'new' });
+                    a.push({ name: iconName, component, groupName: iconGroup.subtitle, isDeprecate: false });
 
                     return a;
                 }, [] as Item[]);

--- a/website/plasma-website/utils/listSizes.ts
+++ b/website/plasma-website/utils/listSizes.ts
@@ -1,0 +1,7 @@
+import { State } from '../store';
+
+export const listSizes: Array<State['size']> = [
+    { value: 'xs', label: '16' },
+    { value: 's', label: '24' },
+    { value: 'm', label: '36' },
+];


### PR DESCRIPTION
### Icons page

- добавлено меню фильтра по размеру 
- внесены дизайн правки   

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.51.1-canary.1265.9664294667.0
  npm install @salutejs/plasma-asdk@0.94.1-canary.1265.9664294667.0
  npm install @salutejs/plasma-b2c@1.336.1-canary.1265.9664294667.0
  npm install @salutejs/plasma-new-hope@0.91.1-canary.1265.9664294667.0
  npm install @salutejs/plasma-web@1.337.1-canary.1265.9664294667.0
  npm install @salutejs/sdds-serv@0.64.1-canary.1265.9664294667.0
  # or 
  yarn add @salutejs/caldera-online@0.51.1-canary.1265.9664294667.0
  yarn add @salutejs/plasma-asdk@0.94.1-canary.1265.9664294667.0
  yarn add @salutejs/plasma-b2c@1.336.1-canary.1265.9664294667.0
  yarn add @salutejs/plasma-new-hope@0.91.1-canary.1265.9664294667.0
  yarn add @salutejs/plasma-web@1.337.1-canary.1265.9664294667.0
  yarn add @salutejs/sdds-serv@0.64.1-canary.1265.9664294667.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
