### PR TITLE
plasma-*: Add `Portal` component

### DIFF
--- a/packages/caldera-online/api/caldera-online.api.md
+++ b/packages/caldera-online/api/caldera-online.api.md
@@ -57,6 +57,7 @@ import { PopupInfo } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupPlacement } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupProvider } from '@salutejs/plasma-new-hope/styled-components';
+import { PortalProps } from '@salutejs/plasma-new-hope/styled-components';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
 import { ReactNode } from 'react';
@@ -86,6 +87,7 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
+import { Variants } from '@salutejs/plasma-new-hope/types/engines/types';
 
 export { addFocus }
 
@@ -437,6 +439,11 @@ export { PopupPlacement }
 export { PopupProps }
 
 export { PopupProvider }
+
+// @public (undocumented)
+export const Portal: FunctionComponent<PropsType<Variants> & PortalProps & RefAttributes<HTMLDivElement>>;
+
+export { PortalProps }
 
 // @public
 export const Radiobox: FunctionComponent<PropsType<    {

--- a/packages/caldera-online/src/components/Portal/Portal.stories.tsx
+++ b/packages/caldera-online/src/components/Portal/Portal.stories.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef } from 'react';
+import type { StoryObj, Meta } from '@storybook/react';
+import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import type { ComponentProps } from 'react';
+import styled from 'styled-components';
+
+import { Button } from '../Button/Button';
+import { BodyM } from '../Typography';
+
+import { Portal } from './Portal';
+
+const meta: Meta<typeof Portal> = {
+    title: 'Controls/Portal',
+    decorators: [InSpacingDecorator],
+    args: {
+        disabled: false,
+    },
+};
+
+export default meta;
+
+type StoryPortalProps = ComponentProps<typeof Portal>;
+
+const StyledWrapper = styled.div`
+    padding: 1.25rem;
+    margin-bottom: 0.625rem;
+    margin-top: 0.625rem;
+
+    border: 1px solid;
+`;
+
+const StoryDefault = ({ disabled }: StoryPortalProps) => {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <StyledWrapper>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</BodyM>
+                <BodyM style={{ marginBottom: '1.25rem' }}>
+                    Если портал выключен (disabled), то содержимое появится в данном блоке.
+                </BodyM>
+                {show && containerRef.current && (
+                    <Portal disabled={disabled} container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </StyledWrapper>
+            <StyledWrapper ref={containerRef} />
+        </>
+    );
+};
+
+export const Default: StoryObj<StoryPortalProps> = {
+    render: (args) => <StoryDefault {...args} />,
+};

--- a/packages/caldera-online/src/components/Portal/Portal.tsx
+++ b/packages/caldera-online/src/components/Portal/Portal.tsx
@@ -1,0 +1,10 @@
+import { portalConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+
+const mergedConfig = mergeConfig(portalConfig);
+const PortalComponent = component(mergedConfig);
+
+/*
+ * Вспомогательный компонент. Используется в Popup, Popover.
+ * Представляет собой ReactDOM.createPortal() в форме компонента.
+ */
+export const Portal = PortalComponent;

--- a/packages/caldera-online/src/components/Portal/index.ts
+++ b/packages/caldera-online/src/components/Portal/index.ts
@@ -1,0 +1,3 @@
+export { Portal } from './Portal';
+
+export type { PortalProps } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/caldera-online/src/index.ts
+++ b/packages/caldera-online/src/index.ts
@@ -4,6 +4,7 @@ export * from './components/Dropdown';
 export * from './components/Link';
 export * from './components/Modal';
 export * from './components/Popup';
+export * from './components/Portal';
 export * from './components/Radiobox';
 export * from './components/Segment';
 export * from './components/Sheet';

--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -184,6 +184,7 @@ import { PopupProps as PopupBaseProps } from '@salutejs/plasma-new-hope/styled-c
 import { PopupProvider as PopupBaseProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupInfo } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupProps } from '@salutejs/plasma-hope';
+import { PortalProps } from '@salutejs/plasma-new-hope/styled-components';
 import { PreviewGallery } from '@salutejs/plasma-hope';
 import { PreviewGalleryItemProps } from '@salutejs/plasma-hope';
 import { PreviewGalleryProps } from '@salutejs/plasma-hope';
@@ -1668,6 +1669,11 @@ export { PopupBaseProvider }
 export { PopupInfo }
 
 export { PopupProps }
+
+// @public (undocumented)
+export const Portal: FunctionComponent<PropsType<Variants> & PortalProps & RefAttributes<HTMLDivElement>>;
+
+export { PortalProps }
 
 export { PreviewGallery }
 

--- a/packages/plasma-b2c/src/components/Popover/Popover.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Popover/Popover.component-test.tsx
@@ -5,7 +5,7 @@ import type { PopoverTrigger } from '.';
 
 const text = 'Голосовая викторина с Валдисом Пельшем';
 
-describe('plasma-web: Popover', () => {
+describe('plasma-b2c: Popover', () => {
     const Popover = getComponent('Popover');
     const Button = getComponent('Button');
     const P1 = getComponent('P1');

--- a/packages/plasma-b2c/src/components/Portal/Portal.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Portal/Portal.component-test.tsx
@@ -1,0 +1,76 @@
+import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
+import { standard as standardTypo } from '@salutejs/plasma-typo';
+import React, { FC, PropsWithChildren, useState, useRef } from 'react';
+import styled, { createGlobalStyle } from 'styled-components';
+
+const StandardTypoStyle = createGlobalStyle(standardTypo);
+
+const text = 'Тортик - это ложь';
+
+const StyledWrapper = styled.div`
+    padding: 1.25rem;
+    margin-bottom: 0.625rem;
+    margin-top: 0.625rem;
+
+    border: 1px solid;
+`;
+
+describe('plasma-b2c: Portal', () => {
+    const Portal = getComponent('Portal');
+    const Button = getComponent('Button');
+    const BodyM = getComponent('BodyM');
+
+    const CypressTestDecoratorWithTypo: FC<PropsWithChildren> = ({ children }) => (
+        <CypressTestDecorator>
+            <StandardTypoStyle />
+            {children}
+        </CypressTestDecorator>
+    );
+
+    function Demo({ disabled = false }: { disabled?: boolean }) {
+        const [show, setShow] = useState(false);
+        const containerRef = useRef<HTMLDivElement>(null);
+
+        return (
+            <>
+                <Button onClick={() => setShow(!show)} />
+                <StyledWrapper id="parentContainer">
+                    <BodyM>
+                        По завершении программы вам предложат тортик и возможность выговориться перед дипломированным
+                        сочувственным слушателем.
+                    </BodyM>
+                    {show && containerRef.current && (
+                        <Portal disabled={disabled} container={containerRef.current}>
+                            <BodyM>{text}</BodyM>
+                        </Portal>
+                    )}
+                </StyledWrapper>
+                <StyledWrapper id="targetContainer" ref={containerRef} />
+            </>
+        );
+    }
+
+    it('open portal', () => {
+        mount(
+            <CypressTestDecoratorWithTypo>
+                <Demo />,
+            </CypressTestDecoratorWithTypo>,
+        );
+
+        cy.get('button').click();
+        cy.get('#parentContainer').contains(text).should('not.exist');
+        cy.get('#targetContainer').contains(text).should('be.visible');
+    });
+
+    it('disabled portal', () => {
+        mount(
+            <CypressTestDecoratorWithTypo>
+                <Demo disabled />,
+            </CypressTestDecoratorWithTypo>,
+        );
+
+        cy.get('button').click();
+        cy.get('#parentContainer').contains(text).should('be.visible');
+        cy.get('#targetContainer').contains(text).should('not.exist');
+    });
+});

--- a/packages/plasma-b2c/src/components/Portal/Portal.stories.tsx
+++ b/packages/plasma-b2c/src/components/Portal/Portal.stories.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef } from 'react';
+import type { StoryObj, Meta } from '@storybook/react';
+import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import type { ComponentProps } from 'react';
+import styled from 'styled-components';
+
+import { Button } from '../Button/Button';
+import { BodyM } from '../Typography';
+
+import { Portal } from './Portal';
+
+const meta: Meta<typeof Portal> = {
+    title: 'Controls/Portal',
+    decorators: [InSpacingDecorator],
+    args: {
+        disabled: false,
+    },
+};
+
+export default meta;
+
+type StoryPortalProps = ComponentProps<typeof Portal>;
+
+const StyledWrapper = styled.div`
+    padding: 1.25rem;
+    margin-bottom: 0.625rem;
+    margin-top: 0.625rem;
+
+    border: 1px solid;
+`;
+
+const StoryDefault = ({ disabled }: StoryPortalProps) => {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <StyledWrapper>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</BodyM>
+                <BodyM style={{ marginBottom: '1.25rem' }}>
+                    Если портал выключен (disabled), то содержимое появится в данном блоке.
+                </BodyM>
+                {show && containerRef.current && (
+                    <Portal disabled={disabled} container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </StyledWrapper>
+            <StyledWrapper ref={containerRef} />
+        </>
+    );
+};
+
+export const Default: StoryObj<StoryPortalProps> = {
+    render: (args) => <StoryDefault {...args} />,
+};

--- a/packages/plasma-b2c/src/components/Portal/Portal.tsx
+++ b/packages/plasma-b2c/src/components/Portal/Portal.tsx
@@ -1,0 +1,10 @@
+import { portalConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+
+const mergedConfig = mergeConfig(portalConfig);
+const PortalComponent = component(mergedConfig);
+
+/*
+ * Вспомогательный компонент. Используется в Popup, Popover.
+ * Представляет собой ReactDOM.createPortal() в форме компонента.
+ */
+export const Portal = PortalComponent;

--- a/packages/plasma-b2c/src/components/Portal/index.ts
+++ b/packages/plasma-b2c/src/components/Portal/index.ts
@@ -1,0 +1,3 @@
+export { Portal } from './Portal';
+
+export type { PortalProps } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/plasma-b2c/src/index.ts
+++ b/packages/plasma-b2c/src/index.ts
@@ -30,6 +30,7 @@ export * from './components/Pagination';
 export * from './components/Popup';
 export * from './components/PopupBase';
 export * from './components/Popover';
+export * from './components/Portal';
 export * from './components/PreviewGallery';
 export * from './components/Price';
 export * from './components/Progress';

--- a/packages/plasma-new-hope/src/components/Popover/Popover.tsx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.tsx
@@ -1,11 +1,12 @@
 import React, { useRef, useCallback, useEffect, useState, forwardRef } from 'react';
 import type { CSSProperties } from 'react';
-import ReactDOM from 'react-dom';
 import { usePopper } from 'react-popper';
 import { useFocusTrap, useForkRef } from '@salutejs/plasma-core';
 
+import { component, mergeConfig } from '../../engines';
 import type { RootProps } from '../../engines/types';
 import { cx } from '../../utils';
+import { portalConfig } from '../Portal';
 
 import { base as viewCSS } from './variations/_view/base';
 import type { PopoverPlacement, PopoverProps } from './Popover.types';
@@ -14,6 +15,9 @@ import { classes } from './Popover.tokens';
 
 export const ESCAPE_KEYCODE = 27;
 export const POPOVER_PORTAL_ID = 'plasma-popover-root';
+
+const mergedPortalConfig = mergeConfig(portalConfig);
+const Portal = component(mergedPortalConfig);
 
 /**
  * Всплывающее окно с возможностью позиционирования
@@ -236,9 +240,8 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
                     >
                         {target}
                     </StyledRoot>
-                    {children &&
-                        portalRef.current &&
-                        ReactDOM.createPortal(
+                    {children && portalRef.current && (
+                        <Portal container={portalRef.current}>
                             <Root view={view} className={className} {...rest}>
                                 <StyledPopover
                                     {...attributes.popper}
@@ -261,9 +264,9 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
                                     )}
                                     {children}
                                 </StyledPopover>
-                            </Root>,
-                            portalRef.current,
-                        )}
+                            </Root>
+                        </Portal>
+                    )}
                 </StyledWrapper>
             );
         },

--- a/packages/plasma-new-hope/src/components/Popup/Popup.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.tsx
@@ -1,9 +1,10 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
-import ReactDOM from 'react-dom';
 import { useForkRef, safeUseId } from '@salutejs/plasma-core';
 
 import { RootProps } from '../../engines/types';
 import { cx } from '../../utils';
+import { portalConfig } from '../Portal';
+import { component, mergeConfig } from '../../engines';
 
 import type { PopupPlacementBasic, PopupPlacement, PopupPositionType, PopupProps } from './Popup.types';
 import { POPUP_PORTAL_ID } from './PopupContext';
@@ -77,6 +78,9 @@ export const handlePosition = (
         transform,
     };
 };
+
+const mergedPortalConfig = mergeConfig(portalConfig);
+const Portal = component(mergedPortalConfig);
 
 /**
  * Базовый копмонент Popup.
@@ -162,8 +166,8 @@ export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
 
             return (
                 <>
-                    {portalRef.current &&
-                        ReactDOM.createPortal(
+                    {portalRef.current && (
+                        <Portal container={portalRef.current}>
                             <Root className={cls} {...rest}>
                                 {overlay}
                                 <PopupRoot
@@ -177,9 +181,9 @@ export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
                                 >
                                     {children}
                                 </PopupRoot>
-                            </Root>,
-                            portalRef.current,
-                        )}
+                            </Root>
+                        </Portal>
+                    )}
                 </>
             );
         },

--- a/packages/plasma-new-hope/src/components/Portal/Portal.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Portal/Portal.template-doc.mdx
@@ -1,0 +1,66 @@
+---
+id: portal
+title: Portal
+---
+
+import { PropsTable, Description } from '@site/src/components';
+
+# Portal
+<Description name="Portal" />
+<PropsTable name="Portal" />
+
+## Использование
+
+```tsx live
+import React, { useState, useRef } from 'react';
+import { Portal, Button, BodyM } from '@salutejs/{{ package }}';
+
+export function App() {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <div style=\{{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}}>
+                <BodyM style=\{{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</BodyM>
+                {show && containerRef.current && (
+                    <Portal container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </div>
+            <div style=\{{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}} ref={containerRef} />
+        </>
+    );
+}
+```
+
+### Disabled
+Отключить портал можно с помощью свойства `disabled`.
+В этом случае содержимое портала добавится внутрь родительского элемента.
+
+```tsx live
+import React, { useState, useRef } from 'react';
+import { Portal, Button, BodyM } from '@salutejs/{{ package }}';
+
+export function App() {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <div style=\{{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}}>
+                <BodyM style=\{{ marginBottom: '1.25rem' }}>Содержимое портала появится в данном блоке.</BodyM>
+                {show && containerRef.current && (
+                    <Portal disabled container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </div>
+            <div style=\{{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}} ref={containerRef} />
+        </>
+    );
+}
+```

--- a/packages/plasma-new-hope/src/components/Portal/Portal.tsx
+++ b/packages/plasma-new-hope/src/components/Portal/Portal.tsx
@@ -1,0 +1,31 @@
+import React, { forwardRef } from 'react';
+import ReactDOM from 'react-dom';
+
+import type { RootProps } from '../../engines/types';
+
+import { PortalProps } from './Portal.types';
+
+/*
+ * Вспомогательный компонент. Используется в Popup, Popover.
+ * Представляет собой ReactDOM.createPortal() в форме компонента.
+ */
+export const portalRoot = (Root: RootProps<HTMLDivElement, Omit<PortalProps, 'container'>>) =>
+    forwardRef<HTMLDivElement, PortalProps>(({ children, container, disabled = false }, outerRootRef) => {
+        const portalContainer = typeof container === 'function' ? container() : container;
+
+        return (
+            <Root disabled={disabled} ref={outerRootRef}>
+                {disabled && children}
+                {!disabled && ReactDOM.createPortal(children, portalContainer)}
+            </Root>
+        );
+    });
+
+export const portalConfig = {
+    name: 'Portal',
+    tag: 'div',
+    layout: portalRoot,
+    base: '',
+    variations: {},
+    defaults: {},
+};

--- a/packages/plasma-new-hope/src/components/Portal/Portal.types.ts
+++ b/packages/plasma-new-hope/src/components/Portal/Portal.types.ts
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+export type PortalProps = {
+    /**
+     * Элемент, в который добавится содержимое портала.
+     */
+    container: HTMLElement | (() => HTMLElement);
+    /**
+     * Содержимое портала.
+     */
+    children?: ReactNode;
+    /**
+     * Отключение портала.
+     * Если портал выключен, то его содержимое добавится внутрь родительского элемента.
+     * @default false
+     */
+    disabled?: boolean;
+};

--- a/packages/plasma-new-hope/src/components/Portal/index.tsx
+++ b/packages/plasma-new-hope/src/components/Portal/index.tsx
@@ -1,0 +1,2 @@
+export { portalConfig, portalRoot } from './Portal';
+export type { PortalProps } from './Portal.types';

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Portal/Portal.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Portal/Portal.stories.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef } from 'react';
+import type { StoryObj, Meta } from '@storybook/react';
+import type { ComponentProps } from 'react';
+import { styled } from '@linaria/react';
+
+import { Button } from '../Button/Button';
+import { WithTheme } from '../../../_helpers';
+import { Body } from '../../../typograpy/components/Body/Body';
+
+import { Portal } from './Portal';
+
+const meta: Meta<typeof Portal> = {
+    title: 'plasma_b2c/Portal',
+    decorators: [WithTheme],
+    args: {
+        disabled: false,
+    },
+};
+
+export default meta;
+
+type StoryPortalProps = ComponentProps<typeof Portal>;
+
+const StyledWrapper = styled.div`
+    padding: 1.25rem;
+    margin-bottom: 0.625rem;
+    margin-top: 0.625rem;
+
+    border: 1px solid;
+`;
+
+const StoryDefault = ({ disabled }: StoryPortalProps) => {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <StyledWrapper>
+                <Body style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</Body>
+                <Body style={{ marginBottom: '1.25rem' }}>
+                    Если портал выключен (disabled), то содержимое появится в данном блоке.
+                </Body>
+                {show && containerRef.current && (
+                    <Portal disabled={disabled} container={containerRef.current}>
+                        <Body bold>Содержимое портала</Body>
+                    </Portal>
+                )}
+            </StyledWrapper>
+            <StyledWrapper ref={containerRef} />
+        </>
+    );
+};
+
+export const Default: StoryObj<StoryPortalProps> = {
+    render: (args) => <StoryDefault {...args} />,
+};

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Portal/Portal.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Portal/Portal.ts
@@ -1,0 +1,6 @@
+import { portalConfig } from '../../../../components/Portal';
+import { component, mergeConfig } from '../../../../engines';
+
+const mergedConfig = mergeConfig(portalConfig);
+
+export const Portal = component(mergedConfig);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Portal/Portal.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Portal/Portal.stories.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef } from 'react';
+import type { StoryObj, Meta } from '@storybook/react';
+import type { ComponentProps } from 'react';
+import { styled } from '@linaria/react';
+
+import { Button } from '../Button/Button';
+import { WithTheme } from '../../../_helpers';
+import { Body } from '../../../typograpy/components/Body/Body';
+
+import { Portal } from './Portal';
+
+const meta: Meta<typeof Portal> = {
+    title: 'plasma_web/Portal',
+    decorators: [WithTheme],
+    args: {
+        disabled: false,
+    },
+};
+
+export default meta;
+
+type StoryPortalProps = ComponentProps<typeof Portal>;
+
+const StyledWrapper = styled.div`
+    padding: 1.25rem;
+    margin-bottom: 0.625rem;
+    margin-top: 0.625rem;
+
+    border: 1px solid;
+`;
+
+const StoryDefault = ({ disabled }: StoryPortalProps) => {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <StyledWrapper>
+                <Body style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</Body>
+                <Body style={{ marginBottom: '1.25rem' }}>
+                    Если портал выключен (disabled), то содержимое появится в данном блоке.
+                </Body>
+                {show && containerRef.current && (
+                    <Portal disabled={disabled} container={containerRef.current}>
+                        <Body bold>Содержимое портала</Body>
+                    </Portal>
+                )}
+            </StyledWrapper>
+            <StyledWrapper ref={containerRef} />
+        </>
+    );
+};
+
+export const Default: StoryObj<StoryPortalProps> = {
+    render: (args) => <StoryDefault {...args} />,
+};

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Portal/Portal.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Portal/Portal.ts
@@ -1,0 +1,6 @@
+import { portalConfig } from '../../../../components/Portal';
+import { component, mergeConfig } from '../../../../engines';
+
+const mergedConfig = mergeConfig(portalConfig);
+
+export const Portal = component(mergedConfig);

--- a/packages/plasma-new-hope/src/index.ts
+++ b/packages/plasma-new-hope/src/index.ts
@@ -51,3 +51,4 @@ export * from './components/Slider';
 export * from './components/Range';
 export * from './components/Accordion';
 export * from './components/DatePicker';
+export * from './components/Portal';

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -184,6 +184,7 @@ import { PopupProps as PopupBaseProps } from '@salutejs/plasma-new-hope/styled-c
 import { PopupProvider as PopupBaseProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupInfo } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupProps } from '@salutejs/plasma-hope';
+import { PortalProps } from '@salutejs/plasma-new-hope/styled-components';
 import { PreviewGallery } from '@salutejs/plasma-hope';
 import { PreviewGalleryItemProps } from '@salutejs/plasma-hope';
 import { PreviewGalleryProps } from '@salutejs/plasma-hope';
@@ -1670,6 +1671,11 @@ export { PopupBaseProvider }
 export { PopupInfo }
 
 export { PopupProps }
+
+// @public (undocumented)
+export const Portal: FunctionComponent<PropsType<Variants> & PortalProps & RefAttributes<HTMLDivElement>>;
+
+export { PortalProps }
 
 export { PreviewGallery }
 

--- a/packages/plasma-web/src/components/Portal/Portal.component-test.tsx
+++ b/packages/plasma-web/src/components/Portal/Portal.component-test.tsx
@@ -1,0 +1,76 @@
+import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
+import { standard as standardTypo } from '@salutejs/plasma-typo';
+import React, { FC, PropsWithChildren, useState, useRef } from 'react';
+import styled, { createGlobalStyle } from 'styled-components';
+
+const StandardTypoStyle = createGlobalStyle(standardTypo);
+
+const text = 'Тортик - это ложь';
+
+const StyledWrapper = styled.div`
+    padding: 1.25rem;
+    margin-bottom: 0.625rem;
+    margin-top: 0.625rem;
+
+    border: 1px solid;
+`;
+
+describe('plasma-web: Portal', () => {
+    const Portal = getComponent('Portal');
+    const Button = getComponent('Button');
+    const BodyM = getComponent('BodyM');
+
+    const CypressTestDecoratorWithTypo: FC<PropsWithChildren> = ({ children }) => (
+        <CypressTestDecorator>
+            <StandardTypoStyle />
+            {children}
+        </CypressTestDecorator>
+    );
+
+    function Demo({ disabled = false }: { disabled?: boolean }) {
+        const [show, setShow] = useState(false);
+        const containerRef = useRef<HTMLDivElement>(null);
+
+        return (
+            <>
+                <Button onClick={() => setShow(!show)} />
+                <StyledWrapper id="parentContainer">
+                    <BodyM>
+                        По завершении программы вам предложат тортик и возможность выговориться перед дипломированным
+                        сочувственным слушателем.
+                    </BodyM>
+                    {show && containerRef.current && (
+                        <Portal disabled={disabled} container={containerRef.current}>
+                            <BodyM>{text}</BodyM>
+                        </Portal>
+                    )}
+                </StyledWrapper>
+                <StyledWrapper id="targetContainer" ref={containerRef} />
+            </>
+        );
+    }
+
+    it('open portal', () => {
+        mount(
+            <CypressTestDecoratorWithTypo>
+                <Demo />,
+            </CypressTestDecoratorWithTypo>,
+        );
+
+        cy.get('button').click();
+        cy.get('#parentContainer').contains(text).should('not.exist');
+        cy.get('#targetContainer').contains(text).should('be.visible');
+    });
+
+    it('disabled portal', () => {
+        mount(
+            <CypressTestDecoratorWithTypo>
+                <Demo disabled />,
+            </CypressTestDecoratorWithTypo>,
+        );
+
+        cy.get('button').click();
+        cy.get('#parentContainer').contains(text).should('be.visible');
+        cy.get('#targetContainer').contains(text).should('not.exist');
+    });
+});

--- a/packages/plasma-web/src/components/Portal/Portal.stories.tsx
+++ b/packages/plasma-web/src/components/Portal/Portal.stories.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef } from 'react';
+import type { StoryObj, Meta } from '@storybook/react';
+import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import type { ComponentProps } from 'react';
+import styled from 'styled-components';
+
+import { Button } from '../Button/Button';
+import { BodyM } from '../Typography';
+
+import { Portal } from './Portal';
+
+const meta: Meta<typeof Portal> = {
+    title: 'Controls/Portal',
+    decorators: [InSpacingDecorator],
+    args: {
+        disabled: false,
+    },
+};
+
+export default meta;
+
+type StoryPortalProps = ComponentProps<typeof Portal>;
+
+const StyledWrapper = styled.div`
+    padding: 1.25rem;
+    margin-bottom: 0.625rem;
+    margin-top: 0.625rem;
+
+    border: 1px solid;
+`;
+
+const StoryDefault = ({ disabled }: StoryPortalProps) => {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <StyledWrapper>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</BodyM>
+                <BodyM style={{ marginBottom: '1.25rem' }}>
+                    Если портал выключен (disabled), то содержимое появится в данном блоке.
+                </BodyM>
+                {show && containerRef.current && (
+                    <Portal disabled={disabled} container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </StyledWrapper>
+            <StyledWrapper ref={containerRef} />
+        </>
+    );
+};
+
+export const Default: StoryObj<StoryPortalProps> = {
+    render: (args) => <StoryDefault {...args} />,
+};

--- a/packages/plasma-web/src/components/Portal/Portal.tsx
+++ b/packages/plasma-web/src/components/Portal/Portal.tsx
@@ -1,0 +1,10 @@
+import { portalConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+
+const mergedConfig = mergeConfig(portalConfig);
+const PortalComponent = component(mergedConfig);
+
+/*
+ * Вспомогательный компонент. Используется в Popup, Popover.
+ * Представляет собой ReactDOM.createPortal() в форме компонента.
+ */
+export const Portal = PortalComponent;

--- a/packages/plasma-web/src/components/Portal/index.ts
+++ b/packages/plasma-web/src/components/Portal/index.ts
@@ -1,0 +1,3 @@
+export { Portal } from './Portal';
+
+export type { PortalProps } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/plasma-web/src/index.ts
+++ b/packages/plasma-web/src/index.ts
@@ -32,6 +32,7 @@ export * from './components/PopupBase';
 export * from './components/Popover';
 export * from './components/Price';
 export * from './components/Progress';
+export * from './components/Portal';
 export * from './components/PreviewGallery';
 export * from './components/Radiobox';
 export * from './components/Range';

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -115,6 +115,7 @@ import { PopupInfo } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupPlacement } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { PopupProvider } from '@salutejs/plasma-new-hope/styled-components';
+import { PortalProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ProgressProps } from '@salutejs/plasma-new-hope/styled-components';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
@@ -1139,6 +1140,11 @@ export { PopupPlacement }
 export { PopupProps }
 
 export { PopupProvider }
+
+// @public (undocumented)
+export const Portal: FunctionComponent<PropsType<Variants> & PortalProps & RefAttributes<HTMLDivElement>>;
+
+export { PortalProps }
 
 // @public (undocumented)
 export const Progress: FunctionComponent<PropsType<    {

--- a/packages/sdds-serv/src/components/Portal/Portal.stories.tsx
+++ b/packages/sdds-serv/src/components/Portal/Portal.stories.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef } from 'react';
+import type { StoryObj, Meta } from '@storybook/react';
+import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import type { ComponentProps } from 'react';
+import styled from 'styled-components';
+
+import { Button } from '../Button/Button';
+import { BodyM } from '../Typography';
+
+import { Portal } from './Portal';
+
+const meta: Meta<typeof Portal> = {
+    title: 'Controls/Portal',
+    decorators: [InSpacingDecorator],
+    args: {
+        disabled: false,
+    },
+};
+
+export default meta;
+
+type StoryPortalProps = ComponentProps<typeof Portal>;
+
+const StyledWrapper = styled.div`
+    padding: 1.25rem;
+    margin-bottom: 0.625rem;
+    margin-top: 0.625rem;
+
+    border: 1px solid;
+`;
+
+const StoryDefault = ({ disabled }: StoryPortalProps) => {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <StyledWrapper>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</BodyM>
+                <BodyM style={{ marginBottom: '1.25rem' }}>
+                    Если портал выключен (disabled), то содержимое появится в данном блоке.
+                </BodyM>
+                {show && containerRef.current && (
+                    <Portal disabled={disabled} container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </StyledWrapper>
+            <StyledWrapper ref={containerRef} />
+        </>
+    );
+};
+
+export const Default: StoryObj<StoryPortalProps> = {
+    render: (args) => <StoryDefault {...args} />,
+};

--- a/packages/sdds-serv/src/components/Portal/Portal.tsx
+++ b/packages/sdds-serv/src/components/Portal/Portal.tsx
@@ -1,0 +1,10 @@
+import { portalConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+
+const mergedConfig = mergeConfig(portalConfig);
+const PortalComponent = component(mergedConfig);
+
+/*
+ * Вспомогательный компонент. Используется в Popup, Popover.
+ * Представляет собой ReactDOM.createPortal() в форме компонента.
+ */
+export const Portal = PortalComponent;

--- a/packages/sdds-serv/src/components/Portal/index.ts
+++ b/packages/sdds-serv/src/components/Portal/index.ts
@@ -1,0 +1,3 @@
+export { Portal } from './Portal';
+
+export type { PortalProps } from '@salutejs/plasma-new-hope/styled-components';

--- a/packages/sdds-serv/src/index.ts
+++ b/packages/sdds-serv/src/index.ts
@@ -21,6 +21,7 @@ export * from './components/Modal';
 export * from './components/Overlay';
 export * from './components/Popover';
 export * from './components/Popup';
+export * from './components/Portal';
 export * from './components/Progress';
 export * from './components/Pagination';
 export * from './components/Range';

--- a/website/caldera-online-docs/docs/components/Portal.mdx
+++ b/website/caldera-online-docs/docs/components/Portal.mdx
@@ -1,0 +1,66 @@
+---
+id: portal
+title: Portal
+---
+
+import { PropsTable, Description } from '@site/src/components';
+
+# Portal
+<Description name="Portal" />
+<PropsTable name="Portal" />
+
+## Использование
+
+```tsx live
+import React, { useState, useRef } from 'react';
+import { Portal, Button, BodyM } from '@salutejs/caldera-online';
+
+export function App() {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}}>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</BodyM>
+                {show && containerRef.current && (
+                    <Portal container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </div>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}} ref={containerRef} />
+        </>
+    );
+}
+```
+
+### Disabled
+Отключить портал можно с помощью свойства `disabled`.
+В этом случае содержимое портала добавится внутрь родительского элемента.
+
+```tsx live
+import React, { useState, useRef } from 'react';
+import { Portal, Button, BodyM } from '@salutejs/caldera-online';
+
+export function App() {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}}>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в данном блоке.</BodyM>
+                {show && containerRef.current && (
+                    <Portal disabled container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </div>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}} ref={containerRef} />
+        </>
+    );
+}
+```

--- a/website/plasma-web-docs/docs/components/Portal.mdx
+++ b/website/plasma-web-docs/docs/components/Portal.mdx
@@ -1,0 +1,67 @@
+---
+id: portal
+title: Portal
+---
+
+import { PropsTable, Description, StorybookLink } from '@site/src/components';
+
+# Portal
+<Description name="Portal" />
+<PropsTable name="Portal" />
+<StorybookLink name="Portal" />
+
+## Использование
+
+```tsx live
+import React, { useState, useRef } from 'react';
+import { Portal, Button, BodyM } from '@salutejs/plasma-web';
+
+export function App() {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}}>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</BodyM>
+                {show && containerRef.current && (
+                    <Portal container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </div>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}} ref={containerRef} />
+        </>
+    );
+}
+```
+
+### Disabled
+Отключить портал можно с помощью свойства `disabled`.
+В этом случае содержимое портала добавится внутрь родительского элемента.
+
+```tsx live
+import React, { useState, useRef } from 'react';
+import { Portal, Button, BodyM } from '@salutejs/plasma-web';
+
+export function App() {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}}>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в данном блоке.</BodyM>
+                {show && containerRef.current && (
+                    <Portal disabled container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </div>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}} ref={containerRef} />
+        </>
+    );
+}
+```

--- a/website/sdds-serv-docs/docs/components/Portal.mdx
+++ b/website/sdds-serv-docs/docs/components/Portal.mdx
@@ -1,0 +1,66 @@
+---
+id: portal
+title: Portal
+---
+
+import { PropsTable, Description } from '@site/src/components';
+
+# Portal
+<Description name="Portal" />
+<PropsTable name="Portal" />
+
+## Использование
+
+```tsx live
+import React, { useState, useRef } from 'react';
+import { Portal, Button, BodyM } from '@salutejs/sdds-serv';
+
+export function App() {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}}>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в нижнем блоке.</BodyM>
+                {show && containerRef.current && (
+                    <Portal container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </div>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}} ref={containerRef} />
+        </>
+    );
+}
+```
+
+### Disabled
+Отключить портал можно с помощью свойства `disabled`.
+В этом случае содержимое портала добавится внутрь родительского элемента.
+
+```tsx live
+import React, { useState, useRef } from 'react';
+import { Portal, Button, BodyM } from '@salutejs/sdds-serv';
+
+export function App() {
+    const [show, setShow] = useState(false);
+    const containerRef = useRef(null);
+
+    return (
+        <>
+            <Button onClick={() => setShow(!show)}>{show ? 'Скрыть' : 'Показать'}</Button>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}}>
+                <BodyM style={{ marginBottom: '1.25rem' }}>Содержимое портала появится в данном блоке.</BodyM>
+                {show && containerRef.current && (
+                    <Portal disabled container={containerRef.current}>
+                        <BodyM bold>Содержимое портала</BodyM>
+                    </Portal>
+                )}
+            </div>
+            <div style={{padding: '1.25rem', marginBottom: '0.625rem', marginTop: '0.625rem', border: '1px solid'}} ref={containerRef} />
+        </>
+    );
+}
+```


### PR DESCRIPTION
### Portal

- компонент добавлен в `plasma-new-hope`, портирован в `plasma-{web, b2c}`, `caldera`, `sdds`
- добавлены тесты и документация
- компонент внедрён в `Popover` и `Popup`
- исправлено имя теста для `Popover`

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.55.0-canary.1272.9742620045.0
  npm install @salutejs/plasma-asdk@0.98.0-canary.1272.9742620045.0
  npm install @salutejs/plasma-b2c@1.340.0-canary.1272.9742620045.0
  npm install @salutejs/plasma-new-hope@0.95.0-canary.1272.9742620045.0
  npm install @salutejs/plasma-web@1.341.0-canary.1272.9742620045.0
  npm install @salutejs/sdds-serv@0.68.0-canary.1272.9742620045.0
  # or 
  yarn add @salutejs/caldera-online@0.55.0-canary.1272.9742620045.0
  yarn add @salutejs/plasma-asdk@0.98.0-canary.1272.9742620045.0
  yarn add @salutejs/plasma-b2c@1.340.0-canary.1272.9742620045.0
  yarn add @salutejs/plasma-new-hope@0.95.0-canary.1272.9742620045.0
  yarn add @salutejs/plasma-web@1.341.0-canary.1272.9742620045.0
  yarn add @salutejs/sdds-serv@0.68.0-canary.1272.9742620045.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
