### PR TITLE
plasma-*: Fix `Sheet` scroll

### DIFF
--- a/packages/caldera-online/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/caldera-online/src/components/Sheet/Sheet.stories.tsx
@@ -222,7 +222,7 @@ const StoryWithInsideScroll = ({
                 <div
                     style={{
                         height: '150px',
-                        overflow: 'scroll',
+                        overflowY: 'scroll',
                         display: 'flex',
                         flexDirection: 'column',
                         gap: '1rem',
@@ -296,7 +296,7 @@ const StoryWithDoubleScroll = ({
                     <div
                         style={{
                             height: '150px',
-                            overflow: 'scroll',
+                            overflowY: 'scroll',
                             display: 'flex',
                             flexDirection: 'column',
                             gap: '1rem',

--- a/packages/plasma-b2c/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-b2c/src/components/Sheet/Sheet.stories.tsx
@@ -222,7 +222,7 @@ const StoryWithInsideScroll = ({
                 <div
                     style={{
                         height: '150px',
-                        overflow: 'scroll',
+                        overflowY: 'scroll',
                         display: 'flex',
                         flexDirection: 'column',
                         gap: '1rem',
@@ -296,7 +296,7 @@ const StoryWithDoubleScroll = ({
                     <div
                         style={{
                             height: '150px',
-                            overflow: 'scroll',
+                            overflowY: 'scroll',
                             display: 'flex',
                             flexDirection: 'column',
                             gap: '1rem',

--- a/packages/plasma-new-hope/src/components/Sheet/Sheet.tsx
+++ b/packages/plasma-new-hope/src/components/Sheet/Sheet.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useRef } from 'react';
 
 import { RootProps } from '../../engines';
 import { Overlay } from '../Overlay';
@@ -44,9 +44,9 @@ export const sheetRoot = (Root: RootProps<HTMLDivElement, SheetProps>) =>
             },
             rootRef,
         ) => {
-            const contentWrapperRef = React.useRef<HTMLDivElement>(null);
-            const contentRef = React.useRef<HTMLDivElement>(null);
-            const handleRef = React.useRef<HTMLDivElement>(null);
+            const contentWrapperRef = useRef<HTMLDivElement>(null);
+            const contentRef = useRef<HTMLDivElement>(null);
+            const handleRef = useRef<HTMLDivElement>(null);
 
             useOverflow({ opened });
             useSheetSwipe({ contentWrapperRef, contentRef, handleRef, throttleMs, onClose });

--- a/packages/plasma-new-hope/src/components/Sheet/Sheet.types.ts
+++ b/packages/plasma-new-hope/src/components/Sheet/Sheet.types.ts
@@ -1,4 +1,4 @@
-import { ReactNode, HTMLAttributes } from 'react';
+import type { ReactNode, HTMLAttributes } from 'react';
 
 export interface SheetProps extends HTMLAttributes<HTMLDivElement> {
     /**

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Sheet/Sheet.stories.tsx
@@ -222,7 +222,7 @@ const StoryWithInsideScroll = ({
                 <div
                     style={{
                         height: '150px',
-                        overflow: 'scroll',
+                        overflowY: 'scroll',
                         display: 'flex',
                         flexDirection: 'column',
                         gap: '1rem',
@@ -296,7 +296,7 @@ const StoryWithDoubleScroll = ({
                     <div
                         style={{
                             height: '150px',
-                            overflow: 'scroll',
+                            overflowY: 'scroll',
                             display: 'flex',
                             flexDirection: 'column',
                             gap: '1rem',

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Sheet/Sheet.stories.tsx
@@ -222,7 +222,7 @@ const StoryWithInsideScroll = ({
                 <div
                     style={{
                         height: '150px',
-                        overflow: 'scroll',
+                        overflowY: 'scroll',
                         display: 'flex',
                         flexDirection: 'column',
                         gap: '1rem',
@@ -296,7 +296,7 @@ const StoryWithDoubleScroll = ({
                     <div
                         style={{
                             height: '150px',
-                            overflow: 'scroll',
+                            overflowY: 'scroll',
                             display: 'flex',
                             flexDirection: 'column',
                             gap: '1rem',

--- a/packages/plasma-web/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-web/src/components/Sheet/Sheet.stories.tsx
@@ -222,7 +222,7 @@ const StoryWithInsideScroll = ({
                 <div
                     style={{
                         height: '150px',
-                        overflow: 'scroll',
+                        overflowY: 'scroll',
                         display: 'flex',
                         flexDirection: 'column',
                         gap: '1rem',
@@ -296,7 +296,7 @@ const StoryWithDoubleScroll = ({
                     <div
                         style={{
                             height: '150px',
-                            overflow: 'scroll',
+                            overflowY: 'scroll',
                             display: 'flex',
                             flexDirection: 'column',
                             gap: '1rem',

--- a/packages/sdds-serv/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/sdds-serv/src/components/Sheet/Sheet.stories.tsx
@@ -222,7 +222,7 @@ const StoryWithInsideScroll = ({
                 <div
                     style={{
                         height: '150px',
-                        overflow: 'scroll',
+                        overflowY: 'scroll',
                         display: 'flex',
                         flexDirection: 'column',
                         gap: '1rem',
@@ -296,7 +296,7 @@ const StoryWithDoubleScroll = ({
                     <div
                         style={{
                             height: '150px',
-                            overflow: 'scroll',
+                            overflowY: 'scroll',
                             display: 'flex',
                             flexDirection: 'column',
                             gap: '1rem',

--- a/website/caldera-online-docs/docs/components/Sheet.mdx
+++ b/website/caldera-online-docs/docs/components/Sheet.mdx
@@ -1,0 +1,139 @@
+---
+id: sheet
+title: Sheet
+---
+
+import { PropsTable, Description } from '@site/src/components';
+
+# Sheet
+<Description name="Sheet" />
+<PropsTable name="Sheet" />
+
+## Использование
+Компонент `Sheet` может содержать любой контент напрямую через `children`.
+
+Также есть возможность добавить любой контент в заголовок и футер с помощью свойств `contentHeader` и `contentFooter`.
+
+```tsx live
+import React, { useState } from 'react';
+import { Sheet, Button } from '@salutejs/caldera-online';
+
+export function App() {
+    const [opened, setOpened] = useState(false);
+
+    return (
+        <>
+            <Button onClick={() => setOpened(true)}>Открыть</Button>
+
+            <Sheet opened={opened}
+                onClose={() => setOpened(false)}
+                contentHeader={
+                    <div>
+                        <h4>header</h4>
+                    </div>
+                }
+                contentFooter={
+                    <div>
+                        <p>footer</p>
+                    </div>
+                }
+            >
+                <div style={{ 'padding-bottom': '300px' }}>body</div>
+            </Sheet>
+        </>
+    );
+}
+```
+
+## Примеры
+
+### Закрепление заголовка и футера
+
+С помощью свойств `isHeaderFixed` и `isFooterFixed` можно закрепить заголовок и футер. 
+В этом случае при появлении прокрутки контент будет скроллится под них.
+
+```tsx live
+import React, { useState } from 'react';
+import { Sheet, Button } from '@salutejs/caldera-online';
+
+export function App() {
+    const [opened, setOpened] = useState(false);
+
+    return (
+        <>
+            <Button onClick={() => setOpened(true)}>Открыть</Button>
+            <Sheet opened={opened}
+                onClose={() => setOpened(false)}
+                contentHeader={
+                    <div>
+                        <h4>header</h4>
+                    </div>
+                }
+                contentFooter={
+                    <div>
+                        <p>footer</p>
+                    </div>
+                }
+                isFooterFixed
+                isHeaderFixed
+            >
+                <div style={{ 'padding-bottom': '300px' }}>body</div>
+            </Sheet>
+        </>
+    );
+}
+```
+
+### Подложка
+
+Наличие или отсутствие подложки задается с помощью свойства `withOverlay`.
+
+В случае, когда подложка отсутствует, у пользователя появляется возможность взаимодействовать с контентом вне шторки.
+
+```tsx live
+import React, { useState } from 'react';
+import { Sheet, Button } from '@salutejs/caldera-online';
+
+export function App() {
+    const [opened, setOpened] = useState(false);
+
+    return (
+        <>
+            <Button onClick={() => setOpened(!opened)}>
+                {opened ? 'Закрыть' : 'Открыть'}
+            </Button>
+            <Sheet opened={opened}
+                onClose={() => setOpened(false)}
+                withOverlay={false}
+            >
+                <div style={{ 'padding-bottom': '300px' }}>body</div>
+            </Sheet>
+        </>
+    );
+}
+```
+
+К подложке можно добавить эффект размытия при помощи свойства `withBlur`.
+
+```tsx live
+import React, { useState } from 'react';
+import { Sheet, Button } from '@salutejs/caldera-online';
+
+export function App() {
+    const [opened, setOpened] = useState(false);
+
+    return (
+        <>
+            <Button onClick={() => setOpened(!opened)}>
+                {opened ? 'Закрыть' : 'Открыть'}
+            </Button>
+            <Sheet opened={opened}
+                onClose={() => setOpened(false)}
+                withBlur
+            >
+                <div style={{ 'padding-bottom': '300px' }}>body</div>
+            </Sheet>
+        </>
+    );
+}
+```


### PR DESCRIPTION
### Sheet

- убран из примеров в `stories` лишний горизонтальный скролл 
- добавлена недостающая документация в `caldera-online` 

**Before**:

<img width="1726" alt="scrollBefore" src="https://github.com/salute-developers/plasma/assets/71961494/f37919f8-df31-427e-aff9-34228cb920b6" />

**After**:

<img width="1725" alt="scrollAfter" src="https://github.com/salute-developers/plasma/assets/71961494/6c3ae1df-e3cc-42d0-ae54-6b11fba55690" />

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.55.1-canary.1273.9743629696.0
  npm install @salutejs/plasma-asdk@0.98.1-canary.1273.9743629696.0
  npm install @salutejs/plasma-b2c@1.340.1-canary.1273.9743629696.0
  npm install @salutejs/plasma-new-hope@0.95.1-canary.1273.9743629696.0
  npm install @salutejs/plasma-web@1.341.1-canary.1273.9743629696.0
  npm install @salutejs/sdds-serv@0.68.1-canary.1273.9743629696.0
  # or 
  yarn add @salutejs/caldera-online@0.55.1-canary.1273.9743629696.0
  yarn add @salutejs/plasma-asdk@0.98.1-canary.1273.9743629696.0
  yarn add @salutejs/plasma-b2c@1.340.1-canary.1273.9743629696.0
  yarn add @salutejs/plasma-new-hope@0.95.1-canary.1273.9743629696.0
  yarn add @salutejs/plasma-web@1.341.1-canary.1273.9743629696.0
  yarn add @salutejs/sdds-serv@0.68.1-canary.1273.9743629696.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
