### PR TITLE
plasma-infra(scaffold): Extend script for update/sync component list 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Salute Frontend Team <salute.developers@gmail.com>",
   "license": "MIT",
   "scripts": {
+    "scaffold:update-components-docs": "npm run scaffold:components",
     "scaffold:docs": "simple-scaffold -c scaffold/scaffold-config.js --name $npm_config_package",
     "scaffold:components": "node scaffold/scaffold-components.js",
     "scaffold:update-docs-ui": "node scaffold/update-docs-ui.js && npm i --no-audit --no-progress --package-lock-only --lockfile-version 2 --legacy-peer-deps --prefix=$npm_config_dir",

--- a/scaffold/Readme.md
+++ b/scaffold/Readme.md
@@ -56,3 +56,19 @@ npm run scaffold:docs --package="plasma-asdk" --vertical="plasma-themes" --theme
 Чтобы избежать данного warning нужно использовать экранирование `\`.
 
 Например: `style=\{{flexDirection: 'column'}}`
+
+### Как обновить список компонентов в уже имеющейся документации?
+
+Есть отдельная команда - `npm run scaffold:update-components-docs`.
+
+Например, для пакета `caldera-online`:
+
+```console
+npm run scaffold:update-components-docs --vertical="caldera-online-themes" --package="caldera-online" --exclude="sheet"
+```
+
+Обновит/добавит/синхронизирует список компонентов документации и библиотеки, при этом **исключит** компонент `Sheet`.
+
+**Примечание:**
+
+Аргумент `exclude` принимает перечисление компонентов через запятую: `--exclude="sheet,textarea,etc"`

--- a/scaffold/scaffold-components.js
+++ b/scaffold/scaffold-components.js
@@ -7,7 +7,13 @@ const fg = require('fast-glob');
 // INFO: Генерация компонентов по шаблону и на основе списка компонентов на основе пакета
 // INFO: для которого делается документация
 async function main() {
-    const { npm_config_package: npmConfigPackage, npm_config_vertical: npmConfigVertical } = process.env || {};
+    const {
+        npm_config_package: npmConfigPackage,
+        npm_config_vertical: npmConfigVertical,
+        npm_config_exclude: npmConfigExclude,
+    } = process.env || {};
+
+    const excludeList = npmConfigExclude ? npmConfigExclude.split(',').map((component) => component?.trim()) : [];
 
     if (!npmConfigPackage) {
         return;
@@ -25,7 +31,9 @@ async function main() {
 
         // INFO: Получаем актуальный список директорий компонентов
         // например ['AutoComplete','Avatar','AvatarGroup','Badge','Button','ButtonGroup','Cell']
-        const components = await readdir(packageDir);
+        const components = (await readdir(packageDir)).filter(
+            (component) => !excludeList.includes(component.toLowerCase()),
+        );
 
         // INFO: Собираем шаблоны документации для компонентов
         // [


### PR DESCRIPTION
### Scaffold

- скрипт для генерации компонентов вынесен в отдельную команду


### What/why changed

Теперь есть возможность запустить команду 

```console
npm run scaffold:update-components-docs --vertical="caldera-online-themes" --package="caldera-online" --exclude="sheet"
```
и тем самым обновить все компоненты документации(в том числе появятся новые, и sync старых).   