### PR TITLE
plasma-icons: Rewrite generate icons for iOS

### DIFF
--- a/packages/plasma-icons/scripts/generateIconsIos.mjs
+++ b/packages/plasma-icons/scripts/generateIconsIos.mjs
@@ -38,10 +38,16 @@ try {
     let pngCount = 0;
     
     for (const sourceDirectory of listSVG) {
-        const [fullSvgName] = sourceDirectory.split('/').reverse();
+        const [fullSvgName, dir] = sourceDirectory.split('/').reverse();
+      
+        // @example Icon.svg.24
+        const [size] = dir.split('.').reverse();
+        
+        // @example Accessibility.svg
         const [svgName] = fullSvgName.split('.');
         
-        const pngDirectory = `${iosIconsDirectory}/${svgName}.imageset`;
+        // @example ./icons-ios/ScenarioSyncAuto45Fill24.imageset
+        const pngDirectory = `${iosIconsDirectory}/${svgName}${size}.imageset`;
         
         try {
             await access(pngDirectory);
@@ -86,23 +92,7 @@ try {
         
         const pngContentsJsonPath = path.join(pngDirectory, 'Contents.json');
         
-        try {
-            // INFO: если Contents.json для этого imageset уже существует нужно
-            // INFO: дописать в images новые значения
-            await access(pngContentsJsonPath);
-            
-            const rawData = await readFile(pngContentsJsonPath, 'utf8');
-            const json = JSON.parse(rawData);
-            
-            const data = {
-                ...json,
-                images: [...json.images, ...images]
-            };
-            
-            await writeFile(pngContentsJsonPath, JSON.stringify(data, null, 2), 'utf8');
-        } catch (e) {
-            await writeFile(pngContentsJsonPath, JSON.stringify(contentsJson, null, 2), 'utf8');
-        }
+        await writeFile(pngContentsJsonPath, JSON.stringify(contentsJson, null, 2), 'utf8');
     }
     
     if (svgCount !== pngCount) {


### PR DESCRIPTION
### iOS

- исправлена генерация иконок под iOS

**Before:**

<img width="248" src="https://github.com/salute-developers/plasma/assets/2895992/e93abb36-8a51-4451-aab3-3107959a8904" />

**After:**

<img width="248" src="https://github.com/salute-developers/plasma/assets/2895992/8415a3b2-3f6e-46fb-9a3e-767f0317aa30" />


### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.102.1-canary.1283.9806525690.0
  npm install @salutejs/plasma-b2c@1.344.1-canary.1283.9806525690.0
  npm install @salutejs/plasma-hope@1.286.1-canary.1283.9806525690.0
  npm install @salutejs/plasma-icons@1.198.1-canary.1283.9806525690.0
  npm install @salutejs/plasma-ui@1.256.1-canary.1283.9806525690.0
  npm install @salutejs/plasma-web@1.345.1-canary.1283.9806525690.0
  npm install @salutejs/sdds-serv@0.72.1-canary.1283.9806525690.0
  # or 
  yarn add @salutejs/plasma-asdk@0.102.1-canary.1283.9806525690.0
  yarn add @salutejs/plasma-b2c@1.344.1-canary.1283.9806525690.0
  yarn add @salutejs/plasma-hope@1.286.1-canary.1283.9806525690.0
  yarn add @salutejs/plasma-icons@1.198.1-canary.1283.9806525690.0
  yarn add @salutejs/plasma-ui@1.256.1-canary.1283.9806525690.0
  yarn add @salutejs/plasma-web@1.345.1-canary.1283.9806525690.0
  yarn add @salutejs/sdds-serv@0.72.1-canary.1283.9806525690.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
