### PR TITLE
plasma-docs: hide short links for storybook

### DIFF
--- a/website/plasma-ui-docs/src/components/Storybook.tsx
+++ b/website/plasma-ui-docs/src/components/Storybook.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { StorybookLink as BaseLink } from '@salutejs/plasma-docs-ui';
 
+// INFO: Список должен совпадать со списком компонентов в библиотеки
 const storyLinks = {
     Badge: 'content-badge--default',
     Button: 'controls-button--default',
@@ -33,6 +34,8 @@ const storyLinks = {
     Typography: 'content-typography--default',
 };
 
-export const StorybookLink: FC<{ name: keyof typeof storyLinks }> = ({ name }) => {
-    return <BaseLink link={`https://bit.ly/3xRatFG?path=/story/${storyLinks[name]}`} />;
+// INFO: Временно убираем кнопку
+export const StorybookLink: FC<{ name: keyof typeof storyLinks }> = () => {
+    // INFO: short links работает с ошибкой
+    return <BaseLink link={null} />;
 };

--- a/website/plasma-web-docs/src/components/Storybook.tsx
+++ b/website/plasma-web-docs/src/components/Storybook.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { StorybookLink as BaseLink } from '@salutejs/plasma-docs-ui';
 
+// INFO: Список должен совпадать со списком компонентов в библиотеки
 const storyLinks = {
     Badge: 'content-badge--default',
     Button: 'controls-button--default',
@@ -28,6 +29,8 @@ const storyLinks = {
     Toolbar: 'controls-toolbar--default',
 };
 
-export const StorybookLink: FC<{ name: keyof typeof storyLinks }> = ({ name }) => {
-    return <BaseLink link={`https://bit.ly/3OtwX5v-storybook/?path=/story/${storyLinks[name]}`} />;
+// INFO: Временно убираем кнопку
+export const StorybookLink: FC<{ name: keyof typeof storyLinks }> = () => {
+    // INFO: short links работает с ошибкой
+    return <BaseLink link={null} />;
 };


### PR DESCRIPTION
### Storybook link

- убрана ссылка/кнопка на storybook из документации для `plasma-{web,ui}`

**Before:**

<img width="1944" src="https://github.com/salute-developers/plasma/assets/2895992/458182dc-07eb-4954-9b06-a2f0eabc867f" />

**After:**

<img width="1944" src="https://github.com/salute-developers/plasma/assets/2895992/ea812456-7644-4194-8188-88a085b416f6" />

### What/why changed

Сокращенные ссылки не работали как ожидается. Поэтому приняли решение временно скрыть/убрать их.  

