### PR TITLE
plasma-*: Fix tech debt

### DIFF
--- a/packages/plasma-new-hope/src/components/Popup/Popup.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.template-doc.mdx
@@ -15,7 +15,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
-import { PopupProvider } from '@salutejs/sdds-serv';
+import { PopupProvider } from '@salutejs/{{ package }}';
 
 import { App } from './App';
 

--- a/packages/plasma-new-hope/src/components/Slider/ui/Handler/Handler.tsx
+++ b/packages/plasma-new-hope/src/components/Slider/ui/Handler/Handler.tsx
@@ -63,8 +63,6 @@ export const Handler = forwardRef<HTMLDivElement, HandlerProps>(
             right: (rightPositionBound ?? stepSize * (max - min)) - (offsetRight ? stepSize : 0),
         };
 
-        console.log(computedBounds);
-
         const showCurrentValueCondition =
             showCurrentValue &&
             ((xPosition >= startOffset && xPosition <= max * stepSize - endOffset) || (xPosition === 0 && value !== 0));

--- a/website/caldera-online-docs/docs/components/Popup.mdx
+++ b/website/caldera-online-docs/docs/components/Popup.mdx
@@ -15,7 +15,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
-import { PopupProvider } from '@salutejs/sdds-serv';
+import { PopupProvider } from '@salutejs/caldera-online';
 
 import { App } from './App';
 


### PR DESCRIPTION
### What/why changed

- удален лишний `console.log(computedBounds);`
- исправлен шаблон для `Popup` (был неправильный import)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.61.1-canary.1290.9868019360.0
  npm install @salutejs/plasma-asdk@0.104.1-canary.1290.9868019360.0
  npm install @salutejs/plasma-b2c@1.346.1-canary.1290.9868019360.0
  npm install @salutejs/plasma-new-hope@0.101.1-canary.1290.9868019360.0
  npm install @salutejs/plasma-web@1.347.1-canary.1290.9868019360.0
  npm install @salutejs/sdds-serv@0.74.1-canary.1290.9868019360.0
  # or 
  yarn add @salutejs/caldera-online@0.61.1-canary.1290.9868019360.0
  yarn add @salutejs/plasma-asdk@0.104.1-canary.1290.9868019360.0
  yarn add @salutejs/plasma-b2c@1.346.1-canary.1290.9868019360.0
  yarn add @salutejs/plasma-new-hope@0.101.1-canary.1290.9868019360.0
  yarn add @salutejs/plasma-web@1.347.1-canary.1290.9868019360.0
  yarn add @salutejs/sdds-serv@0.74.1-canary.1290.9868019360.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
