### PR TITLE
plasma-icons: Changes execute order methods in compose

### DIFF
--- a/packages/plasma-icons/scripts/utils.ts
+++ b/packages/plasma-icons/scripts/utils.ts
@@ -38,8 +38,8 @@ export const getIconAsset = (source: string, iconName: string) => {
         getSvgContent,
         setFillCurrentColor,
         setStrokeCurrentColor,
-        removeOpacity,
         removeFillOpacity,
+        removeOpacity,
         convertInlineStyleToObject,
         camelizeAttributes,
     )(source);


### PR DESCRIPTION
### What/why changed

Изменен порядок исполнения функций для 

```js
    const svgContent = compose(
        removeLineBreak,
        getSvgContent,
        setFillCurrentColor,
        setStrokeCurrentColor,
        removeFillOpacity,
        **removeOpacity**,
        convertInlineStyleToObject,
        camelizeAttributes,
    )(source);
``` 

чтобы корректно обрабатывать свойства в `svg` 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.105.1-canary.1294.9868888674.0
  npm install @salutejs/plasma-b2c@1.347.1-canary.1294.9868888674.0
  npm install @salutejs/plasma-hope@1.287.1-canary.1294.9868888674.0
  npm install @salutejs/plasma-icons@1.198.3-canary.1294.9868888674.0
  npm install @salutejs/plasma-ui@1.257.1-canary.1294.9868888674.0
  npm install @salutejs/plasma-web@1.348.1-canary.1294.9868888674.0
  npm install @salutejs/sdds-serv@0.75.1-canary.1294.9868888674.0
  # or 
  yarn add @salutejs/plasma-asdk@0.105.1-canary.1294.9868888674.0
  yarn add @salutejs/plasma-b2c@1.347.1-canary.1294.9868888674.0
  yarn add @salutejs/plasma-hope@1.287.1-canary.1294.9868888674.0
  yarn add @salutejs/plasma-icons@1.198.3-canary.1294.9868888674.0
  yarn add @salutejs/plasma-ui@1.257.1-canary.1294.9868888674.0
  yarn add @salutejs/plasma-web@1.348.1-canary.1294.9868888674.0
  yarn add @salutejs/sdds-serv@0.75.1-canary.1294.9868888674.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
