### PR TITLE
plasma-*: Fix width autoresize prop in textarea

### DIFF
--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -125,9 +125,9 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaProps>
         const placeLabel = labelPlacement === 'inner' && label && size !== 'xs' ? label : placeholder;
 
         useResizeObserver(outerRef, (currentElement) => {
-            const { width: inlineWidth, height: inlineHeight } = currentElement.style;
+            const { width: inlineWidth } = currentElement.style;
 
-            if (inlineWidth || inlineHeight || cols) {
+            if (inlineWidth || cols) {
                 const { width: elementWidth } = currentElement.getBoundingClientRect();
                 setHelperWidth(`${elementWidth / ROOT_FONT_SIZE}rem`);
             }
@@ -172,7 +172,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaProps>
                 size={size}
                 disabled={disabled}
                 readOnly={readOnly}
-                style={style}
+                style={{ width: helperWidth, ...style }}
                 className={className}
             >
                 {label && labelPlacement === 'outer' && <StyledLabel>{label}</StyledLabel>}


### PR DESCRIPTION
### Textarea

- исправлена логика при использовании свойства `autoResize` (теперь ширина автоматически растягивается)

Результат с включенным `autoResize` после изменения ширины

**До:**
![](https://github.com/salute-developers/plasma/assets/38344415/70ad8513-353e-477f-a0fe-e4d3ee5cfd55)

**После:**
![](https://github.com/salute-developers/plasma/assets/38344415/84306373-b4fb-4f13-8a77-b2fd05c08721)


### What/why changed

В функции, которая изменяет ширину, при изменении родительского элемента работала не правильно. До этого - если изменяется высота, то он пересчитывает и ширину в том числе. Теперь она работает только при изменении ширины родительского элемента

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.68.1-canary.1297.10035953739.0
  npm install @salutejs/plasma-asdk@0.111.1-canary.1297.10035953739.0
  npm install @salutejs/plasma-b2c@1.353.1-canary.1297.10035953739.0
  npm install @salutejs/plasma-new-hope@0.108.1-canary.1297.10035953739.0
  npm install @salutejs/plasma-web@1.354.1-canary.1297.10035953739.0
  npm install @salutejs/sdds-dfa@0.81.1-canary.1297.10035953739.0
  npm install @salutejs/sdds-serv@0.82.1-canary.1297.10035953739.0
  # or 
  yarn add @salutejs/caldera-online@0.68.1-canary.1297.10035953739.0
  yarn add @salutejs/plasma-asdk@0.111.1-canary.1297.10035953739.0
  yarn add @salutejs/plasma-b2c@1.353.1-canary.1297.10035953739.0
  yarn add @salutejs/plasma-new-hope@0.108.1-canary.1297.10035953739.0
  yarn add @salutejs/plasma-web@1.354.1-canary.1297.10035953739.0
  yarn add @salutejs/sdds-dfa@0.81.1-canary.1297.10035953739.0
  yarn add @salutejs/sdds-serv@0.82.1-canary.1297.10035953739.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
