### PR TITLE
plasma-{b2c,web}: Fix vc cdn url

### DIFF
--- a/packages/plasma-b2c/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/packages/plasma-b2c/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -23,7 +23,7 @@ const song = {
     duration: 128,
     id: 123,
     file:
-        'https://vc-static.sberdevices.ru/smartmarket-video-news/media/uploads/15/159f025fe48c54f70b7a4041edbb413044f01a61.mp3',
+        'https://cdn1.newsback.sberdevices.ru/p-newsback/media/uploads/15/159f025fe48c54f70b7a4041edbb413044f01a61.mp3',
     canDelete: true,
 };
 

--- a/packages/plasma-web/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/packages/plasma-web/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -23,7 +23,7 @@ const song = {
     duration: 128,
     id: 123,
     file:
-        'https://vc-static.sberdevices.ru/smartmarket-video-news/media/uploads/15/159f025fe48c54f70b7a4041edbb413044f01a61.mp3',
+        'https://cdn1.newsback.sberdevices.ru/p-newsback/media/uploads/15/159f025fe48c54f70b7a4041edbb413044f01a61.mp3',
     canDelete: true,
 };
 

--- a/website/plasma-web-docs/docs/components/AudioPlayer.mdx
+++ b/website/plasma-web-docs/docs/components/AudioPlayer.mdx
@@ -22,7 +22,7 @@ export function App() {
         name: 'I’m Not Okay',
         duration: 128,
         id: 123,
-        file: 'https://vc-static.sberdevices.ru/smartmarket-video-news/media/uploads/15/159f025fe48c54f70b7a4041edbb413044f01a61.mp3',
+        file: 'https://cdn1.newsback.sberdevices.ru/p-newsback/media/uploads/15/159f025fe48c54f70b7a4041edbb413044f01a61.mp3',
         canDelete: true,
     };
 


### PR DESCRIPTION
### AudioPlayer

- изменен `cdn` в примерах`https://vc-static.sberdevices.ru/smartmarket-video-news/` на `https://cdn1.newsback.sberdevices.ru/p-newsback/`

### What/why changed

По просьбе команды новостей, ради закапывания `vc-static`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.350.1-canary.1298.9905613224.0
  npm install @salutejs/plasma-web@1.351.1-canary.1298.9905613224.0
  # or 
  yarn add @salutejs/plasma-b2c@1.350.1-canary.1298.9905613224.0
  yarn add @salutejs/plasma-web@1.351.1-canary.1298.9905613224.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
