### PR TITLE
plasma-new-hope:  forward styles and className to Tooltip root

### DIFF
--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
@@ -60,6 +60,7 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                 contentLeft,
                 zIndex = '9200',
                 className,
+                style,
                 ...rest
             },
             outerRef,
@@ -101,12 +102,10 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                     aria-hidden={!innerIsOpen}
                     aria-live="polite"
                     role="tooltip"
-                    className={cx(ref?.classList.toString(), animatedClass, className)}
-                    // INFO: Прокидываем стили для Popover из Root Tooltip-а
-
+                    className={cx(ref?.classList.toString(), animatedClass)}
                     {...rest}
                 >
-                    <Root view={view} size={size} ref={setRef}>
+                    <Root view={view} size={size} ref={setRef} className={className} style={style}>
                         <TooltipRoot
                             ref={outerRef}
                             id={id}


### PR DESCRIPTION
### Tooltip

- исправлен проброс стилей в Tooltip

### What/why changed

В Tooltip не было возможности переопределить токены.
Теперь className и style прокидываются в Root
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/caldera-online@0.66.1-canary.1311.9990050021.0
  npm install @salutejs/plasma-asdk@0.109.1-canary.1311.9990050021.0
  npm install @salutejs/plasma-b2c@1.351.1-canary.1311.9990050021.0
  npm install @salutejs/plasma-new-hope@0.106.1-canary.1311.9990050021.0
  npm install @salutejs/plasma-web@1.352.1-canary.1311.9990050021.0
  npm install @salutejs/sdds-dfa@0.79.1-canary.1311.9990050021.0
  npm install @salutejs/sdds-serv@0.80.1-canary.1311.9990050021.0
  # or 
  yarn add @salutejs/caldera-online@0.66.1-canary.1311.9990050021.0
  yarn add @salutejs/plasma-asdk@0.109.1-canary.1311.9990050021.0
  yarn add @salutejs/plasma-b2c@1.351.1-canary.1311.9990050021.0
  yarn add @salutejs/plasma-new-hope@0.106.1-canary.1311.9990050021.0
  yarn add @salutejs/plasma-web@1.352.1-canary.1311.9990050021.0
  yarn add @salutejs/sdds-dfa@0.79.1-canary.1311.9990050021.0
  yarn add @salutejs/sdds-serv@0.80.1-canary.1311.9990050021.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
