### PR TITLE
fix(sdds-serv-docs,sdd-dfa-docs): Fix introducing page

### DIFF
--- a/scaffold/template-docs/docs/intro.mdx
+++ b/scaffold/template-docs/docs/intro.mdx
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
 ```bash
 $ npm install --save react react-dom
 $ npm install --save styled-components
-$ npm install --save @salutejs/{{ name }} @salutejs/plasma-typo @salutejs/{{ vertical }}
+$ npm install --save @salutejs/{{ name }} @salutejs/{{ vertical }}
 ```
 
 ## Настройка
@@ -38,16 +38,13 @@ $ npm install --save @salutejs/{{ name }} @salutejs/plasma-typo @salutejs/{{ ver
 
 ```jsx title="GlobalStyle.tsx"
 import { createGlobalStyle } from 'styled-components';
-import { standard } from '@salutejs/plasma-typo';
 import { {{ theme }}__light } from '@salutejs/{{ vertical }}';
 
 const ThemeStyle = createGlobalStyle({{ theme }}__light);
-const TypoStyle = createGlobalStyle(standard);
 
 export const GlobalStyle = () => (
     <>
         <ThemeStyle />
-        <TypoStyle />
     </>
 );
 ```

--- a/website/sdds-dfa-docs/docs/intro.mdx
+++ b/website/sdds-dfa-docs/docs/intro.mdx
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
 ```bash
 $ npm install --save react react-dom
 $ npm install --save styled-components
-$ npm install --save @salutejs/sdds-dfa @salutejs/plasma-typo @salutejs/sdds-themes
+$ npm install --save @salutejs/sdds-dfa @salutejs/sdds-themes
 ```
 
 ## Настройка
@@ -38,16 +38,13 @@ $ npm install --save @salutejs/sdds-dfa @salutejs/plasma-typo @salutejs/sdds-the
 
 ```jsx title="GlobalStyle.tsx"
 import { createGlobalStyle } from 'styled-components';
-import { standard } from '@salutejs/plasma-typo';
 import { sdds_dfa__light } from '@salutejs/sdds-themes';
 
 const ThemeStyle = createGlobalStyle(sdds_dfa__light);
-const TypoStyle = createGlobalStyle(standard);
 
 export const GlobalStyle = () => (
     <>
         <ThemeStyle />
-        <TypoStyle />
     </>
 );
 ```

--- a/website/sdds-serv-docs/docs/intro.mdx
+++ b/website/sdds-serv-docs/docs/intro.mdx
@@ -26,7 +26,7 @@ import TabItem from '@theme/TabItem';
 
 ```bash
 $ npm install --save react react-dom
-$ npm install --save @salutejs/sdds-serv @salutejs/plasma-typo @salutejs/sdds-themes
+$ npm install --save @salutejs/sdds-serv @salutejs/sdds-themes
 ```
 
 Так же надо установить пакет styled-components
@@ -47,16 +47,13 @@ $ npm install --save @emotion/styled @emotion/react @emotion/css
 
 ```jsx title="GlobalStyle.tsx"
 import { createGlobalStyle } from 'styled-components';
-import { standard } from '@salutejs/plasma-typo';
 import { sdds_serv__light } from '@salutejs/sdds-themes';
 
 const ThemeStyle = createGlobalStyle(sdds_serv__light);
-const TypoStyle = createGlobalStyle(standard);
 
 export const GlobalStyle = () => (
     <>
         <ThemeStyle />
-        <TypoStyle />
     </>
 );
 ```
@@ -67,16 +64,13 @@ export const GlobalStyle = () => (
 
 ```jsx title="GlobalStyle.tsx"
 import { Global, css } from '@emotion/react';
-import { standard } from '@salutejs/plasma-typo';
 import { sdds_serv__light } from '@salutejs/sdds-themes';
 
 const themeStyle = css(sdds_serv__light);
-const typoStyle = css(standard);
 
 export const GlobalStyle = () => (
     <>
         <Global styles={themeStyle} />
-        <Global styles={typoStyle} />
     </>
 );
 ```


### PR DESCRIPTION
### Docs

* Поправлено описание подключения темы для `sdds` вертикали

### What/why changed

Сейчас в документации во вкладке "Введение" упоминается лишнее подключение типографики через зависимость plasma-typo. Это делать не нужно, т.к. токены шрифтов и всех настроек уже лежат в соответствующих темах.
Поэтому необходимо удалить из существующих документаций эту информацию, а также из шаблонов в scaffold.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-ui@1.263.1-canary.1338.10218214240.0
  # or 
  yarn add @salutejs/plasma-ui@1.263.1-canary.1338.10218214240.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
