### PR TITLE
fix: fix Notification animation overflow

### DIFF
--- a/packages/plasma-new-hope/src/components/Notification/NotificationsPortal.tsx
+++ b/packages/plasma-new-hope/src/components/Notification/NotificationsPortal.tsx
@@ -1,5 +1,7 @@
 import React, { FC, ForwardRefExoticComponent, RefAttributes, useMemo } from 'react';
 import { useStoreon } from 'storeon/react';
+import { styled } from '@linaria/react';
+import { popupBaseRootClass } from '@salutejs/plasma-core';
 
 import { PopupProvider, popupConfig } from '../Popup';
 import { component } from '../../engines';
@@ -12,6 +14,12 @@ import { classes } from './Notification.tokens';
 
 // issue #823
 const Popup = component(popupConfig);
+
+const StyledPopup = styled(Popup)`
+    & > .${popupBaseRootClass} {
+        overflow: hidden;
+    }
+`;
 
 /**
  * Обертка для визуального представления уведомлений.
@@ -27,7 +35,7 @@ export const NotificationsPortal: FC<NotificationPortalProps> = ({ config, frame
     return (
         <PopupProvider>
             {notifications.length > 0 && (
-                <Popup isOpen frame={frame} placement="bottom-right" zIndex="9100">
+                <StyledPopup isOpen frame={frame} placement="bottom-right" zIndex="9100">
                     <StyledRoot>
                         {notifications.map(({ id, isHidden, ...rest }) => (
                             <StyledItemWrapper
@@ -46,7 +54,7 @@ export const NotificationsPortal: FC<NotificationPortalProps> = ({ config, frame
                             </StyledItemWrapper>
                         ))}
                     </StyledRoot>
-                </Popup>
+                </StyledPopup>
             )}
         </PopupProvider>
     );


### PR DESCRIPTION
### Контейнер в NotificationProvider

Добавил `overflow: hidden` на контейнер используемого Popup

### What/why changed

Иначе, при анимации скрытия нотификаций появляются общий скрол
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.117.1-canary.1339.10246269224.0
  npm install @salutejs/plasma-b2c@1.359.1-canary.1339.10246269224.0
  npm install @salutejs/plasma-new-hope@0.114.1-canary.1339.10246269224.0
  npm install @salutejs/plasma-web@1.360.1-canary.1339.10246269224.0
  npm install @salutejs/sdds-cs@0.89.1-canary.1339.10246269224.0
  npm install @salutejs/sdds-dfa@0.87.1-canary.1339.10246269224.0
  npm install @salutejs/sdds-serv@0.88.1-canary.1339.10246269224.0
  # or 
  yarn add @salutejs/plasma-asdk@0.117.1-canary.1339.10246269224.0
  yarn add @salutejs/plasma-b2c@1.359.1-canary.1339.10246269224.0
  yarn add @salutejs/plasma-new-hope@0.114.1-canary.1339.10246269224.0
  yarn add @salutejs/plasma-web@1.360.1-canary.1339.10246269224.0
  yarn add @salutejs/sdds-cs@0.89.1-canary.1339.10246269224.0
  yarn add @salutejs/sdds-dfa@0.87.1-canary.1339.10246269224.0
  yarn add @salutejs/sdds-serv@0.88.1-canary.1339.10246269224.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
