### PR TITLE
plasma-b2c: Add view props into radiobox stories

### DIFF
--- a/packages/plasma-b2c/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-b2c/src/components/Radiobox/Radiobox.stories.tsx
@@ -97,7 +97,7 @@ export const Live: Story = {
     render: (args) => <StoryLive {...args} />,
 };
 
-const StoryDefault = ({ name, label, description, disabled, singleLine, size }: RadioboxProps) => {
+const StoryDefault = ({ view, name, label, description, disabled, singleLine, size }: RadioboxProps) => {
     const value = 0;
     const [checked, setChecked] = React.useState(true);
 
@@ -109,6 +109,7 @@ const StoryDefault = ({ name, label, description, disabled, singleLine, size }: 
             description={description}
             disabled={disabled}
             checked={checked}
+            view={view}
             singleLine={singleLine}
             size={size}
             onChange={(event) => {
@@ -125,6 +126,7 @@ const StoryDefault = ({ name, label, description, disabled, singleLine, size }: 
 
 export const Default: Story = {
     args: {
+        view: 'default',
         name: 'Radiobox',
         label: 'Label',
         description: 'Description',

--- a/packages/plasma-new-hope/src/components/TextField/variations/_label-placement/base.ts
+++ b/packages/plasma-new-hope/src/components/TextField/variations/_label-placement/base.ts
@@ -59,8 +59,8 @@ export const base = css`
 
             height: var(${tokens.height});
 
-            padding-top: calc(var(${tokens.height}) / 4);
-            padding-bottom: calc(var(${tokens.height}) / 4);
+            padding-top: calc(calc(var(${tokens.height}) - var(${tokens.labelLineHeight})) / 2);
+            padding-bottom: calc(calc(var(${tokens.height}) - var(${tokens.labelLineHeight})) / 2);
         }
     }
 `;


### PR DESCRIPTION
### Radiobox

- добавлены параметры `view` для примеров в storybook в `plasma-b2c` 

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.129.1-canary.1358.10460366650.0
  npm install @salutejs/plasma-b2c@1.371.1-canary.1358.10460366650.0
  npm install @salutejs/plasma-new-hope@0.126.1-canary.1358.10460366650.0
  npm install @salutejs/plasma-web@1.372.1-canary.1358.10460366650.0
  npm install @salutejs/sdds-cs@0.101.1-canary.1358.10460366650.0
  npm install @salutejs/sdds-dfa@0.99.1-canary.1358.10460366650.0
  npm install @salutejs/sdds-serv@0.100.1-canary.1358.10460366650.0
  # or 
  yarn add @salutejs/plasma-asdk@0.129.1-canary.1358.10460366650.0
  yarn add @salutejs/plasma-b2c@1.371.1-canary.1358.10460366650.0
  yarn add @salutejs/plasma-new-hope@0.126.1-canary.1358.10460366650.0
  yarn add @salutejs/plasma-web@1.372.1-canary.1358.10460366650.0
  yarn add @salutejs/sdds-cs@0.101.1-canary.1358.10460366650.0
  yarn add @salutejs/sdds-dfa@0.99.1-canary.1358.10460366650.0
  yarn add @salutejs/sdds-serv@0.100.1-canary.1358.10460366650.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
