### PR TITLE
fix(new-hope): Textfield label bug

### DIFF
--- a/packages/plasma-new-hope/src/components/TextField/variations/_label-placement/base.ts
+++ b/packages/plasma-new-hope/src/components/TextField/variations/_label-placement/base.ts
@@ -24,7 +24,7 @@ export const base = css`
         }
 
         ${Input}:focus ~ ${Label}, ${Input}:not(:placeholder-shown) ~ ${Label} {
-            height: auto;
+            align-items: flex-start;
             padding: var(${tokens.labelInnerPadding});
 
             font-family: var(${tokens.labelInnerFontFamily});
@@ -56,8 +56,6 @@ export const base = css`
             align-items: center;
 
             box-sizing: border-box;
-
-            transition: padding 0.1s ease-in-out, height 0s;
 
             height: var(${tokens.height});
 


### PR DESCRIPTION
### Textfield

- исправлено "дергание" `label` в `inner` режиме

### What/why changed

`height` срабатывает не сразу, а после изменения шрифта, поэтому появляется дергание. `flex` срабатывает сразу


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.129.1-canary.1359.10459694920.0
  npm install @salutejs/plasma-b2c@1.371.1-canary.1359.10459694920.0
  npm install @salutejs/plasma-new-hope@0.126.1-canary.1359.10459694920.0
  npm install @salutejs/plasma-web@1.372.1-canary.1359.10459694920.0
  npm install @salutejs/sdds-cs@0.101.1-canary.1359.10459694920.0
  npm install @salutejs/sdds-dfa@0.99.1-canary.1359.10459694920.0
  npm install @salutejs/sdds-serv@0.100.1-canary.1359.10459694920.0
  # or 
  yarn add @salutejs/plasma-asdk@0.129.1-canary.1359.10459694920.0
  yarn add @salutejs/plasma-b2c@1.371.1-canary.1359.10459694920.0
  yarn add @salutejs/plasma-new-hope@0.126.1-canary.1359.10459694920.0
  yarn add @salutejs/plasma-web@1.372.1-canary.1359.10459694920.0
  yarn add @salutejs/sdds-cs@0.101.1-canary.1359.10459694920.0
  yarn add @salutejs/sdds-dfa@0.99.1-canary.1359.10459694920.0
  yarn add @salutejs/sdds-serv@0.100.1-canary.1359.10459694920.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
