### PR TITLE
fix(plasma-*): Tabs types and documentation

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -99,6 +99,8 @@ import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { counterTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { CustomComboboxProps } from '@salutejs/plasma-new-hope/types/components/Combobox/Combobox.types';
 import { CustomPopoverProps } from '@salutejs/plasma-new-hope/types/components/Popover/Popover.types';
+import { CustomTabItemProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/TabItem/TabItem.types';
+import { CustomTabsProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/Tabs/Tabs.types';
 import { CustomToastProps } from '@salutejs/plasma-new-hope/types/components/Toast/Toast.types';
 import { DateInfo } from '@salutejs/plasma-new-hope/types/components/Calendar/Calendar.types';
 import { DatePickerCalendarProps } from '@salutejs/plasma-new-hope/types/components/DatePicker/DatePickerBase.types';
@@ -2228,42 +2230,18 @@ export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 export { syntheticFocus }
 
 // @public
-export const TabItem: ForwardRefExoticComponent<AsProps<any> & ButtonHTMLAttributes<HTMLButtonElement> & {
-    isActive?: boolean | undefined;
-    selected?: boolean | undefined;
-    disabled?: boolean | undefined;
-    pilled?: boolean | undefined;
-    animated?: boolean | undefined;
-    contentLeft?: ReactNode;
-    contentRight?: ReactNode;
-    onIndexChange?: ((index: number) => void) | undefined;
-    itemIndex?: number | undefined;
-    size?: string | undefined;
-    view?: string | undefined;
-} & RefAttributes<HTMLDivElement>>;
+export const TabItem: ForwardRefExoticComponent<ButtonHTMLAttributes<HTMLButtonElement> & AsProps_2<any> & CustomTabItemProps & RefAttributes<HTMLDivElement>>;
 
 export { TabItemProps }
 
 export { TabItemRefs }
 
 // @public
-export const Tabs: ForwardRefExoticComponent<AsProps_2<any> & HTMLAttributes<HTMLDivElement> & {
-    clip?: "scroll" | "showAll" | undefined;
-    disabled?: boolean | undefined;
-    stretch?: boolean | undefined;
-    pilled?: boolean | undefined;
-    size?: string | undefined;
-    view?: string | undefined;
-    index?: number | undefined;
-    outsideScroll?: boolean | {
-        left?: string | undefined;
-        right?: string | undefined;
-    } | undefined;
-} & RefAttributes<HTMLDivElement>>;
+export const Tabs: ForwardRefExoticComponent<HTMLAttributes<HTMLDivElement> & AsProps_2<any> & CustomTabsProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsContext }
 
-// @public @deprecated (undocumented)
+// @public
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }

--- a/packages/plasma-b2c/src/components/Tabs/TabsController.tsx
+++ b/packages/plasma-b2c/src/components/Tabs/TabsController.tsx
@@ -4,9 +4,6 @@ import { Tabs } from './Tabs';
 import { TabItem } from './TabItem';
 
 /**
- * @deprecated
- * Используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange
- *
  * Контроллер вкладок.
  * Позволяет использовать клавиши ArrowLeft, ArrowRight, Home, End для навигации по вкладкам.
  */

--- a/packages/plasma-new-hope/src/components/Tabs/Tabs.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Tabs/Tabs.template-doc.mdx
@@ -5,15 +5,6 @@ title: Tabs
 
 import { PropsTable, Description } from '@site/src/components';
 
-# Tabs
-Набор компонентов для создания вкладок.
-Структура для вкладок похожа на структуру маркированных списков.
-
-## TabsController
-
-<Description name="TabsController" />
-<PropsTable name="TabsController" />
-
 ## Tabs
 
 <Description name="Tabs" />
@@ -24,6 +15,11 @@ import { PropsTable, Description } from '@site/src/components';
 <Description name="TabItem" />
 <PropsTable name="TabItem" />
 
+## TabsController (deprecated)
+Вместо этого используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange.
+
+<Description name="TabsController" />
+<PropsTable name="TabsController" />
 
 ## Использование
 

--- a/packages/plasma-new-hope/src/components/Tabs/ui/TabItem/TabItem.tsx
+++ b/packages/plasma-new-hope/src/components/Tabs/ui/TabItem/TabItem.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useRef, useContext, useEffect, useCallback } from 'react';
 import { useForkRef } from '@salutejs/plasma-core';
 
-import { ComponentConfig, RootProps } from '../../../../engines';
+import { RootProps } from '../../../../engines';
 import { classes } from '../../tokens';
 import { cx } from '../../../../utils';
 import { TabsContext } from '../../TabsContext';
@@ -118,7 +118,7 @@ export const tabItemRoot = (Root: RootProps<HTMLDivElement, TabItemProps>) =>
         );
     });
 
-export const tabItemConfig: ComponentConfig = {
+export const tabItemConfig = {
     name: 'TabItem',
     tag: 'button',
     layout: tabItemRoot,

--- a/packages/plasma-new-hope/src/components/Tabs/ui/TabItem/TabItem.types.ts
+++ b/packages/plasma-new-hope/src/components/Tabs/ui/TabItem/TabItem.types.ts
@@ -1,56 +1,56 @@
-import type { AsProps } from '@salutejs/plasma-core';
-import type { ButtonHTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
-export type TabItemProps = AsProps &
-    ButtonHTMLAttributes<HTMLButtonElement> & {
-        /**
-         * Активен ли TabItem
-         * @deprecated Используйте свойство `selected`
-         */
-        isActive?: boolean;
-        /**
-         * Выбран ли TabItem
-         */
-        selected?: boolean;
-        /**
-         * Скрыт ли TabItem
-         * @default false
-         */
-        disabled?: boolean;
-        /**
-         * TabItem c округлым border-radius
-         * @default false
-         */
-        pilled?: boolean;
-        /**
-         * Фон TabItem меняется с анимацией
-         * @default true
-         */
-        animated?: boolean;
-        /**
-         * Контент слева
-         */
-        contentLeft?: React.ReactNode;
-        /**
-         * Контент справа
-         */
-        contentRight?: React.ReactNode;
-        /**
-         *
-         * Колбек, необходимый для клавиатурной навигации
-         */
-        onIndexChange?: (index: number) => void;
-        /**
-         *
-         * Индекс TabItem внутри Tabs - необходим для клавиатурной навигации
-         */
-        itemIndex?: number;
-        /**
-         * Размер TabItem
-         */
-        size?: string;
-        /**
-         * Вид TabItem
-         */
-        view?: string;
-    };
+import { AsProps } from '../../../../types';
+
+export type CustomTabItemProps = {
+    /**
+     * Активен ли TabItem
+     * @deprecated Используйте свойство `selected`
+     */
+    isActive?: boolean;
+    /**
+     * Выбран ли TabItem
+     */
+    selected?: boolean;
+    /**
+     * Скрыт ли TabItem
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * TabItem c округлым border-radius
+     * @default false
+     */
+    pilled?: boolean;
+    /**
+     * Фон TabItem меняется с анимацией
+     * @default true
+     */
+    animated?: boolean;
+    /**
+     * Контент слева
+     */
+    contentLeft?: ReactNode;
+    /**
+     * Контент справа
+     */
+    contentRight?: ReactNode;
+    /**
+     * Callback, необходимый для клавиатурной навигации
+     */
+    onIndexChange?: (index: number) => void;
+    /**
+     * Индекс TabItem внутри Tabs - необходим для клавиатурной навигации
+     */
+    itemIndex?: number;
+    /**
+     * Размер TabItem
+     */
+    size?: string;
+    /**
+     * Вид TabItem
+     */
+    view?: string;
+};
+
+export type TabItemProps = ButtonHTMLAttributes<HTMLButtonElement> & AsProps & CustomTabItemProps;

--- a/packages/plasma-new-hope/src/components/Tabs/ui/Tabs/Tabs.types.ts
+++ b/packages/plasma-new-hope/src/components/Tabs/ui/Tabs/Tabs.types.ts
@@ -2,46 +2,47 @@ import type { HTMLAttributes } from 'react';
 
 import type { AsProps } from '../../../../types';
 
-export type TabsProps = AsProps &
-    HTMLAttributes<HTMLDivElement> & {
-        /**
-         * Как ведет себя компонент при ограничении ширины
-         * @default 'scroll'
-         * @description
-         * scroll - появляется горизонтальная прокрутка
-         * showAll - становится виден контент, выходящий за пределы компонента
-         */
-        clip?: 'scroll' | 'showAll';
-        /**
-         * Табы неактивны
-         * @default false
-         */
-        disabled?: boolean;
-        /**
-         * Табы растянуты на доступную область
-         * @default false
-         */
-        stretch?: boolean;
-        /**
-         * Табы c округлым border-radius
-         * @default false
-         */
-        pilled?: boolean;
-        /**
-         * Размер табов
-         */
-        size?: string;
-        /**
-         * Вид табов
-         */
-        view?: string;
-        /**
-         * Индекс активного элемента, необходим для клавиатурной навигации
-         */
-        index?: number;
-        /**
-         * Уберет скругление с выбранной стороны и подвинет контейнер
-         * @deprecated
-         */
-        outsideScroll?: boolean | { left?: string; right?: string };
-    };
+export type CustomTabsProps = {
+    /**
+     * Как ведет себя компонент при ограничении ширины
+     * @default 'scroll'
+     * @description
+     * scroll - появляется горизонтальная прокрутка
+     * showAll - становится виден контент, выходящий за пределы компонента
+     */
+    clip?: 'scroll' | 'showAll';
+    /**
+     * Табы неактивны
+     * @default false
+     */
+    disabled?: boolean;
+    /**
+     * Табы растянуты на доступную область
+     * @default false
+     */
+    stretch?: boolean;
+    /**
+     * Табы c округлым border-radius
+     * @default false
+     */
+    pilled?: boolean;
+    /**
+     * Размер табов
+     */
+    size?: string;
+    /**
+     * Вид табов
+     */
+    view?: string;
+    /**
+     * Индекс активного элемента, необходим для клавиатурной навигации
+     */
+    index?: number;
+    /**
+     * Уберет скругление с выбранной стороны и подвинет контейнер
+     * @deprecated
+     */
+    outsideScroll?: boolean | { left?: string; right?: string };
+};
+
+export type TabsProps = HTMLAttributes<HTMLDivElement> & AsProps & CustomTabsProps;

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tabs/TabItem.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tabs/TabItem.ts
@@ -1,12 +1,8 @@
-import { ForwardRefExoticComponent, RefAttributes } from 'react';
-
-import { TabItemProps, tabItemConfig } from '../../../../components/Tabs';
+import { tabItemConfig } from '../../../../components/Tabs';
 import { component, mergeConfig } from '../../../../engines';
 
 import { config } from './TabItem.config';
 
 const mergedConfig = mergeConfig(tabItemConfig, config);
 
-export const TabItem = component(mergedConfig) as ForwardRefExoticComponent<
-    TabItemProps & RefAttributes<HTMLDivElement>
->;
+export const TabItem = component(mergedConfig);

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tabs/Tabs.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tabs/Tabs.ts
@@ -1,10 +1,8 @@
-import { ForwardRefExoticComponent, RefAttributes } from 'react';
-
-import { TabsProps, tabsConfig } from '../../../../components/Tabs';
+import { tabsConfig } from '../../../../components/Tabs';
 import { component, mergeConfig } from '../../../../engines';
 
 import { config } from './Tabs.config';
 
 const mergedConfig = mergeConfig(tabsConfig, config);
 
-export const Tabs = component(mergedConfig) as ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>>;
+export const Tabs = component(mergedConfig);

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tabs/TabsController.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tabs/TabsController.tsx
@@ -1,6 +1,11 @@
-import { createTabsController } from '../../../../components/Tabs';
+import { ForwardRefExoticComponent, RefAttributes } from 'react';
+
+import { createTabsController, TabItemProps, TabsProps } from '../../../../components/Tabs';
 
 import { Tabs } from './Tabs';
 import { TabItem } from './TabItem';
 
-export const TabsController = createTabsController(Tabs, TabItem);
+export const TabsController = createTabsController(
+    Tabs as ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>>,
+    TabItem as ForwardRefExoticComponent<TabItemProps & RefAttributes<HTMLDivElement>>,
+);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Tabs/TabItem.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Tabs/TabItem.ts
@@ -1,12 +1,8 @@
-import { ForwardRefExoticComponent, RefAttributes } from 'react';
-
-import { TabItemProps, tabItemConfig } from '../../../../components/Tabs';
+import { tabItemConfig } from '../../../../components/Tabs';
 import { component, mergeConfig } from '../../../../engines';
 
 import { config } from './TabItem.config';
 
 const mergedConfig = mergeConfig(tabItemConfig, config);
 
-export const TabItem = component(mergedConfig) as ForwardRefExoticComponent<
-    TabItemProps & RefAttributes<HTMLDivElement>
->;
+export const TabItem = component(mergedConfig);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Tabs/Tabs.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Tabs/Tabs.ts
@@ -1,10 +1,8 @@
-import { ForwardRefExoticComponent, RefAttributes } from 'react';
-
-import { TabsProps, tabsConfig } from '../../../../components/Tabs';
+import { tabsConfig } from '../../../../components/Tabs';
 import { component, mergeConfig } from '../../../../engines';
 
 import { config } from './Tabs.config';
 
 const mergedConfig = mergeConfig(tabsConfig, config);
 
-export const Tabs = component(mergedConfig) as ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>>;
+export const Tabs = component(mergedConfig);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Tabs/TabsController.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Tabs/TabsController.tsx
@@ -1,6 +1,11 @@
-import { createTabsController } from '../../../../components/Tabs';
+import { ForwardRefExoticComponent, RefAttributes } from 'react';
+
+import { createTabsController, TabItemProps, TabsProps } from '../../../../components/Tabs';
 
 import { Tabs } from './Tabs';
 import { TabItem } from './TabItem';
 
-export const TabsController = createTabsController(Tabs, TabItem);
+export const TabsController = createTabsController(
+    Tabs as ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>>,
+    TabItem as ForwardRefExoticComponent<TabItemProps & RefAttributes<HTMLDivElement>>,
+);

--- a/packages/plasma-new-hope/src/types/AsProps.ts
+++ b/packages/plasma-new-hope/src/types/AsProps.ts
@@ -1,3 +1,5 @@
+// INFO: Issue об этом решении - https://github.com/salute-developers/plasma/issues/1219
+
 /**
  * Работает только со styled-components
  */

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -99,6 +99,8 @@ import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { counterTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { CustomComboboxProps } from '@salutejs/plasma-new-hope/types/components/Combobox/Combobox.types';
 import { CustomPopoverProps } from '@salutejs/plasma-new-hope/types/components/Popover/Popover.types';
+import { CustomTabItemProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/TabItem/TabItem.types';
+import { CustomTabsProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/Tabs/Tabs.types';
 import { CustomToastProps } from '@salutejs/plasma-new-hope/types/components/Toast/Toast.types';
 import { DateInfo } from '@salutejs/plasma-new-hope/types/components/Calendar/Calendar.types';
 import { DatePickerCalendarProps } from '@salutejs/plasma-new-hope/types/components/DatePicker/DatePickerBase.types';
@@ -2230,42 +2232,18 @@ export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 export { syntheticFocus }
 
 // @public
-export const TabItem: ForwardRefExoticComponent<AsProps<any> & ButtonHTMLAttributes<HTMLButtonElement> & {
-    isActive?: boolean | undefined;
-    selected?: boolean | undefined;
-    disabled?: boolean | undefined;
-    pilled?: boolean | undefined;
-    animated?: boolean | undefined;
-    contentLeft?: ReactNode;
-    contentRight?: ReactNode;
-    onIndexChange?: ((index: number) => void) | undefined;
-    itemIndex?: number | undefined;
-    size?: string | undefined;
-    view?: string | undefined;
-} & RefAttributes<HTMLDivElement>>;
+export const TabItem: ForwardRefExoticComponent<ButtonHTMLAttributes<HTMLButtonElement> & AsProps_2<any> & CustomTabItemProps & RefAttributes<HTMLDivElement>>;
 
 export { TabItemProps }
 
 export { TabItemRefs }
 
 // @public
-export const Tabs: ForwardRefExoticComponent<AsProps_2<any> & HTMLAttributes<HTMLDivElement> & {
-    clip?: "scroll" | "showAll" | undefined;
-    disabled?: boolean | undefined;
-    stretch?: boolean | undefined;
-    pilled?: boolean | undefined;
-    size?: string | undefined;
-    view?: string | undefined;
-    index?: number | undefined;
-    outsideScroll?: boolean | {
-        left?: string | undefined;
-        right?: string | undefined;
-    } | undefined;
-} & RefAttributes<HTMLDivElement>>;
+export const Tabs: ForwardRefExoticComponent<HTMLAttributes<HTMLDivElement> & AsProps_2<any> & CustomTabsProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsContext }
 
-// @public @deprecated (undocumented)
+// @public
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }

--- a/packages/plasma-web/src/components/Tabs/TabsController.tsx
+++ b/packages/plasma-web/src/components/Tabs/TabsController.tsx
@@ -4,9 +4,6 @@ import { Tabs } from './Tabs';
 import { TabItem } from './TabItem';
 
 /**
- * @deprecated
- * Используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange
- *
  * Контроллер вкладок.
  * Позволяет использовать клавиши ArrowLeft, ArrowRight, Home, End для навигации по вкладкам.
  */

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -64,6 +64,8 @@ import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { counterTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { CustomPopoverProps } from '@salutejs/plasma-new-hope/types/components/Popover/Popover.types';
+import { CustomTabItemProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/TabItem/TabItem.types';
+import { CustomTabsProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/Tabs/Tabs.types';
 import { CustomToastProps } from '@salutejs/plasma-new-hope/types/components/Toast/Toast.types';
 import { DateInfo } from '@salutejs/plasma-new-hope/types/components/Calendar/Calendar.types';
 import { DatePickerCalendarProps } from '@salutejs/plasma-new-hope/types/components/DatePicker/DatePickerBase.types';
@@ -1812,30 +1814,44 @@ true: PolymorphicClassName;
 pilled: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLElement>>;
+}> & ButtonHTMLAttributes<HTMLButtonElement> & AsProps<any> & CustomTabItemProps & RefAttributes<HTMLDivElement>>;
 
 export { TabItemProps }
 
 export { TabItemRefs }
 
 // @public
-export const Tabs: ForwardRefExoticComponent<AsProps<any> & HTMLAttributes<HTMLDivElement> & {
-    clip?: "scroll" | "showAll" | undefined;
-    disabled?: boolean | undefined;
-    stretch?: boolean | undefined;
-    pilled?: boolean | undefined;
-    size?: string | undefined;
-    view?: string | undefined;
-    index?: number | undefined;
-    outsideScroll?: boolean | {
-        left?: string | undefined;
-        right?: string | undefined;
-    } | undefined;
-} & RefAttributes<HTMLDivElement>>;
+export const Tabs: FunctionComponent<PropsType<    {
+view: {
+clear: PolymorphicClassName;
+filled: PolymorphicClassName;
+divider: PolymorphicClassName;
+};
+size: {
+xs: PolymorphicClassName;
+s: PolymorphicClassName;
+m: PolymorphicClassName;
+l: PolymorphicClassName;
+h5: PolymorphicClassName;
+h4: PolymorphicClassName;
+h3: PolymorphicClassName;
+h2: PolymorphicClassName;
+h1: PolymorphicClassName;
+};
+stretch: {
+true: PolymorphicClassName;
+};
+disabled: {
+true: PolymorphicClassName;
+};
+pilled: {
+true: PolymorphicClassName;
+};
+}> & HTMLAttributes<HTMLDivElement> & AsProps<any> & CustomTabsProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsContext }
 
-// @public @deprecated (undocumented)
+// @public
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }

--- a/packages/sdds-cs/src/components/Tabs/Tabs.tsx
+++ b/packages/sdds-cs/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,4 @@
-import { tabsConfig, component, mergeConfig, TabsProps } from '@salutejs/plasma-new-hope/styled-components';
-import { ForwardRefExoticComponent, RefAttributes } from 'react';
+import { tabsConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
 
 import { config } from './Tabs.config';
 
@@ -7,4 +6,4 @@ const mergedConfig = mergeConfig(tabsConfig, config);
 /**
  * Контейнер вкладок, основной компонент для пользовательской сборки вкладок.
  */
-export const Tabs = component(mergedConfig) as ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>>;
+export const Tabs = component(mergedConfig);

--- a/packages/sdds-cs/src/components/Tabs/TabsController.tsx
+++ b/packages/sdds-cs/src/components/Tabs/TabsController.tsx
@@ -6,9 +6,6 @@ import { Tabs } from './Tabs';
 import { TabItem } from './TabItem';
 
 /**
- * @deprecated
- * Используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange
- *
  * Контроллер вкладок.
  * Позволяет использовать клавиши ArrowLeft, ArrowRight, Home, End для навигации по вкладкам.
  */

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -60,6 +60,8 @@ import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { counterTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { CustomPopoverProps } from '@salutejs/plasma-new-hope/types/components/Popover/Popover.types';
+import { CustomTabItemProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/TabItem/TabItem.types';
+import { CustomTabsProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/Tabs/Tabs.types';
 import { CustomToastProps } from '@salutejs/plasma-new-hope/types/components/Toast/Toast.types';
 import { DateInfo } from '@salutejs/plasma-new-hope/types/components/Calendar/Calendar.types';
 import { DatePickerCalendarProps } from '@salutejs/plasma-new-hope/types/components/DatePicker/DatePickerBase.types';
@@ -1739,30 +1741,44 @@ true: PolymorphicClassName;
 pilled: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLElement>>;
+}> & ButtonHTMLAttributes<HTMLButtonElement> & AsProps<any> & CustomTabItemProps & RefAttributes<HTMLDivElement>>;
 
 export { TabItemProps }
 
 export { TabItemRefs }
 
 // @public
-export const Tabs: ForwardRefExoticComponent<AsProps<any> & HTMLAttributes<HTMLDivElement> & {
-    clip?: "scroll" | "showAll" | undefined;
-    disabled?: boolean | undefined;
-    stretch?: boolean | undefined;
-    pilled?: boolean | undefined;
-    size?: string | undefined;
-    view?: string | undefined;
-    index?: number | undefined;
-    outsideScroll?: boolean | {
-        left?: string | undefined;
-        right?: string | undefined;
-    } | undefined;
-} & RefAttributes<HTMLDivElement>>;
+export const Tabs: FunctionComponent<PropsType<    {
+view: {
+clear: PolymorphicClassName;
+filled: PolymorphicClassName;
+divider: PolymorphicClassName;
+};
+size: {
+xs: PolymorphicClassName;
+s: PolymorphicClassName;
+m: PolymorphicClassName;
+l: PolymorphicClassName;
+h5: PolymorphicClassName;
+h4: PolymorphicClassName;
+h3: PolymorphicClassName;
+h2: PolymorphicClassName;
+h1: PolymorphicClassName;
+};
+stretch: {
+true: PolymorphicClassName;
+};
+disabled: {
+true: PolymorphicClassName;
+};
+pilled: {
+true: PolymorphicClassName;
+};
+}> & HTMLAttributes<HTMLDivElement> & AsProps<any> & CustomTabsProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsContext }
 
-// @public @deprecated (undocumented)
+// @public
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }

--- a/packages/sdds-dfa/src/components/Tabs/Tabs.tsx
+++ b/packages/sdds-dfa/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,4 @@
-import { tabsConfig, component, mergeConfig, TabsProps } from '@salutejs/plasma-new-hope/styled-components';
-import { ForwardRefExoticComponent, RefAttributes } from 'react';
+import { tabsConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
 
 import { config } from './Tabs.config';
 
@@ -7,4 +6,4 @@ const mergedConfig = mergeConfig(tabsConfig, config);
 /**
  * Контейнер вкладок, основной компонент для пользовательской сборки вкладок.
  */
-export const Tabs = component(mergedConfig) as ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>>;
+export const Tabs = component(mergedConfig);

--- a/packages/sdds-dfa/src/components/Tabs/TabsController.tsx
+++ b/packages/sdds-dfa/src/components/Tabs/TabsController.tsx
@@ -6,9 +6,6 @@ import { Tabs } from './Tabs';
 import { TabItem } from './TabItem';
 
 /**
- * @deprecated
- * Используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange
- *
  * Контроллер вкладок.
  * Позволяет использовать клавиши ArrowLeft, ArrowRight, Home, End для навигации по вкладкам.
  */

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -64,6 +64,8 @@ import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { counterTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { CustomPopoverProps } from '@salutejs/plasma-new-hope/types/components/Popover/Popover.types';
+import { CustomTabItemProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/TabItem/TabItem.types';
+import { CustomTabsProps } from '@salutejs/plasma-new-hope/types/components/Tabs/ui/Tabs/Tabs.types';
 import { CustomToastProps } from '@salutejs/plasma-new-hope/types/components/Toast/Toast.types';
 import { DateInfo } from '@salutejs/plasma-new-hope/types/components/Calendar/Calendar.types';
 import { DatePickerCalendarProps } from '@salutejs/plasma-new-hope/types/components/DatePicker/DatePickerBase.types';
@@ -1834,30 +1836,44 @@ true: PolymorphicClassName;
 pilled: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLElement>>;
+}> & ButtonHTMLAttributes<HTMLButtonElement> & AsProps<any> & CustomTabItemProps & RefAttributes<HTMLDivElement>>;
 
 export { TabItemProps }
 
 export { TabItemRefs }
 
 // @public
-export const Tabs: ForwardRefExoticComponent<AsProps<any> & HTMLAttributes<HTMLDivElement> & {
-    clip?: "scroll" | "showAll" | undefined;
-    disabled?: boolean | undefined;
-    stretch?: boolean | undefined;
-    pilled?: boolean | undefined;
-    size?: string | undefined;
-    view?: string | undefined;
-    index?: number | undefined;
-    outsideScroll?: boolean | {
-        left?: string | undefined;
-        right?: string | undefined;
-    } | undefined;
-} & RefAttributes<HTMLDivElement>>;
+export const Tabs: FunctionComponent<PropsType<    {
+view: {
+clear: PolymorphicClassName;
+filled: PolymorphicClassName;
+divider: PolymorphicClassName;
+};
+size: {
+xs: PolymorphicClassName;
+s: PolymorphicClassName;
+m: PolymorphicClassName;
+l: PolymorphicClassName;
+h5: PolymorphicClassName;
+h4: PolymorphicClassName;
+h3: PolymorphicClassName;
+h2: PolymorphicClassName;
+h1: PolymorphicClassName;
+};
+stretch: {
+true: PolymorphicClassName;
+};
+disabled: {
+true: PolymorphicClassName;
+};
+pilled: {
+true: PolymorphicClassName;
+};
+}> & HTMLAttributes<HTMLDivElement> & AsProps<any> & CustomTabsProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsContext }
 
-// @public @deprecated (undocumented)
+// @public
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }

--- a/packages/sdds-serv/src/components/Tabs/Tabs.tsx
+++ b/packages/sdds-serv/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,4 @@
-import { tabsConfig, component, mergeConfig, TabsProps } from '@salutejs/plasma-new-hope/styled-components';
-import { ForwardRefExoticComponent, RefAttributes } from 'react';
+import { tabsConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
 
 import { config } from './Tabs.config';
 
@@ -7,4 +6,4 @@ const mergedConfig = mergeConfig(tabsConfig, config);
 /**
  * Контейнер вкладок, основной компонент для пользовательской сборки вкладок.
  */
-export const Tabs = component(mergedConfig) as ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>>;
+export const Tabs = component(mergedConfig);

--- a/packages/sdds-serv/src/components/Tabs/TabsController.tsx
+++ b/packages/sdds-serv/src/components/Tabs/TabsController.tsx
@@ -6,9 +6,6 @@ import { Tabs } from './Tabs';
 import { TabItem } from './TabItem';
 
 /**
- * @deprecated
- * Используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange
- *
  * Контроллер вкладок.
  * Позволяет использовать клавиши ArrowLeft, ArrowRight, Home, End для навигации по вкладкам.
  */

--- a/website/plasma-web-docs/docs/components/Tabs.mdx
+++ b/website/plasma-web-docs/docs/components/Tabs.mdx
@@ -11,11 +11,6 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 
 <StorybookLink name="Tabs" />
 
-## TabsController
-
-<Description name="TabsController" />
-<PropsTable name="TabsController" />
-
 ## Tabs
 
 <Description name="Tabs" />
@@ -26,6 +21,11 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 <Description name="TabItem" />
 <PropsTable name="TabItem" />
 
+## TabsController (deprecated)
+Вместо этого используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange.
+
+<Description name="TabsController" />
+<PropsTable name="TabsController" />
 
 ## Использование
 

--- a/website/sdds-cs-docs/docs/components/Tabs.mdx
+++ b/website/sdds-cs-docs/docs/components/Tabs.mdx
@@ -9,11 +9,6 @@ import { PropsTable, Description } from '@site/src/components';
 Набор компонентов для создания вкладок.
 Структура для вкладок похожа на структуру маркированных списков.
 
-## TabsController
-
-<Description name="TabsController" />
-<PropsTable name="TabsController" />
-
 ## Tabs
 
 <Description name="Tabs" />
@@ -24,6 +19,11 @@ import { PropsTable, Description } from '@site/src/components';
 <Description name="TabItem" />
 <PropsTable name="TabItem" />
 
+## TabsController (deprecated)
+Вместо этого используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange.
+
+<Description name="TabsController" />
+<PropsTable name="TabsController" />
 
 ## Использование
 
@@ -51,9 +51,95 @@ export function App() {
                         contentLeft={<IconClock size="xs" color="inherit" />}
                         onClick={() => setIndex(i)}
                     >
-                        Label
+                        {`Label${i + 1}`}
                     </TabItem>
                 ))}
+            </Tabs>
+        </div>
+    );
+}
+```
+
+### Пример с прокруткой
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem } from '@salutejs/sdds-cs';
+import { IconClock } from '@salutejs/plasma-icons';
+
+export function App() {
+    const items = Array(8).fill(0);
+    const [index, setIndex] = useState(0);
+
+    return (
+        <div>
+            <Tabs view="divider" size="xs" style={{ width: '15rem' }}>
+                {items.map((_, i) => (
+                    <TabItem
+                        view="divider"
+                        key={`item:${i}`}
+                        size="xs"
+                        selected={i === index}
+                        tabIndex={0}
+                        contentLeft={<IconClock size="xs" color="inherit" />}
+                        onClick={() => setIndex(i)}
+                    >
+                        {`Label${i + 1}`}
+                    </TabItem>
+                ))}
+            </Tabs>
+        </div>
+    );
+}
+```
+
+### Пример с Dropdown
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-cs';
+
+export function App() {
+    const items = Array(8).fill(0);
+    const [index, setIndex] = useState(0);
+
+    const maxItemQuantity = 3;
+    const visibleItems = items.slice(0, maxItemQuantity);
+    const otherItems = items.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((_, i) => {
+        const itemIndex = maxItemQuantity + i;
+
+        return {
+            label: `Label${itemIndex + 1}`,
+            value: itemIndex,
+        };
+    });
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((_, i) => (
+                    <TabItem
+                        key={`item:${i}`}
+                        view="divider"
+                        selected={i === index}
+                        onClick={() => setIndex(i)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${i + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={(item) => setIndex(item.value)}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
             </Tabs>
         </div>
     );
@@ -88,7 +174,7 @@ export function App() {
                         contentLeft={<IconClock size="xs" color="inherit" />}
                         onClick={() => setIndex(i)}
                     >
-                        Label
+                        {`Label${i + 1}`}
                     </TabItem>
                 ))}
             </Tabs>

--- a/website/sdds-dfa-docs/docs/components/Tabs.mdx
+++ b/website/sdds-dfa-docs/docs/components/Tabs.mdx
@@ -9,11 +9,6 @@ import { PropsTable, Description } from '@site/src/components';
 Набор компонентов для создания вкладок.
 Структура для вкладок похожа на структуру маркированных списков.
 
-## TabsController
-
-<Description name="TabsController" />
-<PropsTable name="TabsController" />
-
 ## Tabs
 
 <Description name="Tabs" />
@@ -24,6 +19,11 @@ import { PropsTable, Description } from '@site/src/components';
 <Description name="TabItem" />
 <PropsTable name="TabItem" />
 
+## TabsController (deprecated)
+Вместо этого используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange.
+
+<Description name="TabsController" />
+<PropsTable name="TabsController" />
 
 ## Использование
 

--- a/website/sdds-serv-docs/docs/components/Tabs.mdx
+++ b/website/sdds-serv-docs/docs/components/Tabs.mdx
@@ -9,11 +9,6 @@ import { PropsTable, Description } from '@site/src/components';
 Набор компонентов для создания вкладок.
 Структура для вкладок похожа на структуру маркированных списков.
 
-## TabsController
-
-<Description name="TabsController" />
-<PropsTable name="TabsController" />
-
 ## Tabs
 
 <Description name="Tabs" />
@@ -24,6 +19,11 @@ import { PropsTable, Description } from '@site/src/components';
 <Description name="TabItem" />
 <PropsTable name="TabItem" />
 
+## TabsController (deprecated)
+Вместо этого используйте Tabs, TabItem, указав параметры index, itemIndex, onIndexChange.
+
+<Description name="TabsController" />
+<PropsTable name="TabsController" />
 
 ## Использование
 


### PR DESCRIPTION
### Tabs
- исправлены типы и описание компонента для корректной генерации документации
- добавлены недостающие примеры в документацию `sdds-cs`

### What/why changed

### Before:
<img width="1039" alt="TabsController_before" src="https://github.com/user-attachments/assets/347275bf-75df-420a-86de-85de9ba630bf">

<img width="963" alt="TabItem_before" src="https://github.com/user-attachments/assets/ffbf934c-1d93-4a5a-8de8-c208a5481f0b">

### After:

<img width="1037" alt="tabsController_after_2" src="https://github.com/user-attachments/assets/13f74a84-5336-4d97-93cc-fdb8c01a842d">

<img width="993" alt="TabItem_after" src="https://github.com/user-attachments/assets/82916106-7db1-4395-9280-88dc9a08f016">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.125.1-canary.1362.10423909326.0
  npm install @salutejs/plasma-b2c@1.367.1-canary.1362.10423909326.0
  npm install @salutejs/plasma-new-hope@0.122.1-canary.1362.10423909326.0
  npm install @salutejs/plasma-web@1.368.1-canary.1362.10423909326.0
  npm install @salutejs/sdds-cs@0.97.1-canary.1362.10423909326.0
  npm install @salutejs/sdds-dfa@0.95.1-canary.1362.10423909326.0
  npm install @salutejs/sdds-serv@0.96.1-canary.1362.10423909326.0
  # or 
  yarn add @salutejs/plasma-asdk@0.125.1-canary.1362.10423909326.0
  yarn add @salutejs/plasma-b2c@1.367.1-canary.1362.10423909326.0
  yarn add @salutejs/plasma-new-hope@0.122.1-canary.1362.10423909326.0
  yarn add @salutejs/plasma-web@1.368.1-canary.1362.10423909326.0
  yarn add @salutejs/sdds-cs@0.97.1-canary.1362.10423909326.0
  yarn add @salutejs/sdds-dfa@0.95.1-canary.1362.10423909326.0
  yarn add @salutejs/sdds-serv@0.96.1-canary.1362.10423909326.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
