### PR TITLE
plasma-website: fix searchForm input text shifting

### DIFF
--- a/website/plasma-website/components/roster/SearchForm.tsx
+++ b/website/plasma-website/components/roster/SearchForm.tsx
@@ -66,7 +66,7 @@ const StyledHiddenEl = styled.span`
 const StyledSearchInput = styled.input<{ width: number | 'auto' }>`
     padding: 0;
 
-    width: ${({ width }) => `${width !== 'auto' ? `${width}px` : width}`};
+    width: ${({ width }) => `${width !== 'auto' ? `calc(${width}px + 1rem)` : width}`};
     max-width: calc(100% - var(--page-padding-y) - var(--page-padding-y) * 0.5);
     height: 7.125rem;
 
@@ -102,8 +102,6 @@ const StyleIconClose = styled.span`
 
     width: var(--icon-size);
     height: var(--icon-size);
-
-    margin-left: 1rem;
 
     ${StyledActionIcon};
 


### PR DESCRIPTION
### Website. SearchForm

- Исправлено смещение текста при наборе в поиск

### What/why changed

- Иногда тексту не хватало места при наборе. Это было исправлено путём увеличения ширины `input` на 1rem и удаления отступа слева в 1rem у иконки-крестика, чтобы визуально всё осталось как было.

### Before:

При наборе текста видно небольшое смещение. Есть возможность делать мини-прокрутку при наведении на `input`.

https://github.com/user-attachments/assets/e97640f2-ce55-4b6f-873c-bfaadd8b9bbb


### After:

Баг не проявляется.

https://github.com/user-attachments/assets/6d779fd2-65b0-4359-ad60-ece903b67feb

