### PR TITLE
plasma-*: Fix Modal Overlay & Popup registration logic

### DIFF
--- a/packages/plasma-new-hope/src/components/Modal/Modal.tsx
+++ b/packages/plasma-new-hope/src/components/Modal/Modal.tsx
@@ -11,7 +11,7 @@ import { classes, tokens } from './Modal.tokens';
 import { ModalProps } from './Modal.types';
 import { useModal } from './hooks';
 import { base as viewCSS } from './variations/_view/base';
-import { getIdFirstModal } from './ModalContext';
+import { getIdLastModal } from './ModalContext';
 
 // issue #823
 const Popup = component(popupConfig);
@@ -65,7 +65,7 @@ export const modalRoot = (Root: RootProps<HTMLDivElement, ModalProps>) =>
                 popupInfo,
             });
 
-            const transparent = useMemo(() => getIdFirstModal(popupController.items) !== innerId, [
+            const transparent = useMemo(() => getIdLastModal(popupController.items) !== innerId, [
                 innerId,
                 popupController.items,
             ]);

--- a/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
@@ -50,7 +50,8 @@ export const PopupProvider: FC<PropsWithChildren> = ({ children }) => {
                 document.body.style.overflowY = prevBodyOverflowY.current;
             }
 
-            return prevItems;
+            // при return prevItems не обновится контекст
+            return [...prevItems];
         });
     };
 


### PR DESCRIPTION
### Popup

- исправлена логика регистрации `popup's`

### What/why changed 

Сделали ошибку когда правили другой баг  

фикс для PR https://github.com/salute-developers/plasma/pull/1325
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.133.1-canary.1380.10485553077.0
  npm install @salutejs/plasma-b2c@1.375.1-canary.1380.10485553077.0
  npm install @salutejs/plasma-new-hope@0.128.2-canary.1380.10485553077.0
  npm install @salutejs/plasma-web@1.376.1-canary.1380.10485553077.0
  npm install @salutejs/sdds-cs@0.105.1-canary.1380.10485553077.0
  npm install @salutejs/sdds-dfa@0.103.1-canary.1380.10485553077.0
  npm install @salutejs/sdds-serv@0.104.1-canary.1380.10485553077.0
  # or 
  yarn add @salutejs/plasma-asdk@0.133.1-canary.1380.10485553077.0
  yarn add @salutejs/plasma-b2c@1.375.1-canary.1380.10485553077.0
  yarn add @salutejs/plasma-new-hope@0.128.2-canary.1380.10485553077.0
  yarn add @salutejs/plasma-web@1.376.1-canary.1380.10485553077.0
  yarn add @salutejs/sdds-cs@0.105.1-canary.1380.10485553077.0
  yarn add @salutejs/sdds-dfa@0.103.1-canary.1380.10485553077.0
  yarn add @salutejs/sdds-serv@0.104.1-canary.1380.10485553077.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
