### PR TITLE
feat(plasma-*): forward view to radiobox and checkbox stories

### DIFF
--- a/packages/plasma-b2c/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-b2c/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,41 +1,16 @@
-import React from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 
+import { SSRProvider } from '../SSRProvider';
 import { Link } from '../Link';
+import { List, ListItem } from '../List';
 
 import { Checkbox } from '.';
 import type { CheckboxProps } from '.';
 
-const onChange = action('onChange');
-const onFocus = action('onFocus');
-const onBlur = action('onBlur');
-
-const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
-    component: Checkbox,
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        label: {
-            control: {
-                type: 'text',
-            },
-        },
-        description: {
-            control: {
-                type: 'text',
-            },
-        },
-    },
-};
-
-export default meta;
-
-type Story = StoryObj<CheckboxProps>;
-
 const propsToDisable = [
-    'view',
     'name',
     'indeterminate',
     'id',
@@ -53,19 +28,45 @@ const propsToDisable = [
     'onBlur',
 ];
 
+const onChange = action('onChange');
+const onFocus = action('onFocus');
+const onBlur = action('onBlur');
+
 const sizes = ['m', 's'];
+const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
-const englishDescription = (
-    <div>
-        The most spoken language in the <Link href="/#">world</Link>
-    </div>
-);
+const meta: Meta<CheckboxProps> = {
+    title: 'Controls/Checkbox',
+    component: Checkbox,
+    decorators: [InSpacingDecorator],
+    argTypes: {
+        label: {
+            control: {
+                type: 'text',
+            },
+        },
+        description: {
+            control: {
+                type: 'text',
+            },
+        },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
+        size: {
+            options: sizes,
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        ...disableProps(propsToDisable),
+    },
+};
 
-const chineseLabel = (
-    <div>
-        Chinese is the hardest <Link href="/#">language</Link>
-    </div>
-);
+export default meta;
 
 const name = 'languages';
 
@@ -73,28 +74,63 @@ const items = [
     {
         name,
         value: 'natural',
-        label: 'Natural languages',
+        label: 'Естественные языки',
         disabled: false,
-        description: 'Languages that people speak. They were not designed by people and they evolved naturally.',
+        description: 'Языки, на которых говорят люди. Они не были созданы искуственно и развивались естественно.',
     },
-    { name, value: 'russian', label: 'Russian', disabled: false, parent: 'natural' },
+    { name, value: 'russian', label: 'Русский', disabled: false, parent: 'natural' },
     {
         name,
         value: 'english',
-        label: 'English',
+        label: 'Английский',
         disabled: false,
+        description: (
+            <>
+                Самый распространенный язык в <Link href="/#">мире</Link>
+            </>
+        ),
         parent: 'natural',
-        description: englishDescription,
     },
-    { name, value: 'french', label: 'French', disabled: false, parent: 'natural' },
-    { name, value: 'klingon', label: 'Klingon', disabled: false, parent: 'natural' },
-    { name, value: 'elvish', label: 'Elvish', disabled: true, parent: 'natural' },
-    { name, value: 'dothraki', label: 'Dothraki', disabled: true, parent: 'natural' },
+    { name, value: 'french', label: 'Французский', disabled: false, parent: 'natural' },
     {
         name,
         value: 'chinese',
-        label: chineseLabel,
+        label: (
+            <>
+                Китайский <Link href="/#">язык</Link>
+            </>
+        ),
         parent: 'natural',
+    },
+    {
+        name,
+        value: 'artificial',
+        label: 'Искусственные языки',
+        disabled: false,
+    },
+    {
+        name,
+        value: 'klingon',
+        label: 'Клингонский',
+        disabled: false,
+        description: 'Язык одной из раз в сериале СтарТрек',
+        parent: 'artificial',
+    },
+    {
+        name,
+        value: 'elvish',
+        label: 'Эльфийский',
+        disabled: true,
+        description: 'Искусственный язык из вселенной Властелина колец',
+        parent: 'artificial',
+    },
+    {
+        name,
+        value: 'dothraki',
+        label: 'Дотракийский',
+        disabled: true,
+        description: 'Язык, разработанный для реплик дотракийских племен из вселенной Песнь Льда и Огня',
+        parent: 'artificial',
     },
 ];
 
@@ -125,7 +161,7 @@ const StoryDefault = (args: CheckboxProps) => {
     const [checked, setChecked] = React.useState(true);
 
     return (
-        <>
+        <SSRProvider>
             <Checkbox
                 value={value}
                 checked={checked}
@@ -139,35 +175,26 @@ const StoryDefault = (args: CheckboxProps) => {
                 onBlur={onBlur}
                 {...args}
             />
-        </>
+        </SSRProvider>
     );
 };
 
-export const Default: Story = {
+export const Default: StoryObj<CheckboxProps> = {
     args: {
+        view: 'accent',
+        size: 'm',
         name: 'checkbox',
         label: 'Label',
         description: 'Description',
         disabled: false,
         singleLine: false,
-        size: 'm',
-        view: 'accent',
         focused: true,
-    },
-    argTypes: {
-        ...disableProps(propsToDisable),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
     },
     render: (args) => <StoryDefault {...args} />,
 };
 
-const StoryLive = (args) => {
-    const [values, setValues] = React.useState({
+const StoryLive = (args: CheckboxProps) => {
+    const [values, setValues] = useState({
         russian: true,
         english: true,
         french: true,
@@ -178,61 +205,56 @@ const StoryLive = (args) => {
     });
 
     return (
-        <>
-            {items.map((item) => (
-                <Checkbox
-                    {...getState(values, item.value)}
-                    style={{ marginLeft: item.parent ? 36 : null }}
-                    key={item.value}
-                    name={item.name}
-                    value={item.value}
-                    label={item.label}
-                    disabled={item.disabled}
-                    description={item.description}
-                    onChange={(event) => {
-                        event.persist();
+        <SSRProvider>
+            <List>
+                {items.map((item) => (
+                    <ListItem key={item.value} ml={item.parent ? '16x' : undefined} mb="4x">
+                        <Checkbox
+                            {...getState(values, item.value)}
+                            name={item.name}
+                            value={item.value}
+                            label={item.label}
+                            disabled={item.disabled}
+                            description={item.description}
+                            onChange={(event) => {
+                                event.persist();
 
-                        const { checked } = event.target;
+                                const { checked } = event.target;
 
-                        if (item.parent) {
-                            setValues({ ...values, [item.value]: checked });
-                        } else {
-                            setValues({
-                                ...values,
-                                ...getChildren(item.value).reduce(
-                                    (acc, child) => ({ ...acc, [child.value]: checked }),
-                                    {},
-                                ),
-                            });
-                        }
+                                if (item.parent) {
+                                    setValues({ ...values, [item.value]: checked });
+                                } else {
+                                    setValues({
+                                        ...values,
+                                        ...getChildren(item.value).reduce(
+                                            (acc, child) => ({ ...acc, [child.value]: checked }),
+                                            {},
+                                        ),
+                                    });
+                                }
 
-                        onChange(event);
-                    }}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
-                    {...args}
-                />
-            ))}
-        </>
+                                onChange(event);
+                            }}
+                            onFocus={onFocus}
+                            onBlur={onBlur}
+                            {...args}
+                        />
+                    </ListItem>
+                ))}
+            </List>
+        </SSRProvider>
     );
 };
 
-export const Live: Story = {
+export const Live: StoryObj<CheckboxProps> = {
+    argTypes: {
+        ...disableProps(['label', 'description', 'disabled']),
+    },
     args: {
-        size: 'm',
         view: 'accent',
+        size: 'm',
         singleLine: false,
         focused: true,
-        disabled: false,
-    },
-    argTypes: {
-        ...disableProps([...propsToDisable, 'label', 'description']),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
     },
     render: (args) => <StoryLive {...args} />,
 };

--- a/packages/plasma-b2c/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-b2c/src/components/Radiobox/Radiobox.stories.tsx
@@ -3,7 +3,12 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
-import { Radiobox, RadioboxProps } from '.';
+import { SSRProvider } from '../SSRProvider';
+import { Headline4 } from '../Typography';
+import { List, ListItem } from '../List';
+
+import { Radiobox, RadioGroup } from '.';
+import type { RadioboxProps } from '.';
 
 const onChange = action('onChange');
 const onFocus = action('onFocus');
@@ -14,8 +19,8 @@ const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'posit
 
 const meta: Meta<RadioboxProps> = {
     title: 'Controls/Radiobox',
-    component: Radiobox,
     decorators: [InSpacingDecorator],
+    component: Radiobox,
     argTypes: {
         view: {
             options: views,
@@ -34,105 +39,118 @@ const meta: Meta<RadioboxProps> = {
 
 export default meta;
 
-type Story = StoryObj<RadioboxProps>;
-
-const cDescription = (
-    <div>
-        A general-purpose, procedural computer programming{' '}
-        <a href="https://en.wikipedia.org/wiki/C_(programming_language)">language</a>{' '}
-    </div>
-);
-
-const langName = 'language';
-
 const items = [
     {
-        langName,
+        name: 'language',
         value: 'c',
         label: 'C',
         disabled: false,
-        description: cDescription,
+        description: (
+            <>
+                Си (
+                <a
+                    href="https://ru.wikipedia.org/wiki/%D0%90%D0%BD%D0%B3%D0%BB%D0%B8%D0%B9%D1%81%D0%BA%D0%B8%D0%B9_%D1%8F%D0%B7%D1%8B%D0%BA"
+                    aria-label="английский"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    англ.
+                </a>{' '}
+                C) — компилируемый статически типизированный язык программирования общего назначения.
+            </>
+        ),
     },
-    { langName, value: 'cpp', label: 'C++', disabled: false },
-    { langName, value: 'assembly', label: 'Assembly', disabled: false },
-    { langName, value: 'elixir', label: 'Elixir', disabled: true },
+    { name: 'language', value: 'cpp', label: 'C++', disabled: false },
+    { name: 'language', value: 'assembly', label: 'Assembly', disabled: false },
+    { name: 'language', value: 'elixir', label: 'Elixir', disabled: true },
 ];
 
-const StoryLive = (props: RadioboxProps) => {
-    const [value, setValue] = useState('c');
-
-    return (
-        <>
-            {items.map((item) => (
-                <Radiobox
-                    key={item.value}
-                    name={item.langName}
-                    value={item.value}
-                    label={item.label}
-                    disabled={item.disabled}
-                    checked={value[item.value]}
-                    description={item.description}
-                    onChange={(event) => {
-                        event.persist();
-
-                        setValue(item.value);
-                        onChange(event);
-                    }}
-                    onFocus={onFocus}
-                    onBlur={onBlur}
-                    {...props}
-                />
-            ))}
-        </>
-    );
-};
-
-export const Live: Story = {
-    args: {
-        size: 'm',
-        view: 'accent',
-        singleLine: false,
-        focused: true,
-    },
-    render: (args) => <StoryLive {...args} />,
-};
-
-const StoryDefault = ({ view, name, label, description, disabled, singleLine, size }: RadioboxProps) => {
+const StoryDefault = ({ name, label, description, disabled, singleLine, size, view }: RadioboxProps) => {
     const value = 0;
-    const [checked, setChecked] = React.useState(true);
+    const [checked, setChecked] = useState(true);
 
     return (
-        <Radiobox
-            name={name}
-            value={value}
-            label={label}
-            description={description}
-            disabled={disabled}
-            checked={checked}
-            view={view}
-            singleLine={singleLine}
-            size={size}
-            onChange={(event) => {
-                event.persist();
+        <SSRProvider>
+            <Radiobox
+                name={name}
+                value={value}
+                label={label}
+                description={description}
+                disabled={disabled}
+                checked={checked}
+                singleLine={singleLine}
+                size={size}
+                view={view}
+                onChange={(event) => {
+                    event.persist();
 
-                setChecked(event.target.checked);
-                onChange(event);
-            }}
-            onFocus={onFocus}
-            onBlur={onBlur}
-        />
+                    setChecked(event.target.checked);
+                    onChange(event);
+                }}
+                onFocus={onFocus}
+                onBlur={onBlur}
+            />
+        </SSRProvider>
     );
 };
 
-export const Default: Story = {
+export const Default: StoryObj<RadioboxProps> = {
     args: {
-        view: 'default',
+        view: 'accent',
+        size: 'm',
         name: 'Radiobox',
         label: 'Label',
         description: 'Description',
         disabled: false,
         singleLine: false,
-        size: 'm',
     },
     render: (args) => <StoryDefault {...args} />,
+};
+
+const StoryLive = (props: RadioboxProps) => {
+    const [value, setValue] = useState('c');
+
+    return (
+        <SSRProvider>
+            <RadioGroup aria-labelledby="example-radiogroup-title">
+                <Headline4 id="example-radiogroup-title" mb="8x">
+                    Выберите язык программирования
+                </Headline4>
+                <List>
+                    {items.map((item) => (
+                        <ListItem key={item.value} mb="4x">
+                            <Radiobox
+                                key={item.value}
+                                name={item.name}
+                                value={item.value}
+                                label={item.label}
+                                disabled={item.disabled}
+                                checked={value === item.value}
+                                description={item.description}
+                                onChange={(event) => {
+                                    event.persist();
+
+                                    setValue(item.value);
+                                    onChange(event);
+                                }}
+                                onFocus={onFocus}
+                                onBlur={onBlur}
+                                {...props}
+                            />
+                        </ListItem>
+                    ))}
+                </List>
+            </RadioGroup>
+        </SSRProvider>
+    );
+};
+
+export const Live: StoryObj<RadioboxProps> = {
+    args: {
+        view: 'accent',
+        size: 'm',
+        singleLine: false,
+        focused: true,
+    },
+    render: (args) => <StoryLive {...args} />,
 };

--- a/packages/plasma-web/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-web/src/components/Checkbox/Checkbox.stories.tsx
@@ -11,7 +11,6 @@ import { Checkbox } from '.';
 import type { CheckboxProps } from '.';
 
 const propsToDisable = [
-    'view',
     'name',
     'indeterminate',
     'id',
@@ -33,6 +32,9 @@ const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
+const sizes = ['m', 's'];
+const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
+
 const meta: Meta<CheckboxProps> = {
     title: 'Controls/Checkbox',
     component: Checkbox,
@@ -48,12 +50,23 @@ const meta: Meta<CheckboxProps> = {
                 type: 'text',
             },
         },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
+        size: {
+            options: sizes,
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        ...disableProps(propsToDisable),
     },
 };
 
 export default meta;
-
-const sizes = ['m', 's'];
 
 const name = 'languages';
 
@@ -167,23 +180,14 @@ const StoryDefault = (args: CheckboxProps) => {
 };
 
 export const Default: StoryObj<CheckboxProps> = {
-    argTypes: {
-        ...disableProps(propsToDisable),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-    },
     args: {
+        view: 'accent',
+        size: 'm',
         name: 'checkbox',
         label: 'Label',
         description: 'Description',
         disabled: false,
         singleLine: false,
-        size: 'm',
-        view: 'accent',
         focused: true,
     },
     render: (args) => <StoryDefault {...args} />,
@@ -244,17 +248,11 @@ const StoryLive = (args: CheckboxProps) => {
 
 export const Live: StoryObj<CheckboxProps> = {
     argTypes: {
-        ...disableProps([...propsToDisable, 'label', 'description']),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
+        ...disableProps(['label', 'description', 'disabled']),
     },
     args: {
-        size: 'm',
         view: 'accent',
+        size: 'm',
         singleLine: false,
         focused: true,
     },

--- a/packages/plasma-web/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-web/src/components/Radiobox/Radiobox.stories.tsx
@@ -20,6 +20,7 @@ const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'posit
 const meta: Meta<RadioboxProps> = {
     title: 'Controls/Radiobox',
     decorators: [InSpacingDecorator],
+    component: Radiobox,
     argTypes: {
         view: {
             options: views,
@@ -95,13 +96,13 @@ const StoryDefault = ({ name, label, description, disabled, singleLine, size, vi
 
 export const Default: StoryObj<RadioboxProps> = {
     args: {
+        view: 'accent',
+        size: 'm',
         name: 'Radiobox',
         label: 'Label',
         description: 'Description',
         disabled: false,
         singleLine: false,
-        size: 'm',
-        view: 'accent',
     },
     render: (args) => <StoryDefault {...args} />,
 };
@@ -146,8 +147,8 @@ const StoryLive = (props: RadioboxProps) => {
 
 export const Live: StoryObj<RadioboxProps> = {
     args: {
-        size: 'm',
         view: 'accent',
+        size: 'm',
         singleLine: false,
         focused: true,
     },

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -1566,7 +1566,7 @@ accent: PolymorphicClassName;
 };
 }> & (({
     target?: "textfield-like" | undefined;
-    view?: "default" | "positive" | "negative" | "warning" | undefined;
+    view?: "default" | "positive" | "warning" | "negative" | undefined;
     contentLeft?: React_2.ReactNode;
     labelPlacement?: "inner" | "outer" | undefined;
     placeholder?: string | undefined;
@@ -1603,7 +1603,7 @@ accent: PolymorphicClassName;
     chipView?: string | undefined;
 } & Omit<React_2.ButtonHTMLAttributes<HTMLButtonElement>, "onChange" | "nonce" | "onResize" | "onResizeCapture" | "value"> & React_2.RefAttributes<HTMLButtonElement>) | ({
     target?: "textfield-like" | undefined;
-    view?: "default" | "positive" | "negative" | "warning" | undefined;
+    view?: "default" | "positive" | "warning" | "negative" | undefined;
     contentLeft?: React_2.ReactNode;
     labelPlacement?: "inner" | "outer" | undefined;
     placeholder?: string | undefined;

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -1566,7 +1566,7 @@ accent: PolymorphicClassName;
 };
 }> & (({
     target?: "textfield-like" | undefined;
-    view?: "default" | "positive" | "warning" | "negative" | undefined;
+    view?: "default" | "positive" | "negative" | "warning" | undefined;
     contentLeft?: React_2.ReactNode;
     labelPlacement?: "inner" | "outer" | undefined;
     placeholder?: string | undefined;
@@ -1603,7 +1603,7 @@ accent: PolymorphicClassName;
     chipView?: string | undefined;
 } & Omit<React_2.ButtonHTMLAttributes<HTMLButtonElement>, "onChange" | "nonce" | "onResize" | "onResizeCapture" | "value"> & React_2.RefAttributes<HTMLButtonElement>) | ({
     target?: "textfield-like" | undefined;
-    view?: "default" | "positive" | "warning" | "negative" | undefined;
+    view?: "default" | "positive" | "negative" | "warning" | undefined;
     contentLeft?: React_2.ReactNode;
     labelPlacement?: "inner" | "outer" | undefined;
     placeholder?: string | undefined;

--- a/packages/sdds-cs/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-cs/src/components/Checkbox/Checkbox.stories.tsx
@@ -12,30 +12,7 @@ const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
-const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
-    component: Checkbox,
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        label: {
-            control: {
-                type: 'text',
-            },
-        },
-        description: {
-            control: {
-                type: 'text',
-            },
-        },
-    },
-};
-
-export default meta;
-
-type Story = StoryObj<CheckboxProps>;
-
 const propsToDisable = [
-    'view',
     'name',
     'indeterminate',
     'id',
@@ -55,6 +32,41 @@ const propsToDisable = [
 
 const sizes = ['s'];
 const views = ['accent'];
+
+const meta: Meta<CheckboxProps> = {
+    title: 'Controls/Checkbox',
+    component: Checkbox,
+    decorators: [InSpacingDecorator],
+    argTypes: {
+        label: {
+            control: {
+                type: 'text',
+            },
+        },
+        description: {
+            control: {
+                type: 'text',
+            },
+        },
+        size: {
+            options: sizes,
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
+        ...disableProps(propsToDisable),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<CheckboxProps>;
 
 const englishDescription = (
     <div>
@@ -155,21 +167,6 @@ export const Default: Story = {
         view: 'accent',
         focused: true,
     },
-    argTypes: {
-        ...disableProps(propsToDisable),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        view: {
-            options: views,
-            control: {
-                type: 'select',
-            },
-        },
-    },
     render: (args) => <StoryDefault {...args} />,
 };
 
@@ -233,19 +230,7 @@ export const Live: Story = {
         disabled: false,
     },
     argTypes: {
-        ...disableProps([...propsToDisable, 'label', 'description']),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        view: {
-            options: views,
-            control: {
-                type: 'select',
-            },
-        },
+        ...disableProps(['label', 'description']),
     },
     render: (args) => <StoryLive {...args} />,
 };

--- a/packages/sdds-dfa/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-dfa/src/components/Checkbox/Checkbox.stories.tsx
@@ -12,30 +12,10 @@ const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
-const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
-    component: Checkbox,
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        label: {
-            control: {
-                type: 'text',
-            },
-        },
-        description: {
-            control: {
-                type: 'text',
-            },
-        },
-    },
-};
-
-export default meta;
-
-type Story = StoryObj<CheckboxProps>;
+const sizes = ['m', 's'];
+const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const propsToDisable = [
-    'view',
     'name',
     'indeterminate',
     'id',
@@ -53,8 +33,40 @@ const propsToDisable = [
     'onBlur',
 ];
 
-const sizes = ['m', 's'];
-const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
+const meta: Meta<CheckboxProps> = {
+    title: 'Controls/Checkbox',
+    component: Checkbox,
+    decorators: [InSpacingDecorator],
+    argTypes: {
+        label: {
+            control: {
+                type: 'text',
+            },
+        },
+        description: {
+            control: {
+                type: 'text',
+            },
+        },
+        size: {
+            options: sizes,
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
+        ...disableProps(propsToDisable),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<CheckboxProps>;
 
 const englishDescription = (
     <div>
@@ -155,21 +167,6 @@ export const Default: Story = {
         view: 'accent',
         focused: true,
     },
-    argTypes: {
-        ...disableProps(propsToDisable),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        view: {
-            options: views,
-            control: {
-                type: 'select',
-            },
-        },
-    },
     render: (args) => <StoryDefault {...args} />,
 };
 
@@ -233,19 +230,7 @@ export const Live: Story = {
         disabled: false,
     },
     argTypes: {
-        ...disableProps([...propsToDisable, 'label', 'description']),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        view: {
-            options: views,
-            control: {
-                type: 'select',
-            },
-        },
+        ...disableProps(['label', 'description']),
     },
     render: (args) => <StoryLive {...args} />,
 };

--- a/packages/sdds-serv/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-serv/src/components/Checkbox/Checkbox.stories.tsx
@@ -12,30 +12,10 @@ const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
-const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
-    component: Checkbox,
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        label: {
-            control: {
-                type: 'text',
-            },
-        },
-        description: {
-            control: {
-                type: 'text',
-            },
-        },
-    },
-};
-
-export default meta;
-
-type Story = StoryObj<CheckboxProps>;
+const sizes = ['m', 's'];
+const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const propsToDisable = [
-    'view',
     'name',
     'indeterminate',
     'id',
@@ -53,8 +33,40 @@ const propsToDisable = [
     'onBlur',
 ];
 
-const sizes = ['m', 's'];
-const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
+const meta: Meta<CheckboxProps> = {
+    title: 'Controls/Checkbox',
+    component: Checkbox,
+    decorators: [InSpacingDecorator],
+    argTypes: {
+        label: {
+            control: {
+                type: 'text',
+            },
+        },
+        description: {
+            control: {
+                type: 'text',
+            },
+        },
+        size: {
+            options: sizes,
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
+        ...disableProps(propsToDisable),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<CheckboxProps>;
 
 const englishDescription = (
     <div>
@@ -155,21 +167,6 @@ export const Default: Story = {
         view: 'accent',
         focused: true,
     },
-    argTypes: {
-        ...disableProps(propsToDisable),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        view: {
-            options: views,
-            control: {
-                type: 'select',
-            },
-        },
-    },
     render: (args) => <StoryDefault {...args} />,
 };
 
@@ -233,19 +230,7 @@ export const Live: Story = {
         disabled: false,
     },
     argTypes: {
-        ...disableProps([...propsToDisable, 'label', 'description']),
-        size: {
-            options: sizes,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        view: {
-            options: views,
-            control: {
-                type: 'select',
-            },
-        },
+        ...disableProps(['label', 'description']),
     },
     render: (args) => <StoryLive {...args} />,
 };


### PR DESCRIPTION
### Radiobox

- добавлен пропс view в сторибук для Radiobox и Checkbox
- удалены 3 view из sdds-cs для Radiobox и Checkbox, так как их нет в макетах

### What/why changed

Не отображалось поле выбора view в сторибук для Radiobox и Checkbox.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.140.0-canary.1385.10628883741.0
  npm install @salutejs/plasma-b2c@1.382.0-canary.1385.10628883741.0
  npm install @salutejs/plasma-new-hope@0.134.0-canary.1385.10628883741.0
  npm install @salutejs/plasma-web@1.384.0-canary.1385.10628883741.0
  npm install @salutejs/sdds-cs@0.112.0-canary.1385.10628883741.0
  npm install @salutejs/sdds-dfa@0.110.0-canary.1385.10628883741.0
  npm install @salutejs/sdds-serv@0.111.0-canary.1385.10628883741.0
  # or 
  yarn add @salutejs/plasma-asdk@0.140.0-canary.1385.10628883741.0
  yarn add @salutejs/plasma-b2c@1.382.0-canary.1385.10628883741.0
  yarn add @salutejs/plasma-new-hope@0.134.0-canary.1385.10628883741.0
  yarn add @salutejs/plasma-web@1.384.0-canary.1385.10628883741.0
  yarn add @salutejs/sdds-cs@0.112.0-canary.1385.10628883741.0
  yarn add @salutejs/sdds-dfa@0.110.0-canary.1385.10628883741.0
  yarn add @salutejs/sdds-serv@0.111.0-canary.1385.10628883741.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
