### PR TITLE
plasma-{new-hope, web}, sdds-dfa: removed redundant dependencies from `Slider` hooks; docs fixed

### DIFF
--- a/packages/plasma-new-hope/src/components/Slider/Slider.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Slider/Slider.template-doc.mdx
@@ -1,0 +1,78 @@
+---
+id: slider
+title: Slider
+---
+
+import { PropsTable, Description } from '@site/src/components';
+
+# Slider
+
+<Description name="Slider" />
+<PropsTable name="Slider" />
+
+## Использование
+
+```tsx live
+import React from 'react';
+import { Slider  } from '@salutejs/{{ package }}';
+
+export function App() {
+    return (
+        <section>
+            <Slider onChangeCommitted={() => {}} min={0} max={100} value={30} />
+        </section>
+    );
+}
+```
+
+Можно использовать диапазон значений.
+
+```tsx live
+import React, { useState } from 'react';
+import { Slider  } from '@salutejs/{{ package }}';
+
+export function App() {
+    const [value, setValue] = useState([10, 80]);
+    const sortValues = (values) => {
+        return values
+            .map((val) => {
+                if (val < 0) {
+                    return 0;
+                }
+                if (val > 100) {
+                    return 100;
+                }
+                return val;
+            })
+            .sort((a, b) => a - b);
+    };
+
+    const onChangeHandle = (values) => {
+        setValue(sortValues(values));
+    };
+
+    const onChangeCommitedHandle = (values) => {
+        setValue(sortValues(values));
+    };
+
+    const onBlurTextField = (values) => {
+        setValue(sortValues(values));
+    };
+
+    const onKeyDownTextField = (values, event) => {
+        if (event.key === 'Enter') {
+            setValue(sortValues(values));
+        }
+    };
+
+    return (
+        <section>
+            <Slider value={value}
+                onKeyDownTextField={onKeyDownTextField}
+                onBlurTextField={onBlurTextField}
+                onChangeCommitted={onChangeCommitedHandle}
+                onChange={onChangeHandle} min={0} max={100} />
+        </section>
+    );
+}
+```

--- a/packages/plasma-new-hope/src/components/Slider/components/SliderBase/SliderBase.tsx
+++ b/packages/plasma-new-hope/src/components/Slider/components/SliderBase/SliderBase.tsx
@@ -35,7 +35,7 @@ export const SliderBase: React.FC<PropsWithChildren<SliderViewProps>> = ({
         };
 
         resizeHandler();
-    }, [labelPlacement, rangeValuesPlacement, ref.current]);
+    }, [labelPlacement, rangeValuesPlacement]);
 
     const onHandleChange: MouseEventHandler<HTMLDivElement> = (e) => {
         if (!onChange || disabled) {
@@ -66,7 +66,7 @@ export const SliderBase: React.FC<PropsWithChildren<SliderViewProps>> = ({
         window.addEventListener('resize', resizeHandler);
 
         return () => window.removeEventListener('resize', resizeHandler);
-    }, [min, max, setStepSize, ref.current, gap, labelPlacement, rangeValuesPlacement]);
+    }, [min, max, setStepSize, gap, labelPlacement, rangeValuesPlacement]);
 
     const fillStyle = { left: `${railFillXPosition}px`, width: `${railFillWidth}px` };
 

--- a/website/plasma-web-docs/docs/components/Slider.mdx
+++ b/website/plasma-web-docs/docs/components/Slider.mdx
@@ -7,8 +7,6 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 
 # Slider
 
-Слайдер позволяет определить числовое значение в пределах указанного промежутка.
-
 <Description name="Slider" />
 <PropsTable name="Slider" />
 <StorybookLink name="Slider" />

--- a/website/sdds-dfa-docs/docs/components/Slider.mdx
+++ b/website/sdds-dfa-docs/docs/components/Slider.mdx
@@ -1,0 +1,78 @@
+---
+id: slider
+title: Slider
+---
+
+import { PropsTable, Description } from '@site/src/components';
+
+# Slider
+
+<Description name="Slider" />
+<PropsTable name="Slider" />
+
+## Использование
+
+```tsx live
+import React from 'react';
+import { Slider  } from '@salutejs/sdds-dfa';
+
+export function App() {
+    return (
+        <section>
+            <Slider onChangeCommitted={() => {}} min={0} max={100} value={30} />
+        </section>
+    );
+}
+```
+
+Можно использовать диапазон значений.
+
+```tsx live
+import React, { useState } from 'react';
+import { Slider  } from '@salutejs/plasma-web';
+
+export function App() {
+    const [value, setValue] = useState([10, 80]);
+    const sortValues = (values) => {
+        return values
+            .map((val) => {
+                if (val < 0) {
+                    return 0;
+                }
+                if (val > 100) {
+                    return 100;
+                }
+                return val;
+            })
+            .sort((a, b) => a - b);
+    };
+
+    const onChangeHandle = (values) => {
+        setValue(sortValues(values));
+    };
+
+    const onChangeCommitedHandle = (values) => {
+        setValue(sortValues(values));
+    };
+
+    const onBlurTextField = (values) => {
+        setValue(sortValues(values));
+    };
+
+    const onKeyDownTextField = (values, event) => {
+        if (event.key === 'Enter') {
+            setValue(sortValues(values));
+        }
+    };
+
+    return (
+        <section>
+            <Slider value={value}
+                onKeyDownTextField={onKeyDownTextField}
+                onBlurTextField={onBlurTextField}
+                onChangeCommitted={onChangeCommitedHandle}
+                onChange={onChangeHandle} min={0} max={100} />
+        </section>
+    );
+}
+```


### PR DESCRIPTION
### Slider

- удалена лишняя зависимость `ref.current` в hooks 
- исправлена документация в `plasma-web`
- для `plasma-new-hope` и `sdds-dfa` добавлены недостающие файлы документации

### What/why changed

- `ref.current` не нужен в зависимости хука, т.к. его изменение не влечет за собой rerender. Убрали их, чтобы в консоль не попадал warning. 

#### Before
<img width="882" alt="before" src="https://github.com/user-attachments/assets/363942a1-e8eb-4f20-aeb1-3401e54226f0">

#### After
<img width="883" alt="after" src="https://github.com/user-attachments/assets/1f32559f-271a-43d9-bfb0-df8976cc82c3">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.136.1-canary.1386.10523593917.0
  npm install @salutejs/plasma-b2c@1.378.1-canary.1386.10523593917.0
  npm install @salutejs/plasma-new-hope@0.130.1-canary.1386.10523593917.0
  npm install @salutejs/plasma-web@1.379.1-canary.1386.10523593917.0
  npm install @salutejs/sdds-cs@0.108.1-canary.1386.10523593917.0
  npm install @salutejs/sdds-dfa@0.106.1-canary.1386.10523593917.0
  npm install @salutejs/sdds-serv@0.107.1-canary.1386.10523593917.0
  # or 
  yarn add @salutejs/plasma-asdk@0.136.1-canary.1386.10523593917.0
  yarn add @salutejs/plasma-b2c@1.378.1-canary.1386.10523593917.0
  yarn add @salutejs/plasma-new-hope@0.130.1-canary.1386.10523593917.0
  yarn add @salutejs/plasma-web@1.379.1-canary.1386.10523593917.0
  yarn add @salutejs/sdds-cs@0.108.1-canary.1386.10523593917.0
  yarn add @salutejs/sdds-dfa@0.106.1-canary.1386.10523593917.0
  yarn add @salutejs/sdds-serv@0.107.1-canary.1386.10523593917.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
