### PR TITLE
plasma-docs: Update sdds-serv docs

### DIFF
--- a/packages/plasma-new-hope/src/components/Tabs/Tabs.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Tabs/Tabs.template-doc.mdx
@@ -69,7 +69,7 @@ export function App() {
 
     return (
         <div>
-            <Tabs view="divider" size="xs" style={{ width: '15rem' }}>
+            <Tabs view="divider" size="xs" style=\{{ width: '15rem' }}>
                 {items.map((_, i) => (
                     <TabItem
                         view="divider"
@@ -113,7 +113,7 @@ export function App() {
     });
 
     return (
-        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+        <div style=\{{ height: '15rem', alignItems: 'flex-start' }}>
             <Tabs clip="showAll" view="divider" size="xs">
                 {visibleItems.map((_, i) => (
                     <TabItem
@@ -128,7 +128,7 @@ export function App() {
                     </TabItem>
                 ))}
                 {dropdownItems.length > 0 && (
-                    <div style={{ marginLeft: '1.75rem' }}>
+                    <div style=\{{ marginLeft: '1.75rem' }}>
                         <Dropdown size="xs" items={dropdownItems} onItemSelect={(item) => setIndex(item.value)}>
                             <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
                                 ShowAll

--- a/website/sdds-serv-docs/docs/components/Tooltip.mdx
+++ b/website/sdds-serv-docs/docs/components/Tooltip.mdx
@@ -1,0 +1,30 @@
+---
+id: Tooltip
+title: Tooltip
+---
+
+import { PropsTable, Description } from '@site/src/components';
+
+# Tooltip
+<Description name="Tooltip" />
+<PropsTable name="Tooltip" />
+
+## Базовое применение
+
+`Tooltip` оборачивает собой любой компонент и открывается в заданную сторону(причем можно передавать массив, тогда сторона будет определяться автоматически из переданных).
+
+Предполагается оборачивать иконки из пакета `@salutejs/plasma-icons`
+
+```tsx live
+import React from 'react';
+import { Tooltip } from '@salutejs/sdds-serv';
+import { IconApps } from '@salutejs/plasma-icons';
+
+export function App() {
+    return (
+        <div style={{marginLeft: '100px',marginBottom: '35px'}}>
+            <Tooltip target={( <IconApps />)} text="Высокое качество воспроизведения" placement="bottom" hasArrow opened />
+        </div>
+    );
+}
+```


### PR DESCRIPTION
### What/why changed

добавили в документацию раздел для `Tooltip` 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.136.2-canary.1391.10525070095.0
  npm install @salutejs/plasma-b2c@1.378.2-canary.1391.10525070095.0
  npm install @salutejs/plasma-new-hope@0.130.2-canary.1391.10525070095.0
  npm install @salutejs/plasma-web@1.379.2-canary.1391.10525070095.0
  npm install @salutejs/sdds-cs@0.108.2-canary.1391.10525070095.0
  npm install @salutejs/sdds-dfa@0.106.2-canary.1391.10525070095.0
  npm install @salutejs/sdds-serv@0.107.2-canary.1391.10525070095.0
  # or 
  yarn add @salutejs/plasma-asdk@0.136.2-canary.1391.10525070095.0
  yarn add @salutejs/plasma-b2c@1.378.2-canary.1391.10525070095.0
  yarn add @salutejs/plasma-new-hope@0.130.2-canary.1391.10525070095.0
  yarn add @salutejs/plasma-web@1.379.2-canary.1391.10525070095.0
  yarn add @salutejs/sdds-cs@0.108.2-canary.1391.10525070095.0
  yarn add @salutejs/sdds-dfa@0.106.2-canary.1391.10525070095.0
  yarn add @salutejs/sdds-serv@0.107.2-canary.1391.10525070095.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
