### PR TITLE
plasma-web: size `xs` added to `TextField`

### DIFF
--- a/packages/plasma-web/src/components/TextField/TextField.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.tsx
@@ -58,16 +58,15 @@ export const TextField = forwardRef<HTMLInputElement, CustomTextFieldProps>((pro
         _label = placeholder;
         _labelPlacement = 'inner';
     }
-    const _size = size === 'xs' ? 's' : size;
 
     if (enumerationType === 'chip') {
         return (
             <TextFieldComponent
                 {...rest}
                 view={_view}
-                size={_size}
                 labelPlacement={_labelPlacement}
                 label={_label}
+                size={size}
                 placeholder={placeholder}
                 leftHelper={helperText}
                 ref={ref}
@@ -82,9 +81,9 @@ export const TextField = forwardRef<HTMLInputElement, CustomTextFieldProps>((pro
         <TextFieldComponent
             {...rest}
             view={_view}
-            size={_size}
             labelPlacement={_labelPlacement}
             label={_label}
+            size={size}
             placeholder={placeholder}
             leftHelper={helperText}
             ref={ref}


### PR DESCRIPTION
### TextField
- добавлен размер `xs` в `plasma-web` 

### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-web@1.381.0-canary.1395.10561418913.0
  # or 
  yarn add @salutejs/plasma-web@1.381.0-canary.1395.10561418913.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
