### PR TITLE
plasma-(*): Add format and lang in Datepicker

### DIFF
--- a/packages/plasma-b2c/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-b2c/src/components/DatePicker/DatePicker.stories.tsx
@@ -45,6 +45,18 @@ const meta: Meta = {
                 type: 'date',
             },
         },
+        lang: {
+            options: ['ru', 'en'],
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
+            },
+        },
     },
 };
 
@@ -108,6 +120,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         defaultDate: new Date(2024, 5, 14),
         min: new Date(2024, 1, 1),
         max: new Date(2024, 12, 29),
@@ -244,6 +258,8 @@ export const Range: StoryObj<StoryPropsRange> = {
         dividerVariant: 'dash',
         min: new Date(2024, 1, 1),
         max: new Date(2024, 12, 29),
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         maskWithFormat: false,
         disabled: false,
         readOnly: false,
@@ -323,6 +339,8 @@ export const Deferred: StoryObj<StoryPropsDefault> = {
     args: {
         label: 'Лейбл',
         leftHelper: 'Подсказка к полю',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePicker.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePicker.template-doc.mdx
@@ -70,6 +70,38 @@ export function App() {
 }
 ```
 
+### Язык даты
+Язык даты задается с помощью свойства `lang`.
+
+| Обозначение | Отображение | Описание            |
+|-------------|-------------|---------------------|
+| ru          | June        | Английский Язык     |
+| en          | июнь        | Русский язык        |
+
+По умолчанию используется `ru`
+
+```tsx live
+import React from 'react';
+import { DatePicker } from '@salutejs/{{ package }}';
+import { IconDone } from '@salutejs/plasma-icons';
+
+export function App() {
+    return (
+        <div style=\{{ height: "450px" }}>
+            <DatePicker
+                label="Лейбл"
+                leftHelper="Подсказка к полю"
+                placeholder="Введите дату"
+                format="DD MMMM YYYY"
+                lang="en"
+                maskWithFormat
+                contentRight={<IconDone size="s" />}
+            />
+        </div>
+    );
+}
+```
+
 ### Валидация и индикация успешного ввода даты.
 За индикацию ошибки или успешного ввода отвечают `valueError`, `valueSuccess`.
 В данном примере валидация происходит при нажатии клавиши `Enter` после ввода значений:

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePickerBase.types.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePickerBase.types.ts
@@ -3,6 +3,8 @@ import type { Dispatch, MutableRefObject, SetStateAction, SyntheticEvent, Change
 import type { CalendarStateType } from '../Calendar';
 import type { DateInfo, DisabledDay, EventDay } from '../Calendar/Calendar.types';
 
+import type { Langs } from './utils/dateHelper';
+
 export type DatePickerCalendarProps = {
     /**
      * Формат даты.
@@ -61,6 +63,11 @@ export type DatePickerCalendarProps = {
      * Тип отображения календаря: дни, месяца, года.
      */
     type?: CalendarStateType;
+
+    /**
+     * Язык в маске ввода
+     */
+    lang?: Langs;
 };
 
 export type DatePickerdVariationProps = {
@@ -89,6 +96,7 @@ export type UseDatePickerProps = {
     setIsInnerOpen: Dispatch<SetStateAction<boolean>>;
     dateFormatDelimiter: () => string;
     format?: string;
+    lang?: Langs;
     disabled?: boolean;
     readOnly?: boolean;
     maskWithFormat?: boolean;

--- a/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.tsx
@@ -66,6 +66,7 @@ export const datePickerRangeRoot = (
                 secondTextfieldTextAfter,
 
                 format = 'DD.MM.YYYY',
+                lang = 'ru',
                 maskWithFormat,
                 min,
                 max,
@@ -113,13 +114,15 @@ export const datePickerRangeRoot = (
             );
             const [isInnerOpen, setIsInnerOpen] = useState(opened);
 
-            const [calendarFirstValue, setCalendarFirstValue] = useState(formatCalendarValue(defaultFirstDate, format));
-            const [inputFirstValue, setInputFirstValue] = useState(formatInputValue(defaultFirstDate, format));
+            const [calendarFirstValue, setCalendarFirstValue] = useState(
+                formatCalendarValue(defaultFirstDate, format, lang),
+            );
+            const [inputFirstValue, setInputFirstValue] = useState(formatInputValue(defaultFirstDate, format, lang));
 
             const [calendarSecondValue, setCalendarSecondValue] = useState(
-                formatCalendarValue(defaultSecondDate, format),
+                formatCalendarValue(defaultSecondDate, format, lang),
             );
-            const [inputSecondValue, setInputSecondValue] = useState(formatInputValue(defaultSecondDate, format));
+            const [inputSecondValue, setInputSecondValue] = useState(formatInputValue(defaultSecondDate, format, lang));
 
             const dateFormatDelimiter = useCallback(() => getDateFormatDelimiter(format), [format]);
 
@@ -133,6 +136,7 @@ export const datePickerRangeRoot = (
                 setIsInnerOpen,
                 dateFormatDelimiter,
                 format,
+                lang,
                 disabled,
                 readOnly,
                 maskWithFormat,
@@ -153,6 +157,7 @@ export const datePickerRangeRoot = (
                 setIsInnerOpen,
                 dateFormatDelimiter,
                 format,
+                lang,
                 disabled,
                 readOnly,
                 maskWithFormat,
@@ -248,14 +253,22 @@ export const datePickerRangeRoot = (
             }, [opened]);
 
             useEffect(() => {
-                setCalendarFirstValue(formatCalendarValue(defaultFirstDate, format));
-                setInputFirstValue(formatInputValue(defaultFirstDate, format));
+                setCalendarFirstValue(formatCalendarValue(defaultFirstDate, format, lang));
+                setInputFirstValue(formatInputValue(defaultFirstDate, format, lang));
             }, [defaultFirstDate]);
 
             useEffect(() => {
-                setCalendarSecondValue(formatCalendarValue(defaultSecondDate, format));
-                setInputSecondValue(formatInputValue(defaultSecondDate, format));
+                setCalendarSecondValue(formatCalendarValue(defaultSecondDate, format, lang));
+                setInputSecondValue(formatInputValue(defaultSecondDate, format, lang));
             }, [defaultSecondDate]);
+
+            useEffect(() => {
+                setCalendarFirstValue(formatCalendarValue(defaultFirstDate, format, lang));
+                setInputFirstValue(formatInputValue(defaultFirstDate, format, lang));
+
+                setCalendarSecondValue(formatCalendarValue(defaultSecondDate, format, lang));
+                setInputSecondValue(formatInputValue(defaultSecondDate, format, lang));
+            }, [format, lang]);
 
             return (
                 <Root

--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
@@ -41,6 +41,7 @@ export const datePickerRoot = (
                 valueError,
                 valueSuccess,
                 format = 'DD.MM.YYYY',
+                lang = 'ru',
                 maskWithFormat,
                 min,
                 max,
@@ -72,8 +73,8 @@ export const datePickerRoot = (
             const inputRef = useRef<HTMLInputElement | null>(null);
             const [isInnerOpen, setIsInnerOpen] = useState(opened);
 
-            const [calendarValue, setCalendarValue] = useState(formatCalendarValue(defaultDate, format));
-            const [inputValue, setInputValue] = useState(formatInputValue(defaultDate, format));
+            const [calendarValue, setCalendarValue] = useState(formatCalendarValue(defaultDate, format, lang));
+            const [inputValue, setInputValue] = useState(formatInputValue(defaultDate, format, lang));
 
             const innerLabelPlacement = labelPlacement === 'inner';
 
@@ -92,6 +93,7 @@ export const datePickerRoot = (
                 setIsInnerOpen,
                 dateFormatDelimiter,
                 format,
+                lang,
                 disabled,
                 readOnly,
                 maskWithFormat,
@@ -135,9 +137,14 @@ export const datePickerRoot = (
             }, [opened]);
 
             useEffect(() => {
-                setCalendarValue(formatCalendarValue(defaultDate, format));
-                setInputValue(formatInputValue(defaultDate, format));
+                setCalendarValue(formatCalendarValue(defaultDate, format, lang));
+                setInputValue(formatInputValue(defaultDate, format, lang));
             }, [defaultDate]);
+
+            useEffect(() => {
+                setCalendarValue(formatCalendarValue(defaultDate, format, lang));
+                setInputValue(formatInputValue(defaultDate, format, lang));
+            }, [format, lang]);
 
             return (
                 <Root

--- a/packages/plasma-new-hope/src/components/DatePicker/hooks/useDatePicker.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/hooks/useDatePicker.ts
@@ -12,6 +12,7 @@ export const useDatePicker = ({
     setIsInnerOpen,
     dateFormatDelimiter,
     format,
+    lang = 'ru',
     disabled,
     readOnly,
     maskWithFormat,
@@ -52,10 +53,10 @@ export const useDatePicker = ({
         if (!format) {
             setCalendarValue(formatCalendarValue(newValue));
         } else if (newValue?.length === format.length) {
-            setCalendarValue(formatCalendarValue(newValue, format));
+            setCalendarValue(formatCalendarValue(newValue, format, lang));
         }
 
-        setInputValue(formatInputValue(newValue, format));
+        setInputValue(formatInputValue(newValue, format, lang));
 
         onChangeValue?.(event, newValue);
     };
@@ -78,18 +79,18 @@ export const useDatePicker = ({
         }
 
         if (isCalendarValue) {
-            setCalendarValue(formatCalendarValue(date, format));
-            setInputValue(formatInputValue(date, format));
+            setCalendarValue(formatCalendarValue(date, format, lang));
+            setInputValue(formatInputValue(date, format, lang));
 
             return onCommitDate?.(date, false, true, dateInfo);
         }
 
         const formatString = applyFormat ? format : undefined;
 
-        const { value: newDate, isError, isSuccess } = getDateFromFormat(date, formatString);
+        const { value: newDate, isError, isSuccess } = getDateFromFormat(date, formatString, lang);
 
-        setCalendarValue(formatCalendarValue(newDate, format));
-        setInputValue(formatInputValue(newDate, format));
+        setCalendarValue(formatCalendarValue(newDate, format, lang));
+        setInputValue(formatInputValue(newDate, format, lang));
 
         onCommitDate?.(newDate, isError, isSuccess);
     };

--- a/packages/plasma-new-hope/src/components/DatePicker/utils/dateHelper.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/utils/dateHelper.ts
@@ -1,44 +1,46 @@
 import { customDayjs } from '../../../utils/datejs';
 
-export const formatInputValue = (value?: Date | string, format?: string) => {
-    if (!value) {
+export type Langs = 'ru' | 'en';
+
+export const formatInputValue = (value?: Date | string, format?: string, lang?: Langs) => {
+    if (!value || !lang) {
         return '';
     }
 
     if (format && customDayjs(value, format, true).isValid()) {
-        return customDayjs(value, format).format(format);
+        return customDayjs(value, format).locale(lang).format(format);
     }
 
     if (format && String(value).length >= 10 && String(new Date(value)) !== 'Invalid Date') {
-        return customDayjs(value).format(format);
+        return customDayjs(value).locale(lang).format(format);
     }
 
     return String(value);
 };
 
-export const formatCalendarValue = (value?: Date | string, format?: string) => {
-    if (!value) {
+export const formatCalendarValue = (value?: Date | string, format?: string, lang?: Langs) => {
+    if (!value || !lang) {
         return undefined;
     }
 
     if (format && customDayjs(value, format, true).isValid()) {
-        return customDayjs(value, format, true).toDate();
+        return customDayjs(value, format, true).locale(lang).toDate();
     }
 
     if (String(new Date(value)) !== 'Invalid Date') {
-        return customDayjs(value).toDate();
+        return customDayjs(value).locale(lang).toDate();
     }
 
     return undefined;
 };
 
-export const getDateFromFormat = (value: Date | string, format?: string) => {
-    if (format && customDayjs(value, format, true).isValid()) {
-        return { value: customDayjs(value, format, true).toDate(), isError: false, isSuccess: true };
+export const getDateFromFormat = (value: Date | string, format?: string, lang?: Langs) => {
+    if (format && customDayjs(value, format, true).isValid() && lang) {
+        return { value: customDayjs(value, format, true).locale(lang).toDate(), isError: false, isSuccess: true };
     }
 
-    if (!format && String(new Date(value)) !== 'Invalid Date') {
-        return { value: customDayjs(value).toDate(), isError: false, isSuccess: true };
+    if (!format && String(new Date(value)) !== 'Invalid Date' && lang) {
+        return { value: customDayjs(value).locale(lang).toDate(), isError: false, isSuccess: true };
     }
 
     return { value, isError: true, isSuccess: false };

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
@@ -47,6 +47,12 @@ const meta: Meta = {
                 type: 'date',
             },
         },
+        lang: {
+            options: ['ru', 'en'],
+            control: {
+                type: 'inline-radio',
+            },
+        },
     },
 };
 
@@ -63,6 +69,8 @@ const StoryDefault = ({
     valueError,
     valueSuccess,
     size,
+    lang,
+    format,
     ...rest
 }: StoryPropsDefault) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -83,6 +91,8 @@ const StoryDefault = ({
             onChangeValue={(e, currentValue) => {
                 onChangeValue(e, currentValue);
             }}
+            lang={lang}
+            format={format}
             onCommitDate={() => setIsOpen(false)}
             {...rest}
         />
@@ -100,6 +110,12 @@ export const Default: StoryObj<StoryPropsDefault> = {
             options: labelPlacements,
             control: {
                 type: 'inline-radio',
+            },
+        },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
             },
         },
     },
@@ -121,6 +137,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         enableContentRight: true,
         valueError: false,
         valueSuccess: false,
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
     },
     render: (args) => <StoryDefault {...args} />,
 };
@@ -230,6 +248,12 @@ export const Range: StoryObj<StoryPropsRange> = {
                 type: 'inline-radio',
             },
         },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
+            },
+        },
     },
     args: {
         label: 'Лейбл',
@@ -255,6 +279,9 @@ export const Range: StoryObj<StoryPropsRange> = {
         enableFirstTextfieldContentRight: false,
         enableSecondTextfieldContentLeft: false,
         enableSecondTextfieldContentRight: false,
+
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
 
         firstValueError: false,
         firstValueSuccess: false,
@@ -319,6 +346,12 @@ export const Deferred: StoryObj<StoryPropsDefault> = {
             options: labelPlacements,
             control: {
                 type: 'inline-radio',
+            },
+        },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
             },
         },
     },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/DatePicker/DatePicker.stories.tsx
@@ -47,6 +47,12 @@ const meta: Meta = {
                 type: 'date',
             },
         },
+        lang: {
+            options: ['ru', 'en'],
+            control: {
+                type: 'inline-radio',
+            },
+        },
     },
 };
 
@@ -63,6 +69,8 @@ const StoryDefault = ({
     valueError,
     valueSuccess,
     size,
+    lang,
+    format,
     ...rest
 }: StoryPropsDefault) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -83,6 +91,8 @@ const StoryDefault = ({
             onChangeValue={(e, currentValue) => {
                 onChangeValue(e, currentValue);
             }}
+            lang={lang}
+            format={format}
             onCommitDate={() => setIsOpen(false)}
             {...rest}
         />
@@ -102,6 +112,12 @@ export const Default: StoryObj<StoryPropsDefault> = {
                 type: 'inline-radio',
             },
         },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
+            },
+        },
     },
     args: {
         label: 'Лейбл',
@@ -109,6 +125,7 @@ export const Default: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',
+        labelPlacement: 'outer',
         defaultDate: new Date(2024, 5, 14),
         min: new Date(2024, 1, 1),
         max: new Date(2024, 12, 29),
@@ -120,6 +137,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         enableContentRight: true,
         valueError: false,
         valueSuccess: false,
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
     },
     render: (args) => <StoryDefault {...args} />,
 };
@@ -229,6 +248,12 @@ export const Range: StoryObj<StoryPropsRange> = {
                 type: 'inline-radio',
             },
         },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
+            },
+        },
     },
     args: {
         label: 'Лейбл',
@@ -254,6 +279,9 @@ export const Range: StoryObj<StoryPropsRange> = {
         enableFirstTextfieldContentRight: false,
         enableSecondTextfieldContentLeft: false,
         enableSecondTextfieldContentRight: false,
+
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
 
         firstValueError: false,
         firstValueSuccess: false,
@@ -318,6 +346,12 @@ export const Deferred: StoryObj<StoryPropsDefault> = {
             options: labelPlacements,
             control: {
                 type: 'inline-radio',
+            },
+        },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
             },
         },
     },

--- a/packages/plasma-new-hope/src/utils/datejs.ts
+++ b/packages/plasma-new-hope/src/utils/datejs.ts
@@ -3,6 +3,9 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear';
 import advancedFormat from 'dayjs/plugin/advancedFormat';
 
+import 'dayjs/locale/ru';
+import 'dayjs/locale/en';
+
 dayjs.extend(customParseFormat);
 dayjs.extend(quarterOfYear);
 dayjs.extend(advancedFormat);

--- a/packages/plasma-web/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-web/src/components/DatePicker/DatePicker.stories.tsx
@@ -45,6 +45,18 @@ const meta: Meta = {
                 type: 'date',
             },
         },
+        lang: {
+            options: ['ru', 'en'],
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
+            },
+        },
     },
 };
 
@@ -108,6 +120,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         defaultDate: new Date(2024, 5, 14),
         min: new Date(2024, 1, 1),
         max: new Date(2024, 12, 29),
@@ -240,6 +254,8 @@ export const Range: StoryObj<StoryPropsRange> = {
         secondTextfieldTextAfter: '',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         isDoubleCalendar: false,
         dividerVariant: 'dash',
         min: new Date(2024, 1, 1),
@@ -326,6 +342,8 @@ export const Deferred: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         labelPlacement: 'outer',
         min: new Date(2024, 1, 1),
         max: new Date(2024, 12, 29),

--- a/packages/sdds-cs/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-cs/src/components/DatePicker/DatePicker.stories.tsx
@@ -45,6 +45,18 @@ const meta: Meta = {
                 type: 'date',
             },
         },
+        lang: {
+            options: ['ru', 'en'],
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
+            },
+        },
     },
 };
 
@@ -107,6 +119,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 's',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         labelPlacement: 'outer',
         defaultDate: new Date(2024, 5, 14),
         min: new Date(2024, 1, 1),
@@ -240,6 +254,8 @@ export const Range: StoryObj<StoryPropsRange> = {
         secondTextfieldTextAfter: '',
         size: 's',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         isDoubleCalendar: false,
         dividerVariant: 'dash',
         min: new Date(2024, 1, 1),

--- a/packages/sdds-dfa/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-dfa/src/components/DatePicker/DatePicker.stories.tsx
@@ -45,6 +45,18 @@ const meta: Meta = {
                 type: 'date',
             },
         },
+        lang: {
+            options: ['ru', 'en'],
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
+            },
+        },
     },
 };
 
@@ -107,6 +119,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         labelPlacement: 'outer',
         defaultDate: new Date(2024, 5, 14),
         min: new Date(2024, 1, 1),
@@ -240,6 +254,8 @@ export const Range: StoryObj<StoryPropsRange> = {
         secondTextfieldTextAfter: '',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         isDoubleCalendar: false,
         dividerVariant: 'dash',
         min: new Date(2024, 1, 1),
@@ -326,6 +342,8 @@ export const Deferred: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         labelPlacement: 'outer',
         min: new Date(2024, 1, 1),
         max: new Date(2024, 12, 29),

--- a/packages/sdds-serv/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-serv/src/components/DatePicker/DatePicker.stories.tsx
@@ -45,6 +45,18 @@ const meta: Meta = {
                 type: 'date',
             },
         },
+        lang: {
+            options: ['ru', 'en'],
+            control: {
+                type: 'inline-radio',
+            },
+        },
+        format: {
+            options: ['DD.MM.YYYY', 'DD MMMM YYYY'],
+            control: {
+                type: 'select',
+            },
+        },
     },
 };
 
@@ -107,6 +119,8 @@ export const Default: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         labelPlacement: 'outer',
         defaultDate: new Date(2024, 5, 14),
         min: new Date(2024, 1, 1),
@@ -240,6 +254,8 @@ export const Range: StoryObj<StoryPropsRange> = {
         secondTextfieldTextAfter: '',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         isDoubleCalendar: false,
         dividerVariant: 'dash',
         min: new Date(2024, 1, 1),
@@ -326,6 +342,8 @@ export const Deferred: StoryObj<StoryPropsDefault> = {
         placeholder: '30.05.2024',
         size: 'l',
         view: 'default',
+        lang: 'ru',
+        format: 'DD.MM.YYYY',
         labelPlacement: 'outer',
         min: new Date(2024, 1, 1),
         max: new Date(2024, 12, 29),

--- a/website/plasma-b2c-docs/docs/components/DatePicker.mdx
+++ b/website/plasma-b2c-docs/docs/components/DatePicker.mdx
@@ -73,6 +73,38 @@ export function App() {
 }
 ```
 
+### Язык даты
+Язык даты задается с помощью свойства `lang`.
+
+| Обозначение | Отображение | Описание            |
+|-------------|-------------|---------------------|
+| ru          | June        | Английский Язык     |
+| en          | июнь        | Русский язык        |
+
+По умолчанию используется `ru`
+
+```tsx live
+import React from 'react';
+import { DatePicker } from '@salutejs/plasma-b2c';
+import { IconDone } from '@salutejs/plasma-icons';
+
+export function App() {
+    return (
+        <div style={{ height: "450px" }}>
+            <DatePicker
+                label="Лейбл"
+                leftHelper="Подсказка к полю"
+                placeholder="Введите дату"
+                format="DD MMMM YYYY"
+                lang="en"
+                maskWithFormat
+                contentRight={<IconDone size="s" />}
+            />
+        </div>
+    );
+}
+```
+
 ### Валидация и индикация успешного ввода даты.
 За индикацию ошибки или успешного ввода отвечают `valueError`, `valueSuccess`.
 В данном примере валидация происходит при нажатии клавиши `Enter` после ввода значений:

--- a/website/plasma-web-docs/docs/components/DatePicker.mdx
+++ b/website/plasma-web-docs/docs/components/DatePicker.mdx
@@ -71,6 +71,38 @@ export function App() {
 }
 ```
 
+### Язык даты
+Язык даты задается с помощью свойства `lang`.
+
+| Обозначение | Отображение | Описание            |
+|-------------|-------------|---------------------|
+| ru          | June        | Английский Язык     |
+| en          | июнь        | Русский язык        |
+
+По умолчанию используется `ru`
+
+```tsx live
+import React from 'react';
+import { DatePicker } from '@salutejs/plasma-b2c';
+import { IconDone } from '@salutejs/plasma-icons';
+
+export function App() {
+    return (
+        <div style={{ height: "450px" }}>
+            <DatePicker
+                label="Лейбл"
+                leftHelper="Подсказка к полю"
+                placeholder="Введите дату"
+                format="DD MMMM YYYY"
+                lang="en"
+                maskWithFormat
+                contentRight={<IconDone size="s" />}
+            />
+        </div>
+    );
+}
+```
+
 ### Валидация и индикация успешного ввода даты.
 За индикацию ошибки или успешного ввода отвечают `valueError`, `valueSuccess`.
 В данном примере валидация происходит при нажатии клавиши `Enter` после ввода значений:

--- a/website/sdds-cs-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-cs-docs/docs/components/DatePicker.mdx
@@ -70,6 +70,38 @@ export function App() {
 }
 ```
 
+### Язык даты
+Язык даты задается с помощью свойства `lang`.
+
+| Обозначение | Отображение | Описание            |
+|-------------|-------------|---------------------|
+| ru          | June        | Английский Язык     |
+| en          | июнь        | Русский язык        |
+
+По умолчанию используется `ru`
+
+```tsx live
+import React from 'react';
+import { DatePicker } from '@salutejs/plasma-b2c';
+import { IconDone } from '@salutejs/plasma-icons';
+
+export function App() {
+    return (
+        <div style={{ height: "450px" }}>
+            <DatePicker
+                label="Лейбл"
+                leftHelper="Подсказка к полю"
+                placeholder="Введите дату"
+                format="DD MMMM YYYY"
+                lang="en"
+                maskWithFormat
+                contentRight={<IconDone size="s" />}
+            />
+        </div>
+    );
+}
+```
+
 ### Валидация и индикация успешного ввода даты.
 За индикацию ошибки или успешного ввода отвечают `valueError`, `valueSuccess`.
 В данном примере валидация происходит при нажатии клавиши `Enter` после ввода значений:

--- a/website/sdds-dfa-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-dfa-docs/docs/components/DatePicker.mdx
@@ -70,6 +70,38 @@ export function App() {
 }
 ```
 
+### Язык даты
+Язык даты задается с помощью свойства `lang`.
+
+| Обозначение | Отображение | Описание            |
+|-------------|-------------|---------------------|
+| ru          | June        | Английский Язык     |
+| en          | июнь        | Русский язык        |
+
+По умолчанию используется `ru`
+
+```tsx live
+import React from 'react';
+import { DatePicker } from '@salutejs/plasma-b2c';
+import { IconDone } from '@salutejs/plasma-icons';
+
+export function App() {
+    return (
+        <div style={{ height: "450px" }}>
+            <DatePicker
+                label="Лейбл"
+                leftHelper="Подсказка к полю"
+                placeholder="Введите дату"
+                format="DD MMMM YYYY"
+                lang="en"
+                maskWithFormat
+                contentRight={<IconDone size="s" />}
+            />
+        </div>
+    );
+}
+```
+
 ### Валидация и индикация успешного ввода даты.
 За индикацию ошибки или успешного ввода отвечают `valueError`, `valueSuccess`.
 В данном примере валидация происходит при нажатии клавиши `Enter` после ввода значений:

--- a/website/sdds-serv-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-serv-docs/docs/components/DatePicker.mdx
@@ -70,6 +70,38 @@ export function App() {
 }
 ```
 
+### Язык даты
+Язык даты задается с помощью свойства `lang`.
+
+| Обозначение | Отображение | Описание            |
+|-------------|-------------|---------------------|
+| ru          | June        | Английский Язык     |
+| en          | июнь        | Русский язык        |
+
+По умолчанию используется `ru`
+
+```tsx live
+import React from 'react';
+import { DatePicker } from '@salutejs/plasma-b2c';
+import { IconDone } from '@salutejs/plasma-icons';
+
+export function App() {
+    return (
+        <div style={{ height: "450px" }}>
+            <DatePicker
+                label="Лейбл"
+                leftHelper="Подсказка к полю"
+                placeholder="Введите дату"
+                format="DD MMMM YYYY"
+                lang="en"
+                maskWithFormat
+                contentRight={<IconDone size="s" />}
+            />
+        </div>
+    );
+}
+```
+
 ### Валидация и индикация успешного ввода даты.
 За индикацию ошибки или успешного ввода отвечают `valueError`, `valueSuccess`.
 В данном примере валидация происходит при нажатии клавиши `Enter` после ввода значений:


### PR DESCRIPTION
### DatePicker

- добавлена поддержка русского и английского языка
- добавлено форматирование даты 

### What/why changed

- добавлен параметр `lang` с параметрами `ru` и `en`
- обновлен Storybook и документация

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.142.0-canary.1404.10657398641.0
  npm install @salutejs/plasma-b2c@1.384.0-canary.1404.10657398641.0
  npm install @salutejs/plasma-new-hope@0.136.0-canary.1404.10657398641.0
  npm install @salutejs/plasma-web@1.386.0-canary.1404.10657398641.0
  npm install @salutejs/sdds-cs@0.114.0-canary.1404.10657398641.0
  npm install @salutejs/sdds-dfa@0.112.0-canary.1404.10657398641.0
  npm install @salutejs/sdds-serv@0.113.0-canary.1404.10657398641.0
  # or 
  yarn add @salutejs/plasma-asdk@0.142.0-canary.1404.10657398641.0
  yarn add @salutejs/plasma-b2c@1.384.0-canary.1404.10657398641.0
  yarn add @salutejs/plasma-new-hope@0.136.0-canary.1404.10657398641.0
  yarn add @salutejs/plasma-web@1.386.0-canary.1404.10657398641.0
  yarn add @salutejs/sdds-cs@0.114.0-canary.1404.10657398641.0
  yarn add @salutejs/sdds-dfa@0.112.0-canary.1404.10657398641.0
  yarn add @salutejs/sdds-serv@0.113.0-canary.1404.10657398641.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
