### PR TITLE
plasma-*: PopupProvider server rendering

### DIFF
--- a/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
@@ -21,7 +21,7 @@ const PopupContext = createContext<PopupContextType>({
 export const usePopupContext = () => useContext(PopupContext);
 
 export const PopupProvider: FC<PropsWithChildren> = ({ children }) => {
-    const prevBodyOverflowY = useRef(document.body.style.overflowY);
+    const prevBodyOverflowY = useRef(typeof document !== 'undefined' ? document.body.style.overflowY : '');
     const [items, setItems] = useState<PopupInfo[]>([]);
 
     const register = (info: PopupInfo) => {


### PR DESCRIPTION
### PopupProvider

- удалено обращение к `document` на сервере
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.144.1-canary.1411.10666649424.0
  npm install @salutejs/plasma-b2c@1.386.1-canary.1411.10666649424.0
  npm install @salutejs/plasma-new-hope@0.137.1-canary.1411.10666649424.0
  npm install @salutejs/plasma-web@1.388.1-canary.1411.10666649424.0
  npm install @salutejs/sdds-cs@0.116.1-canary.1411.10666649424.0
  npm install @salutejs/sdds-dfa@0.114.1-canary.1411.10666649424.0
  npm install @salutejs/sdds-serv@0.115.1-canary.1411.10666649424.0
  # or 
  yarn add @salutejs/plasma-asdk@0.144.1-canary.1411.10666649424.0
  yarn add @salutejs/plasma-b2c@1.386.1-canary.1411.10666649424.0
  yarn add @salutejs/plasma-new-hope@0.137.1-canary.1411.10666649424.0
  yarn add @salutejs/plasma-web@1.388.1-canary.1411.10666649424.0
  yarn add @salutejs/sdds-cs@0.116.1-canary.1411.10666649424.0
  yarn add @salutejs/sdds-dfa@0.114.1-canary.1411.10666649424.0
  yarn add @salutejs/sdds-serv@0.115.1-canary.1411.10666649424.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
