### PR TITLE
plasma-*: Fix popup mount logic

### DIFF
--- a/packages/plasma-b2c/src/components/Drawer/Drawer.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Drawer/Drawer.component-test.tsx
@@ -204,7 +204,7 @@ describe('plasma-b2c: Drawer', () => {
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(300);
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('close X', () => {
@@ -222,7 +222,7 @@ describe('plasma-b2c: Drawer', () => {
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(300);
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('placement: left', () => {

--- a/packages/plasma-b2c/src/components/ModalBase/ModalBase.stories.tsx
+++ b/packages/plasma-b2c/src/components/ModalBase/ModalBase.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { surfaceSolid02 } from '@salutejs/plasma-tokens-b2c';
 import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
@@ -14,7 +14,11 @@ import type { ModalBaseProps } from '.';
 
 const meta: Meta<ModalBaseProps> = {
     title: 'Controls/ModalBase',
+    component: ModalBase,
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [
@@ -95,9 +99,9 @@ const StyledModal = styled(ModalBase)`
 `;
 
 const StoryModalBaseDemo = ({ placement, offsetX, offsetY, ...rest }: StoryModalBaseProps) => {
-    const [isOpenA, setIsOpenA] = React.useState(false);
-    const [isOpenB, setIsOpenB] = React.useState(false);
-    const [isOpenC, setIsOpenC] = React.useState(false);
+    const [isOpenA, setIsOpenA] = useState(false);
+    const [isOpenB, setIsOpenB] = useState(false);
+    const [isOpenC, setIsOpenC] = useState(false);
 
     return (
         <SSRProvider>
@@ -174,6 +178,18 @@ export const ModalBaseDemo: StoryObj<StoryModalBaseProps> = {
 
 const StyledModalAnimation = styled(ModalBase)`
     /* stylelint-disable */
+
+    ${({ placement }) =>
+        placement !== 'center'
+            ? css`
+                  --initial-position: 0, 100%;
+                  --end-position: 0, -50%;
+              `
+            : css`
+                  --initial-position: -50%, 100%;
+                  --end-position: -50%, -50%;
+              `}
+
     && .${popupBaseClasses.root} {
         animation: fadeIn 1s forwards;
     }
@@ -214,24 +230,24 @@ const StyledModalAnimation = styled(ModalBase)`
     @keyframes fadeIn {
         from {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
 
         to {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
     }
 
     @keyframes fadeOut {
         from {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
 
         to {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
     }
 `;
@@ -250,7 +266,6 @@ const StoryModalAnimationDemo = ({ placement, offsetX, offsetY, ...rest }: Story
                 <Button view="default" text="Открыть новое модальное окно" onClick={() => setIsOpen(!isOpen)} />
                 <StyledModalAnimation
                     id="modal"
-                    frame="theme-root"
                     withAnimation
                     onClose={() => setIsOpen(false)}
                     opened={isOpen}

--- a/packages/plasma-b2c/src/components/Popover/Popover.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Popover/Popover.component-test.tsx
@@ -10,12 +10,7 @@ describe('plasma-b2c: Popover', () => {
     const Button = getComponent('Button');
     const P1 = getComponent('P1');
 
-    function Demo(props: {
-        trigger?: PopoverTrigger;
-        closeOnOverlayClick?: boolean;
-        closeOnBeyondTargetHover?: boolean;
-        closeOnEsc?: boolean;
-    }) {
+    const Demo = (props: { trigger?: PopoverTrigger; closeOnOverlayClick?: boolean; closeOnEsc?: boolean }) => {
         const [isOpen, setIsOpen] = React.useState(false);
 
         return (
@@ -33,7 +28,7 @@ describe('plasma-b2c: Popover', () => {
                 </div>
             </Popover>
         );
-    }
+    };
 
     it('open popover by click', () => {
         mount(
@@ -43,7 +38,7 @@ describe('plasma-b2c: Popover', () => {
         );
 
         cy.get('button').first().click();
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('p').contains(text).should('be.visible');
     });
 
     it('open popover by hover', () => {
@@ -53,8 +48,8 @@ describe('plasma-b2c: Popover', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('button').first().trigger('mouseover');
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('button').first().trigger('mouseover', { force: true });
+        cy.get('p').contains(text).should('be.visible');
     });
 
     it('close popover by mouseleave a target', () => {
@@ -64,11 +59,11 @@ describe('plasma-b2c: Popover', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('button').first().trigger('mouseover');
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('button').first().trigger('mouseover', { force: true });
+        cy.get('p').contains(text).should('be.visible');
 
-        cy.get('button').first().trigger('mouseout');
-        cy.get('div').contains(text).should('not.be.visible');
+        cy.get('button').first().trigger('mouseout', { force: true });
+        cy.get('.popover-root').should('not.be.visible');
     });
 
     it('close popover', () => {
@@ -79,10 +74,10 @@ describe('plasma-b2c: Popover', () => {
         );
 
         cy.get('button').first().click();
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('p').contains(text).should('be.visible');
 
         cy.get('button').contains('close').click();
-        cy.get('div').contains(text).should('not.be.visible');
+        cy.get('p').contains(text).should('not.be.visible');
     });
 
     it('close popover by overlay click', () => {
@@ -93,10 +88,10 @@ describe('plasma-b2c: Popover', () => {
         );
 
         cy.get('button').first().click();
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('p').contains(text).should('be.visible');
 
         cy.get('body').click(5, 5);
-        cy.get('div').contains(text).should('not.be.visible');
+        cy.get('p').contains(text).should('not.be.visible');
     });
 
     it('close popover by ESC', () => {
@@ -107,9 +102,9 @@ describe('plasma-b2c: Popover', () => {
         );
 
         cy.get('button').first().click();
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('p').contains(text).should('be.visible');
 
         cy.get('body').type('{esc}');
-        cy.get('div').contains(text).should('not.be.visible');
+        cy.get('p').contains(text).should('not.be.visible');
     });
 });

--- a/packages/plasma-b2c/src/components/PopupBase/PopupBase.stories.tsx
+++ b/packages/plasma-b2c/src/components/PopupBase/PopupBase.stories.tsx
@@ -14,6 +14,9 @@ const meta: Meta<PopupBaseProps> = {
     title: 'Controls/PopupBase',
     component: PopupBase,
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/plasma-new-hope/src/components/Popup/Popup.styles.ts
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.styles.ts
@@ -3,7 +3,28 @@ import { styled } from '@linaria/react';
 import type { PopupRootContainerProps } from './Popup.types';
 import { DEFAULT_Z_INDEX } from './utils';
 
-export const StyledPortal = styled.div``;
+export const StyledPortal = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: ${DEFAULT_Z_INDEX};
+
+    :empty {
+        width: 0;
+        pointer-events: none;
+    }
+
+    :not(:empty) {
+        width: auto;
+        pointer-events: auto;
+    }
+`;
+
+export const StyledPortalContainer = styled.div`
+    width: 0;
+`;
 
 export const PopupView = styled.div`
     position: relative;

--- a/packages/plasma-new-hope/src/components/Popup/Popup.styles.ts
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.styles.ts
@@ -3,24 +3,7 @@ import { styled } from '@linaria/react';
 import type { PopupRootContainerProps } from './Popup.types';
 import { DEFAULT_Z_INDEX } from './utils';
 
-export const StyledPortal = styled.div`
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: ${DEFAULT_Z_INDEX};
-
-    :empty {
-        width: 0;
-        pointer-events: none;
-    }
-
-    :not(:empty) {
-        width: auto;
-        pointer-events: auto;
-    }
-`;
+export const StyledPortal = styled.div``;
 
 export const StyledPortalContainer = styled.div`
     width: 0;
@@ -33,7 +16,7 @@ export const PopupView = styled.div`
 `;
 
 export const PopupRootContainer = styled.div<PopupRootContainerProps>`
-    position: absolute;
+    position: ${({ frame }) => (frame === 'document' ? 'fixed' : 'absolute')};
     z-index: ${({ zIndex }) => zIndex || DEFAULT_Z_INDEX};
     left: ${({ position }) => position.left || ''};
     right: ${({ position }) => position.right || ''};

--- a/packages/plasma-new-hope/src/components/Popup/Popup.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useRef } from 'react';
+import ReactDOM from 'react-dom';
 import { useForkRef, safeUseId } from '@salutejs/plasma-core';
 
 import { RootProps } from '../../engines/types';
@@ -10,6 +11,7 @@ import { POPUP_PORTAL_ID } from './PopupContext';
 import { PopupRoot } from './PopupRoot';
 import { usePopup } from './hooks';
 import { classes } from './Popup.tokens';
+import { StyledPortalContainer } from './Popup.styles';
 
 export const handlePosition = (
     placement: PopupPlacement,
@@ -39,8 +41,8 @@ export const handlePosition = (
     let transform;
     const placements = placement.split('-') as PopupPlacementBasic[];
 
-    placements.forEach((placement: PopupPlacementBasic) => {
-        switch (placement) {
+    placements.forEach((placementValue: PopupPlacementBasic) => {
+        switch (placementValue) {
             case 'left':
                 left = x;
                 break;
@@ -79,7 +81,7 @@ export const handlePosition = (
 };
 
 /**
- * Базовый копмонент Popup.
+ * Базовый компонент Popup.
  */
 export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
     forwardRef<HTMLDivElement, PopupProps>(
@@ -93,6 +95,7 @@ export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
                 frame = 'document',
                 children,
                 overlay,
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 role,
                 zIndex,
                 popupInfo,
@@ -114,44 +117,10 @@ export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
                 withAnimation,
             });
 
-            const portalRef = useRef<HTMLElement | null>(null);
+            const portalRef = useRef<HTMLDivElement | null>(null);
             const contentRef = useRef<HTMLDivElement | null>(null);
 
             const innerRef = useForkRef<HTMLDivElement>(contentRef, outerRootRef);
-
-            const [, forceRender] = useState(false);
-
-            useEffect(() => {
-                let portal = document.getElementById(POPUP_PORTAL_ID);
-
-                if (typeof frame !== 'string' && frame && frame.current) {
-                    portal = frame.current;
-                }
-
-                if (!portal) {
-                    portal = document.createElement('div');
-                    portal.setAttribute('id', POPUP_PORTAL_ID);
-                    /**
-                     * Нужно для того, чтобы во фрейме не происходило скачков контента
-                     * при анимации через transform, если есть элемент с шириной/высотой в 100% (Overlay)
-                     */
-                    portal.style.width = '0';
-
-                    if (typeof frame === 'string' && frame !== 'document') {
-                        document.getElementById(frame)?.appendChild(portal);
-                    } else {
-                        document.body.appendChild(portal);
-                    }
-                }
-
-                portalRef.current = portal;
-
-                /**
-                 * Изменение стейта нужно для того, чтобы Popup
-                 * отобразился после записи DOM элемента в portalRef.current
-                 */
-                forceRender(true);
-            }, []);
 
             if (!isVisible && !innerIsOpen) {
                 return null;
@@ -163,28 +132,46 @@ export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
                 animationInfo?.endTransition ? classes.endTransition : '',
             );
 
-            return (
-                <>
-                    {portalRef.current && (
-                        <Portal container={portalRef.current}>
-                            <Root className={cls} {...rest}>
-                                {overlay}
-                                <PopupRoot
-                                    id={innerId}
-                                    ref={innerRef}
-                                    position={handlePosition(placement, offset)}
-                                    frame={frame}
-                                    zIndex={zIndex}
-                                    animationInfo={animationInfo}
-                                    setVisible={setVisible}
-                                >
-                                    {children}
-                                </PopupRoot>
-                            </Root>
-                        </Portal>
-                    )}
-                </>
+            const rootNode = (
+                <Root className={cls} {...rest}>
+                    {overlay}
+                    <PopupRoot
+                        id={innerId}
+                        ref={innerRef}
+                        position={handlePosition(placement, offset)}
+                        frame={frame}
+                        zIndex={zIndex}
+                        animationInfo={animationInfo}
+                        setVisible={setVisible}
+                    >
+                        {children}
+                    </PopupRoot>
+                </Root>
             );
+
+            if (typeof frame !== 'string' && frame && frame.current) {
+                return <Portal container={frame.current}>{rootNode}</Portal>;
+            }
+
+            const withFrameId = typeof frame === 'string' && frame !== 'document';
+            const containerElement = withFrameId && document.getElementById(frame as string);
+
+            if (containerElement) {
+                return (
+                    <>
+                        {ReactDOM.createPortal(
+                            <StyledPortalContainer ref={portalRef}>
+                                {portalRef.current && <Portal container={portalRef.current}>{rootNode}</Portal>}
+                            </StyledPortalContainer>,
+                            containerElement,
+                        )}
+                    </>
+                );
+            }
+
+            const globalPortal = typeof document !== 'undefined' && document.getElementById(POPUP_PORTAL_ID);
+
+            return <>{globalPortal && <Portal container={globalPortal}>{rootNode}</Portal>}</>;
         },
     );
 

--- a/packages/plasma-new-hope/src/components/Popup/Popup.types.ts
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.types.ts
@@ -9,6 +9,7 @@ export interface PopupInfo {
 
 export interface PopupContextType {
     items: PopupInfo[];
+    rootId: string;
     register: (info: PopupInfo) => void;
     unregister: (id: string) => void;
 }

--- a/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
@@ -1,8 +1,10 @@
-import React, { createContext, useEffect, useState, useContext, FC, PropsWithChildren, useRef } from 'react';
+import React, { createContext, useState, useContext, FC, PropsWithChildren, useRef } from 'react';
+import ReactDOM from 'react-dom';
 
 import { hasModals } from '../Modal/ModalContext';
 
 import type { PopupContextType, PopupInfo } from './Popup.types';
+import { StyledPortal } from './Popup.styles';
 
 export const POPUP_PORTAL_ID = 'plasma-popup-root';
 
@@ -10,9 +12,11 @@ const items: PopupInfo[] = [];
 
 const PopupContext = createContext<PopupContextType>({
     items,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     register(_info: PopupInfo): void {
         throw new Error('Function not implemented. Add PopupProvider');
     },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     unregister(_id: string): void {
         throw new Error('Function not implemented. Add PopupProvider');
     },
@@ -22,6 +26,7 @@ export const usePopupContext = () => useContext(PopupContext);
 
 export const PopupProvider: FC<PropsWithChildren> = ({ children }) => {
     const prevBodyOverflowY = useRef(typeof document !== 'undefined' ? document.body.style.overflowY : '');
+    // eslint-disable-next-line no-shadow
     const [items, setItems] = useState<PopupInfo[]>([]);
 
     const register = (info: PopupInfo) => {
@@ -61,14 +66,10 @@ export const PopupProvider: FC<PropsWithChildren> = ({ children }) => {
         unregister,
     };
 
-    useEffect(() => {
-        return () => {
-            const portal = document.createElement('div');
-            if (portal && document.body.contains(portal)) {
-                document.body.removeChild(portal);
-            }
-        };
-    }, []);
-
-    return <PopupContext.Provider value={context}>{children}</PopupContext.Provider>;
+    return (
+        <PopupContext.Provider value={context}>
+            {children}
+            {ReactDOM.createPortal(<StyledPortal id={POPUP_PORTAL_ID} />, document.body)}
+        </PopupContext.Provider>
+    );
 };

--- a/packages/plasma-new-hope/src/components/Popup/PopupRoot.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/PopupRoot.tsx
@@ -11,7 +11,7 @@ import { classes } from './Popup.tokens';
  * Управляет показом/скрытием и анимацией всплывающего окна.
  */
 export const PopupRoot = forwardRef<HTMLDivElement, PopupRootProps>(
-    ({ id, placement, offset, frame, setVisible, children, role, zIndex, animationInfo, className, ...rest }, ref) => {
+    ({ id, placement, offset, setVisible, children, role, frame, zIndex, animationInfo, ...rest }, ref) => {
         const contentRef = useRef<HTMLDivElement | null>(null);
         const innerRef = useForkRef<HTMLDivElement>(contentRef, ref);
 
@@ -39,6 +39,7 @@ export const PopupRoot = forwardRef<HTMLDivElement, PopupRootProps>(
                 placement={placement}
                 offset={offset}
                 zIndex={zIndex}
+                frame={frame}
                 onAnimationEnd={handleAnimationEnd}
                 onTransitionEnd={handleAnimationEnd}
                 {...rest}

--- a/packages/plasma-new-hope/src/components/Popup/hooks/usePopup.ts
+++ b/packages/plasma-new-hope/src/components/Popup/hooks/usePopup.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import type { PopupAnimationInfo, PopupHookArgs } from '../Popup.types';
 import { usePopupContext } from '../PopupContext';
 
-// Хук для поключения анимации
+// Хук для подключения анимации
 const usePopupAnimation = (): PopupAnimationInfo => {
     const [endAnimation, setEndAnimation] = useState<boolean>(false);
     const [endTransition, setEndTransition] = useState<boolean>(false);

--- a/packages/plasma-new-hope/src/components/Popup/hooks/usePopup.ts
+++ b/packages/plasma-new-hope/src/components/Popup/hooks/usePopup.ts
@@ -55,5 +55,5 @@ export const usePopup = ({ isOpen, id, popupInfo, withAnimation }: PopupHookArgs
         };
     }, [id]);
 
-    return { isVisible, setVisible, animationInfo, withAnimation };
+    return { isVisible, setVisible, animationInfo, withAnimation, rootId: popupController.rootId };
 };

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Modal/Modal.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Modal/Modal.stories.tsx
@@ -14,6 +14,9 @@ import { Modal, modalClasses } from './Modal';
 export default {
     title: 'plasma_b2c/Modal',
     decorators: [WithTheme],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Popup/Popup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Popup/Popup.stories.tsx
@@ -12,6 +12,9 @@ import { Popup, popupClasses, PopupProvider } from './Popup';
 const meta: Meta<typeof Popup> = {
     title: 'plasma_b2c/Popup',
     decorators: [WithTheme],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Modal/Modal.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Modal/Modal.stories.tsx
@@ -14,6 +14,9 @@ import { Modal, modalClasses } from './Modal';
 export default {
     title: 'plasma_web/Modal',
     decorators: [WithTheme],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Popup/Popup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Popup/Popup.stories.tsx
@@ -12,6 +12,9 @@ import { Popup, popupClasses, PopupProvider } from './Popup';
 const meta: Meta<typeof Popup> = {
     title: 'plasma_web/Popup',
     decorators: [WithTheme],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/plasma-web/src/components/Drawer/Drawer.component-test.tsx
+++ b/packages/plasma-web/src/components/Drawer/Drawer.component-test.tsx
@@ -214,7 +214,7 @@ describe('plasma-b2c: Drawer', () => {
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(300);
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('close X', () => {
@@ -232,7 +232,7 @@ describe('plasma-b2c: Drawer', () => {
 
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(300);
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('placement: left', () => {

--- a/packages/plasma-web/src/components/Modal/Modal.component-test.tsx
+++ b/packages/plasma-web/src/components/Modal/Modal.component-test.tsx
@@ -8,7 +8,7 @@ const StandardTypoStyle = createGlobalStyle(standardTypo);
 
 const NoAnimationStyle = createGlobalStyle`
     /* stylelint-disable-next-line selector-max-id, selector-max-universal */
-    #plasma-modals-root * {
+    * {
         animation: none !important;
     }
 `;

--- a/packages/plasma-web/src/components/ModalBase/ModalBase.component-test.tsx
+++ b/packages/plasma-web/src/components/ModalBase/ModalBase.component-test.tsx
@@ -119,7 +119,7 @@ describe('plasma-web: ModalBase', () => {
         cy.get('button').click();
         cy.get('#modal-content').should('be.visible');
         cy.get('body').type('{esc}');
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('close overlay', () => {
@@ -132,7 +132,7 @@ describe('plasma-web: ModalBase', () => {
         cy.get('button').click();
         cy.get('#modal-content').should('be.visible');
         cy.get('body').click(5, 5);
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('double close', () => {
@@ -149,7 +149,7 @@ describe('plasma-web: ModalBase', () => {
         cy.matchImageSnapshot();
         cy.get('#modalA-content').should('be.visible');
         cy.get('body').click(5, 5);
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('withBlur', () => {

--- a/packages/plasma-web/src/components/ModalBase/ModalBase.stories.tsx
+++ b/packages/plasma-web/src/components/ModalBase/ModalBase.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { StoryObj, Meta } from '@storybook/react';
 import { surfaceSolid02 } from '@salutejs/plasma-tokens-web';
 
@@ -16,6 +16,9 @@ const meta: Meta<ModalBaseProps> = {
     title: 'Controls/ModalBase',
     component: ModalBase,
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [
@@ -175,6 +178,18 @@ export const ModalBaseDemo: StoryObj<StoryModalBaseProps> = {
 
 const StyledModalAnimation = styled(ModalBase)`
     /* stylelint-disable */
+
+    ${({ placement }) =>
+        placement !== 'center'
+            ? css`
+                  --initial-position: 0, 100%;
+                  --end-position: 0, -50%;
+              `
+            : css`
+                  --initial-position: -50%, 100%;
+                  --end-position: -50%, -50%;
+              `}
+
     && .${popupBaseClasses.root} {
         animation: fadeIn 1s forwards;
     }
@@ -215,24 +230,24 @@ const StyledModalAnimation = styled(ModalBase)`
     @keyframes fadeIn {
         from {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
 
         to {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
     }
 
     @keyframes fadeOut {
         from {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
 
         to {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
     }
 `;
@@ -251,7 +266,6 @@ const StoryModalAnimationDemo = ({ placement, offsetX, offsetY, ...rest }: Story
                 <Button view="default" text="Открыть новое модальное окно" onClick={() => setIsOpen(!isOpen)} />
                 <StyledModalAnimation
                     id="modal"
-                    frame="theme-root"
                     withAnimation
                     onClose={() => setIsOpen(false)}
                     opened={isOpen}

--- a/packages/plasma-web/src/components/Notification/Notification.component-test.tsx
+++ b/packages/plasma-web/src/components/Notification/Notification.component-test.tsx
@@ -78,9 +78,9 @@ describe('plasma-web: Notification', () => {
             </CypressTestDecoratorWithTypo>,
         );
 
-        cy.get('button').contains('Открыть').click();
+        cy.get('button').contains('Открыть').click({ force: true });
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click();
+        cy.get('button').contains('Закрыть').click({ force: true });
         cy.get('#plasma-popup-root').should('be.empty');
     });
 
@@ -135,9 +135,9 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click();
+        cy.get('button').contains('Открыть').click({ force: true });
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click();
+        cy.get('button').contains('Закрыть').click({ force: true });
     });
 
     it('icon positions', () => {
@@ -209,9 +209,9 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click();
+        cy.get('button').contains('Открыть').click({ force: true });
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click();
+        cy.get('button').contains('Закрыть').click({ force: true });
     });
 
     it('long text', () => {
@@ -247,9 +247,9 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click();
+        cy.get('button').contains('Открыть').click({ force: true });
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click();
+        cy.get('button').contains('Закрыть').click({ force: true });
     });
 
     it('oneline horizontal', () => {
@@ -285,9 +285,9 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click();
+        cy.get('button').contains('Открыть').click({ force: true });
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click();
+        cy.get('button').contains('Закрыть').click({ force: true });
     });
 
     it('close on icon', () => {
@@ -323,8 +323,8 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click();
-        cy.get('.notification-close-icon').click();
+        cy.get('button').contains('Открыть').click({ force: true });
+        cy.get('.notification-close-icon').click({ force: true });
         cy.get('#plasma-popup-root').should('be.empty');
     });
 });

--- a/packages/plasma-web/src/components/Notification/Notification.component-test.tsx
+++ b/packages/plasma-web/src/components/Notification/Notification.component-test.tsx
@@ -8,7 +8,7 @@ const StandardTypoStyle = createGlobalStyle(standardTypo);
 
 const NoAnimationStyle = createGlobalStyle`
     /* stylelint-disable-next-line selector-max-id, selector-max-universal */
-    #plasma-popup-root * {
+    * {
         animation: none !important;
     }
 `;
@@ -78,10 +78,10 @@ describe('plasma-web: Notification', () => {
             </CypressTestDecoratorWithTypo>,
         );
 
-        cy.get('button').contains('Открыть').click({ force: true });
+        cy.get('button').contains('Открыть').click();
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click({ force: true });
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('button').contains('Закрыть').click();
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('layout', () => {
@@ -135,9 +135,9 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click({ force: true });
+        cy.get('button').contains('Открыть').click();
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click({ force: true });
+        cy.get('button').contains('Закрыть').click();
     });
 
     it('icon positions', () => {
@@ -209,9 +209,9 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click({ force: true });
+        cy.get('button').contains('Открыть').click();
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click({ force: true });
+        cy.get('button').contains('Закрыть').click();
     });
 
     it('long text', () => {
@@ -247,9 +247,9 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click({ force: true });
+        cy.get('button').contains('Открыть').click();
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click({ force: true });
+        cy.get('button').contains('Закрыть').click();
     });
 
     it('oneline horizontal', () => {
@@ -285,9 +285,9 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click({ force: true });
+        cy.get('button').contains('Открыть').click();
         cy.matchImageSnapshot();
-        cy.get('button').contains('Закрыть').click({ force: true });
+        cy.get('button').contains('Закрыть').click();
     });
 
     it('close on icon', () => {
@@ -323,8 +323,8 @@ describe('plasma-web: Notification', () => {
                 </NotificationsProvider>
             </CypressTestDecoratorWithTypo>,
         );
-        cy.get('button').contains('Открыть').click({ force: true });
-        cy.get('.notification-close-icon').click({ force: true });
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('button').contains('Открыть').click();
+        cy.get('.notification-close-icon').click();
+        cy.get('.popup-base-root').should('not.exist');
     });
 });

--- a/packages/plasma-web/src/components/Popover/Popover.component-test.tsx
+++ b/packages/plasma-web/src/components/Popover/Popover.component-test.tsx
@@ -10,7 +10,7 @@ describe('plasma-web: Popover', () => {
     const Button = getComponent('Button');
     const P1 = getComponent('P1');
 
-    function Demo(props: { trigger?: PopoverTrigger; closeOnOverlayClick?: boolean; closeOnEsc?: boolean }) {
+    const Demo = (props: { trigger?: PopoverTrigger; closeOnOverlayClick?: boolean; closeOnEsc?: boolean }) => {
         const [isOpen, setIsOpen] = React.useState(false);
 
         return (
@@ -28,7 +28,7 @@ describe('plasma-web: Popover', () => {
                 </div>
             </Popover>
         );
-    }
+    };
 
     it('open popover by click', () => {
         mount(
@@ -38,7 +38,7 @@ describe('plasma-web: Popover', () => {
         );
 
         cy.get('button').first().click();
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('p').contains(text).should('be.visible');
     });
 
     it('open popover by hover', () => {
@@ -48,8 +48,22 @@ describe('plasma-web: Popover', () => {
             </CypressTestDecorator>,
         );
 
-        cy.get('button').first().trigger('mouseover');
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('button').first().trigger('mouseover', { force: true });
+        cy.get('p').contains(text).should('be.visible');
+    });
+
+    it('close popover by mouseleave a target', () => {
+        mount(
+            <CypressTestDecorator>
+                <Demo trigger="hover" />
+            </CypressTestDecorator>,
+        );
+
+        cy.get('button').first().trigger('mouseover', { force: true });
+        cy.get('p').contains(text).should('be.visible');
+
+        cy.get('button').first().trigger('mouseout', { force: true });
+        cy.get('.popover-root').should('not.be.visible');
     });
 
     it('close popover', () => {
@@ -60,10 +74,10 @@ describe('plasma-web: Popover', () => {
         );
 
         cy.get('button').first().click();
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('p').contains(text).should('be.visible');
 
         cy.get('button').contains('close').click();
-        cy.get('div').contains(text).should('not.be.visible');
+        cy.get('p').contains(text).should('not.be.visible');
     });
 
     it('close popover by overlay click', () => {
@@ -74,10 +88,10 @@ describe('plasma-web: Popover', () => {
         );
 
         cy.get('button').first().click();
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('p').contains(text).should('be.visible');
 
         cy.get('body').click(5, 5);
-        cy.get('div').contains(text).should('not.be.visible');
+        cy.get('p').contains(text).should('not.be.visible');
     });
 
     it('close popover by ESC', () => {
@@ -88,9 +102,9 @@ describe('plasma-web: Popover', () => {
         );
 
         cy.get('button').first().click();
-        cy.get('div').contains(text).should('be.visible');
+        cy.get('p').contains(text).should('be.visible');
 
         cy.get('body').type('{esc}');
-        cy.get('div').contains(text).should('not.be.visible');
+        cy.get('p').contains(text).should('not.be.visible');
     });
 });

--- a/packages/plasma-web/src/components/PopupBase/PopupBase.component-test.tsx
+++ b/packages/plasma-web/src/components/PopupBase/PopupBase.component-test.tsx
@@ -123,7 +123,7 @@ describe('plasma-web: PopupBase', () => {
         cy.get('button').click();
         cy.get('#popup-content').should('be.visible');
         cy.get('button').contains('Close').click();
-        cy.get('#plasma-popup-root').should('be.empty');
+        cy.get('.popup-base-root').should('not.exist');
     });
 
     it('placement basic', () => {

--- a/packages/plasma-web/src/components/PopupBase/PopupBase.stories.tsx
+++ b/packages/plasma-web/src/components/PopupBase/PopupBase.stories.tsx
@@ -14,6 +14,9 @@ const meta: Meta<PopupBaseProps> = {
     title: 'Controls/PopupBase',
     component: PopupBase,
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/sdds-cs/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-cs/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
@@ -14,6 +14,9 @@ import type { ModalProps } from '.';
 const meta: Meta<ModalProps> = {
     title: 'Controls/Modal',
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [
@@ -173,6 +176,17 @@ export const ModalDemo: StoryObj<StoryModalProps> = {
 
 const StyledModalAnimation = styled(Modal)`
     /* stylelint-disable */
+    ${({ placement }) =>
+        placement !== 'center'
+            ? css`
+                  --initial-position: 0, 100%;
+                  --end-position: 0, -50%;
+              `
+            : css`
+                  --initial-position: -50%, 100%;
+                  --end-position: -50%, -50%;
+              `}
+
     && .${popupClasses.root} {
         animation: fadeIn 1s forwards;
     }
@@ -213,24 +227,24 @@ const StyledModalAnimation = styled(Modal)`
     @keyframes fadeIn {
         from {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
 
         to {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
     }
 
     @keyframes fadeOut {
         from {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
 
         to {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
     }
 `;

--- a/packages/sdds-cs/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-cs/src/components/Popup/Popup.stories.tsx
@@ -13,6 +13,9 @@ const meta: Meta<PopupProps> = {
     title: 'Controls/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/sdds-dfa/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-dfa/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useCallback, useRef, useState } from 'react';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
@@ -14,6 +14,9 @@ import type { ModalProps } from '.';
 const meta: Meta<ModalProps> = {
     title: 'Controls/Modal',
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [
@@ -173,6 +176,17 @@ export const ModalDemo: StoryObj<StoryModalProps> = {
 
 const StyledModalAnimation = styled(Modal)`
     /* stylelint-disable */
+    ${({ placement }) =>
+        placement !== 'center'
+            ? css`
+                  --initial-position: 0, 100%;
+                  --end-position: 0, -50%;
+              `
+            : css`
+                  --initial-position: -50%, 100%;
+                  --end-position: -50%, -50%;
+              `}
+
     && .${popupClasses.root} {
         animation: fadeIn 1s forwards;
     }
@@ -213,24 +227,24 @@ const StyledModalAnimation = styled(Modal)`
     @keyframes fadeIn {
         from {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
 
         to {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
     }
 
     @keyframes fadeOut {
         from {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
 
         to {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
     }
 `;

--- a/packages/sdds-dfa/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-dfa/src/components/Popup/Popup.stories.tsx
@@ -13,6 +13,9 @@ const meta: Meta<PopupProps> = {
     title: 'Controls/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/sdds-finportal/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-finportal/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useCallback, useRef, useState } from 'react';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
@@ -14,6 +14,9 @@ import type { ModalProps } from '.';
 const meta: Meta<ModalProps> = {
     title: 'Controls/Modal',
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [
@@ -173,6 +176,17 @@ export const ModalDemo: StoryObj<StoryModalProps> = {
 
 const StyledModalAnimation = styled(Modal)`
     /* stylelint-disable */
+    ${({ placement }) =>
+        placement !== 'center'
+            ? css`
+                  --initial-position: 0, 100%;
+                  --end-position: 0, -50%;
+              `
+            : css`
+                  --initial-position: -50%, 100%;
+                  --end-position: -50%, -50%;
+              `}
+
     && .${popupClasses.root} {
         animation: fadeIn 1s forwards;
     }
@@ -213,24 +227,24 @@ const StyledModalAnimation = styled(Modal)`
     @keyframes fadeIn {
         from {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
 
         to {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
     }
 
     @keyframes fadeOut {
         from {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
 
         to {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
     }
 `;

--- a/packages/sdds-finportal/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-finportal/src/components/Popup/Popup.stories.tsx
@@ -13,6 +13,9 @@ const meta: Meta<PopupProps> = {
     title: 'Controls/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [

--- a/packages/sdds-serv/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-serv/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useCallback, useRef, useState } from 'react';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
@@ -14,6 +14,9 @@ import type { ModalProps } from '.';
 const meta: Meta<ModalProps> = {
     title: 'Controls/Modal',
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [
@@ -173,6 +176,17 @@ export const ModalDemo: StoryObj<StoryModalProps> = {
 
 const StyledModalAnimation = styled(Modal)`
     /* stylelint-disable */
+    ${({ placement }) =>
+        placement !== 'center'
+            ? css`
+                  --initial-position: 0, 100%;
+                  --end-position: 0, -50%;
+              `
+            : css`
+                  --initial-position: -50%, 100%;
+                  --end-position: -50%, -50%;
+              `}
+
     && .${popupClasses.root} {
         animation: fadeIn 1s forwards;
     }
@@ -213,24 +227,24 @@ const StyledModalAnimation = styled(Modal)`
     @keyframes fadeIn {
         from {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
 
         to {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
     }
 
     @keyframes fadeOut {
         from {
             opacity: 1;
-            transform: translate(-50%, -50%);
+            transform: translate(var(--end-position));
         }
 
         to {
             opacity: 0;
-            transform: translate(-50%, 100%);
+            transform: translate(var(--initial-position));
         }
     }
 `;

--- a/packages/sdds-serv/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-serv/src/components/Popup/Popup.stories.tsx
@@ -13,6 +13,9 @@ const meta: Meta<PopupProps> = {
     title: 'Controls/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
+    parameters: {
+        docs: { story: { inline: false, iframeHeight: '30rem' } },
+    },
     argTypes: {
         placement: {
             options: [


### PR DESCRIPTION
### Popup

- добавлены storybook декораторы для `Popup` и `Notification` для правильного отображения: `Drawer, Modal, Notification, Popup`

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.171.2-canary.1412.11251053962.0
  npm install @salutejs/plasma-b2c@1.413.2-canary.1412.11251053962.0
  npm install @salutejs/plasma-new-hope@0.162.2-canary.1412.11251053962.0
  npm install @salutejs/plasma-web@1.415.2-canary.1412.11251053962.0
  npm install @salutejs/sdds-cs@0.143.2-canary.1412.11251053962.0
  npm install @salutejs/sdds-dfa@0.141.2-canary.1412.11251053962.0
  npm install @salutejs/sdds-finportal@0.135.2-canary.1412.11251053962.0
  npm install @salutejs/sdds-serv@0.142.2-canary.1412.11251053962.0
  # or 
  yarn add @salutejs/plasma-asdk@0.171.2-canary.1412.11251053962.0
  yarn add @salutejs/plasma-b2c@1.413.2-canary.1412.11251053962.0
  yarn add @salutejs/plasma-new-hope@0.162.2-canary.1412.11251053962.0
  yarn add @salutejs/plasma-web@1.415.2-canary.1412.11251053962.0
  yarn add @salutejs/sdds-cs@0.143.2-canary.1412.11251053962.0
  yarn add @salutejs/sdds-dfa@0.141.2-canary.1412.11251053962.0
  yarn add @salutejs/sdds-finportal@0.135.2-canary.1412.11251053962.0
  yarn add @salutejs/sdds-serv@0.142.2-canary.1412.11251053962.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
