### PR TITLE
feat(plasma-*): Badge add prop clear

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -477,17 +477,46 @@ true: PolymorphicClassName;
 transparent: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLDivElement> & {
+clear: {
+true: PolymorphicClassName;
+};
+}> & ((HTMLAttributes<HTMLDivElement> & {
 text?: string | undefined;
 contentLeft?: ReactNode;
 contentRight?: ReactNode;
-pilled?: boolean | undefined;
-transparent?: boolean | undefined;
 size?: string | undefined;
 view?: string | undefined;
 } & {
 children?: ReactNode;
-} & RefAttributes<HTMLDivElement>>;
+} & {
+clear?: true | undefined;
+pilled?: false | undefined;
+transparent?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: true | undefined;
+transparent?: boolean | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: boolean | undefined;
+transparent?: true | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>))>;
 
 export { BadgeProps }
 

--- a/packages/plasma-b2c/src/components/Badge/Badge.config.ts
+++ b/packages/plasma-b2c/src/components/Badge/Badge.config.ts
@@ -13,6 +13,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-secondary);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             accent: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -20,6 +22,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-accent);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-accent);
+
+                ${badgeTokens.colorClear}: var(--text-accent);
             `,
             positive: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -27,6 +31,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-positive);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-positive);
+
+                ${badgeTokens.colorClear}: var(--text-positive);
             `,
             warning: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -34,6 +40,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-warning);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-warning);
+
+                ${badgeTokens.colorClear}: var(--text-warning);
             `,
             negative: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -41,6 +49,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-negative);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-negative);
+
+                ${badgeTokens.colorClear}: var(--text-negative);
             `,
             dark: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -48,6 +58,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-light-surface-transparent-deep);
+
+                ${badgeTokens.colorClear}: var(--on-light-text-primary);
             `,
             light: css`
                 ${badgeTokens.color}: var(--on-light-text-primary);
@@ -55,6 +67,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-dark-surface-transparent-card);
+
+                ${badgeTokens.colorClear}: var(--on-dark-text-primary);
             `,
         },
         size: {
@@ -122,6 +136,9 @@ export const config = {
             `,
         },
         transparent: {
+            true: css``,
+        },
+        clear: {
             true: css``,
         },
     },

--- a/packages/plasma-b2c/src/components/Badge/Badge.stories.tsx
+++ b/packages/plasma-b2c/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
 
@@ -21,13 +21,25 @@ const meta: Meta<typeof Badge> = {
                 type: 'select',
             },
         },
+        pilled: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
+        transparent: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
         ...disableProps(['contentLeft', 'contentRight']),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Badge>;
+type StoryProps = ComponentProps<typeof Badge> & {
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
+};
+type Story = StoryObj<StoryProps>;
 
 const BellIcon = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
@@ -39,16 +51,36 @@ const BellIcon = (props) => (
 );
 
 export const Default: Story = {
+    argTypes: {
+        enableContentLeft: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentRight', truthy: false },
+        },
+        enableContentRight: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentLeft', truthy: false },
+        },
+    },
     args: {
         text: 'Hello',
         view: 'default',
         size: 'm',
+        enableContentLeft: false,
+        enableContentRight: false,
+        clear: false,
         pilled: false,
         transparent: false,
     },
-};
+    render: ({ enableContentLeft, enableContentRight, size, ...rest }: StoryProps) => {
+        const iconSize = size === 'l' ? '1rem' : '0.75rem';
 
-export const WithIcon: Story = {
-    args: { ...Default.args },
-    render: (args) => <Badge contentLeft={<BellIcon width="1rem" height="1rem" />} {...args} />,
+        return (
+            <Badge
+                contentLeft={enableContentLeft ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                size={size}
+                {...rest}
+            />
+        );
+    },
 };

--- a/packages/plasma-new-hope/src/components/Badge/Badge.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Badge/Badge.template-doc.mdx
@@ -69,7 +69,7 @@ import { Badge } from '@salutejs/{{ package }}';
 export function App() {
     const Badges = ({transparent, clear}) => {
         return (
-            <div>
+            <div style=\{{ display: 'flex', gap: '0.5rem' }}>
                 <Badge text="Бейдж" size="l" view="primary" transparent={transparent} clear={clear} />
                 <Badge text="Бейдж" size="l" view="accent" transparent={transparent} clear={clear} />
                 <Badge text="Бейдж" size="l" view="positive" transparent={transparent} clear={clear} />

--- a/packages/plasma-new-hope/src/components/Badge/Badge.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Badge/Badge.template-doc.mdx
@@ -60,41 +60,32 @@ export function App() {
 + `"dark"` – темный badge;
 + `"light"` – светлый badge.
 
-```tsx live 
-import React from 'react';
-import { Badge } from '@salutejs/{{ package }}';
-
-export function App() {
-    return (
-        <div>
-            <Badge text="Бейдж" size="l" view="primary" />
-            <Badge text="Бейдж" size="l" view="accent" />
-            <Badge text="Бейдж" size="l" view="positive" />
-            <Badge text="Бейдж" size="l" view="warning" />
-            <Badge text="Бейдж" size="l" view="negative" />
-            <Badge text="Бейдж" size="l" view="dark" />
-            <Badge text="Бейдж" size="l" view="light" />
-        </div>
-    );
-}
-```
-
-Так же на вид badge влияет свойство `transparent`:
+Так же на вид badge влияет свойства `transparent` и `clear`.
 
 ```tsx live 
 import React from 'react';
 import { Badge } from '@salutejs/{{ package }}';
 
 export function App() {
+    const Badges = ({transparent, clear}) => {
+        return (
+            <div>
+                <Badge text="Бейдж" size="l" view="primary" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="accent" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="positive" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="warning" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="negative" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="dark" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="light" transparent={transparent} clear={clear} />
+            </div>
+        )
+    }
+
     return (
-        <div>
-            <Badge text="Бейдж" size="l" view="primary" transparent />
-            <Badge text="Бейдж" size="l" view="accent" transparent />
-            <Badge text="Бейдж" size="l" view="positive" transparent />
-            <Badge text="Бейдж" size="l" view="warning" transparent />
-            <Badge text="Бейдж" size="l" view="negative" transparent />
-            <Badge text="Бейдж" size="l" view="dark" transparent />
-            <Badge text="Бейдж" size="l" view="light" transparent />
+        <div style=\{{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+            <Badges />
+            <Badges transparent />
+            <Badges clear />
         </div>
     );
 }

--- a/packages/plasma-new-hope/src/components/Badge/Badge.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Badge/Badge.tokens.ts
@@ -1,6 +1,7 @@
 export const classes = {
     badgePilled: 'badge-pilled',
     badgeTransparent: 'badge-transparent',
+    badgeClear: 'badge-clear',
 };
 
 export const tokens = {
@@ -8,6 +9,7 @@ export const tokens = {
     color: '--plasma-badge-color',
     backgroundTransparent: '--plasma-badge-background-transparent',
     colorTransparent: '--plasma-badge-color-transparent',
+    colorClear: '--plasma-badge-color-clear',
 
     borderRadius: '--plasma-badge-border-radius',
     pilledBorderRadius: '--plasma-badge-pilled-border-radius',

--- a/packages/plasma-new-hope/src/components/Badge/Badge.tsx
+++ b/packages/plasma-new-hope/src/components/Badge/Badge.tsx
@@ -7,11 +7,12 @@ import { base as viewCSS } from './variations/_view/base';
 import { base as sizeCSS } from './variations/_size/base';
 import { base as pilledCSS } from './variations/_pilled/base';
 import { base as transparentCSS } from './variations/_transparent/base';
-import type { BadgeProps } from './Badge.types';
+import { base as clearCSS } from './variations/_clear/base';
+import type { BadgeProps, BadgeRootProps } from './Badge.types';
 import { StyledContentLeft, StyledContentMain, StyledContentRight, base } from './Badge.styles';
 import { classes } from './Badge.tokens';
 
-export const badgeRoot = (Root: RootProps<HTMLDivElement, BadgeProps>) =>
+export const badgeRoot = (Root: RootProps<HTMLDivElement, BadgeRootProps>) =>
     forwardRef<HTMLDivElement, BadgeProps>((props, ref) => {
         const {
             children,
@@ -23,21 +24,24 @@ export const badgeRoot = (Root: RootProps<HTMLDivElement, BadgeProps>) =>
             view,
             pilled = false,
             transparent = false,
+            clear = false,
             ...rest
         } = props;
 
         const pilledClass = pilled ? classes.badgePilled : undefined;
         const transparentClass = transparent ? classes.badgeTransparent : undefined;
+        const clearClass = clear ? classes.badgeClear : undefined;
         const txt = !text && typeof children === 'string' ? children : text;
 
         return (
             <Root
                 ref={ref}
-                className={cx(pilledClass, transparentClass, className)}
+                className={cx(pilledClass, transparentClass, clearClass, className)}
                 view={view}
                 size={size}
                 pilled={pilled}
                 transparent={transparent}
+                clear={clear}
                 {...rest}
             >
                 {contentLeft && <StyledContentLeft>{contentLeft}</StyledContentLeft>}
@@ -65,6 +69,10 @@ export const badgeConfig = {
         },
         transparent: {
             css: transparentCSS,
+            attrs: true,
+        },
+        clear: {
+            css: clearCSS,
             attrs: true,
         },
     },

--- a/packages/plasma-new-hope/src/components/Badge/Badge.types.ts
+++ b/packages/plasma-new-hope/src/components/Badge/Badge.types.ts
@@ -1,5 +1,55 @@
 import type { HTMLAttributes, PropsWithChildren, ReactNode } from 'react';
 
+type ClearViewProps =
+    | {
+          /**
+           * view применяется с clear-токенами
+           * @default
+           * false
+           */
+          clear?: true;
+          /**
+           * Компонент c округлым border-radius
+           * @default
+           * false
+           */
+          pilled?: false;
+          /**
+           * view применяется с учетом прозрачности
+           * @default
+           * false
+           */
+          transparent?: false;
+      }
+    | {
+          /**
+           * Компонент c округлым border-radius
+           */
+          pilled?: true;
+          /**
+           * view применяется с учетом прозрачности
+           */
+          transparent?: boolean;
+          /**
+           * view применяется с clear-токенами
+           */
+          clear?: false;
+      }
+    | {
+          /**
+           * Компонент c округлым border-radius
+           */
+          pilled?: boolean;
+          /**
+           * view применяется с учетом прозрачности
+           */
+          transparent?: true;
+          /**
+           * view применяется с clear-токенами
+           */
+          clear?: false;
+      };
+
 type CustomBadgeProps = {
     /**
      * Текстовая надпись
@@ -14,18 +64,6 @@ type CustomBadgeProps = {
      */
     contentRight?: ReactNode;
     /**
-     * Компонент c округлым border-radius
-     * @default
-     * false
-     */
-    pilled?: boolean;
-    /**
-     * view применяется с учетом прозрачности
-     * @default
-     * false
-     */
-    transparent?: boolean;
-    /**
      * Размер Badge
      * @default
      * m
@@ -39,4 +77,10 @@ type CustomBadgeProps = {
     view?: string;
 } & PropsWithChildren;
 
-export type BadgeProps = HTMLAttributes<HTMLDivElement> & CustomBadgeProps;
+export type BadgeProps = HTMLAttributes<HTMLDivElement> & CustomBadgeProps & ClearViewProps;
+export type BadgeRootProps = HTMLAttributes<HTMLDivElement> &
+    CustomBadgeProps & {
+        pilled?: boolean;
+        transparent?: boolean;
+        clear?: boolean;
+    };

--- a/packages/plasma-new-hope/src/components/Badge/variations/_clear/base.ts
+++ b/packages/plasma-new-hope/src/components/Badge/variations/_clear/base.ts
@@ -1,0 +1,11 @@
+import { css } from '@linaria/core';
+
+import { classes, tokens } from '../../Badge.tokens';
+
+export const base = css`
+    &.${classes.badgeClear} {
+        color: var(${tokens.colorClear});
+        background-color: transparent;
+        padding: 0;
+    }
+`;

--- a/packages/plasma-new-hope/src/components/Badge/variations/_clear/tokens.json
+++ b/packages/plasma-new-hope/src/components/Badge/variations/_clear/tokens.json
@@ -1,0 +1,1 @@
+["--plasma-badge-color-clear"]

--- a/packages/plasma-new-hope/src/components/Badge/variations/_pilled/base.ts
+++ b/packages/plasma-new-hope/src/components/Badge/variations/_pilled/base.ts
@@ -3,7 +3,7 @@ import { css } from '@linaria/core';
 import { classes, tokens } from '../../Badge.tokens';
 
 export const base = css`
-    &.${String(classes.badgePilled)} {
+    &.${classes.badgePilled} {
         border-radius: var(${tokens.pilledBorderRadius});
     }
 `;

--- a/packages/plasma-new-hope/src/components/Badge/variations/_transparent/base.ts
+++ b/packages/plasma-new-hope/src/components/Badge/variations/_transparent/base.ts
@@ -3,7 +3,7 @@ import { css } from '@linaria/core';
 import { classes, tokens } from '../../Badge.tokens';
 
 export const base = css`
-    &.${String(classes.badgeTransparent)} {
+    &.${classes.badgeTransparent} {
         color: var(${tokens.colorTransparent});
         background-color: var(${tokens.backgroundTransparent});
     }

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Badge/Badge.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Badge/Badge.config.ts
@@ -15,6 +15,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-secondary);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             accent: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -22,6 +24,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-accent);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-accent);
+
+                ${badgeTokens.colorClear}: var(--text-accent);
             `,
             positive: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -29,6 +33,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-positive);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-positive);
+
+                ${badgeTokens.colorClear}: var(--text-positive);
             `,
             warning: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -36,6 +42,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-warning);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-warning);
+
+                ${badgeTokens.colorClear}: var(--text-warning);
             `,
             negative: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -43,6 +51,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-negative);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-negative);
+
+                ${badgeTokens.colorClear}: var(--text-negative);
             `,
             dark: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -50,6 +60,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-light-surface-transparent-deep);
+
+                ${badgeTokens.colorClear}: var(--on-light-text-primary);
             `,
             light: css`
                 ${badgeTokens.color}: var(--on-light-text-primary);
@@ -57,6 +69,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-dark-surface-transparent-card);
+
+                ${badgeTokens.colorClear}: var(--on-dark-text-primary);
             `,
         },
         size: {
@@ -124,6 +138,9 @@ export const config = {
             `,
         },
         transparent: {
+            true: css``,
+        },
+        clear: {
             true: css``,
         },
     },

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Badge/Badge.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { disableProps } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
 
@@ -23,13 +23,25 @@ const meta: Meta<typeof Badge> = {
                 type: 'select',
             },
         },
+        pilled: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
+        transparent: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
         ...disableProps(['contentLeft', 'contentRight']),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Badge>;
+type StoryProps = ComponentProps<typeof Badge> & {
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
+};
+type Story = StoryObj<StoryProps>;
 
 const BellIcon = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
@@ -41,16 +53,36 @@ const BellIcon = (props) => (
 );
 
 export const Default: Story = {
+    argTypes: {
+        enableContentLeft: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentRight', truthy: false },
+        },
+        enableContentRight: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentLeft', truthy: false },
+        },
+    },
     args: {
         text: 'Hello',
         view: 'default',
         size: 'm',
+        enableContentLeft: false,
+        enableContentRight: false,
+        clear: false,
         pilled: false,
         transparent: false,
     },
-};
+    render: ({ enableContentLeft, enableContentRight, size, ...rest }: StoryProps) => {
+        const iconSize = size === 'l' ? '1rem' : '0.75rem';
 
-export const WithIcon: Story = {
-    args: { ...Default.args },
-    render: (args) => <Badge contentLeft={<BellIcon width="1rem" height="1rem" />} {...args} />,
+        return (
+            <Badge
+                contentLeft={enableContentLeft ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                size={size}
+                {...rest}
+            />
+        );
+    },
 };

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Badge/Badge.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Badge/Badge.config.ts
@@ -15,6 +15,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-secondary);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             accent: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -22,6 +24,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-accent);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-accent);
+
+                ${badgeTokens.colorClear}: var(--text-accent);
             `,
             positive: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -29,6 +33,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-positive);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-positive);
+
+                ${badgeTokens.colorClear}: var(--text-positive);
             `,
             warning: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -36,6 +42,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-warning);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-warning);
+
+                ${badgeTokens.colorClear}: var(--text-warning);
             `,
             negative: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -43,6 +51,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-negative);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-negative);
+
+                ${badgeTokens.colorClear}: var(--text-negative);
             `,
             dark: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -50,6 +60,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-light-surface-transparent-deep);
+
+                ${badgeTokens.colorClear}: var(--on-light-text-primary);
             `,
             light: css`
                 ${badgeTokens.color}: var(--on-light-text-primary);
@@ -57,6 +69,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-dark-surface-transparent-card);
+
+                ${badgeTokens.colorClear}: var(--on-dark-text-primary);
             `,
         },
         size: {
@@ -124,6 +138,9 @@ export const config = {
             `,
         },
         transparent: {
+            true: css``,
+        },
+        clear: {
             true: css``,
         },
     },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Badge/Badge.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { disableProps } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
 
@@ -8,6 +8,7 @@ import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
     title: 'plasma_web/Badge',
+    component: Badge,
     decorators: [WithTheme],
     argTypes: {
         size: {
@@ -22,13 +23,25 @@ const meta: Meta<typeof Badge> = {
                 type: 'select',
             },
         },
+        pilled: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
+        transparent: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
         ...disableProps(['contentLeft', 'contentRight']),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Badge>;
+type StoryProps = ComponentProps<typeof Badge> & {
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
+};
+type Story = StoryObj<StoryProps>;
 
 const BellIcon = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
@@ -40,16 +53,36 @@ const BellIcon = (props) => (
 );
 
 export const Default: Story = {
+    argTypes: {
+        enableContentLeft: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentRight', truthy: false },
+        },
+        enableContentRight: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentLeft', truthy: false },
+        },
+    },
     args: {
         text: 'Hello',
         view: 'default',
         size: 'm',
+        enableContentLeft: false,
+        enableContentRight: false,
+        clear: false,
         pilled: false,
         transparent: false,
     },
-};
+    render: ({ enableContentLeft, enableContentRight, size, ...rest }: StoryProps) => {
+        const iconSize = size === 'l' ? '1rem' : '0.75rem';
 
-export const WithIcon: Story = {
-    args: { ...Default.args },
-    render: (args) => <Badge contentLeft={<BellIcon width="1rem" height="1rem" />} {...args} />,
+        return (
+            <Badge
+                contentLeft={enableContentLeft ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                size={size}
+                {...rest}
+            />
+        );
+    },
 };

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -478,17 +478,46 @@ true: PolymorphicClassName;
 transparent: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLDivElement> & {
+clear: {
+true: PolymorphicClassName;
+};
+}> & ((HTMLAttributes<HTMLDivElement> & {
 text?: string | undefined;
 contentLeft?: ReactNode;
 contentRight?: ReactNode;
-pilled?: boolean | undefined;
-transparent?: boolean | undefined;
 size?: string | undefined;
 view?: string | undefined;
 } & {
 children?: ReactNode;
-} & RefAttributes<HTMLDivElement>>;
+} & {
+clear?: true | undefined;
+pilled?: false | undefined;
+transparent?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: true | undefined;
+transparent?: boolean | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: boolean | undefined;
+transparent?: true | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>))>;
 
 export { BadgeProps }
 

--- a/packages/plasma-web/src/components/Badge/Badge.config.ts
+++ b/packages/plasma-web/src/components/Badge/Badge.config.ts
@@ -13,6 +13,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-secondary);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             /**
              * @deprecated
@@ -24,6 +26,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-secondary);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             accent: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -31,6 +35,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-accent);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-accent);
+
+                ${badgeTokens.colorClear}: var(--text-accent);
             `,
             positive: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -38,6 +44,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-positive);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-positive);
+
+                ${badgeTokens.colorClear}: var(--text-positive);
             `,
             warning: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -45,6 +53,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-warning);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-warning);
+
+                ${badgeTokens.colorClear}: var(--text-warning);
             `,
             negative: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -52,6 +62,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-negative);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-negative);
+
+                ${badgeTokens.colorClear}: var(--text-negative);
             `,
             dark: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -59,6 +71,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-light-surface-transparent-deep);
+
+                ${badgeTokens.colorClear}: var(--on-light-text-primary);
             `,
             light: css`
                 ${badgeTokens.color}: var(--on-light-text-primary);
@@ -66,6 +80,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-dark-surface-transparent-card);
+
+                ${badgeTokens.colorClear}: var(--on-dark-text-primary);
             `,
         },
         size: {
@@ -133,6 +149,9 @@ export const config = {
             `,
         },
         transparent: {
+            true: css``,
+        },
+        clear: {
             true: css``,
         },
     },

--- a/packages/plasma-web/src/components/Badge/Badge.stories.tsx
+++ b/packages/plasma-web/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
 
@@ -21,13 +21,25 @@ const meta: Meta<typeof Badge> = {
                 type: 'select',
             },
         },
+        pilled: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
+        transparent: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
         ...disableProps(['contentLeft', 'contentRight']),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Badge>;
+type StoryProps = ComponentProps<typeof Badge> & {
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
+};
+type Story = StoryObj<StoryProps>;
 
 const BellIcon = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
@@ -39,16 +51,36 @@ const BellIcon = (props) => (
 );
 
 export const Default: Story = {
+    argTypes: {
+        enableContentLeft: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentRight', truthy: false },
+        },
+        enableContentRight: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentLeft', truthy: false },
+        },
+    },
     args: {
         text: 'Hello',
         view: 'default',
         size: 'm',
+        enableContentLeft: false,
+        enableContentRight: false,
+        clear: false,
         pilled: false,
         transparent: false,
     },
-};
+    render: ({ enableContentLeft, enableContentRight, size, ...rest }: StoryProps) => {
+        const iconSize = size === 'l' ? '1rem' : '0.75rem';
 
-export const WithIcon: Story = {
-    args: { ...Default.args },
-    render: (args) => <Badge contentLeft={<BellIcon width="1rem" height="1rem" />} {...args} />,
+        return (
+            <Badge
+                contentLeft={enableContentLeft ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                size={size}
+                {...rest}
+            />
+        );
+    },
 };

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -308,17 +308,46 @@ true: PolymorphicClassName;
 transparent: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLDivElement> & {
+clear: {
+true: PolymorphicClassName;
+};
+}> & ((HTMLAttributes<HTMLDivElement> & {
 text?: string | undefined;
 contentLeft?: ReactNode;
 contentRight?: ReactNode;
-pilled?: boolean | undefined;
-transparent?: boolean | undefined;
 size?: string | undefined;
 view?: string | undefined;
 } & {
 children?: ReactNode;
-} & RefAttributes<HTMLDivElement>>;
+} & {
+clear?: true | undefined;
+pilled?: false | undefined;
+transparent?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: true | undefined;
+transparent?: boolean | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: boolean | undefined;
+transparent?: true | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>))>;
 
 export { BadgeProps }
 

--- a/packages/sdds-cs/src/components/Badge/Badge.config.ts
+++ b/packages/sdds-cs/src/components/Badge/Badge.config.ts
@@ -10,24 +10,29 @@ export const config = {
             default: css`
                 ${badgeTokens.color}: var(--inverse-text-primary);
                 ${badgeTokens.background}: var(--surface-solid-default);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             accent: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
                 ${badgeTokens.background}: var(--surface-accent);
 
                 ${badgeTokens.colorTransparent}: var(--text-accent);
+                ${badgeTokens.colorClear}: var(--text-accent);
             `,
             positive: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
                 ${badgeTokens.background}: var(--surface-positive);
 
                 ${badgeTokens.colorTransparent}: var(--text-positive);
+                ${badgeTokens.colorClear}: var(--text-positive);
             `,
             negative: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
                 ${badgeTokens.background}: var(--surface-negative);
 
                 ${badgeTokens.colorTransparent}: var(--text-negative);
+                ${badgeTokens.colorClear}: var(--text-negative);
             `,
         },
         size: {
@@ -57,6 +62,9 @@ export const config = {
             `,
         },
         transparent: {
+            true: css``,
+        },
+        clear: {
             true: css``,
         },
     },

--- a/packages/sdds-cs/src/components/Badge/Badge.stories.tsx
+++ b/packages/sdds-cs/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
 
@@ -21,13 +21,21 @@ const meta: Meta<typeof Badge> = {
                 type: 'select',
             },
         },
-        ...disableProps(['contentLeft', 'contentRight', 'size', 'transparent']),
+        pilled: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
+        ...disableProps(['contentLeft', 'contentRight', 'transparent', 'size']),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Badge>;
+type StoryProps = ComponentProps<typeof Badge> & {
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
+};
+type Story = StoryObj<StoryProps>;
 
 const BellIcon = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
@@ -39,16 +47,33 @@ const BellIcon = (props) => (
 );
 
 export const Default: Story = {
+    argTypes: {
+        enableContentLeft: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentRight', truthy: false },
+        },
+        enableContentRight: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentLeft', truthy: false },
+        },
+    },
     args: {
         text: 'Hello',
         view: 'default',
         size: 's',
+        enableContentLeft: false,
+        enableContentRight: false,
+        clear: false,
         pilled: false,
-        transparent: false,
     },
-};
-
-export const WithIcon: Story = {
-    args: { ...Default.args },
-    render: (args) => <Badge contentLeft={<BellIcon width="1rem" height="1rem" />} {...args} />,
+    render: ({ enableContentLeft, enableContentRight, size, ...rest }: StoryProps) => {
+        return (
+            <Badge
+                contentLeft={enableContentLeft ? <BellIcon width="0.75rem" height="0.75rem" /> : undefined}
+                contentRight={enableContentRight ? <BellIcon width="0.75rem" height="0.75rem" /> : undefined}
+                size={size}
+                {...rest}
+            />
+        );
+    },
 };

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -283,17 +283,46 @@ true: PolymorphicClassName;
 transparent: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLDivElement> & {
+clear: {
+true: PolymorphicClassName;
+};
+}> & ((HTMLAttributes<HTMLDivElement> & {
 text?: string | undefined;
 contentLeft?: ReactNode;
 contentRight?: ReactNode;
-pilled?: boolean | undefined;
-transparent?: boolean | undefined;
 size?: string | undefined;
 view?: string | undefined;
 } & {
 children?: ReactNode;
-} & RefAttributes<HTMLDivElement>>;
+} & {
+clear?: true | undefined;
+pilled?: false | undefined;
+transparent?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: true | undefined;
+transparent?: boolean | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: boolean | undefined;
+transparent?: true | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>))>;
 
 export { BadgeProps }
 

--- a/packages/sdds-dfa/src/components/Badge/Badge.config.ts
+++ b/packages/sdds-dfa/src/components/Badge/Badge.config.ts
@@ -13,6 +13,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-secondary);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             accent: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -20,6 +22,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-accent);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-accent);
+
+                ${badgeTokens.colorClear}: var(--text-accent);
             `,
             positive: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -27,6 +31,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-positive);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-positive);
+
+                ${badgeTokens.colorClear}: var(--text-positive);
             `,
             warning: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -34,6 +40,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-warning);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-warning);
+
+                ${badgeTokens.colorClear}: var(--text-warning);
             `,
             negative: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -41,6 +49,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-negative);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-negative);
+
+                ${badgeTokens.colorClear}: var(--text-negative);
             `,
             dark: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -48,6 +58,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-light-surface-transparent-deep);
+
+                ${badgeTokens.colorClear}: var(--on-light-text-primary);
             `,
             light: css`
                 ${badgeTokens.color}: var(--on-light-text-primary);
@@ -55,6 +67,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-dark-surface-transparent-card);
+
+                ${badgeTokens.colorClear}: var(--on-dark-text-primary);
             `,
         },
         size: {
@@ -122,6 +136,9 @@ export const config = {
             `,
         },
         transparent: {
+            true: css``,
+        },
+        clear: {
             true: css``,
         },
     },

--- a/packages/sdds-dfa/src/components/Badge/Badge.stories.tsx
+++ b/packages/sdds-dfa/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
 
@@ -21,13 +21,25 @@ const meta: Meta<typeof Badge> = {
                 type: 'select',
             },
         },
+        pilled: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
+        transparent: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
         ...disableProps(['contentLeft', 'contentRight']),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Badge>;
+type StoryProps = ComponentProps<typeof Badge> & {
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
+};
+type Story = StoryObj<StoryProps>;
 
 const BellIcon = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
@@ -39,16 +51,36 @@ const BellIcon = (props) => (
 );
 
 export const Default: Story = {
+    argTypes: {
+        enableContentLeft: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentRight', truthy: false },
+        },
+        enableContentRight: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentLeft', truthy: false },
+        },
+    },
     args: {
         text: 'Hello',
         view: 'default',
         size: 'm',
+        enableContentLeft: false,
+        enableContentRight: false,
+        clear: false,
         pilled: false,
         transparent: false,
     },
-};
+    render: ({ enableContentLeft, enableContentRight, size, ...rest }: StoryProps) => {
+        const iconSize = size === 'l' ? '1rem' : '0.75rem';
 
-export const WithIcon: Story = {
-    args: { ...Default.args },
-    render: (args) => <Badge contentLeft={<BellIcon width="1rem" height="1rem" />} {...args} />,
+        return (
+            <Badge
+                contentLeft={enableContentLeft ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                size={size}
+                {...rest}
+            />
+        );
+    },
 };

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -321,17 +321,46 @@ true: PolymorphicClassName;
 transparent: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLDivElement> & {
+clear: {
+true: PolymorphicClassName;
+};
+}> & ((HTMLAttributes<HTMLDivElement> & {
 text?: string | undefined;
 contentLeft?: ReactNode;
 contentRight?: ReactNode;
-pilled?: boolean | undefined;
-transparent?: boolean | undefined;
 size?: string | undefined;
 view?: string | undefined;
 } & {
 children?: ReactNode;
-} & RefAttributes<HTMLDivElement>>;
+} & {
+clear?: true | undefined;
+pilled?: false | undefined;
+transparent?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: true | undefined;
+transparent?: boolean | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: boolean | undefined;
+transparent?: true | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>))>;
 
 export { BadgeProps }
 

--- a/packages/sdds-finportal/src/components/Badge/Badge.config.ts
+++ b/packages/sdds-finportal/src/components/Badge/Badge.config.ts
@@ -13,6 +13,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-secondary);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             accent: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -20,6 +22,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-accent);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-accent);
+
+                ${badgeTokens.colorClear}: var(--text-accent);
             `,
             positive: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -27,6 +31,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-positive);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-positive);
+
+                ${badgeTokens.colorClear}: var(--text-positive);
             `,
             warning: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -34,6 +40,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-warning);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-warning);
+
+                ${badgeTokens.colorClear}: var(--text-warning);
             `,
             negative: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -41,6 +49,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-negative);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-negative);
+
+                ${badgeTokens.colorClear}: var(--text-negative);
             `,
             dark: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -48,6 +58,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-light-surface-transparent-deep);
+
+                ${badgeTokens.colorClear}: var(--on-light-text-primary);
             `,
             light: css`
                 ${badgeTokens.color}: var(--on-light-text-primary);
@@ -55,6 +67,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-dark-surface-transparent-card);
+
+                ${badgeTokens.colorClear}: var(--on-dark-text-primary);
             `,
         },
         size: {
@@ -122,6 +136,9 @@ export const config = {
             `,
         },
         transparent: {
+            true: css``,
+        },
+        clear: {
             true: css``,
         },
     },

--- a/packages/sdds-finportal/src/components/Badge/Badge.stories.tsx
+++ b/packages/sdds-finportal/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
 
@@ -21,13 +21,25 @@ const meta: Meta<typeof Badge> = {
                 type: 'select',
             },
         },
+        pilled: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
+        transparent: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
         ...disableProps(['contentLeft', 'contentRight']),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Badge>;
+type StoryProps = ComponentProps<typeof Badge> & {
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
+};
+type Story = StoryObj<StoryProps>;
 
 const BellIcon = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
@@ -39,16 +51,36 @@ const BellIcon = (props) => (
 );
 
 export const Default: Story = {
+    argTypes: {
+        enableContentLeft: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentRight', truthy: false },
+        },
+        enableContentRight: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentLeft', truthy: false },
+        },
+    },
     args: {
         text: 'Hello',
         view: 'default',
         size: 'm',
+        enableContentLeft: false,
+        enableContentRight: false,
+        clear: false,
         pilled: false,
         transparent: false,
     },
-};
+    render: ({ enableContentLeft, enableContentRight, size, ...rest }: StoryProps) => {
+        const iconSize = size === 'l' ? '1rem' : '0.75rem';
 
-export const WithIcon: Story = {
-    args: { ...Default.args },
-    render: (args) => <Badge contentLeft={<BellIcon width="1rem" height="1rem" />} {...args} />,
+        return (
+            <Badge
+                contentLeft={enableContentLeft ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                size={size}
+                {...rest}
+            />
+        );
+    },
 };

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -323,17 +323,46 @@ true: PolymorphicClassName;
 transparent: {
 true: PolymorphicClassName;
 };
-}> & HTMLAttributes<HTMLDivElement> & {
+clear: {
+true: PolymorphicClassName;
+};
+}> & ((HTMLAttributes<HTMLDivElement> & {
 text?: string | undefined;
 contentLeft?: ReactNode;
 contentRight?: ReactNode;
-pilled?: boolean | undefined;
-transparent?: boolean | undefined;
 size?: string | undefined;
 view?: string | undefined;
 } & {
 children?: ReactNode;
-} & RefAttributes<HTMLDivElement>>;
+} & {
+clear?: true | undefined;
+pilled?: false | undefined;
+transparent?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: true | undefined;
+transparent?: boolean | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>) | (HTMLAttributes<HTMLDivElement> & {
+text?: string | undefined;
+contentLeft?: ReactNode;
+contentRight?: ReactNode;
+size?: string | undefined;
+view?: string | undefined;
+} & {
+children?: ReactNode;
+} & {
+pilled?: boolean | undefined;
+transparent?: true | undefined;
+clear?: false | undefined;
+} & RefAttributes<HTMLDivElement>))>;
 
 export { BadgeProps }
 

--- a/packages/sdds-serv/src/components/Badge/Badge.config.ts
+++ b/packages/sdds-serv/src/components/Badge/Badge.config.ts
@@ -13,6 +13,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-secondary);
+
+                ${badgeTokens.colorClear}: var(--text-primary);
             `,
             accent: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -20,6 +22,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-accent);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-accent);
+
+                ${badgeTokens.colorClear}: var(--text-accent);
             `,
             positive: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -27,6 +31,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-positive);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-positive);
+
+                ${badgeTokens.colorClear}: var(--text-positive);
             `,
             warning: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -34,6 +40,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-warning);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-warning);
+
+                ${badgeTokens.colorClear}: var(--text-warning);
             `,
             negative: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -41,6 +49,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--text-negative);
                 ${badgeTokens.backgroundTransparent}: var(--surface-transparent-negative);
+
+                ${badgeTokens.colorClear}: var(--text-negative);
             `,
             dark: css`
                 ${badgeTokens.color}: var(--on-dark-text-primary);
@@ -48,6 +58,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-light-surface-transparent-deep);
+
+                ${badgeTokens.colorClear}: var(--on-light-text-primary);
             `,
             light: css`
                 ${badgeTokens.color}: var(--on-light-text-primary);
@@ -55,6 +67,8 @@ export const config = {
 
                 ${badgeTokens.colorTransparent}: var(--on-dark-text-primary);
                 ${badgeTokens.backgroundTransparent}: var(--on-dark-surface-transparent-card);
+
+                ${badgeTokens.colorClear}: var(--on-dark-text-primary);
             `,
         },
         size: {
@@ -122,6 +136,9 @@ export const config = {
             `,
         },
         transparent: {
+            true: css``,
+        },
+        clear: {
             true: css``,
         },
     },

--- a/packages/sdds-serv/src/components/Badge/Badge.stories.tsx
+++ b/packages/sdds-serv/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
 
@@ -21,13 +21,25 @@ const meta: Meta<typeof Badge> = {
                 type: 'select',
             },
         },
+        pilled: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
+        transparent: {
+            control: { type: 'boolean' },
+            if: { arg: 'clear', truthy: false },
+        },
         ...disableProps(['contentLeft', 'contentRight']),
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Badge>;
+type StoryProps = ComponentProps<typeof Badge> & {
+    enableContentLeft: boolean;
+    enableContentRight: boolean;
+};
+type Story = StoryObj<StoryProps>;
 
 const BellIcon = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
@@ -39,16 +51,36 @@ const BellIcon = (props) => (
 );
 
 export const Default: Story = {
+    argTypes: {
+        enableContentLeft: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentRight', truthy: false },
+        },
+        enableContentRight: {
+            control: { type: 'boolean' },
+            if: { arg: 'enableContentLeft', truthy: false },
+        },
+    },
     args: {
         text: 'Hello',
         view: 'default',
         size: 'm',
+        enableContentLeft: false,
+        enableContentRight: false,
+        clear: false,
         pilled: false,
         transparent: false,
     },
-};
+    render: ({ enableContentLeft, enableContentRight, size, ...rest }: StoryProps) => {
+        const iconSize = size === 'l' ? '1rem' : '0.75rem';
 
-export const WithIcon: Story = {
-    args: { ...Default.args },
-    render: (args) => <Badge contentLeft={<BellIcon width="1rem" height="1rem" />} {...args} />,
+        return (
+            <Badge
+                contentLeft={enableContentLeft ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <BellIcon width={iconSize} height={iconSize} /> : undefined}
+                size={size}
+                {...rest}
+            />
+        );
+    },
 };

--- a/website/plasma-b2c-docs/docs/components/Badge.mdx
+++ b/website/plasma-b2c-docs/docs/components/Badge.mdx
@@ -3,17 +3,18 @@ id: badge
 title: Badge
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description } from '@site/src/components';
 
 # Badge
 <Description name="Badge" />
 <PropsTable name="Badge"  exclude={['css']} />
-<StorybookLink name="Badge" />
 
 ## Примеры
 
-### Размер Badge
-Размер задается с помощью свойства `size`. Возможные значения свойства: `"l"`, `"m"`, `"s"`.
+### Размер badge
+Размер задается с помощью свойства `size`.
+
+Возможные значения свойства: `"l"`, `"m"`, `"s"`.
 
 ```tsx live 
 import React from 'react';
@@ -30,7 +31,7 @@ export function App() {
 }
 ```
 
-### Скругленность Badge
+### Скругленность badge
 Скругленность задается с помощью свойства `pilled`:
 
 ```tsx live 
@@ -48,59 +49,50 @@ export function App() {
 }
 ```
 
-### Вид Badge
-Вид Badge задается с помощью свойства `view`. Возможные значения свойства `view`:
+### Вид badge
+Вид `badge` задается с помощью свойства `view`. Возможные значения свойства `view`:
 
-+ `"default"` – основной бейдж;
++ `"primary"` – основной badge;
 + `"accent"` – бейдж акцентного цвета;
 + `"positive"` – успешное завершение;
 + `"warning"` – предупреждение;
 + `"negative"` – ошибка;
-+ `"dark"` – темный бэйдж;
-+ `"light"` – светлый бэйдж.
++ `"dark"` – темный badge;
++ `"light"` – светлый badge.
+
+Так же на вид badge влияет свойства `transparent` и `clear`.
 
 ```tsx live 
 import React from 'react';
 import { Badge } from '@salutejs/plasma-b2c';
 
 export function App() {
+    const Badges = ({transparent, clear}) => {
+        return (
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <Badge text="Бейдж" size="l" view="primary" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="accent" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="positive" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="warning" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="negative" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="dark" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="light" transparent={transparent} clear={clear} />
+            </div>
+        )
+    }
+
     return (
-        <div>
-            <Badge text="Бейдж" size="l" view="default" />
-            <Badge text="Бейдж" size="l" view="accent" />
-            <Badge text="Бейдж" size="l" view="positive" />
-            <Badge text="Бейдж" size="l" view="warning" />
-            <Badge text="Бейдж" size="l" view="negative" />
-            <Badge text="Бейдж" size="l" view="dark" />
-            <Badge text="Бейдж" size="l" view="light" />
-        </div>
-    );
-}
-```
-
-Так же на вид Badge влияет свойство `transparent`:
-
-```tsx live 
-import React from 'react';
-import { Badge } from '@salutejs/plasma-b2c';
-
-export function App() {
-    return (
-        <div>
-            <Badge text="Бейдж" size="l" view="default" transparent />
-            <Badge text="Бейдж" size="l" view="accent" transparent />
-            <Badge text="Бейдж" size="l" view="positive" transparent />
-            <Badge text="Бейдж" size="l" view="warning" transparent />
-            <Badge text="Бейдж" size="l" view="negative" transparent />
-            <Badge text="Бейдж" size="l" view="dark" transparent />
-            <Badge text="Бейдж" size="l" view="light" transparent />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+            <Badges />
+            <Badges transparent />
+            <Badges clear />
         </div>
     );
 }
 ```
 
 ### Иконка слева / справа
-В левой и/или правой части Badge можно отобразить иконку:
+В левой и/или правой части badge можно отобразить иконку:
 
 ```tsx live
 import React from 'react';
@@ -113,14 +105,14 @@ export function App() {
             <Badge 
                 text="Бейдж" 
                 size="l"   
-                view="default" 
+                view="primary" 
                 contentLeft={
                     <IconEye color="inherit" size="xs" />
                 } />
             <Badge 
                 text="Бейдж" 
                 size="l"   
-                view="default" 
+                view="primary" 
                 contentRight={
                     <IconEye color="inherit" size="xs" />
                 } />

--- a/website/plasma-web-docs/docs/components/Badge.mdx
+++ b/website/plasma-web-docs/docs/components/Badge.mdx
@@ -3,17 +3,18 @@ id: badge
 title: Badge
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description } from '@site/src/components';
 
 # Badge
 <Description name="Badge" />
 <PropsTable name="Badge"  exclude={['css']} />
-<StorybookLink name="Badge" />
 
 ## Примеры
 
-### Размер бейджа
-Размер задается с помощью свойства `size`. Возможные значения свойтсва: `"l"`, `"m"`, `"s"`.
+### Размер badge
+Размер задается с помощью свойства `size`.
+
+Возможные значения свойства: `"l"`, `"m"`, `"s"`.
 
 ```tsx live 
 import React from 'react';
@@ -30,7 +31,7 @@ export function App() {
 }
 ```
 
-### Скругленность бейджа
+### Скругленность badge
 Скругленность задается с помощью свойства `pilled`:
 
 ```tsx live 
@@ -48,59 +49,50 @@ export function App() {
 }
 ```
 
-### Вид бейджа
-Вид бейджа задается с помощью свойства `view`. Возможные значения свойства `view`:
+### Вид badge
+Вид `badge` задается с помощью свойства `view`. Возможные значения свойства `view`:
 
-+ `"default"` – основной бейдж;
++ `"primary"` – основной badge;
 + `"accent"` – бейдж акцентного цвета;
 + `"positive"` – успешное завершение;
 + `"warning"` – предупреждение;
 + `"negative"` – ошибка;
-+ `"dark"` – темный бэйдж;
-+ `"light"` – светлый бэйдж.
++ `"dark"` – темный badge;
++ `"light"` – светлый badge.
+
+Так же на вид badge влияет свойства `transparent` и `clear`.
 
 ```tsx live 
 import React from 'react';
 import { Badge } from '@salutejs/plasma-web';
 
 export function App() {
+    const Badges = ({transparent, clear}) => {
+        return (
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <Badge text="Бейдж" size="l" view="primary" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="accent" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="positive" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="warning" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="negative" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="dark" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="light" transparent={transparent} clear={clear} />
+            </div>
+        )
+    }
+
     return (
-        <div>
-            <Badge text="Бейдж" size="l" view="default" />
-            <Badge text="Бейдж" size="l" view="accent" />
-            <Badge text="Бейдж" size="l" view="positive" />
-            <Badge text="Бейдж" size="l" view="warning" />
-            <Badge text="Бейдж" size="l" view="negative" />
-            <Badge text="Бейдж" size="l" view="dark" />
-            <Badge text="Бейдж" size="l" view="light" />
-        </div>
-    );
-}
-```
-
-так же на вид бейджа влияет свойство `transparent`:
-
-```tsx live 
-import React from 'react';
-import { Badge } from '@salutejs/plasma-web';
-
-export function App() {
-    return (
-        <div>
-            <Badge text="Бейдж" size="l" view="default" transparent />
-            <Badge text="Бейдж" size="l" view="accent" transparent />
-            <Badge text="Бейдж" size="l" view="positive" transparent />
-            <Badge text="Бейдж" size="l" view="warning" transparent />
-            <Badge text="Бейдж" size="l" view="negative" transparent />
-            <Badge text="Бейдж" size="l" view="dark" transparent />
-            <Badge text="Бейдж" size="l" view="light" transparent />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+            <Badges />
+            <Badges transparent />
+            <Badges clear />
         </div>
     );
 }
 ```
 
 ### Иконка слева / справа
-В левой и/или правой части бейджа можно отобразить иконку:
+В левой и/или правой части badge можно отобразить иконку:
 
 ```tsx live
 import React from 'react';
@@ -113,14 +105,14 @@ export function App() {
             <Badge 
                 text="Бейдж" 
                 size="l"   
-                view="default" 
+                view="primary" 
                 contentLeft={
                     <IconEye color="inherit" size="xs" />
                 } />
             <Badge 
                 text="Бейдж" 
                 size="l"   
-                view="default" 
+                view="primary" 
                 contentRight={
                     <IconEye color="inherit" size="xs" />
                 } />

--- a/website/sdds-cs-docs/docs/components/Badge.mdx
+++ b/website/sdds-cs-docs/docs/components/Badge.mdx
@@ -11,7 +11,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 ## Примеры
 
-### Размер бейджа
+### Размер badge
 Размер задается с помощью свойства `size`.
 
 Возможные значения свойства: `"l"`, `"m"`, `"s"`.
@@ -31,7 +31,7 @@ export function App() {
 }
 ```
 
-### Скругленность бейджа
+### Скругленность badge
 Скругленность задается с помощью свойства `pilled`:
 
 ```tsx live 
@@ -49,59 +49,50 @@ export function App() {
 }
 ```
 
-### Вид бейджа
-Вид бейджа задается с помощью свойства `view`. Возможные значения свойства `view`:
+### Вид badge
+Вид `badge` задается с помощью свойства `view`. Возможные значения свойства `view`:
 
-+ `"default"` – основной бейдж;
++ `"primary"` – основной badge;
 + `"accent"` – бейдж акцентного цвета;
 + `"positive"` – успешное завершение;
 + `"warning"` – предупреждение;
 + `"negative"` – ошибка;
-+ `"dark"` – темный бэйдж;
-+ `"light"` – светлый бэйдж.
++ `"dark"` – темный badge;
++ `"light"` – светлый badge.
+
+Так же на вид badge влияет свойства `transparent` и `clear`.
 
 ```tsx live 
 import React from 'react';
 import { Badge } from '@salutejs/sdds-cs';
 
 export function App() {
+    const Badges = ({transparent, clear}) => {
+        return (
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <Badge text="Бейдж" size="l" view="primary" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="accent" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="positive" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="warning" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="negative" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="dark" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="light" transparent={transparent} clear={clear} />
+            </div>
+        )
+    }
+
     return (
-        <div>
-            <Badge text="Бейдж" size="l" view="default" />
-            <Badge text="Бейдж" size="l" view="accent" />
-            <Badge text="Бейдж" size="l" view="positive" />
-            <Badge text="Бейдж" size="l" view="warning" />
-            <Badge text="Бейдж" size="l" view="negative" />
-            <Badge text="Бейдж" size="l" view="dark" />
-            <Badge text="Бейдж" size="l" view="light" />
-        </div>
-    );
-}
-```
-
-так же на вид бейджа влияет свойство `transparent`:
-
-```tsx live 
-import React from 'react';
-import { Badge } from '@salutejs/sdds-cs';
-
-export function App() {
-    return (
-        <div>
-            <Badge text="Бейдж" size="l" view="default" transparent />
-            <Badge text="Бейдж" size="l" view="accent" transparent />
-            <Badge text="Бейдж" size="l" view="positive" transparent />
-            <Badge text="Бейдж" size="l" view="warning" transparent />
-            <Badge text="Бейдж" size="l" view="negative" transparent />
-            <Badge text="Бейдж" size="l" view="dark" transparent />
-            <Badge text="Бейдж" size="l" view="light" transparent />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+            <Badges />
+            <Badges transparent />
+            <Badges clear />
         </div>
     );
 }
 ```
 
 ### Иконка слева / справа
-В левой и/или правой части бейджа можно отобразить иконку:
+В левой и/или правой части badge можно отобразить иконку:
 
 ```tsx live
 import React from 'react';
@@ -114,14 +105,14 @@ export function App() {
             <Badge 
                 text="Бейдж" 
                 size="l"   
-                view="default" 
+                view="primary" 
                 contentLeft={
                     <IconEye color="inherit" size="xs" />
                 } />
             <Badge 
                 text="Бейдж" 
                 size="l"   
-                view="default" 
+                view="primary" 
                 contentRight={
                     <IconEye color="inherit" size="xs" />
                 } />

--- a/website/sdds-dfa-docs/docs/components/Badge.mdx
+++ b/website/sdds-dfa-docs/docs/components/Badge.mdx
@@ -60,41 +60,32 @@ export function App() {
 + `"dark"` – темный badge;
 + `"light"` – светлый badge.
 
-```tsx live 
-import React from 'react';
-import { Badge } from '@salutejs/sdds-dfa';
-
-export function App() {
-    return (
-        <div>
-            <Badge text="Бейдж" size="l" view="primary" />
-            <Badge text="Бейдж" size="l" view="accent" />
-            <Badge text="Бейдж" size="l" view="positive" />
-            <Badge text="Бейдж" size="l" view="warning" />
-            <Badge text="Бейдж" size="l" view="negative" />
-            <Badge text="Бейдж" size="l" view="dark" />
-            <Badge text="Бейдж" size="l" view="light" />
-        </div>
-    );
-}
-```
-
-Так же на вид badge влияет свойство `transparent`:
+Так же на вид badge влияет свойства `transparent` и `clear`.
 
 ```tsx live 
 import React from 'react';
 import { Badge } from '@salutejs/sdds-dfa';
 
 export function App() {
+    const Badges = ({transparent, clear}) => {
+        return (
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <Badge text="Бейдж" size="l" view="primary" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="accent" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="positive" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="warning" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="negative" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="dark" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="light" transparent={transparent} clear={clear} />
+            </div>
+        )
+    }
+
     return (
-        <div>
-            <Badge text="Бейдж" size="l" view="primary" transparent />
-            <Badge text="Бейдж" size="l" view="accent" transparent />
-            <Badge text="Бейдж" size="l" view="positive" transparent />
-            <Badge text="Бейдж" size="l" view="warning" transparent />
-            <Badge text="Бейдж" size="l" view="negative" transparent />
-            <Badge text="Бейдж" size="l" view="dark" transparent />
-            <Badge text="Бейдж" size="l" view="light" transparent />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+            <Badges />
+            <Badges transparent />
+            <Badges clear />
         </div>
     );
 }

--- a/website/sdds-serv-docs/docs/components/Badge.mdx
+++ b/website/sdds-serv-docs/docs/components/Badge.mdx
@@ -11,7 +11,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 ## Примеры
 
-### Размер бейджа
+### Размер badge
 Размер задается с помощью свойства `size`.
 
 Возможные значения свойства: `"l"`, `"m"`, `"s"`.
@@ -31,7 +31,7 @@ export function App() {
 }
 ```
 
-### Скругленность бейджа
+### Скругленность badge
 Скругленность задается с помощью свойства `pilled`:
 
 ```tsx live 
@@ -49,59 +49,50 @@ export function App() {
 }
 ```
 
-### Вид бейджа
-Вид бейджа задается с помощью свойства `view`. Возможные значения свойства `view`:
+### Вид badge
+Вид `badge` задается с помощью свойства `view`. Возможные значения свойства `view`:
 
-+ `"default"` – основной бейдж;
++ `"primary"` – основной badge;
 + `"accent"` – бейдж акцентного цвета;
 + `"positive"` – успешное завершение;
 + `"warning"` – предупреждение;
 + `"negative"` – ошибка;
-+ `"dark"` – темный бэйдж;
-+ `"light"` – светлый бэйдж.
++ `"dark"` – темный badge;
++ `"light"` – светлый badge.
+
+Так же на вид badge влияет свойства `transparent` и `clear`.
 
 ```tsx live 
 import React from 'react';
 import { Badge } from '@salutejs/sdds-serv';
 
 export function App() {
+    const Badges = ({transparent, clear}) => {
+        return (
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <Badge text="Бейдж" size="l" view="primary" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="accent" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="positive" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="warning" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="negative" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="dark" transparent={transparent} clear={clear} />
+                <Badge text="Бейдж" size="l" view="light" transparent={transparent} clear={clear} />
+            </div>
+        )
+    }
+
     return (
-        <div>
-            <Badge text="Бейдж" size="l" view="default" />
-            <Badge text="Бейдж" size="l" view="accent" />
-            <Badge text="Бейдж" size="l" view="positive" />
-            <Badge text="Бейдж" size="l" view="warning" />
-            <Badge text="Бейдж" size="l" view="negative" />
-            <Badge text="Бейдж" size="l" view="dark" />
-            <Badge text="Бейдж" size="l" view="light" />
-        </div>
-    );
-}
-```
-
-так же на вид бейджа влияет свойство `transparent`:
-
-```tsx live 
-import React from 'react';
-import { Badge } from '@salutejs/sdds-serv';
-
-export function App() {
-    return (
-        <div>
-            <Badge text="Бейдж" size="l" view="default" transparent />
-            <Badge text="Бейдж" size="l" view="accent" transparent />
-            <Badge text="Бейдж" size="l" view="positive" transparent />
-            <Badge text="Бейдж" size="l" view="warning" transparent />
-            <Badge text="Бейдж" size="l" view="negative" transparent />
-            <Badge text="Бейдж" size="l" view="dark" transparent />
-            <Badge text="Бейдж" size="l" view="light" transparent />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+            <Badges />
+            <Badges transparent />
+            <Badges clear />
         </div>
     );
 }
 ```
 
 ### Иконка слева / справа
-В левой и/или правой части бейджа можно отобразить иконку:
+В левой и/или правой части badge можно отобразить иконку:
 
 ```tsx live
 import React from 'react';
@@ -114,14 +105,14 @@ export function App() {
             <Badge 
                 text="Бейдж" 
                 size="l"   
-                view="default" 
+                view="primary" 
                 contentLeft={
                     <IconEye color="inherit" size="xs" />
                 } />
             <Badge 
                 text="Бейдж" 
                 size="l"   
-                view="default" 
+                view="primary" 
                 contentRight={
                     <IconEye color="inherit" size="xs" />
                 } />


### PR DESCRIPTION
### Badge

- добавлено свойство `clear`, которое меняет отображение view
- обновлена документация и сторибук

**After**:

<img width="328" src="https://github.com/user-attachments/assets/d44c10e8-ffe3-4137-a833-4351b7b82bdc">

### What/why changed

Добавлено свойство `clear`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.149.0-canary.1424.10812555652.0
  npm install @salutejs/plasma-b2c@1.391.0-canary.1424.10812555652.0
  npm install @salutejs/plasma-new-hope@0.142.0-canary.1424.10812555652.0
  npm install @salutejs/plasma-web@1.393.0-canary.1424.10812555652.0
  npm install @salutejs/sdds-cs@0.121.0-canary.1424.10812555652.0
  npm install @salutejs/sdds-dfa@0.119.0-canary.1424.10812555652.0
  npm install @salutejs/sdds-finportal@0.113.0-canary.1424.10812555652.0
  npm install @salutejs/sdds-serv@0.120.0-canary.1424.10812555652.0
  # or 
  yarn add @salutejs/plasma-asdk@0.149.0-canary.1424.10812555652.0
  yarn add @salutejs/plasma-b2c@1.391.0-canary.1424.10812555652.0
  yarn add @salutejs/plasma-new-hope@0.142.0-canary.1424.10812555652.0
  yarn add @salutejs/plasma-web@1.393.0-canary.1424.10812555652.0
  yarn add @salutejs/sdds-cs@0.121.0-canary.1424.10812555652.0
  yarn add @salutejs/sdds-dfa@0.119.0-canary.1424.10812555652.0
  yarn add @salutejs/sdds-finportal@0.113.0-canary.1424.10812555652.0
  yarn add @salutejs/sdds-serv@0.120.0-canary.1424.10812555652.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
