### PR TITLE
fix(sdds-*): Use correct default view for Grid

### DIFF
--- a/packages/plasma-new-hope/src/components/Grid/Grid.tsx
+++ b/packages/plasma-new-hope/src/components/Grid/Grid.tsx
@@ -12,7 +12,7 @@ export const gridRoot = (Root: RootProps<HTMLDivElement, GridProps>) =>
     forwardRef<HTMLDivElement, GridProps>((props, ref) => {
         const { children, view, className, style, maxWidth, ...rest } = props;
 
-        const viewClass = getGridViewClass(view || 'deafult');
+        const viewClass = getGridViewClass(view || 'default');
         const maxWidthValue = view === 'legacy' ? '90rem' : null;
         const maxWidthToken =
             maxWidthValue || maxWidth

--- a/packages/sdds-cs/src/components/Grid/Grid.config.tsx
+++ b/packages/sdds-cs/src/components/Grid/Grid.config.tsx
@@ -2,7 +2,7 @@ import { css, gridTokens, getBaseGridView } from '@salutejs/plasma-new-hope/styl
 
 export const config = {
     defaults: {
-        view: 'legacy',
+        view: 'default',
     },
     variations: {
         view: {

--- a/packages/sdds-dfa/src/components/Grid/Grid.config.tsx
+++ b/packages/sdds-dfa/src/components/Grid/Grid.config.tsx
@@ -2,7 +2,7 @@ import { css, gridTokens, getBaseGridView } from '@salutejs/plasma-new-hope/styl
 
 export const config = {
     defaults: {
-        view: 'legacy',
+        view: 'default',
     },
     variations: {
         view: {

--- a/packages/sdds-finportal/src/components/Grid/Grid.config.tsx
+++ b/packages/sdds-finportal/src/components/Grid/Grid.config.tsx
@@ -2,7 +2,7 @@ import { css, gridTokens, getBaseGridView } from '@salutejs/plasma-new-hope/styl
 
 export const config = {
     defaults: {
-        view: 'legacy',
+        view: 'default',
     },
     variations: {
         view: {

--- a/packages/sdds-serv/src/components/Grid/Grid.config.tsx
+++ b/packages/sdds-serv/src/components/Grid/Grid.config.tsx
@@ -2,7 +2,7 @@ import { css, gridTokens, getBaseGridView } from '@salutejs/plasma-new-hope/styl
 
 export const config = {
     defaults: {
-        view: 'legacy',
+        view: 'default',
     },
     variations: {
         view: {


### PR DESCRIPTION
### Grid

- исправили `view` по-умолчанию для `sdds` вертикалей 

**Before:**
<img width="1920" src="https://github.com/user-attachments/assets/6476ef70-294d-492b-b462-2e42cdb341d4" />
 
**After:**
<img width="1920" src="https://github.com/user-attachments/assets/aa004cf2-9e43-4691-84f3-fb33f94b3e5f" />


### What/why changed

Ранее использовалось значение `legacy` которое не предусмотрено для `sdds` вертикалей 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.150.1-canary.1431.10831152564.0
  npm install @salutejs/plasma-b2c@1.392.1-canary.1431.10831152564.0
  npm install @salutejs/plasma-new-hope@0.143.1-canary.1431.10831152564.0
  npm install @salutejs/plasma-web@1.394.1-canary.1431.10831152564.0
  npm install @salutejs/sdds-cs@0.122.1-canary.1431.10831152564.0
  npm install @salutejs/sdds-dfa@0.120.1-canary.1431.10831152564.0
  npm install @salutejs/sdds-finportal@0.114.1-canary.1431.10831152564.0
  npm install @salutejs/sdds-serv@0.121.1-canary.1431.10831152564.0
  # or 
  yarn add @salutejs/plasma-asdk@0.150.1-canary.1431.10831152564.0
  yarn add @salutejs/plasma-b2c@1.392.1-canary.1431.10831152564.0
  yarn add @salutejs/plasma-new-hope@0.143.1-canary.1431.10831152564.0
  yarn add @salutejs/plasma-web@1.394.1-canary.1431.10831152564.0
  yarn add @salutejs/sdds-cs@0.122.1-canary.1431.10831152564.0
  yarn add @salutejs/sdds-dfa@0.120.1-canary.1431.10831152564.0
  yarn add @salutejs/sdds-finportal@0.114.1-canary.1431.10831152564.0
  yarn add @salutejs/sdds-serv@0.121.1-canary.1431.10831152564.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
