### PR TITLE
feat(plasma-new-hope): Add TextField ref to deps for placeholder

### DIFF
--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -88,7 +88,9 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldProps>) =
 
             const controlledRefs = { contentRef, inputRef, chipsRefs };
 
-            const [hasValue, setHasValue] = useState(Boolean(outerValue) || Boolean(rest?.defaultValue));
+            const [hasValue, setHasValue] = useState(
+                Boolean(outerValue) || Boolean(inputRef?.current?.value) || Boolean(rest?.defaultValue),
+            );
             const [chips, setChips] = useState<Array<ChipValues>>([]);
 
             const uniqId = safeUseId();
@@ -198,8 +200,12 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldProps>) =
             }, [isChipEnumeration, values]);
 
             useEffect(() => {
-                setHasValue(Boolean(outerValue) || Boolean(rest?.defaultValue));
-            }, [outerValue, rest.defaultValue]);
+                setHasValue(Boolean(rest?.defaultValue));
+            }, [rest.defaultValue]);
+
+            useEffect(() => {
+                setHasValue(Boolean(outerValue) || Boolean(inputRef?.current?.value));
+            }, [outerValue, inputRef?.current?.value]);
 
             const innerOptional = Boolean(required ? false : optional);
             const hasPlaceholderOptional = innerOptional && !innerLabelValue && !hasOuterLabel;


### PR DESCRIPTION
### TextField

- ref добавлена в зависимости для определения отображения placeholder

### What/why changed

Ref добавлена в зависимости для определения отображения placeholder. Была проблема с отображением placeholder, при установке его значения через ref.current.value

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.152.0-canary.1433.10848014265.0
  npm install @salutejs/plasma-b2c@1.394.0-canary.1433.10848014265.0
  npm install @salutejs/plasma-new-hope@0.145.0-canary.1433.10848014265.0
  npm install @salutejs/plasma-web@1.396.0-canary.1433.10848014265.0
  npm install @salutejs/sdds-cs@0.124.0-canary.1433.10848014265.0
  npm install @salutejs/sdds-dfa@0.122.0-canary.1433.10848014265.0
  npm install @salutejs/sdds-finportal@0.116.0-canary.1433.10848014265.0
  npm install @salutejs/sdds-serv@0.123.0-canary.1433.10848014265.0
  # or 
  yarn add @salutejs/plasma-asdk@0.152.0-canary.1433.10848014265.0
  yarn add @salutejs/plasma-b2c@1.394.0-canary.1433.10848014265.0
  yarn add @salutejs/plasma-new-hope@0.145.0-canary.1433.10848014265.0
  yarn add @salutejs/plasma-web@1.396.0-canary.1433.10848014265.0
  yarn add @salutejs/sdds-cs@0.124.0-canary.1433.10848014265.0
  yarn add @salutejs/sdds-dfa@0.122.0-canary.1433.10848014265.0
  yarn add @salutejs/sdds-finportal@0.116.0-canary.1433.10848014265.0
  yarn add @salutejs/sdds-serv@0.123.0-canary.1433.10848014265.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
