### PR TITLE
plasma-*: Fixed issue with predefined value in single Combobox

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
@@ -63,7 +63,10 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             closeAfterSelect: outerCloseAfterSelect,
             ...rest
         } = props;
-        const [textValue, setTextValue] = useState('');
+        // Создаем структуры для быстрой работы с деревом
+        const [valueToCheckedMap, valueToItemMap, labelToItemMap] = useMemo(() => getTreeMaps(items), [items]);
+
+        const [textValue, setTextValue] = useState(valueToItemMap.get(outerValue as string)?.label || '');
         const [internalValue, setInternalValue] = useState<string | string[]>(multiple ? [] : '');
 
         const value = outerValue || internalValue;
@@ -74,9 +77,6 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
         const treeId = safeUseId();
 
         const transformedItems = useMemo(() => initialItemsTransform(items || []), [items]);
-
-        // Создаем структуры для быстрой работы с деревом
-        const [valueToCheckedMap, valueToItemMap, labelToItemMap] = useMemo(() => getTreeMaps(items), [items]);
 
         const filteredItems = filterItems(
             transformedItems,


### PR DESCRIPTION
### Combobox

- исправлен баг, когда прокидывалось изначальное значение значение в single combobox, но не отображалось;
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.154.0-canary.1436.10882554984.0
  npm install @salutejs/plasma-b2c@1.396.0-canary.1436.10882554984.0
  npm install @salutejs/plasma-new-hope@0.146.0-canary.1436.10882554984.0
  npm install @salutejs/plasma-web@1.398.0-canary.1436.10882554984.0
  npm install @salutejs/sdds-cs@0.126.0-canary.1436.10882554984.0
  npm install @salutejs/sdds-dfa@0.124.0-canary.1436.10882554984.0
  npm install @salutejs/sdds-finportal@0.118.0-canary.1436.10882554984.0
  npm install @salutejs/sdds-serv@0.125.0-canary.1436.10882554984.0
  # or 
  yarn add @salutejs/plasma-asdk@0.154.0-canary.1436.10882554984.0
  yarn add @salutejs/plasma-b2c@1.396.0-canary.1436.10882554984.0
  yarn add @salutejs/plasma-new-hope@0.146.0-canary.1436.10882554984.0
  yarn add @salutejs/plasma-web@1.398.0-canary.1436.10882554984.0
  yarn add @salutejs/sdds-cs@0.126.0-canary.1436.10882554984.0
  yarn add @salutejs/sdds-dfa@0.124.0-canary.1436.10882554984.0
  yarn add @salutejs/sdds-finportal@0.118.0-canary.1436.10882554984.0
  yarn add @salutejs/sdds-serv@0.125.0-canary.1436.10882554984.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
