### PR TITLE
plasma-*: Focus TextArea by click inside

### DIFF
--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -169,10 +169,25 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaProps>
                 if (value === undefined) {
                     setUncontrolledValue(event?.target.value);
                 }
+
                 onChange?.(event);
             },
             [value, onChange],
         );
+
+        const handleTextAreaFocus = () => {
+            if (readOnly || disabled || !outerRef?.current) {
+                return;
+            }
+
+            outerRef.current.scrollTo({
+                top: 0,
+                left: outerRef.current.offsetLeft,
+                behavior: 'smooth',
+            });
+
+            outerRef.current.focus();
+        };
 
         const dynamicLabelClasses = getDynamicLabelClasses(
             {
@@ -202,6 +217,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaProps>
                 clear={clear}
                 style={{ width: helperWidth, ...style }}
                 className={cx(clearClass, hasDividerClass, className)}
+                onClick={handleTextAreaFocus}
             >
                 {hasOuterLabel && (
                     <StyledLabel>


### PR DESCRIPTION
### TextArea 

- добавлена фокусировка по клику на дочерние элементы

### What/why changed

По клику на helpers / icons будет появляться курсор на TextArea

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.175.1-canary.1444.11348071542.0
  npm install @salutejs/plasma-b2c@1.417.1-canary.1444.11348071542.0
  npm install @salutejs/plasma-new-hope@0.166.1-canary.1444.11348071542.0
  npm install @salutejs/plasma-web@1.419.1-canary.1444.11348071542.0
  npm install @salutejs/sdds-cs@0.147.1-canary.1444.11348071542.0
  npm install @salutejs/sdds-dfa@0.145.1-canary.1444.11348071542.0
  npm install @salutejs/sdds-finportal@0.139.1-canary.1444.11348071542.0
  npm install @salutejs/sdds-serv@0.146.1-canary.1444.11348071542.0
  # or 
  yarn add @salutejs/plasma-asdk@0.175.1-canary.1444.11348071542.0
  yarn add @salutejs/plasma-b2c@1.417.1-canary.1444.11348071542.0
  yarn add @salutejs/plasma-new-hope@0.166.1-canary.1444.11348071542.0
  yarn add @salutejs/plasma-web@1.419.1-canary.1444.11348071542.0
  yarn add @salutejs/sdds-cs@0.147.1-canary.1444.11348071542.0
  yarn add @salutejs/sdds-dfa@0.145.1-canary.1444.11348071542.0
  yarn add @salutejs/sdds-finportal@0.139.1-canary.1444.11348071542.0
  yarn add @salutejs/sdds-serv@0.146.1-canary.1444.11348071542.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
