### PR TITLE
[PLASMA-3579]: Improved tree shaking

### DIFF
--- a/packages/plasma-b2c/css/package.json
+++ b/packages/plasma-b2c/css/package.json
@@ -1,5 +1,6 @@
 {
     "module": "es/index.js",
     "main": "cjs/index.js",
-    "types": "index.d.ts"
+    "types": "index.d.ts",
+    "sideEffects": ["*.css"]
 }

--- a/packages/plasma-new-hope/emotion/package.json
+++ b/packages/plasma-new-hope/emotion/package.json
@@ -1,5 +1,6 @@
 {
     "module": "es/index.js",
     "main": "cjs/index.js",
-    "types": "../types/index.d.ts"
+    "types": "../types/index.d.ts",
+    "sideEffects": false
 }

--- a/packages/plasma-new-hope/package.json
+++ b/packages/plasma-new-hope/package.json
@@ -123,5 +123,6 @@
     "react-draggable": "4.4.3",
     "react-popper": "2.3.0",
     "storeon": "3.1.5"
-  }
+  },
+  "sideEffects": ["*.css"]
 }

--- a/packages/plasma-new-hope/styled-components/package.json
+++ b/packages/plasma-new-hope/styled-components/package.json
@@ -1,5 +1,6 @@
 {
     "module": "es/index.js",
     "main": "cjs/index.js",
-    "types": "../types/index.d.ts"
+    "types": "../types/index.d.ts",
+    "sideEffects": false
 }

--- a/packages/plasma-web/css/package.json
+++ b/packages/plasma-web/css/package.json
@@ -1,5 +1,6 @@
 {
     "module": "es/index.js",
     "main": "cjs/index.js",
-    "types": "index.d.ts"
+    "types": "index.d.ts",
+    "sideEffects": ["*.css"]
 }


### PR DESCRIPTION
### What/why changed

#### Пример для тестирования - https://stackblitz.com/edit/vitejs-vite-mdq2av

Для корректной работы tree shaking в наших пакетах сделали следующее.

Добавили свойство `sideEffects` в `plasma-new-hope`: 
- в root  используем `"sideEffects": ["*.css"]`
- для styled-components\emotion используем `"sideEffects": false`

Добавили свойство `sideEffects` в `plasma-{web, b2c}\css`: 
- используем `"sideEffects": ["*.css"]`

Данные собраны на примере: 

```tsx
import React from 'react';
import { TextField, Button, TextArea } from '@salutejs/plasma-web/css';

export function App() {
	return (
		<div style={{display: 'flex', flexDirection: 'column', gap: '2rem'}}>
			<TextField placeholder="Plasma WEB CSS" size="l" />
			<Button view="accent" text="Plasma WEB CSS"/>
		</div>
	);
}
``` 

**BEFORE:**

### build dev `"@salutejs/plasma-web": latest`

<img width="338" src="https://github.com/user-attachments/assets/07c49f62-8422-4fb8-adea-6b7704595af5" />

<img width="1024" src="https://github.com/user-attachments/assets/c5b974ee-a97e-41e7-a472-8e032ea6e551" />

------

**AFTER:**

### build dev `"@salutejs/plasma-web": "^1.413.1-canary.1448.11178495216.0"`

<img width="332" src="https://github.com/user-attachments/assets/4e6fbaa5-0a1e-47ee-9620-f9c0dde76298" />

<img width="1024" src="https://github.com/user-attachments/assets/6cfc7833-03b9-4f3f-9e2e-bfe43093d136" />

<img width="1024" src="https://github.com/user-attachments/assets/86540eed-7455-4ffb-bc60-41b3a9b8b950" />


### build dev `"@salutejs/plasma-b2c": "^1.411.1-canary.1448.11178495216.0"`

<img width="330" src="https://github.com/user-attachments/assets/4012b87b-55a1-4754-89b7-46726030ab18" />

<img width="1024" src="https://github.com/user-attachments/assets/4049a1fa-4e9b-4eb7-a1b5-fb76e5e6b42c" />

<img width="1024" src="https://github.com/user-attachments/assets/543aab83-81e4-406c-bc95-fc15056dcab5" />


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.182.1-canary.1448.11473442920.0
  npm install @salutejs/plasma-b2c@1.424.1-canary.1448.11473442920.0
  npm install @salutejs/plasma-new-hope@0.173.1-canary.1448.11473442920.0
  npm install @salutejs/plasma-web@1.426.1-canary.1448.11473442920.0
  npm install @salutejs/sdds-cs@0.154.1-canary.1448.11473442920.0
  npm install @salutejs/sdds-dfa@0.152.1-canary.1448.11473442920.0
  npm install @salutejs/sdds-finportal@0.146.1-canary.1448.11473442920.0
  npm install @salutejs/sdds-serv@0.153.1-canary.1448.11473442920.0
  # or 
  yarn add @salutejs/plasma-asdk@0.182.1-canary.1448.11473442920.0
  yarn add @salutejs/plasma-b2c@1.424.1-canary.1448.11473442920.0
  yarn add @salutejs/plasma-new-hope@0.173.1-canary.1448.11473442920.0
  yarn add @salutejs/plasma-web@1.426.1-canary.1448.11473442920.0
  yarn add @salutejs/sdds-cs@0.154.1-canary.1448.11473442920.0
  yarn add @salutejs/sdds-dfa@0.152.1-canary.1448.11473442920.0
  yarn add @salutejs/sdds-finportal@0.146.1-canary.1448.11473442920.0
  yarn add @salutejs/sdds-serv@0.153.1-canary.1448.11473442920.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
