### PR TITLE
feat(plasma-web, b2c): Added mappings for placement prop in Dropdown

### DIFF
--- a/packages/plasma-b2c/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-b2c/src/components/Dropdown/Dropdown.stories.tsx
@@ -24,6 +24,7 @@ const meta: Meta<DropdownProps> = {
             control: {
                 type: 'select',
             },
+            mapping: placements,
         },
         trigger: {
             options: triggers,

--- a/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
@@ -24,6 +24,7 @@ const meta: Meta<DropdownProps> = {
             control: {
                 type: 'select',
             },
+            mapping: placements,
         },
         trigger: {
             options: triggers,

--- a/packages/sdds-cs/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-cs/src/components/Combobox/Combobox.stories.tsx
@@ -17,7 +17,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/ComboboxNew',
+    title: 'Controls/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-dfa/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/ComboboxNew',
+    title: 'Controls/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-finportal/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/ComboboxNew',
+    title: 'Controls/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/sdds-serv/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-serv/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/ComboboxNew',
+    title: 'Controls/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {


### PR DESCRIPTION
### Dropdown

- исправлен баг с некорректной работой св-ва `placement` в storybook в новой вкладке;
- убрана приписка `new` в названиях сторей для `combobox` в sdds-*;

### What/why changed

Исправлен баг с некорректной работой св-ва `placement` в storybook при открытии новой вкладки.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.402.1-canary.1455.11029890540.0
  npm install @salutejs/plasma-web@1.404.1-canary.1455.11029890540.0
  npm install @salutejs/sdds-cs@0.132.1-canary.1455.11029890540.0
  npm install @salutejs/sdds-dfa@0.130.1-canary.1455.11029890540.0
  npm install @salutejs/sdds-finportal@0.124.1-canary.1455.11029890540.0
  npm install @salutejs/sdds-serv@0.131.1-canary.1455.11029890540.0
  # or 
  yarn add @salutejs/plasma-b2c@1.402.1-canary.1455.11029890540.0
  yarn add @salutejs/plasma-web@1.404.1-canary.1455.11029890540.0
  yarn add @salutejs/sdds-cs@0.132.1-canary.1455.11029890540.0
  yarn add @salutejs/sdds-dfa@0.130.1-canary.1455.11029890540.0
  yarn add @salutejs/sdds-finportal@0.124.1-canary.1455.11029890540.0
  yarn add @salutejs/sdds-serv@0.131.1-canary.1455.11029890540.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
