### PR TITLE
[PLASMA-3591]: Fix Accordion types 

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -346,7 +346,7 @@ filled: PolymorphicClassName;
 fixed: PolymorphicClassName;
 };
 }> & {
-view: string;
+view?: string | undefined;
 size?: string | undefined;
 singleActive?: boolean | undefined;
 defaultActiveEventKey?: number[] | undefined;
@@ -1425,7 +1425,7 @@ l: PolymorphicClassName;
 view: {
 default: PolymorphicClassName;
 };
-}> & Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "size" | "value" | "type" | "target" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
+}> & Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value" | "type" | "target" | "size" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
     valueType?: "single" | undefined;
     value?: ComboboxPrimitiveValue | undefined;
     onChangeValue?: ((value?: ComboboxPrimitiveValue | undefined) => void) | undefined;
@@ -1441,7 +1441,7 @@ l: PolymorphicClassName;
 view: {
 default: PolymorphicClassName;
 };
-}> & Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "size" | "value" | "type" | "target" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
+}> & Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value" | "type" | "target" | "size" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
     valueType: "multiple";
     value?: ComboboxPrimitiveValue[] | undefined;
     onChangeValue?: ((value?: ComboboxPrimitiveValue[] | undefined) => void) | undefined;

--- a/packages/plasma-new-hope/src/components/Accordion/Accordion.types.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/Accordion.types.ts
@@ -4,7 +4,7 @@ type CustomAccordionProps = {
     /**
      * Тип аккордеона
      */
-    view: string;
+    view?: string;
 
     /**
      * Размер

--- a/packages/plasma-new-hope/src/components/Accordion/Accordion.types.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/Accordion.types.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 type CustomAccordionProps = {
     /**
-     * Тип аккордеона
+     * Тип отображения для accordion
      */
     view?: string;
 
@@ -12,7 +12,7 @@ type CustomAccordionProps = {
     size?: string;
 
     /**
-     * Возможность раскрытия всех элементов или только одногo
+     * Возможность раскрытия всех элементов или только одного
      */
     singleActive?: boolean;
 
@@ -32,7 +32,7 @@ type CustomAccordionProps = {
     stretching?: 'fixed' | 'filled';
 
     /**
-     * Коллбэк при открытии или закрытии элемента аккордеона
+     * Callback при открытии или закрытии элемента accordion
      */
     onChange?: (index?: number, value?: boolean) => void;
 

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect } from 'react';
 
 import { convertRoundnessMatrix } from '../../../../utils/roundness';
 import { classes, tokens } from '../../Accordion.tokens';
-import { HTMLAttributesWithoutOnChange } from '../../../../engines/types';
 import { cx } from '../../../../utils';
 
 import {
@@ -20,7 +19,7 @@ import {
 } from './AccordionItem.styles';
 import type { AccordionItemProps } from './AccordionItem.types';
 
-export const AccordionItem: React.FC<HTMLAttributesWithoutOnChange<HTMLElement> & AccordionItemProps> = ({
+export const AccordionItem: React.FC<AccordionItemProps> = ({
     value,
     contentRight,
     contentLeft,

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.types.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.types.ts
@@ -1,8 +1,8 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, HTMLAttributes } from 'react';
 
 import type { Pin } from '../../../../utils/roundness';
 
-type CustomAccordionItemProps = {
+type Props = {
     /**
      * Значение раскрытия accordion
      */
@@ -73,4 +73,4 @@ type CustomAccordionItemProps = {
     view?: string;
 };
 
-export type AccordionItemProps = CustomAccordionItemProps;
+export type AccordionItemProps = Omit<HTMLAttributes<HTMLElement>, 'onChange' | 'title'> & Props;

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.types.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.types.ts
@@ -4,7 +4,7 @@ import type { Pin } from '../../../../utils/roundness';
 
 type CustomAccordionItemProps = {
     /**
-     * Значение раскрытия аккордеона
+     * Значение раскрытия accordion
      */
     value?: boolean;
 
@@ -29,12 +29,12 @@ type CustomAccordionItemProps = {
     contentRight?: ReactNode;
 
     /**
-     * Скругление аккордеона
+     * Скругление accordion
      */
     pin?: Pin;
 
     /**
-     * Заголовок аккордеона
+     * Заголовок accordion
      */
     title: ReactNode;
 
@@ -44,7 +44,7 @@ type CustomAccordionItemProps = {
     children: ReactNode;
 
     /**
-     * @deprecated Внутренняя функция при открытии аккардеона (будет удалена в ближайшее время)
+     * @deprecated Внутренняя функция при открытии accordion (будет удалена в ближайшее время)
      */
     onChange?: (index: number, value: boolean) => void;
 
@@ -67,7 +67,10 @@ type CustomAccordionItemProps = {
      */
     index?: number;
 
-    view: string;
+    /**
+     * @deprecated Внутреннее свойство (будет удалено в ближайшее время)
+     */
+    view?: string;
 };
 
 export type AccordionItemProps = CustomAccordionItemProps;

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -346,7 +346,7 @@ filled: PolymorphicClassName;
 fixed: PolymorphicClassName;
 };
 }> & {
-view: string;
+view?: string | undefined;
 size?: string | undefined;
 singleActive?: boolean | undefined;
 defaultActiveEventKey?: number[] | undefined;
@@ -1426,7 +1426,7 @@ l: PolymorphicClassName;
 view: {
 default: PolymorphicClassName;
 };
-}> & Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "size" | "value" | "type" | "target" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
+}> & Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value" | "type" | "target" | "size" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
     valueType?: "single" | undefined;
     value?: ComboboxPrimitiveValue | undefined;
     onChangeValue?: ((value?: ComboboxPrimitiveValue | undefined) => void) | undefined;
@@ -1442,7 +1442,7 @@ l: PolymorphicClassName;
 view: {
 default: PolymorphicClassName;
 };
-}> & Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "size" | "value" | "type" | "target" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
+}> & Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value" | "type" | "target" | "size" | "checked" | "minLength" | "maxLength"> & CustomComboboxProps & {
     valueType: "multiple";
     value?: ComboboxPrimitiveValue[] | undefined;
     onChangeValue?: ((value?: ComboboxPrimitiveValue[] | undefined) => void) | undefined;

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -226,7 +226,7 @@ size: {
 s: PolymorphicClassName;
 };
 }> & {
-view: string;
+view?: string | undefined;
 size?: string | undefined;
 singleActive?: boolean | undefined;
 defaultActiveEventKey?: number[] | undefined;

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -231,7 +231,7 @@ s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
 }> & {
-view: string;
+view?: string | undefined;
 size?: string | undefined;
 singleActive?: boolean | undefined;
 defaultActiveEventKey?: number[] | undefined;

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -231,7 +231,7 @@ s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
 }> & {
-view: string;
+view?: string | undefined;
 size?: string | undefined;
 singleActive?: boolean | undefined;
 defaultActiveEventKey?: number[] | undefined;


### PR DESCRIPTION
### Accordion

- свойство `view` помечено как `optional`
- свойство `view` для AccordionItem помечено как `deprecated`      
- свойство `title` для `AccordionItem` теперь `ReactNode` 


### What/why changed



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.170.1-canary.1467.11208747391.0
  npm install @salutejs/plasma-b2c@1.412.1-canary.1467.11208747391.0
  npm install @salutejs/plasma-new-hope@0.161.1-canary.1467.11208747391.0
  npm install @salutejs/plasma-web@1.414.1-canary.1467.11208747391.0
  npm install @salutejs/sdds-cs@0.142.1-canary.1467.11208747391.0
  npm install @salutejs/sdds-dfa@0.140.1-canary.1467.11208747391.0
  npm install @salutejs/sdds-finportal@0.134.1-canary.1467.11208747391.0
  npm install @salutejs/sdds-serv@0.141.1-canary.1467.11208747391.0
  # or 
  yarn add @salutejs/plasma-asdk@0.170.1-canary.1467.11208747391.0
  yarn add @salutejs/plasma-b2c@1.412.1-canary.1467.11208747391.0
  yarn add @salutejs/plasma-new-hope@0.161.1-canary.1467.11208747391.0
  yarn add @salutejs/plasma-web@1.414.1-canary.1467.11208747391.0
  yarn add @salutejs/sdds-cs@0.142.1-canary.1467.11208747391.0
  yarn add @salutejs/sdds-dfa@0.140.1-canary.1467.11208747391.0
  yarn add @salutejs/sdds-finportal@0.134.1-canary.1467.11208747391.0
  yarn add @salutejs/sdds-serv@0.141.1-canary.1467.11208747391.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
