### PR TITLE
feat(plasma-new-hope): Got rid of styled-components imports in new-hope

### DIFF
--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 
 import { IconChevronDownFill, IconMinus } from '../../../_Icon';
 import { classes, tokens } from '../../Accordion.tokens';

--- a/packages/plasma-new-hope/src/components/Breadcrumbs/ui/BreadcrumbShorter/BreadcrumbShorter.styles.ts
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/ui/BreadcrumbShorter/BreadcrumbShorter.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 
 import { addFocus } from '../../../../mixins';
 import { tokens } from '../../Breadcrumbs.tokens';

--- a/packages/plasma-new-hope/src/components/ButtonBase/index.ts
+++ b/packages/plasma-new-hope/src/components/ButtonBase/index.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 
 import { addFocus } from '../../mixins';
 

--- a/packages/plasma-new-hope/src/components/Cell/Cell.styles.ts
+++ b/packages/plasma-new-hope/src/components/Cell/Cell.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
 import type { AlignProp } from './Cell.types';

--- a/packages/plasma-new-hope/src/components/Cell/ui/CellTextbox/CellTextbox.styles.ts
+++ b/packages/plasma-new-hope/src/components/Cell/ui/CellTextbox/CellTextbox.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 
 import { tokens } from '../../Cell.tokens';
 

--- a/packages/plasma-new-hope/src/components/Cell/ui/CellTextboxLabel/CellTextboxLabel.styles.ts
+++ b/packages/plasma-new-hope/src/components/Cell/ui/CellTextboxLabel/CellTextboxLabel.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 
 import { tokens } from '../../Cell.tokens';
 

--- a/packages/plasma-new-hope/src/components/Cell/ui/CellTextboxSubtitle/CellTextboxSubtitle.styles.ts
+++ b/packages/plasma-new-hope/src/components/Cell/ui/CellTextboxSubtitle/CellTextboxSubtitle.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 
 import { tokens } from '../../Cell.tokens';
 

--- a/packages/plasma-new-hope/src/components/Cell/ui/CellTextboxTitle/CellTextboxTitle.styles.ts
+++ b/packages/plasma-new-hope/src/components/Cell/ui/CellTextboxTitle/CellTextboxTitle.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 
 import { tokens } from '../../Cell.tokens';
 

--- a/packages/plasma-new-hope/src/components/Drawer/Drawer.styles.ts
+++ b/packages/plasma-new-hope/src/components/Drawer/Drawer.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import { styled } from '@linaria/react';
 
 import { component } from '../../engines';
 import { popupClasses, popupConfig } from '../Popup';
@@ -83,7 +83,7 @@ const templateAnimationStyle = (placement: DrawerPlacement) => `
                     transform: ${animationVariants[placement].hide.end};
                     opacity: 0;
                 }
-            }   
+            }
         }
     `;
 
@@ -128,8 +128,8 @@ export const StyledPopup = styled(Popup)<{
     }
 
     && .${popupClasses.root}, && .${popupClasses.root} > div {
-        width: ${({ width }) => width};
-        height: ${({ height }) => height};
+        width: ${({ width }) => width || 'auto'};
+        height: ${({ height }) => height || 'auto'};
     }
 
     ${getAnimationStyles()}


### PR DESCRIPTION
### Plasma-new-hope imports

Заменены импорты со `styled-components` на `linaria` в рамках пакета `plasma-new-hope`.

### What/why changed

Заменены импорты со `styled-components` на `linaria` в рамках пакета `plasma-new-hope`.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.170.0-canary.1468.11177090450.0
  npm install @salutejs/plasma-b2c@1.412.0-canary.1468.11177090450.0
  npm install @salutejs/plasma-new-hope@0.161.0-canary.1468.11177090450.0
  npm install @salutejs/plasma-web@1.414.0-canary.1468.11177090450.0
  npm install @salutejs/sdds-cs@0.142.0-canary.1468.11177090450.0
  npm install @salutejs/sdds-dfa@0.140.0-canary.1468.11177090450.0
  npm install @salutejs/sdds-finportal@0.134.0-canary.1468.11177090450.0
  npm install @salutejs/sdds-serv@0.141.0-canary.1468.11177090450.0
  # or 
  yarn add @salutejs/plasma-asdk@0.170.0-canary.1468.11177090450.0
  yarn add @salutejs/plasma-b2c@1.412.0-canary.1468.11177090450.0
  yarn add @salutejs/plasma-new-hope@0.161.0-canary.1468.11177090450.0
  yarn add @salutejs/plasma-web@1.414.0-canary.1468.11177090450.0
  yarn add @salutejs/sdds-cs@0.142.0-canary.1468.11177090450.0
  yarn add @salutejs/sdds-dfa@0.140.0-canary.1468.11177090450.0
  yarn add @salutejs/sdds-finportal@0.134.0-canary.1468.11177090450.0
  yarn add @salutejs/sdds-serv@0.141.0-canary.1468.11177090450.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
