### PR TITLE
feat(plasma-new-hope, *-docs): Add onClick for item to `Breadcrumbs` component

### DIFF
--- a/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.styles.ts
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.styles.ts
@@ -13,6 +13,9 @@ const Link = component(mergedLinkConfig);
 
 export const StyledLink = styled(Link)<{ isHref: boolean }>`
     opacity: ${({ isHref }) => (isHref ? 1 : `var(${tokens.breadcrumbsOpacity})`)};
+    cursor: ${({ isHref }) => (isHref ? 'pointer' : 'auto')};
+
+    --plasma-link-disabled-opacity: var(${tokens.breadcrumbsOpacity});
 
     ${addFocus({
         outlineOffset: '0rem',

--- a/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.template-doc.mdx
@@ -8,7 +8,51 @@ import { PropsTable } from '@site/src/components';
 # Breadcrumbs
 <PropsTable name="Breadcrumbs" />
 
-# Обычное использование
+# Типизация элементов
+
+Параметр `items` является обязательным и поддерживает следующие типы:
+
+```tsx
+type Items =
+    | {
+          /**
+           * Обработчик клика на элемент
+           */
+          onClick?: () => void;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+      }
+    | {
+          /**
+           * Ссылка на страницу ( если не указана, то ссылка не кликабельна )
+           */
+          href?: string;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+      }
+    | {
+          /**
+           * Функция рендера элемента
+           */
+          renderItem: () => ReactNode;
+      };
+```
+
+При использовании одного из трёх вариантов, свойства остальных будут не доступны.
+
+# Пример
 
 ```tsx live
 import React from 'react';
@@ -17,9 +61,17 @@ import { Breadcrumbs } from '@salutejs/{{ package }}';
 export function App() {
     const items = [
         { title: 'Home', href: '/' },
-        { title: 'About as', href: '/' },
-        { renderItem: () => <span>Custom Item</span> },
-        { title: 'Contacts' },
+        { title: 'Without link' },
+        { title: 'Disabled', disabled: true },
+        { title: 'Disabled with link', href: '/', disabled: true },
+        {
+            title: 'On Click',
+            onClick: () => {
+                alert('On Click');
+            },
+        },
+        { renderItem: () => <span style=\{{ cursor: 'pointer' }}>Custom </span> },
+        { title: 'Main' },
     ];
 
     return (

--- a/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -18,7 +18,9 @@ export const breadcrumbsRoot = (Root: RootProps<HTMLDivElement, BreadcrumbsProps
 
             return (
                 <Root ref={outerRootRef} size={size} view={view} className={cx(className)} items={items}>
-                    {itemsWithSeparator.map((item) => item)}
+                    {itemsWithSeparator.map((item, index) => (
+                        <React.Fragment key={index}>{item}</React.Fragment>
+                    ))}
                 </Root>
             );
         },

--- a/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.types.ts
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.types.ts
@@ -3,20 +3,48 @@ import { HTMLAttributes, ReactNode } from 'react';
 export type BreadcrumbsItem =
     | {
           /**
-           * Ссылка на страницу ( если не указана, то ссылка не кликабельна )
+           * Обработчик клика на элемент
            */
-          href?: string;
-
+          onClick?: () => void;
           /**
            * Элемент заголовка
            */
           title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+
+          href?: never;
+          renderItem?: never;
+      }
+    | {
+          /**
+           * Ссылка на страницу ( если не указана, то ссылка не кликабельна )
+           */
+          href?: string;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+
+          onClick?: never;
+          renderItem?: never;
       }
     | {
           /**
            * Функция рендера элемента
            */
           renderItem: () => ReactNode;
+
+          onClick?: never;
+          disabled?: never;
+          href?: never;
+          title?: never;
       };
 
 type Breadcrumbs = {

--- a/packages/plasma-new-hope/src/components/Breadcrumbs/utils/index.tsx
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/utils/index.tsx
@@ -31,12 +31,21 @@ export const convertIconSize = (size?: string) => {
 export const getRenderItems = (items: BreadcrumbsItem[], renderSeparator: ReactNode, showItems?: number) => {
     const renderItems = shortItems(
         items.map((item: BreadcrumbsItem) => {
-            if ('renderItem' in item) {
+            if (item.renderItem) {
                 return item.renderItem();
             }
+
+            const { title, disabled, href, onClick } = item;
+
             return (
-                <StyledLink tabIndex={0} href={item.href} isHref={Boolean(item.href)}>
-                    {item.title}
+                <StyledLink
+                    tabIndex={0}
+                    href={href}
+                    disabled={disabled}
+                    onClick={onClick}
+                    isHref={Boolean(href || onClick)}
+                >
+                    {title}
                 </StyledLink>
             );
         }),

--- a/website/plasma-b2c-docs/docs/components/Breadcrumbs.mdx
+++ b/website/plasma-b2c-docs/docs/components/Breadcrumbs.mdx
@@ -56,7 +56,7 @@ type Items =
 
 ```tsx live
 import React from 'react';
-import { Breadcrumbs } from '@salutejs/plasma-web';
+import { Breadcrumbs } from '@salutejs/plasma-b2c';
 
 export function App() {
     const items = [
@@ -84,7 +84,7 @@ export function App() {
 # Использование с shorter
 ```tsx live
 import React from 'react';
-import { Breadcrumbs } from '@salutejs/plasma-web';
+import { Breadcrumbs } from '@salutejs/plasma-b2c';
 
 export function App() {
     const items = [
@@ -110,7 +110,7 @@ export function App() {
 # Использование с кастомным элементом
 ```tsx live
 import React from 'react';
-import { Breadcrumbs, Dropdown } from '@salutejs/plasma-web';
+import { Breadcrumbs, Dropdown } from '@salutejs/plasma-b2c';
 
 export function App() {
     const items = [

--- a/website/sdds-cs-docs/docs/components/Breadcrumbs.mdx
+++ b/website/sdds-cs-docs/docs/components/Breadcrumbs.mdx
@@ -8,18 +8,70 @@ import { PropsTable } from '@site/src/components';
 # Breadcrumbs
 <PropsTable name="Breadcrumbs" />
 
-# Обычное использование
+# Типизация элементов
+
+Параметр `items` является обязательным и поддерживает следующие типы:
+
+```tsx
+type Items =
+    | {
+          /**
+           * Обработчик клика на элемент
+           */
+          onClick?: () => void;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+      }
+    | {
+          /**
+           * Ссылка на страницу ( если не указана, то ссылка не кликабельна )
+           */
+          href?: string;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+      }
+    | {
+          /**
+           * Функция рендера элемента
+           */
+          renderItem: () => ReactNode;
+      };
+```
+
+При использовании одного из трёх вариантов, свойства остальных будут не доступны.
+
+# Пример
 
 ```tsx live
 import React from 'react';
-import { Breadcrumbs } from '@salutejs/sdds-serv';
+import { Breadcrumbs } from '@salutejs/sdds-cs';
 
 export function App() {
     const items = [
         { title: 'Home', href: '/' },
-        { title: 'About as', href: '/' },
-        { renderItem: () => <span>Custom Item</span> },
-        { title: 'Contacts' },
+        { title: 'Without link' },
+        { title: 'Disabled', disabled: true },
+        { title: 'Disabled with link', href: '/', disabled: true },
+        {
+            title: 'On Click',
+            onClick: () => {
+                alert('On Click');
+            },
+        },
+        { renderItem: () => <span style={{ cursor: 'pointer' }}>Custom </span> },
+        { title: 'Main' },
     ];
 
     return (
@@ -32,7 +84,7 @@ export function App() {
 # Использование с shorter
 ```tsx live
 import React from 'react';
-import { Breadcrumbs } from '@salutejs/sdds-serv';
+import { Breadcrumbs } from '@salutejs/sdds-cs';
 
 export function App() {
     const items = [
@@ -58,7 +110,7 @@ export function App() {
 # Использование с кастомным элементом
 ```tsx live
 import React from 'react';
-import { Breadcrumbs, Dropdown } from '@salutejs/sdds-serv';
+import { Breadcrumbs, Dropdown } from '@salutejs/sdds-cs';
 
 export function App() {
     const items = [

--- a/website/sdds-dfa-docs/docs/components/Breadcrumbs.mdx
+++ b/website/sdds-dfa-docs/docs/components/Breadcrumbs.mdx
@@ -8,7 +8,51 @@ import { PropsTable } from '@site/src/components';
 # Breadcrumbs
 <PropsTable name="Breadcrumbs" />
 
-# Обычное использование
+# Типизация элементов
+
+Параметр `items` является обязательным и поддерживает следующие типы:
+
+```tsx
+type Items =
+    | {
+          /**
+           * Обработчик клика на элемент
+           */
+          onClick?: () => void;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+      }
+    | {
+          /**
+           * Ссылка на страницу ( если не указана, то ссылка не кликабельна )
+           */
+          href?: string;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+      }
+    | {
+          /**
+           * Функция рендера элемента
+           */
+          renderItem: () => ReactNode;
+      };
+```
+
+При использовании одного из трёх вариантов, свойства остальных будут не доступны.
+
+# Пример
 
 ```tsx live
 import React from 'react';
@@ -17,9 +61,17 @@ import { Breadcrumbs } from '@salutejs/sdds-dfa';
 export function App() {
     const items = [
         { title: 'Home', href: '/' },
-        { title: 'About as', href: '/' },
-        { renderItem: () => <span>Custom Item</span> },
-        { title: 'Contacts' },
+        { title: 'Without link' },
+        { title: 'Disabled', disabled: true },
+        { title: 'Disabled with link', href: '/', disabled: true },
+        {
+            title: 'On Click',
+            onClick: () => {
+                alert('On Click');
+            },
+        },
+        { renderItem: () => <span style={{ cursor: 'pointer' }}>Custom </span> },
+        { title: 'Main' },
     ];
 
     return (

--- a/website/sdds-serv-docs/docs/components/Breadcrumbs.mdx
+++ b/website/sdds-serv-docs/docs/components/Breadcrumbs.mdx
@@ -8,7 +8,51 @@ import { PropsTable } from '@site/src/components';
 # Breadcrumbs
 <PropsTable name="Breadcrumbs" />
 
-# Обычное использование
+# Типизация элементов
+
+Параметр `items` является обязательным и поддерживает следующие типы:
+
+```tsx
+type Items =
+    | {
+          /**
+           * Обработчик клика на элемент
+           */
+          onClick?: () => void;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+      }
+    | {
+          /**
+           * Ссылка на страницу ( если не указана, то ссылка не кликабельна )
+           */
+          href?: string;
+          /**
+           * Элемент заголовка
+           */
+          title: string;
+          /**
+           * Элемент выключен
+           */
+          disabled?: boolean;
+      }
+    | {
+          /**
+           * Функция рендера элемента
+           */
+          renderItem: () => ReactNode;
+      };
+```
+
+При использовании одного из трёх вариантов, свойства остальных будут не доступны.
+
+# Пример
 
 ```tsx live
 import React from 'react';
@@ -17,9 +61,17 @@ import { Breadcrumbs } from '@salutejs/sdds-serv';
 export function App() {
     const items = [
         { title: 'Home', href: '/' },
-        { title: 'About as', href: '/' },
-        { renderItem: () => <span>Custom Item</span> },
-        { title: 'Contacts' },
+        { title: 'Without link' },
+        { title: 'Disabled', disabled: true },
+        { title: 'Disabled with link', href: '/', disabled: true },
+        {
+            title: 'On Click',
+            onClick: () => {
+                alert('On Click');
+            },
+        },
+        { renderItem: () => <span style={{ cursor: 'pointer' }}>Custom </span> },
+        { title: 'Main' },
     ];
 
     return (


### PR DESCRIPTION
### Breadcrumbs

* Добавлена поддержка обработчика `onClick` при клике на ссылку
* Поправлены union типы 
* Обновлена документация с указанием типов элементов

### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.173.0-canary.1480.11325361501.0
  npm install @salutejs/plasma-b2c@1.415.0-canary.1480.11325361501.0
  npm install @salutejs/plasma-new-hope@0.164.0-canary.1480.11325361501.0
  npm install @salutejs/plasma-web@1.417.0-canary.1480.11325361501.0
  npm install @salutejs/sdds-cs@0.145.0-canary.1480.11325361501.0
  npm install @salutejs/sdds-dfa@0.143.0-canary.1480.11325361501.0
  npm install @salutejs/sdds-finportal@0.137.0-canary.1480.11325361501.0
  npm install @salutejs/sdds-serv@0.144.0-canary.1480.11325361501.0
  # or 
  yarn add @salutejs/plasma-asdk@0.173.0-canary.1480.11325361501.0
  yarn add @salutejs/plasma-b2c@1.415.0-canary.1480.11325361501.0
  yarn add @salutejs/plasma-new-hope@0.164.0-canary.1480.11325361501.0
  yarn add @salutejs/plasma-web@1.417.0-canary.1480.11325361501.0
  yarn add @salutejs/sdds-cs@0.145.0-canary.1480.11325361501.0
  yarn add @salutejs/sdds-dfa@0.143.0-canary.1480.11325361501.0
  yarn add @salutejs/sdds-finportal@0.137.0-canary.1480.11325361501.0
  yarn add @salutejs/sdds-serv@0.144.0-canary.1480.11325361501.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
