### PR TITLE
`plasma-new-hope`: fix Attach

### DIFF
--- a/packages/plasma-new-hope/src/components/Attach/Attach.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Attach/Attach.template-doc.mdx
@@ -61,3 +61,72 @@ export function App() {
     );
 }
 ```
+
+### Пример использования в форме
+
+```tsx live
+import React, { useState } from 'react';
+import { Attach, Button } from '@salutejs/{{ package }}';
+
+function App() {
+    const ids = ['0', '1', '2'];
+    const [isLoading, setIsLoading] = useState(false);
+    const [attachedFiles, setAttachedFiles] = useState([]);
+
+    const handleAttachFile = (e) => {
+        setAttachedFiles((prevAttachedFiles) => [
+            ...prevAttachedFiles,
+            {
+                fileData: e.target.files[0],
+                id: e.target.id,
+            },
+        ]);
+    };
+
+    const handleAttachClear = (id) => {
+        setAttachedFiles(attachedFiles.filter((file) => file.id !== id));
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setIsLoading(true);
+  
+        const formData = new FormData(e.target);
+        console.log('formData', Object.fromEntries(formData));
+
+        setTimeout(() => {
+            setAttachedFiles([]);
+            setIsLoading(false);
+        }, 2000);
+    };
+
+    return (
+        <>
+            <span>{isLoading ? 'Форма отправляется' : 'Прикрепленные файлы:'}</span>
+            {!isLoading && attachedFiles.length > 0 && (
+                <div style=\{{ display: 'flex', flexDirection: 'column', gap: '0px' }}>
+                    {attachedFiles.map((file) => (
+                        <span>{file.fileData.name}</span>
+                    ))}
+                </div>
+            )}
+
+            {!isLoading && (
+                <form onSubmit={handleSubmit} style=\{{ display: 'flex', flexDirection: 'column', gap: '30px' }}>
+                    {ids.map((id) => (
+                        <Attach
+                            id={id}
+                            name={`attach${id}`}
+                            text={`Загрузить файл ${id}`}
+                            onChange={handleAttachFile}
+                            onClear={() => handleAttachClear(id)}
+                        />
+                    ))}
+
+                    <Button type="submit">Отправить</Button>
+                </form>
+            )}
+        </>
+    );
+}
+```

--- a/packages/plasma-new-hope/src/components/Attach/Attach.tsx
+++ b/packages/plasma-new-hope/src/components/Attach/Attach.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { useForkRef, useIsomorphicLayoutEffect } from '@salutejs/plasma-core';
 
 import { RootProps } from '../../engines';
@@ -28,6 +29,10 @@ export const attachRoot = (Root: RootProps<HTMLDivElement, AttachProps>) =>
             style,
             isLoading,
             disabled,
+            id,
+            name,
+            onChange,
+            onClear,
             ...rest
         } = props;
 
@@ -115,17 +120,25 @@ export const attachRoot = (Root: RootProps<HTMLDivElement, AttachProps>) =>
             inputRef.current.click();
         };
 
-        const handleChange = () => {
-            if (!inputRef.current || !inputRef.current.files) {
+        const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+            if (!e.target.files) {
                 return;
             }
 
-            setFilename(inputRef.current.files[0].name);
+            if (onChange) {
+                onChange(e);
+            }
+
+            setFilename(e.target.files[0].name);
         };
 
         const handleClear = () => {
             if (!inputRef.current) {
                 return;
+            }
+
+            if (onClear) {
+                onClear();
             }
 
             inputRef.current.value = '';
@@ -145,13 +158,11 @@ export const attachRoot = (Root: RootProps<HTMLDivElement, AttachProps>) =>
                     ref={inputRef}
                     accept={accept}
                     type="file"
-                    id="attachHiddenInput"
-                    name="attachHiddenInput"
+                    id={id}
+                    name={name}
                     onChange={handleChange}
                 />
-                <StyledHiddenInputHelper ref={inputHelperRef} id="attachHiddenInputHelper">
-                    {filename}
-                </StyledHiddenInputHelper>
+                <StyledHiddenInputHelper ref={inputHelperRef}>{filename}</StyledHiddenInputHelper>
 
                 <AttachButton
                     buttonType={buttonType}

--- a/packages/plasma-new-hope/src/components/Attach/Attach.types.ts
+++ b/packages/plasma-new-hope/src/components/Attach/Attach.types.ts
@@ -27,6 +27,10 @@ export type BaseAttachProps = {
      * Вид Attach
      */
     view?: string;
+    /**
+     * Callback при удалении прикрепленного файла
+     */
+    onClear?: () => void;
 };
 
 export type AttachButtonProps = (

--- a/website/plasma-b2c-docs/docs/components/Attach.mdx
+++ b/website/plasma-b2c-docs/docs/components/Attach.mdx
@@ -62,3 +62,72 @@ export function App() {
     );
 }
 ```
+
+### Пример использования в форме
+
+```tsx live
+import React, { useState } from 'react';
+import { Attach, Button } from '@salutejs/plasma-b2c';
+
+function App() {
+    const ids = ['0', '1', '2'];
+    const [isLoading, setIsLoading] = useState(false);
+    const [attachedFiles, setAttachedFiles] = useState([]);
+
+    const handleAttachFile = (e) => {
+        setAttachedFiles((prevAttachedFiles) => [
+            ...prevAttachedFiles,
+            {
+                fileData: e.target.files[0],
+                id: e.target.id,
+            },
+        ]);
+    };
+
+    const handleAttachClear = (id) => {
+        setAttachedFiles(attachedFiles.filter((file) => file.id !== id));
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setIsLoading(true);
+  
+        const formData = new FormData(e.target);
+        console.log('formData', Object.fromEntries(formData));
+
+        setTimeout(() => {
+            setAttachedFiles([]);
+            setIsLoading(false);
+        }, 2000);
+    };
+
+    return (
+        <>
+            <span>{isLoading ? 'Форма отправляется' : 'Прикрепленные файлы:'}</span>
+            {!isLoading && attachedFiles.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0px' }}>
+                    {attachedFiles.map((file) => (
+                        <span>{file.fileData.name}</span>
+                    ))}
+                </div>
+            )}
+
+            {!isLoading && (
+                <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '30px' }}>
+                    {ids.map((id) => (
+                        <Attach
+                            id={id}
+                            name={`attach${id}`}
+                            text={`Загрузить файл ${id}`}
+                            onChange={handleAttachFile}
+                            onClear={() => handleAttachClear(id)}
+                        />
+                    ))}
+
+                    <Button type="submit">Отправить</Button>
+                </form>
+            )}
+        </>
+    );
+}
+```

--- a/website/plasma-web-docs/docs/components/Attach.mdx
+++ b/website/plasma-web-docs/docs/components/Attach.mdx
@@ -62,3 +62,72 @@ export function App() {
     );
 }
 ```
+
+### Пример использования в форме
+
+```tsx live
+import React, { useState } from 'react';
+import { Attach, Button } from '@salutejs/plasma-web';
+
+function App() {
+    const ids = ['0', '1', '2'];
+    const [isLoading, setIsLoading] = useState(false);
+    const [attachedFiles, setAttachedFiles] = useState([]);
+
+    const handleAttachFile = (e) => {
+        setAttachedFiles((prevAttachedFiles) => [
+            ...prevAttachedFiles,
+            {
+                fileData: e.target.files[0],
+                id: e.target.id,
+            },
+        ]);
+    };
+
+    const handleAttachClear = (id) => {
+        setAttachedFiles(attachedFiles.filter((file) => file.id !== id));
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setIsLoading(true);
+  
+        const formData = new FormData(e.target);
+        console.log('formData', Object.fromEntries(formData));
+
+        setTimeout(() => {
+            setAttachedFiles([]);
+            setIsLoading(false);
+        }, 2000);
+    };
+
+    return (
+        <>
+            <span>{isLoading ? 'Форма отправляется' : 'Прикрепленные файлы:'}</span>
+            {!isLoading && attachedFiles.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0px' }}>
+                    {attachedFiles.map((file) => (
+                        <span>{file.fileData.name}</span>
+                    ))}
+                </div>
+            )}
+
+            {!isLoading && (
+                <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '30px' }}>
+                    {ids.map((id) => (
+                        <Attach
+                            id={id}
+                            name={`attach${id}`}
+                            text={`Загрузить файл ${id}`}
+                            onChange={handleAttachFile}
+                            onClear={() => handleAttachClear(id)}
+                        />
+                    ))}
+
+                    <Button type="submit">Отправить</Button>
+                </form>
+            )}
+        </>
+    );
+}
+```

--- a/website/sdds-cs-docs/docs/components/Attach.mdx
+++ b/website/sdds-cs-docs/docs/components/Attach.mdx
@@ -61,3 +61,72 @@ export function App() {
     );
 }
 ```
+
+### Пример использования в форме
+
+```tsx live
+import React, { useState } from 'react';
+import { Attach, Button } from '@salutejs/sdds-cs';
+
+function App() {
+    const ids = ['0', '1', '2'];
+    const [isLoading, setIsLoading] = useState(false);
+    const [attachedFiles, setAttachedFiles] = useState([]);
+
+    const handleAttachFile = (e) => {
+        setAttachedFiles((prevAttachedFiles) => [
+            ...prevAttachedFiles,
+            {
+                fileData: e.target.files[0],
+                id: e.target.id,
+            },
+        ]);
+    };
+
+    const handleAttachClear = (id) => {
+        setAttachedFiles(attachedFiles.filter((file) => file.id !== id));
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setIsLoading(true);
+  
+        const formData = new FormData(e.target);
+        console.log('formData', Object.fromEntries(formData));
+
+        setTimeout(() => {
+            setAttachedFiles([]);
+            setIsLoading(false);
+        }, 2000);
+    };
+
+    return (
+        <>
+            <span>{isLoading ? 'Форма отправляется' : 'Прикрепленные файлы:'}</span>
+            {!isLoading && attachedFiles.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0px' }}>
+                    {attachedFiles.map((file) => (
+                        <span>{file.fileData.name}</span>
+                    ))}
+                </div>
+            )}
+
+            {!isLoading && (
+                <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '30px' }}>
+                    {ids.map((id) => (
+                        <Attach
+                            id={id}
+                            name={`attach${id}`}
+                            text={`Загрузить файл ${id}`}
+                            onChange={handleAttachFile}
+                            onClear={() => handleAttachClear(id)}
+                        />
+                    ))}
+
+                    <Button type="submit">Отправить</Button>
+                </form>
+            )}
+        </>
+    );
+}
+```

--- a/website/sdds-dfa-docs/docs/components/Attach.mdx
+++ b/website/sdds-dfa-docs/docs/components/Attach.mdx
@@ -61,3 +61,72 @@ export function App() {
     );
 }
 ```
+
+### Пример использования в форме
+
+```tsx live
+import React, { useState } from 'react';
+import { Attach, Button } from '@salutejs/sdds-dfa';
+
+function App() {
+    const ids = ['0', '1', '2'];
+    const [isLoading, setIsLoading] = useState(false);
+    const [attachedFiles, setAttachedFiles] = useState([]);
+
+    const handleAttachFile = (e) => {
+        setAttachedFiles((prevAttachedFiles) => [
+            ...prevAttachedFiles,
+            {
+                fileData: e.target.files[0],
+                id: e.target.id,
+            },
+        ]);
+    };
+
+    const handleAttachClear = (id) => {
+        setAttachedFiles(attachedFiles.filter((file) => file.id !== id));
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setIsLoading(true);
+  
+        const formData = new FormData(e.target);
+        console.log('formData', Object.fromEntries(formData));
+
+        setTimeout(() => {
+            setAttachedFiles([]);
+            setIsLoading(false);
+        }, 2000);
+    };
+
+    return (
+        <>
+            <span>{isLoading ? 'Форма отправляется' : 'Прикрепленные файлы:'}</span>
+            {!isLoading && attachedFiles.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0px' }}>
+                    {attachedFiles.map((file) => (
+                        <span>{file.fileData.name}</span>
+                    ))}
+                </div>
+            )}
+
+            {!isLoading && (
+                <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '30px' }}>
+                    {ids.map((id) => (
+                        <Attach
+                            id={id}
+                            name={`attach${id}`}
+                            text={`Загрузить файл ${id}`}
+                            onChange={handleAttachFile}
+                            onClear={() => handleAttachClear(id)}
+                        />
+                    ))}
+
+                    <Button type="submit">Отправить</Button>
+                </form>
+            )}
+        </>
+    );
+}
+```

--- a/website/sdds-serv-docs/docs/components/Attach.mdx
+++ b/website/sdds-serv-docs/docs/components/Attach.mdx
@@ -61,3 +61,72 @@ export function App() {
     );
 }
 ```
+
+### Пример использования в форме
+
+```tsx live
+import React, { useState } from 'react';
+import { Attach, Button } from '@salutejs/sdds-serv';
+
+function App() {
+    const ids = ['0', '1', '2'];
+    const [isLoading, setIsLoading] = useState(false);
+    const [attachedFiles, setAttachedFiles] = useState([]);
+
+    const handleAttachFile = (e) => {
+        setAttachedFiles((prevAttachedFiles) => [
+            ...prevAttachedFiles,
+            {
+                fileData: e.target.files[0],
+                id: e.target.id,
+            },
+        ]);
+    };
+
+    const handleAttachClear = (id) => {
+        setAttachedFiles(attachedFiles.filter((file) => file.id !== id));
+    };
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        setIsLoading(true);
+  
+        const formData = new FormData(e.target);
+        console.log('formData', Object.fromEntries(formData));
+
+        setTimeout(() => {
+            setAttachedFiles([]);
+            setIsLoading(false);
+        }, 2000);
+    };
+
+    return (
+        <>
+            <span>{isLoading ? 'Форма отправляется' : 'Прикрепленные файлы:'}</span>
+            {!isLoading && attachedFiles.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0px' }}>
+                    {attachedFiles.map((file) => (
+                        <span>{file.fileData.name}</span>
+                    ))}
+                </div>
+            )}
+
+            {!isLoading && (
+                <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '30px' }}>
+                    {ids.map((id) => (
+                        <Attach
+                            id={id}
+                            name={`attach${id}`}
+                            text={`Загрузить файл ${id}`}
+                            onChange={handleAttachFile}
+                            onClear={() => handleAttachClear(id)}
+                        />
+                    ))}
+
+                    <Button type="submit">Отправить</Button>
+                </form>
+            )}
+        </>
+    );
+}
+```


### PR DESCRIPTION
### Attach
- исправлен `onChange`, `id` и `name`
- добавлено свойство `onClear`
- в документацию добавлен пример с использованием компонента внутри формы

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.174.1-canary.1481.11343722626.0
  npm install @salutejs/plasma-b2c@1.416.1-canary.1481.11343722626.0
  npm install @salutejs/plasma-new-hope@0.165.1-canary.1481.11343722626.0
  npm install @salutejs/plasma-web@1.418.1-canary.1481.11343722626.0
  npm install @salutejs/sdds-cs@0.146.1-canary.1481.11343722626.0
  npm install @salutejs/sdds-dfa@0.144.1-canary.1481.11343722626.0
  npm install @salutejs/sdds-finportal@0.138.1-canary.1481.11343722626.0
  npm install @salutejs/sdds-serv@0.145.1-canary.1481.11343722626.0
  # or 
  yarn add @salutejs/plasma-asdk@0.174.1-canary.1481.11343722626.0
  yarn add @salutejs/plasma-b2c@1.416.1-canary.1481.11343722626.0
  yarn add @salutejs/plasma-new-hope@0.165.1-canary.1481.11343722626.0
  yarn add @salutejs/plasma-web@1.418.1-canary.1481.11343722626.0
  yarn add @salutejs/sdds-cs@0.146.1-canary.1481.11343722626.0
  yarn add @salutejs/sdds-dfa@0.144.1-canary.1481.11343722626.0
  yarn add @salutejs/sdds-finportal@0.138.1-canary.1481.11343722626.0
  yarn add @salutejs/sdds-serv@0.145.1-canary.1481.11343722626.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
