### PR TITLE
feat(*): Fix Accordion Right Content and Paddings

### DIFF
--- a/packages/plasma-b2c/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/plasma-b2c/src/components/Accordion/Accordion.stories.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react';
-import type { ComponentProps } from 'react';
+import React, { useState, ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { disableProps } from '@salutejs/plasma-sb-utils';
+import { IconPlus } from '@salutejs/plasma-icons';
+
+import { IconButton } from '../IconButton/IconButton';
 
 import { Accordion, AccordionItem } from '.';
 
@@ -56,4 +58,64 @@ export const Default: StoryObj<ComponentProps<typeof Accordion>> = {
             </Accordion>
         );
     },
+};
+
+const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
+
+const ControlledAccordion = (props: ComponentProps<typeof Accordion>) => {
+    const args = { ...props, text: undefined };
+    const [activeFirst, setActiveFirst] = useState(false);
+    const [activeSecond, setActiveSecond] = useState(false);
+    const [activeThree, setActiveThree] = useState(false);
+
+    return (
+        <Accordion {...args}>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveFirst(!activeFirst)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeFirst}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveSecond(!activeSecond)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeSecond}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveThree(!activeThree)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeThree}
+            >
+                {args.body}
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+export const Controlled: StoryObj<ComponentProps<typeof Accordion>> = {
+    render: (props: ComponentProps<typeof Accordion>) => ControlledAccordion(props),
 };

--- a/packages/plasma-new-hope/src/components/Accordion/Accordion.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Accordion/Accordion.template-doc.mdx
@@ -135,6 +135,38 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Использование Accordion в Controlled варианте
+
+```tsx live
+    import React, { useState } from 'react';
+    import { Accordion, AccordionItem, IconButton } from '@salutejs/{{ package }}';
+    import { IconPlus } from '@salutejs/plasma-icons';
+
+    export function App() {
+        const [activeFirst, setActiveFirst] = useState(false);
+        const [activeSecond, setActiveSecond] = useState(false);
+        const [activeThree, setActiveThree] = useState(false);
+
+        const contentRight = (active, setActive) => {
+            return (
+                <IconButton view="secondary" size="s" onClick={() => setActive(!active)}>
+                    <IconPlus size="xs" />
+                </IconButton>
+            )
+        }
+
+        return (
+            <div>
+                <Accordion size="s" singleActive={true}>
+                    <AccordionItem opened={activeFirst} contentRight={contentRight(activeFirst, setActiveFirst)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeSecond} contentRight={contentRight(activeSecond, setActiveSecond)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeThree} contentRight={contentRight(activeThree, setActiveThree)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                </Accordion>
+            </div>
+        );
+    }
+    ```
+
 ### Использование Accordion SingleActive
 
 ```tsx live

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, forwardRef, useEffect } from 'react';
 
 import { convertRoundnessMatrix } from '../../../../utils/roundness';
 import { classes, tokens } from '../../Accordion.tokens';
@@ -19,105 +19,118 @@ import {
 } from './AccordionItem.styles';
 import type { AccordionItemProps } from './AccordionItem.types';
 
-export const AccordionItem: React.FC<AccordionItemProps> = ({
-    value,
-    contentRight,
-    contentLeft,
-    title,
-    pin = 'square-square',
-    children,
-    type = 'sign',
-    index,
-    className,
-    style,
-    eventKey,
-    disabled,
-    alignWithTitle = true,
-    view,
-    onChange,
-}) => {
-    const key = eventKey ?? index ?? 0;
+export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
+    (
+        {
+            value,
+            contentRight,
+            contentLeft,
+            title,
+            pin = 'square-square',
+            children,
+            type = 'sign',
+            index,
+            className,
+            style,
+            eventKey,
+            disabled,
+            alignWithTitle = true,
+            opened,
+            view,
+            onChange,
+            onClick,
+        },
+        outerRef,
+    ) => {
+        const key = eventKey ?? index ?? 0;
 
-    const [leftPadding, setLeftPadding] = useState<string | number | null>();
+        const [leftPadding, setLeftPadding] = useState<string | number | null>();
 
-    const handleOpen = () => {
-        if (disabled) {
-            return;
-        }
-        if (onChange) {
-            onChange(key, !value);
-        }
-    };
+        const handleOpen = () => {
+            if (disabled) {
+                return;
+            }
+            if (onChange) {
+                onChange(key, !value);
+            }
+            if (onClick) {
+                onClick(key, !value);
+            }
+        };
 
-    const leftContentRef = useRef<HTMLDivElement>(null);
+        const leftContentRef = useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
-        const leftContentWidth = leftContentRef?.current?.offsetWidth ?? 0;
-        const leftPaddingBody =
-            leftContentWidth && (alignWithTitle || view === 'clear')
-                ? `calc(${leftContentWidth}px + var(${tokens.accordionItemGap}))`
-                : 0;
-        setLeftPadding(leftPaddingBody);
-    }, [value, type, leftContentRef, setLeftPadding]);
+        useEffect(() => {
+            const leftContentWidth = leftContentRef?.current?.offsetWidth ?? 0;
+            const leftPaddingBody =
+                leftContentWidth && (alignWithTitle || view === 'clear')
+                    ? `calc(${leftContentWidth}px + var(${tokens.accordionItemGap}))`
+                    : 0;
+            setLeftPadding(leftPaddingBody);
+        }, [value, type, leftContentRef, setLeftPadding]);
 
-    const openedBodyClass = value ? classes.accordionItemShowBody : undefined;
+        const openedBodyClass = opened ?? value ? classes.accordionItemShowBody : undefined;
 
-    const StyledAnimationPLus = () => (
-        <StyledPlus>
-            <StyledMinus size="xs" color="inhert" />
-            <StyledMinus
-                size="xs"
-                color="inhert"
-                className={openedBodyClass ?? classes.accordionPlusAnimationElement}
-            />
-        </StyledPlus>
-    );
+        const StyledAnimationPlus = () => (
+            <StyledPlus>
+                <StyledMinus size="xs" color="inherit" />
+                <StyledMinus
+                    size="xs"
+                    color="inhert"
+                    className={openedBodyClass ?? classes.accordionPlusAnimationElement}
+                />
+            </StyledPlus>
+        );
 
-    const accordionBorderRadius = convertRoundnessMatrix(pin, `var(${tokens.accordionItemBorderRadius})`, '1.5rem');
-    const disabledClass = disabled ? classes.accordionDisabled : '';
+        const accordionBorderRadius = convertRoundnessMatrix(pin, `var(${tokens.accordionItemBorderRadius})`, '1.5rem');
+        const disabledClass = disabled ? classes.accordionDisabled : '';
 
-    const leftContent = contentLeft ?? (type === 'arrow' ? <StyledArrow size="xs" color="inhert" /> : undefined);
-    const leftContentRotate = type === 'arrow' && value ? classes.accordionItemShowBody : undefined;
+        const leftContent = contentLeft ?? (type === 'arrow' ? <StyledArrow size="xs" color="inherit" /> : undefined);
+        const leftContentRotate = type === 'arrow' && (opened ?? value) ? classes.accordionItemShowBody : undefined;
 
-    const rightContent = contentRight ?? (type === 'sign' ? <StyledAnimationPLus /> : undefined);
-    const rightContentRotate = type === 'sign' && value ? classes.accordionItemShowBody : undefined;
+        const rightContent = contentRight ?? (type === 'sign' ? <StyledAnimationPlus /> : undefined);
+        const rightContentRotate = type === 'sign' && (opened ?? value) ? classes.accordionItemShowBody : undefined;
 
-    return (
-        <StyledAccordionItem
-            className={cx(classes.accordionItem, className, disabledClass)}
-            key={key}
-            style={{ borderRadius: accordionBorderRadius, ...style }}
-        >
-            <StyledAccordionHeader
-                role="tab"
-                tabIndex={0}
-                onClick={handleOpen}
-                aria-expanded={value}
-                aria-controls={`accordion-item-section${key}`}
-                id={`accordion-item-${key}`}
+        return (
+            <StyledAccordionItem
+                className={cx(classes.accordionItem, className, disabledClass)}
+                key={key}
+                ref={outerRef}
+                style={{ borderRadius: accordionBorderRadius, ...style }}
             >
-                <StyledAccordionHeaderLeft>
-                    {leftContent && (
-                        <StyledAccordionContentLeft ref={leftContentRef} className={leftContentRotate}>
-                            {leftContent}
-                        </StyledAccordionContentLeft>
+                <StyledAccordionHeader
+                    role="tab"
+                    tabIndex={0}
+                    onClick={handleOpen}
+                    aria-expanded={opened ?? value}
+                    aria-controls={`accordion-item-section${key}`}
+                    id={`accordion-item-${key}`}
+                >
+                    <StyledAccordionHeaderLeft>
+                        {leftContent && (
+                            <StyledAccordionContentLeft ref={leftContentRef} className={leftContentRotate}>
+                                {leftContent}
+                            </StyledAccordionContentLeft>
+                        )}
+                        <StyledAccordionTitle>{title}</StyledAccordionTitle>
+                    </StyledAccordionHeaderLeft>
+
+                    {contentRight || (
+                        <StyledAccordionContentRight className={rightContentRotate}>
+                            {rightContent && rightContent}
+                        </StyledAccordionContentRight>
                     )}
-                    <StyledAccordionTitle>{title}</StyledAccordionTitle>
-                </StyledAccordionHeaderLeft>
-
-                <StyledAccordionContentRight className={rightContentRotate}>
-                    {rightContent && rightContent}
-                </StyledAccordionContentRight>
-            </StyledAccordionHeader>
-            <StyledAccordionBodyAnimate
-                aria-labelledby={`accordion-item-${key}`}
-                aria-hidden={!value}
-                id={`accordion-item-section${key}`}
-                className={cx(openedBodyClass)}
-                style={{ paddingLeft: `${leftPadding}` }}
-            >
-                <StyledAccordionBody className={classes.accordionItemBody}>{children}</StyledAccordionBody>
-            </StyledAccordionBodyAnimate>
-        </StyledAccordionItem>
-    );
-};
+                </StyledAccordionHeader>
+                <StyledAccordionBodyAnimate
+                    aria-labelledby={`accordion-item-${key}`}
+                    aria-hidden={!(opened ?? value)}
+                    id={`accordion-item-section${key}`}
+                    className={cx(openedBodyClass)}
+                    style={{ paddingLeft: `${leftPadding}` }}
+                >
+                    <StyledAccordionBody className={classes.accordionItemBody}>{children}</StyledAccordionBody>
+                </StyledAccordionBodyAnimate>
+            </StyledAccordionItem>
+        );
+    },
+);

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.types.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.types.ts
@@ -4,7 +4,7 @@ import type { Pin } from '../../../../utils/roundness';
 
 type Props = {
     /**
-     * Значение раскрытия accordion
+     * Значение раскрытия элемента accordion
      */
     value?: boolean;
 
@@ -29,41 +29,51 @@ type Props = {
     contentRight?: ReactNode;
 
     /**
-     * Скругление accordion
+     * Скругление элемента accordion
      */
     pin?: Pin;
 
     /**
-     * Заголовок accordion
+     * Заголовок элемента accordion
      */
-    title: ReactNode;
+    title?: ReactNode | string;
 
     /**
-     * Контент аккордеона
+     * Контент элемента accordion
      */
     children: ReactNode;
 
     /**
-     * @deprecated Внутренняя функция при открытии accordion (будет удалена в ближайшее время)
+     * @deprecated Внутренняя функция при открытии accordion (будет удалена в ближайшее время), использовать onClick
      */
     onChange?: (index: number, value: boolean) => void;
 
     /**
-     * Блокировка элемента
+     * Функция при открытии accordion
+     */
+    onClick?: (index: number, value: boolean) => void;
+
+    /**
+     * Блокировка элемента accordion
      */
     disabled?: boolean;
+
+    /**
+     * Контроль элемента accordion из вне
+     */
+    opened?: boolean;
 
     //
     // Свойства которые автоматически добавляется Accordion'ом
     //
 
     /**
-     * Индекс элемента, который необходимо автоматически открыть
+     * Индекс элемента accordion, который необходимо автоматически открыть
      */
     eventKey?: number;
 
     /**
-     * @deprecated Внутреннее свойство индекс элемента (будет удалено в ближайшее время)
+     * @deprecated Внутреннее свойство индекс элемента accordion (будет удалено в ближайшее время)
      */
     index?: number;
 

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Accordion/Accordion.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { ComponentProps, ReactNode } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { disableProps } from '@salutejs/plasma-sb-utils';
@@ -7,6 +7,8 @@ import { mergeConfig } from '../../../../engines';
 import { WithTheme, argTypesFromConfig } from '../../../_helpers';
 import { accordionConfig } from '../../../../components/Accordion';
 import { Pin } from '../../../../utils/roundness';
+import { IconButton } from '../IconButton/IconButton';
+import { IconPlus } from '../../../../components/_Icon';
 
 import { config } from './Accordion.config';
 import { Accordion, AccordionItem } from './Accordion';
@@ -90,4 +92,64 @@ export const Default: StoryObj<AccordionProps> = {
             </Accordion>
         );
     },
+};
+
+const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
+
+const ControlledAccordion = (props: AccordionProps) => {
+    const args = { ...props, text: undefined };
+    const [activeFirst, setActiveFirst] = useState(false);
+    const [activeSecond, setActiveSecond] = useState(false);
+    const [activeThree, setActiveThree] = useState(false);
+
+    return (
+        <Accordion {...args}>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveFirst(!activeFirst)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeFirst}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveSecond(!activeSecond)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeSecond}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveThree(!activeThree)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeThree}
+            >
+                {args.body}
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+export const Controlled: StoryObj<AccordionProps> = {
+    render: (props: AccordionProps) => ControlledAccordion(props),
 };

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Accordion/Accordion.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { ComponentProps, ReactNode } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { disableProps } from '@salutejs/plasma-sb-utils';
@@ -7,6 +7,8 @@ import { mergeConfig } from '../../../../engines';
 import { WithTheme, argTypesFromConfig } from '../../../_helpers';
 import { accordionConfig } from '../../../../components/Accordion';
 import { Pin } from '../../../../utils/roundness';
+import { IconButton } from '../IconButton/IconButton';
+import { IconPlus } from '../../../../components/_Icon';
 
 import { config } from './Accordion.config';
 import { Accordion, AccordionItem } from './Accordion';
@@ -90,4 +92,64 @@ export const Default: StoryObj<AccordionProps> = {
             </Accordion>
         );
     },
+};
+
+const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
+
+const ControlledAccordion = (props: AccordionProps) => {
+    const args = { ...props, text: undefined };
+    const [activeFirst, setActiveFirst] = useState(false);
+    const [activeSecond, setActiveSecond] = useState(false);
+    const [activeThree, setActiveThree] = useState(false);
+
+    return (
+        <Accordion {...args}>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveFirst(!activeFirst)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeFirst}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveSecond(!activeSecond)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeSecond}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveThree(!activeThree)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeThree}
+            >
+                {args.body}
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+export const Controlled: StoryObj<AccordionProps> = {
+    render: (props: AccordionProps) => ControlledAccordion(props),
 };

--- a/packages/plasma-web/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/plasma-web/src/components/Accordion/Accordion.stories.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react';
-import type { ComponentProps } from 'react';
+import React, { useState, ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { disableProps } from '@salutejs/plasma-sb-utils';
+import { IconPlus } from '@salutejs/plasma-icons';
+
+import { IconButton } from '../IconButton/IconButton';
 
 import { Accordion, AccordionItem } from '.';
 
@@ -55,4 +57,64 @@ export const Default: StoryObj<ComponentProps<typeof Accordion>> = {
             </Accordion>
         );
     },
+};
+
+const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
+
+const ControlledAccordion = (props: ComponentProps<typeof Accordion>) => {
+    const args = { ...props, text: undefined };
+    const [activeFirst, setActiveFirst] = useState(false);
+    const [activeSecond, setActiveSecond] = useState(false);
+    const [activeThree, setActiveThree] = useState(false);
+
+    return (
+        <Accordion {...args}>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveFirst(!activeFirst)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeFirst}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveSecond(!activeSecond)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeSecond}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveThree(!activeThree)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeThree}
+            >
+                {args.body}
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+export const Controlled: StoryObj<ComponentProps<typeof Accordion>> = {
+    render: (props: ComponentProps<typeof Accordion>) => ControlledAccordion(props),
 };

--- a/packages/sdds-cs/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-cs/src/components/Accordion/Accordion.config.ts
@@ -18,6 +18,7 @@ export const config = {
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0;
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: var(${accordionTokens.accordionItemPaddingHorizontal});
             `,
             clear: css`
                 ${accordionTokens.accordionGap}: 0;
@@ -31,6 +32,7 @@ export const config = {
                 ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.125rem solid var(--surface-solid-tertiary);
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;
             `,
         },
         size: {

--- a/packages/sdds-cs/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/sdds-cs/src/components/Accordion/Accordion.stories.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react';
-import type { ComponentProps, ReactNode } from 'react';
+import React, { useState, ComponentProps, ReactNode } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
+import { IconPlus } from '@salutejs/plasma-icons';
+
+import { IconButton } from '../IconButton/IconButton';
 
 import { Accordion, AccordionItem } from './Accordion';
 
@@ -94,4 +96,64 @@ export const Default: StoryObj<AccordionProps> = {
             </Accordion>
         );
     },
+};
+
+const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
+
+const ControlledAccordion = (props: ComponentProps<typeof Accordion>) => {
+    const args = { ...props, text: undefined };
+    const [activeFirst, setActiveFirst] = useState(false);
+    const [activeSecond, setActiveSecond] = useState(false);
+    const [activeThree, setActiveThree] = useState(false);
+
+    return (
+        <Accordion {...args}>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveFirst(!activeFirst)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeFirst}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveSecond(!activeSecond)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeSecond}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveThree(!activeThree)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeThree}
+            >
+                {args.body}
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+export const Controlled: StoryObj<ComponentProps<typeof Accordion>> = {
+    render: (props: ComponentProps<typeof Accordion>) => ControlledAccordion(props),
 };

--- a/packages/sdds-dfa/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-dfa/src/components/Accordion/Accordion.config.ts
@@ -18,6 +18,7 @@ export const config = {
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0;
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: var(${accordionTokens.accordionItemPaddingHorizontal});
             `,
             clear: css`
                 ${accordionTokens.accordionGap}: 0;
@@ -31,6 +32,7 @@ export const config = {
                 ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.125rem solid var(--surface-solid-tertiary);
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;
             `,
         },
         size: {

--- a/packages/sdds-dfa/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/sdds-dfa/src/components/Accordion/Accordion.stories.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react';
-import type { ComponentProps, ReactNode } from 'react';
+import React, { useState, ComponentProps, ReactNode } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
+import { IconPlus } from '@salutejs/plasma-icons';
+
+import { IconButton } from '../IconButton/IconButton';
 
 import { Accordion, AccordionItem } from './Accordion';
 
@@ -100,4 +102,64 @@ export const Default: StoryObj<AccordionProps> = {
             </Accordion>
         );
     },
+};
+
+const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
+
+const ControlledAccordion = (props: ComponentProps<typeof Accordion>) => {
+    const args = { ...props, text: undefined };
+    const [activeFirst, setActiveFirst] = useState(false);
+    const [activeSecond, setActiveSecond] = useState(false);
+    const [activeThree, setActiveThree] = useState(false);
+
+    return (
+        <Accordion {...args}>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveFirst(!activeFirst)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeFirst}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveSecond(!activeSecond)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeSecond}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveThree(!activeThree)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeThree}
+            >
+                {args.body}
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+export const Controlled: StoryObj<ComponentProps<typeof Accordion>> = {
+    render: (props: ComponentProps<typeof Accordion>) => ControlledAccordion(props),
 };

--- a/packages/sdds-finportal/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-finportal/src/components/Accordion/Accordion.config.ts
@@ -18,6 +18,7 @@ export const config = {
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0;
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: var(${accordionTokens.accordionItemPaddingHorizontal});
             `,
             clear: css`
                 ${accordionTokens.accordionGap}: 0;
@@ -31,6 +32,7 @@ export const config = {
                 ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.125rem solid var(--surface-solid-tertiary);
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;
             `,
         },
         size: {

--- a/packages/sdds-finportal/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/sdds-finportal/src/components/Accordion/Accordion.stories.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react';
-import type { ComponentProps, ReactNode } from 'react';
+import React, { useState, ComponentProps, ReactNode } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
+import { IconPlus } from '@salutejs/plasma-icons';
+
+import { IconButton } from '../IconButton/IconButton';
 
 import { Accordion, AccordionItem } from './Accordion';
 
@@ -100,4 +102,64 @@ export const Default: StoryObj<AccordionProps> = {
             </Accordion>
         );
     },
+};
+
+const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
+
+const ControlledAccordion = (props: ComponentProps<typeof Accordion>) => {
+    const args = { ...props, text: undefined };
+    const [activeFirst, setActiveFirst] = useState(false);
+    const [activeSecond, setActiveSecond] = useState(false);
+    const [activeThree, setActiveThree] = useState(false);
+
+    return (
+        <Accordion {...args}>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveFirst(!activeFirst)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeFirst}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveSecond(!activeSecond)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeSecond}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveThree(!activeThree)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeThree}
+            >
+                {args.body}
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+export const Controlled: StoryObj<ComponentProps<typeof Accordion>> = {
+    render: (props: ComponentProps<typeof Accordion>) => ControlledAccordion(props),
 };

--- a/packages/sdds-serv/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-serv/src/components/Accordion/Accordion.config.ts
@@ -18,6 +18,7 @@ export const config = {
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0;
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: var(${accordionTokens.accordionItemPaddingHorizontal});
             `,
             clear: css`
                 ${accordionTokens.accordionGap}: 0;
@@ -31,6 +32,7 @@ export const config = {
                 ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.125rem solid var(--surface-solid-tertiary);
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;
             `,
         },
         size: {

--- a/packages/sdds-serv/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/sdds-serv/src/components/Accordion/Accordion.stories.tsx
@@ -1,7 +1,9 @@
-import * as React from 'react';
-import type { ComponentProps, ReactNode } from 'react';
+import React, { useState, ComponentProps, ReactNode } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
+import { IconPlus } from '@salutejs/plasma-icons';
+
+import { IconButton } from '../IconButton/IconButton';
 
 import { Accordion, AccordionItem } from './Accordion';
 
@@ -100,4 +102,64 @@ export const Default: StoryObj<AccordionProps> = {
             </Accordion>
         );
     },
+};
+
+const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
+
+const ControlledAccordion = (props: ComponentProps<typeof Accordion>) => {
+    const args = { ...props, text: undefined };
+    const [activeFirst, setActiveFirst] = useState(false);
+    const [activeSecond, setActiveSecond] = useState(false);
+    const [activeThree, setActiveThree] = useState(false);
+
+    return (
+        <Accordion {...args}>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveFirst(!activeFirst)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeFirst}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveSecond(!activeSecond)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeSecond}
+            >
+                {args.body}
+            </AccordionItem>
+            <AccordionItem
+                contentRight={
+                    <IconButton view="secondary" size={args.size} onClick={() => setActiveThree(!activeThree)}>
+                        <IconPlus size={getSizeForIcon(args.size)} />
+                    </IconButton>
+                }
+                alignWithTitle={args.alignWithTitle}
+                type={args.type}
+                pin={args.pin}
+                title={args.title}
+                opened={activeThree}
+            >
+                {args.body}
+            </AccordionItem>
+        </Accordion>
+    );
+};
+
+export const Controlled: StoryObj<ComponentProps<typeof Accordion>> = {
+    render: (props: ComponentProps<typeof Accordion>) => ControlledAccordion(props),
 };

--- a/website/plasma-b2c-docs/docs/components/Accordion.mdx
+++ b/website/plasma-b2c-docs/docs/components/Accordion.mdx
@@ -157,6 +157,38 @@ import TabItem from '@theme/TabItem';
     }
     ```
 
+### Использование Accordion в Controlled варианте
+
+```tsx live
+    import React, { useState } from 'react';
+    import { Accordion, AccordionItem, IconButton } from '@salutejs/plasma-b2c';
+    import { IconPlus } from '@salutejs/plasma-icons';
+
+    export function App() {
+        const [activeFirst, setActiveFirst] = useState(false);
+        const [activeSecond, setActiveSecond] = useState(false);
+        const [activeThree, setActiveThree] = useState(false);
+
+        const contentRight = (active, setActive) => {
+            return (
+                <IconButton view="secondary" size="s" onClick={() => setActive(!active)}>
+                    <IconPlus size="xs" />
+                </IconButton>
+            )
+        }
+
+        return (
+            <div>
+                <Accordion size="s" singleActive={true}>
+                    <AccordionItem opened={activeFirst} contentRight={contentRight(activeFirst, setActiveFirst)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeSecond} contentRight={contentRight(activeSecond, setActiveSecond)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeThree} contentRight={contentRight(activeThree, setActiveThree)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                </Accordion>
+            </div>
+        );
+    }
+    ```
+
 ### Использование Accordion с eventKey и defaultActiveEventKey
 
 ```tsx live

--- a/website/plasma-web-docs/docs/components/Accordion.mdx
+++ b/website/plasma-web-docs/docs/components/Accordion.mdx
@@ -138,6 +138,38 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Использование Accordion в Controlled варианте
+
+```tsx live
+    import React, { useState } from 'react';
+    import { Accordion, AccordionItem, IconButton } from '@salutejs/plasma-web';
+    import { IconPlus } from '@salutejs/plasma-icons';
+
+    export function App() {
+        const [activeFirst, setActiveFirst] = useState(false);
+        const [activeSecond, setActiveSecond] = useState(false);
+        const [activeThree, setActiveThree] = useState(false);
+
+        const contentRight = (active, setActive) => {
+            return (
+                <IconButton view="secondary" size="s" onClick={() => setActive(!active)}>
+                    <IconPlus size="xs" />
+                </IconButton>
+            )
+        }
+
+        return (
+            <div>
+                <Accordion size="s" singleActive={true}>
+                    <AccordionItem opened={activeFirst} contentRight={contentRight(activeFirst, setActiveFirst)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeSecond} contentRight={contentRight(activeSecond, setActiveSecond)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeThree} contentRight={contentRight(activeThree, setActiveThree)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                </Accordion>
+            </div>
+        );
+    }
+    ```
+
 ### Использование Accorion SignleActive
 
 ```tsx live

--- a/website/sdds-cs-docs/docs/components/Accordion.mdx
+++ b/website/sdds-cs-docs/docs/components/Accordion.mdx
@@ -114,6 +114,38 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Использование Accordion в Controlled варианте
+
+```tsx live
+    import React, { useState } from 'react';
+    import { Accordion, AccordionItem, IconButton } from '@salutejs/sdds-cs';
+    import { IconPlus } from '@salutejs/plasma-icons';
+
+    export function App() {
+        const [activeFirst, setActiveFirst] = useState(false);
+        const [activeSecond, setActiveSecond] = useState(false);
+        const [activeThree, setActiveThree] = useState(false);
+
+        const contentRight = (active, setActive) => {
+            return (
+                <IconButton view="secondary" size="s" onClick={() => setActive(!active)}>
+                    <IconPlus size="xs" />
+                </IconButton>
+            )
+        }
+
+        return (
+            <div>
+                <Accordion size="s" singleActive={true}>
+                    <AccordionItem opened={activeFirst} contentRight={contentRight(activeFirst, setActiveFirst)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeSecond} contentRight={contentRight(activeSecond, setActiveSecond)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeThree} contentRight={contentRight(activeThree, setActiveThree)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                </Accordion>
+            </div>
+        );
+    }
+    ```
+
 ### Использование Accordion SingleActive
 
 ```tsx live

--- a/website/sdds-dfa-docs/docs/components/Accordion.mdx
+++ b/website/sdds-dfa-docs/docs/components/Accordion.mdx
@@ -135,6 +135,38 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Использование Accordion в Controlled варианте
+
+```tsx live
+    import React, { useState } from 'react';
+    import { Accordion, AccordionItem, IconButton } from '@salutejs/sdds-dfa';
+    import { IconPlus } from '@salutejs/plasma-icons';
+
+    export function App() {
+        const [activeFirst, setActiveFirst] = useState(false);
+        const [activeSecond, setActiveSecond] = useState(false);
+        const [activeThree, setActiveThree] = useState(false);
+
+        const contentRight = (active, setActive) => {
+            return (
+                <IconButton view="secondary" size="s" onClick={() => setActive(!active)}>
+                    <IconPlus size="xs" />
+                </IconButton>
+            )
+        }
+
+        return (
+            <div>
+                <Accordion size="s" singleActive={true}>
+                    <AccordionItem opened={activeFirst} contentRight={contentRight(activeFirst, setActiveFirst)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeSecond} contentRight={contentRight(activeSecond, setActiveSecond)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeThree} contentRight={contentRight(activeThree, setActiveThree)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                </Accordion>
+            </div>
+        );
+    }
+    ```
+
 ### Использование Accordion SingleActive
 
 ```tsx live

--- a/website/sdds-serv-docs/docs/components/Accordion.mdx
+++ b/website/sdds-serv-docs/docs/components/Accordion.mdx
@@ -135,6 +135,38 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Использование Accordion в Controlled варианте
+
+```tsx live
+    import React, { useState } from 'react';
+    import { Accordion, AccordionItem, IconButton } from '@salutejs/sdds-serv';
+    import { IconPlus } from '@salutejs/plasma-icons';
+
+    export function App() {
+        const [activeFirst, setActiveFirst] = useState(false);
+        const [activeSecond, setActiveSecond] = useState(false);
+        const [activeThree, setActiveThree] = useState(false);
+
+        const contentRight = (active, setActive) => {
+            return (
+                <IconButton view="secondary" size="s" onClick={() => setActive(!active)}>
+                    <IconPlus size="xs" />
+                </IconButton>
+            )
+        }
+
+        return (
+            <div>
+                <Accordion size="s" singleActive={true}>
+                    <AccordionItem opened={activeFirst} contentRight={contentRight(activeFirst, setActiveFirst)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeSecond} contentRight={contentRight(activeSecond, setActiveSecond)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                    <AccordionItem opened={activeThree} contentRight={contentRight(activeThree, setActiveThree)} type="arrow" title="Как оплатить заправку бонусами СберСпасибо?">После указания деталей заправки нажмите кнопку «К оплате». Откроется окно оплаты, где вы сможете списать бонусы и оплатить ими до 99% стоимости топлива</AccordionItem>
+                </Accordion>
+            </div>
+        );
+    }
+    ```
+
 ### Использование Accordion SingleActive
 
 ```tsx live


### PR DESCRIPTION
### Fix Accordion

- Исправлен параметр `contentRight`
- Исправлен отступы во всех поставках `sdds` в `AccordionItem`
- Добавлен новый параметр `opened`, для контроля состоянием вне компонента
- Добавлена возможность прокидывать `ref` в `AccordionItem`

### What/why changed (Это обязательный заголовок)

- Добавлена возможность прокдывать кнопки в `contentRight`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.180.0-canary.1484.11400899769.0
  npm install @salutejs/plasma-b2c@1.422.0-canary.1484.11400899769.0
  npm install @salutejs/plasma-new-hope@0.171.0-canary.1484.11400899769.0
  npm install @salutejs/plasma-web@1.424.0-canary.1484.11400899769.0
  npm install @salutejs/sdds-cs@0.152.0-canary.1484.11400899769.0
  npm install @salutejs/sdds-dfa@0.150.0-canary.1484.11400899769.0
  npm install @salutejs/sdds-finportal@0.144.0-canary.1484.11400899769.0
  npm install @salutejs/sdds-serv@0.151.0-canary.1484.11400899769.0
  # or 
  yarn add @salutejs/plasma-asdk@0.180.0-canary.1484.11400899769.0
  yarn add @salutejs/plasma-b2c@1.422.0-canary.1484.11400899769.0
  yarn add @salutejs/plasma-new-hope@0.171.0-canary.1484.11400899769.0
  yarn add @salutejs/plasma-web@1.424.0-canary.1484.11400899769.0
  yarn add @salutejs/sdds-cs@0.152.0-canary.1484.11400899769.0
  yarn add @salutejs/sdds-dfa@0.150.0-canary.1484.11400899769.0
  yarn add @salutejs/sdds-finportal@0.144.0-canary.1484.11400899769.0
  yarn add @salutejs/sdds-serv@0.151.0-canary.1484.11400899769.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
