### PR TITLE
feat(new-hope): Textarea, add to hook useAutoResize defaultValue

### DIFF
--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -153,7 +153,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaProps>
             }
         });
 
-        useAutoResize(autoResize || Boolean(clear), outerRef, value, minAuto, maxAuto);
+        useAutoResize(autoResize || Boolean(clear), outerRef, value, minAuto, maxAuto, defaultValue);
 
         const onFocusHandler = useCallback(() => {
             setFocused(true);

--- a/packages/plasma-new-hope/src/components/TextArea/hooks/useAutoResize.ts
+++ b/packages/plasma-new-hope/src/components/TextArea/hooks/useAutoResize.ts
@@ -8,6 +8,7 @@ export const useAutoResize = <T extends HTMLTextAreaElement>(
     value?: string | ReadonlyArray<string> | number,
     minAuto?: number,
     maxAuto?: number,
+    defaultValue?: string | ReadonlyArray<string> | number,
 ) => {
     const isManualResize = useRef<boolean>(false);
     const previousHeight = useRef<number | undefined>();
@@ -38,5 +39,5 @@ export const useAutoResize = <T extends HTMLTextAreaElement>(
             ref.current.style.height = `${newHeight}rem`;
             previousHeight.current = newHeight;
         }
-    }, [ref, active, value]);
+    }, [ref, active, value, defaultValue]);
 };


### PR DESCRIPTION
### Textarea, add to hook useAutoResize defaultValue

- В хук `useAutoResize` добавлен параметр `defaultValue`

### What/why changed (Это обязательный заголовок)

- В хук `useAutoResize` добавлен параметр `defaultValue`