### PR TITLE
sdds-cs: Fix default value for prop size

### DIFF
--- a/packages/sdds-cs/src/components/Breadcrumbs/Breadcrumbs.config.ts
+++ b/packages/sdds-cs/src/components/Breadcrumbs/Breadcrumbs.config.ts
@@ -3,7 +3,7 @@ import { css, breadcrumbsTokens } from '@salutejs/plasma-new-hope/styled-compone
 export const config = {
     defaults: {
         view: 'default',
-        size: 'm',
+        size: 's',
     },
     variations: {
         view: {

--- a/packages/sdds-cs/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/sdds-cs/src/components/DatePicker/DatePicker.config.ts
@@ -3,7 +3,7 @@ import { datePickerTokens as tokens, css } from '@salutejs/plasma-new-hope/style
 export const config = {
     defaults: {
         view: 'default',
-        size: 'm',
+        size: 's',
     },
     variations: {
         view: {

--- a/website/sdds-cs-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-cs-docs/docs/components/DatePicker.mdx
@@ -13,7 +13,7 @@ import { PropsTable, Description } from '@site/src/components';
 Компонент `DatePicker` представляет собой поле ввода даты с выпадающим календарем.
 
 Размер `DatePicker` задаётся с помощью свойства `size`.
-Возможные значения свойства: `"l"`, `"m"`, `"s"`, `"xs"`.
+Возможные значения свойства: `s`
 
 ```tsx live
 import React from 'react';


### PR DESCRIPTION
### What/why changed

Исправлены неправильные значения по умолчанию для компонентов 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-cs@0.153.1-canary.1496.11455162336.0
  # or 
  yarn add @salutejs/sdds-cs@0.153.1-canary.1496.11455162336.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
