### PR TITLE
fix(plasma-new-hope): Fix Calendar hover behaviour

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarDays/CalendarDays.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarDays/CalendarDays.tsx
@@ -109,6 +109,8 @@ export const CalendarDays: React.FC<CalendarDaysProps> = ({
         [getSelectedDate, onHoverDay, value],
     );
 
+    const handleMouseOutGrid = () => onHoverDay?.(undefined);
+
     const getRefs = (element: HTMLDivElement, isDayInCurrentMonth: boolean, i: number, j: number) => {
         if (isDayInCurrentMonth) {
             outerRefs.current[i + offset][j] = element;
@@ -122,7 +124,12 @@ export const CalendarDays: React.FC<CalendarDaysProps> = ({
     }, []);
 
     return (
-        <StyledCalendarDays role="grid" aria-labelledby="id-grid-label" onKeyDown={onKeyDown}>
+        <StyledCalendarDays
+            role="grid"
+            aria-labelledby="id-grid-label"
+            onKeyDown={onKeyDown}
+            onMouseLeave={handleMouseOutGrid}
+        >
             <StyledCalendarDaysHint id="withShift">
                 Для навигации только по доступным датам удерживайте клавишу Shift.
             </StyledCalendarDaysHint>

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarMonths/CalendarMonths.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarMonths/CalendarMonths.tsx
@@ -105,6 +105,8 @@ export const CalendarMonths: React.FC<CalendarMonthsProps> = ({
         [getSelectedDate, onHoverMonth, value],
     );
 
+    const handleMouseOutGrid = () => onHoverMonth?.(undefined);
+
     const getRefs = useCallback(
         (element: HTMLDivElement, i: number, j: number) => {
             outerRefs.current[i + offset][j] = element;
@@ -119,7 +121,12 @@ export const CalendarMonths: React.FC<CalendarMonthsProps> = ({
     }, []);
 
     return (
-        <StyledCalendarMonths role="grid" aria-labelledby="id-grid-label" onKeyDown={onKeyDown}>
+        <StyledCalendarMonths
+            role="grid"
+            aria-labelledby="id-grid-label"
+            onKeyDown={onKeyDown}
+            onMouseLeave={handleMouseOutGrid}
+        >
             {months.map((month, i) => (
                 <StyledFlex role="row" key={i}>
                     {month.map(

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarQuarters/CalendarQuarters.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarQuarters/CalendarQuarters.tsx
@@ -104,6 +104,8 @@ export const CalendarQuarters: React.FC<CalendarQuartersProps> = ({
         [getSelectedDate, onHoverQuarter, value],
     );
 
+    const handleMouseOutGrid = () => onHoverQuarter?.(undefined);
+
     const getRefs = useCallback(
         (element: HTMLDivElement, i: number, j: number) => {
             outerRefs.current[i + offset][j] = element;
@@ -118,7 +120,12 @@ export const CalendarQuarters: React.FC<CalendarQuartersProps> = ({
     }, []);
 
     return (
-        <StyledCalendarQuarters role="grid" aria-labelledby="id-grid-label" onKeyDown={onKeyDown}>
+        <StyledCalendarQuarters
+            role="grid"
+            aria-labelledby="id-grid-label"
+            onKeyDown={onKeyDown}
+            onMouseLeave={handleMouseOutGrid}
+        >
             {quarters.map((quarter, i) => (
                 <StyledFlex role="row" key={i}>
                     {quarter.map(

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarYears/CalendarYears.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarYears/CalendarYears.tsx
@@ -105,6 +105,8 @@ export const CalendarYears: React.FC<CalendarYearsProps> = ({
         [getSelectedDate, onHoverYear, value],
     );
 
+    const handleMouseOutGrid = () => onHoverYear?.(undefined);
+
     const getRefs = useCallback(
         (element: HTMLDivElement, i: number, j: number) => {
             outerRefs.current[i + offset][j] = element;
@@ -119,7 +121,12 @@ export const CalendarYears: React.FC<CalendarYearsProps> = ({
     }, []);
 
     return (
-        <StyledCalendarYears role="grid" aria-labelledby="id-grid-label" onKeyDown={onKeyDown}>
+        <StyledCalendarYears
+            role="grid"
+            aria-labelledby="id-grid-label"
+            onKeyDown={onKeyDown}
+            onMouseLeave={handleMouseOutGrid}
+        >
             {years.map((year, i) => (
                 <StyledFlex role="row" key={i}>
                     {year.map(

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.styles.ts
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.styles.ts
@@ -11,12 +11,12 @@ const Tooltip = component(mergedConfig);
 
 export const Hint = styled(Tooltip)``;
 
-export const OuterLabelWrapper = styled.div<{ isInnnerLabel: boolean }>`
+export const OuterLabelWrapper = styled.div<{ isInnerLabel: boolean }>`
     display: flex;
     align-items: center;
 
-    margin-bottom: ${({ isInnnerLabel }) =>
-        isInnnerLabel ? `var(${tokens.titleCaptionInnerLabelOffset})` : `var(${tokens.labelMarginBottom})`};
+    margin-bottom: ${({ isInnerLabel }) =>
+        isInnerLabel ? `var(${tokens.titleCaptionInnerLabelOffset})` : `var(${tokens.labelMarginBottom})`};
 `;
 
 export const StyledLabel = styled.div`

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -266,7 +266,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaRootPr
                 {...(hintText && { hintView, hintSize })}
             >
                 {(hasOuterLabel || titleCaption) && (
-                    <OuterLabelWrapper isInnnerLabel={labelPlacement === 'inner'}>
+                    <OuterLabelWrapper isInnerLabel={labelPlacement === 'inner'}>
                         {hasOuterLabel && (
                             <StyledIndicatorWrapper>
                                 <StyledLabel>{label}</StyledLabel>

--- a/packages/plasma-new-hope/src/components/TextField/TextField.styles.ts
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.styles.ts
@@ -85,12 +85,12 @@ export const InputPlaceholder = styled.div`
     color: var(${tokens.placeholderColor});
 `;
 
-export const OuterLabelWrapper = styled.div<{ isInnnerLabel: boolean }>`
+export const OuterLabelWrapper = styled.div<{ isInnerLabel: boolean }>`
     display: flex;
     align-items: center;
 
-    margin-bottom: ${({ isInnnerLabel }) =>
-        isInnnerLabel ? `var(${tokens.titleCaptionInnerLabelOffset})` : `var(${tokens.labelOffset})`};
+    margin-bottom: ${({ isInnerLabel }) =>
+        isInnerLabel ? `var(${tokens.titleCaptionInnerLabelOffset})` : `var(${tokens.labelOffset})`};
 `;
 
 export const TitleCaption = styled.div`

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -294,7 +294,7 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldRootProps
                     {...(hintText && { hintView, hintSize })}
                 >
                     {(hasOuterLabel || titleCaption) && (
-                        <OuterLabelWrapper isInnnerLabel={labelPlacement === 'inner'}>
+                        <OuterLabelWrapper isInnerLabel={labelPlacement === 'inner'}>
                             {hasOuterLabel && (
                                 <StyledIndicatorWrapper>
                                     <Label id={labelId} htmlFor={id}>


### PR DESCRIPTION
### Calendar

- поправлено поведение hover для дней на календарной сетке

**Before**:

https://github.com/user-attachments/assets/992d2566-10a1-40ff-8d76-d3e2d8de4d13

**After**:

https://github.com/user-attachments/assets/8e0bf060-a103-46ba-aa4a-b5bc6bef632d

### What/why changed

Поправлено поведение hover для дней на календарной сетке.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.182.2-canary.1498.11494484213.0
  npm install @salutejs/plasma-b2c@1.424.2-canary.1498.11494484213.0
  npm install @salutejs/plasma-new-hope@0.173.2-canary.1498.11494484213.0
  npm install @salutejs/plasma-web@1.426.2-canary.1498.11494484213.0
  npm install @salutejs/sdds-cs@0.154.2-canary.1498.11494484213.0
  npm install @salutejs/sdds-dfa@0.152.2-canary.1498.11494484213.0
  npm install @salutejs/sdds-finportal@0.146.2-canary.1498.11494484213.0
  npm install @salutejs/sdds-serv@0.153.2-canary.1498.11494484213.0
  # or 
  yarn add @salutejs/plasma-asdk@0.182.2-canary.1498.11494484213.0
  yarn add @salutejs/plasma-b2c@1.424.2-canary.1498.11494484213.0
  yarn add @salutejs/plasma-new-hope@0.173.2-canary.1498.11494484213.0
  yarn add @salutejs/plasma-web@1.426.2-canary.1498.11494484213.0
  yarn add @salutejs/sdds-cs@0.154.2-canary.1498.11494484213.0
  yarn add @salutejs/sdds-dfa@0.152.2-canary.1498.11494484213.0
  yarn add @salutejs/sdds-finportal@0.146.2-canary.1498.11494484213.0
  yarn add @salutejs/sdds-serv@0.153.2-canary.1498.11494484213.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
