### PR TITLE
fix(plasma-new-hope): Fix DatePicker placeholder type

### DIFF
--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.types.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.types.ts
@@ -12,6 +12,10 @@ export type DatePickerTextFieldProps = {
      */
     defaultDate?: Date;
     /**
+     * Placeholder для поля ввода
+     */
+    placeholder?: string;
+    /**
      * Свойство для названия поля при работе с формой
      */
     name?: string;


### PR DESCRIPTION
### DatePicker

- добавлена явная типизация placeholder для Single DatePicker

**Before**:
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/a13844e4-ffcd-4901-aa35-6527de2779ec">

**After**:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/8de62195-e2bd-42a5-860e-bdeed2cacaed">


### What/why changed

Добавлена явная типизация placeholder для Single DatePicker.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.182.2-canary.1501.11495261464.0
  npm install @salutejs/plasma-b2c@1.424.2-canary.1501.11495261464.0
  npm install @salutejs/plasma-new-hope@0.173.2-canary.1501.11495261464.0
  npm install @salutejs/plasma-web@1.426.2-canary.1501.11495261464.0
  npm install @salutejs/sdds-cs@0.154.2-canary.1501.11495261464.0
  npm install @salutejs/sdds-dfa@0.152.2-canary.1501.11495261464.0
  npm install @salutejs/sdds-finportal@0.146.2-canary.1501.11495261464.0
  npm install @salutejs/sdds-serv@0.153.2-canary.1501.11495261464.0
  # or 
  yarn add @salutejs/plasma-asdk@0.182.2-canary.1501.11495261464.0
  yarn add @salutejs/plasma-b2c@1.424.2-canary.1501.11495261464.0
  yarn add @salutejs/plasma-new-hope@0.173.2-canary.1501.11495261464.0
  yarn add @salutejs/plasma-web@1.426.2-canary.1501.11495261464.0
  yarn add @salutejs/sdds-cs@0.154.2-canary.1501.11495261464.0
  yarn add @salutejs/sdds-dfa@0.152.2-canary.1501.11495261464.0
  yarn add @salutejs/sdds-finportal@0.146.2-canary.1501.11495261464.0
  yarn add @salutejs/sdds-serv@0.153.2-canary.1501.11495261464.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
