### PR TITLE
fix(plasma-new-hope): Fix useFocusTrap import

### DIFF
--- a/packages/plasma-new-hope/src/components/Drawer/Drawer.tsx
+++ b/packages/plasma-new-hope/src/components/Drawer/Drawer.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useMemo } from 'react';
-import { useFocusTrap, useForkRef, safeUseId } from '@salutejs/plasma-core';
+import { useForkRef, safeUseId } from '@salutejs/plasma-core';
 
 import { component, mergeConfig } from '../../engines';
 import type { RootProps } from '../../engines';
@@ -8,6 +8,7 @@ import { Overlay } from '../Overlay';
 import { DEFAULT_Z_INDEX } from '../Popup/utils';
 import { panelConfig } from '../Panel';
 import { cx, getSizeValueFromProp } from '../../utils';
+import { useFocusTrap } from '../../hooks';
 
 import { classes, tokens } from './Drawer.tokens';
 import type { DrawerProps } from './Drawer.types';


### PR DESCRIPTION
### Misc

- исправлен импорт useFocusTrap внутри Drawer

**Before**:

https://github.com/user-attachments/assets/515ec287-9ecf-4914-9187-c5d5cc002b29


**After**:

https://github.com/user-attachments/assets/6728cf1a-415e-4034-a3e0-6243f56a74d2



### What/why changed
При открытии модалки из drawer и фокусе на контент, происходит переполнение стека.
Проблема заключается в том, что useFocusTrap импортируется из plasma-core и из хуков в new-hope. Из-за этого происходит конфликт.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.182.4-canary.1508.11518994013.0
  npm install @salutejs/plasma-b2c@1.424.4-canary.1508.11518994013.0
  npm install @salutejs/plasma-new-hope@0.173.4-canary.1508.11518994013.0
  npm install @salutejs/plasma-web@1.426.4-canary.1508.11518994013.0
  npm install @salutejs/sdds-cs@0.154.5-canary.1508.11518994013.0
  npm install @salutejs/sdds-dfa@0.152.5-canary.1508.11518994013.0
  npm install @salutejs/sdds-finportal@0.146.5-canary.1508.11518994013.0
  npm install @salutejs/sdds-serv@0.153.5-canary.1508.11518994013.0
  # or 
  yarn add @salutejs/plasma-asdk@0.182.4-canary.1508.11518994013.0
  yarn add @salutejs/plasma-b2c@1.424.4-canary.1508.11518994013.0
  yarn add @salutejs/plasma-new-hope@0.173.4-canary.1508.11518994013.0
  yarn add @salutejs/plasma-web@1.426.4-canary.1508.11518994013.0
  yarn add @salutejs/sdds-cs@0.154.5-canary.1508.11518994013.0
  yarn add @salutejs/sdds-dfa@0.152.5-canary.1508.11518994013.0
  yarn add @salutejs/sdds-finportal@0.146.5-canary.1508.11518994013.0
  yarn add @salutejs/sdds-serv@0.153.5-canary.1508.11518994013.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
