### PR TITLE
fix(plasma-new-hope): Add more canUseDOM checks to Popup

### DIFF
--- a/packages/plasma-new-hope/src/components/Popup/Popup.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.tsx
@@ -147,7 +147,7 @@ export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
                 </Root>
             );
 
-            if (typeof frame !== 'string' && frame && frame.current) {
+            if (typeof frame !== 'string' && frame && frame.current && canUseDOM) {
                 return <Portal container={frame.current}>{rootNode}</Portal>;
             }
 

--- a/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
@@ -83,9 +83,11 @@ export const PopupProvider: FC<PropsWithChildren> = ({ children }) => {
     return (
         <PopupContext.Provider value={context}>
             {children}
-            <Portal container={document.body}>
-                <StyledPortal id={rootId} />
-            </Portal>
+            {canUseDOM && (
+                <Portal container={document.body}>
+                    <StyledPortal id={rootId} />
+                </Portal>
+            )}
         </PopupContext.Provider>
     );
 };

--- a/packages/plasma-new-hope/src/components/Portal/Portal.tsx
+++ b/packages/plasma-new-hope/src/components/Portal/Portal.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react';
 import ReactDOM from 'react-dom';
 
+import { canUseDOM } from '../../utils';
+
 import { PortalProps } from './Portal.types';
 
 /**
@@ -8,6 +10,10 @@ import { PortalProps } from './Portal.types';
  * Представляет собой ReactDOM.createPortal() в форме компонента.
  */
 export const Portal: FC<PortalProps> = ({ children, container, disabled = false }) => {
+    if (!canUseDOM) {
+        return null;
+    }
+
     const portalContainer = typeof container === 'function' ? container() : container;
 
     return (


### PR DESCRIPTION
### Misc

- добавлено больше проверок canUseDom

**After**:
<img width="559" alt="image" src="https://github.com/user-attachments/assets/f72dfbf6-022e-4749-ba96-50b92dfbdaf6">

### What/why changed 

Билд Next начал опять падать с ошибками о неверном обращении к DOM после рефактора архитектуры Popup.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.187.1-canary.1515.11581730946.0
  npm install @salutejs/plasma-b2c@1.429.1-canary.1515.11581730946.0
  npm install @salutejs/plasma-new-hope@0.178.1-canary.1515.11581730946.0
  npm install @salutejs/plasma-web@1.431.1-canary.1515.11581730946.0
  npm install @salutejs/sdds-cs@0.159.1-canary.1515.11581730946.0
  npm install @salutejs/sdds-dfa@0.157.1-canary.1515.11581730946.0
  npm install @salutejs/sdds-finportal@0.151.1-canary.1515.11581730946.0
  npm install @salutejs/sdds-serv@0.158.1-canary.1515.11581730946.0
  # or 
  yarn add @salutejs/plasma-asdk@0.187.1-canary.1515.11581730946.0
  yarn add @salutejs/plasma-b2c@1.429.1-canary.1515.11581730946.0
  yarn add @salutejs/plasma-new-hope@0.178.1-canary.1515.11581730946.0
  yarn add @salutejs/plasma-web@1.431.1-canary.1515.11581730946.0
  yarn add @salutejs/sdds-cs@0.159.1-canary.1515.11581730946.0
  yarn add @salutejs/sdds-dfa@0.157.1-canary.1515.11581730946.0
  yarn add @salutejs/sdds-finportal@0.151.1-canary.1515.11581730946.0
  yarn add @salutejs/sdds-serv@0.158.1-canary.1515.11581730946.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
