### PR TITLE
[PLASMA-3849]: Работа с draft конфигурациями компонентов в `finportal-draft` 

### DIFF
--- a/packages/sdds-finportal/.gitignore
+++ b/packages/sdds-finportal/.gitignore
@@ -11,3 +11,4 @@
 /index.*
 /helpers
 build-sb
+build-sb-draft

--- a/packages/sdds-finportal/.storybook/main.ts
+++ b/packages/sdds-finportal/.storybook/main.ts
@@ -1,7 +1,6 @@
 import { mergeConfig } from 'vite';
 import type { StorybookConfig } from '@storybook/react-vite';
 
-const USE_STYLED_COMPONENTS = process.env.USE_STYLED_COMPONENTS || false;
 const USE_EMOTION_COMPONENTS = process.env.USE_EMOTION_COMPONENTS || false;
 
 const storyMap = {
@@ -10,13 +9,9 @@ const storyMap = {
 };
 
 const stories = ['../README.stories.mdx'];
+const CSS_IN_JS = USE_EMOTION_COMPONENTS ? 'emotion' : 'styled-components';
 
-if (USE_EMOTION_COMPONENTS) {
-    stories.push(...storyMap['emotion']);
-} else {
-    // default
-    stories.push(...storyMap['styled-components']);
-}
+stories.push(...storyMap[CSS_IN_JS]);
 
 const config: StorybookConfig = {
     staticDirs: ['public'],
@@ -42,6 +37,9 @@ const config: StorybookConfig = {
             },
             build: {
                 sourcemap: false,
+            },
+            define: {
+                'import.meta.env.IS_DRAFT': process.env.IS_DRAFT || false,
             },
         });
     },

--- a/packages/sdds-finportal/package.json
+++ b/packages/sdds-finportal/package.json
@@ -78,6 +78,8 @@
     "build:esm": "BABEL_ENV=esm SC_NAMESPACE=sdds-srvc babel ./src --out-dir ./es --extensions .ts,.tsx",
     "generate:typings": "tsc --outDir . --emitDeclarationOnly",
     "storybook": "storybook dev -p ${PORT:-7007} -c .storybook",
+    "storybook:draft": "IS_DRAFT=true storybook dev -p ${PORT:-7007} -c .storybook",
+    "storybook:build:draft": "IS_DRAFT=true storybook build -c .storybook -o build-sb-draft",
     "storybook:build": "storybook build -c .storybook -o build-sb",
     "typescript-coverage": "npx typescript-coverage-report > /dev/null",
     "lint": "../../node_modules/.bin/eslint ./src --ext .js,.ts,.tsx --quiet"

--- a/packages/sdds-finportal/src/helpers/createComponentByConfig.ts
+++ b/packages/sdds-finportal/src/helpers/createComponentByConfig.ts
@@ -1,0 +1,6 @@
+import { component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+
+// INFO: Temporary method
+export const createComponentByConfig = (baseConfig: any, config: any) => {
+    return component(mergeConfig(baseConfig, config));
+};

--- a/packages/sdds-finportal/src/helpers/hasComponentDraftConfig.ts
+++ b/packages/sdds-finportal/src/helpers/hasComponentDraftConfig.ts
@@ -1,0 +1,9 @@
+// INFO: Этот метод будет удален после внесения всех изменений в пакет
+// INFO: Предназначен для внутреннего использования
+export const hasComponentDraftConfig = () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const { IS_DRAFT = false } = import.meta.env;
+
+    return IS_DRAFT;
+};


### PR DESCRIPTION
### What/why changed

#### Задача

Нужно вносить изменения в конфигурации компонентов, но нельзя чтобы они 
- протекали в текущие реализации
- были доступны **только** в storybook для проверки

#### Решение

Создаем дубликат конфигурации компонент, например для компонента - `Badge.config.draft.ts`. 

ИМХО c таким подходом 

- все изменения изолированы 
- находятся рядом с родными компонентами
- малый шанс сделать ошибку и не внести изменения в draft когда меняется основной конфиг            

На уровне сборки storybook в файле `main.ts` объявляем флаг `IS_DRAFT`:

```ts
define: {
     'import.meta.env.IS_DRAFT': process.env.IS_DRAFT || false,
},
```

и когда мы хотим собрать/посмотреть в storybook компонент с draft конфигурацией то вызываем `storybook:draft`

Под капотом команды лежит

```console
"IS_DRAFT=true storybook dev -p ${PORT:-7007} -c .storybook",
```   

Теперь в в самой stories вносим изменения

```ts
import { badgeConfig } from '@salutejs/plasma-new-hope/styled-components';

// Метод чтобы понять черновки или нет
import { hasComponentDraftConfig } from '../../helpers/hasComponentDraftConfig';
// Метод который собирает компонент на основе конфигураций
import { createComponentByConfig } from '../../helpers/createComponentByConfig';

import { config as defaultConfig } from './Badge.config';
import { config as draftConfig } from './Badge.config.draft';

const config = hasComponentDraftConfig() ? draftConfig : defaultConfig;

// Конечный компонент
const Badge = createComponentByConfig(badgeConfig, config);

...
```          

#### Build

Результат build кладем в директорию `build-sb-draft` на уровне пакета

#### Deploy

Результат `build-sb-draft` кладем в директорию `{название пакета}-draft-storybook` на наш сайт

**Примечания:**

Изменения для CI будут в отдельном PR
Изменения для комнентов будут в отдельном PR's

Как пример можно глянуть в песочнице - https://github.com/Yakutoc/plasma-dev-stage/actions/runs/11735924904?pr=32  

#### Примеры для компонента Badge

https://plasma.sberdevices.ru/pr/pr-32/sdds-finportal-storybook/?path=/story/content-badge--default

https://plasma.sberdevices.ru/pr/pr-32/sdds-finportal-draft-storybook/?path=/story/content-badge--default

#### Codesandbox

https://codesandbox.io/p/sandbox/plasma-sdds-serv-example-forked-t2gc9z 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-finportal@0.168.2-canary.1524.11926491838.0
  # or 
  yarn add @salutejs/sdds-finportal@0.168.2-canary.1524.11926491838.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
