### PR TITLE
feat(plasma-new-hope): Add autoComplete prop to Range

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -1406,6 +1406,7 @@ name?: string | undefined;
 label?: string | undefined;
 view?: string | undefined;
 disabled?: boolean | undefined;
+autoComplete?: string | undefined;
 readOnly?: boolean | undefined;
 size?: string | undefined;
 contentLeft?: ReactNode;
@@ -3323,6 +3324,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3359,6 +3361,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3395,6 +3398,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;

--- a/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.tsx
@@ -34,6 +34,7 @@ export const datePickerRangeRoot = (
         (
             {
                 className,
+                autoComplete,
 
                 isDoubleCalendar = false,
                 opened = false,
@@ -282,6 +283,7 @@ export const datePickerRangeRoot = (
                     //@ts-ignore */}
                     <StyledRange
                         ref={rangeRef}
+                        autoComplete={autoComplete}
                         dividerIcon={dividerIcon}
                         dividerVariant={dividerVariant}
                         disabled={disabled}

--- a/packages/plasma-new-hope/src/components/Range/Range.tsx
+++ b/packages/plasma-new-hope/src/components/Range/Range.tsx
@@ -25,6 +25,7 @@ export const rangeRoot = (Root: RootProps<HTMLDivElement, RangeProps>) =>
     forwardRef<RangeInputRefs, RangeProps>(
         (
             {
+                autoComplete,
                 label,
                 leftHelper,
                 contentLeft,
@@ -136,6 +137,7 @@ export const rangeRoot = (Root: RootProps<HTMLDivElement, RangeProps>) =>
                             onSearch={handleSearchFirstValue}
                             onFocus={onFocusFirstTextfield}
                             onBlur={onBlurFirstTextfield}
+                            autoComplete={autoComplete}
                         />
                         {Divider}
                         <StyledInput
@@ -153,6 +155,7 @@ export const rangeRoot = (Root: RootProps<HTMLDivElement, RangeProps>) =>
                             onSearch={handleSearchSecondValue}
                             onFocus={onFocusSecondTextfield}
                             onBlur={onBlurSecondTextfield}
+                            autoComplete={autoComplete}
                         />
                         {contentRight && <StyledContentRight>{contentRight}</StyledContentRight>}
                     </ContentWrapper>

--- a/packages/plasma-new-hope/src/components/Range/Range.types.ts
+++ b/packages/plasma-new-hope/src/components/Range/Range.types.ts
@@ -110,6 +110,10 @@ export type RangeInnerProps = {
      */
     secondTextfieldTextAfter?: string;
     /**
+     * Автозаполнение полей.
+     */
+    autoComplete?: string;
+    /**
      * Вариант отображения
      */
     view?: string;

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -1408,6 +1408,7 @@ name?: string | undefined;
 label?: string | undefined;
 view?: string | undefined;
 disabled?: boolean | undefined;
+autoComplete?: string | undefined;
 readOnly?: boolean | undefined;
 size?: string | undefined;
 contentLeft?: ReactNode;
@@ -3325,6 +3326,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3361,6 +3363,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3397,6 +3400,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -1479,6 +1479,7 @@ name?: string | undefined;
 label?: string | undefined;
 view?: string | undefined;
 disabled?: boolean | undefined;
+autoComplete?: string | undefined;
 readOnly?: boolean | undefined;
 size?: string | undefined;
 contentLeft?: ReactNode;
@@ -3098,6 +3099,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3134,6 +3136,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3170,6 +3173,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -1523,6 +1523,7 @@ name?: string | undefined;
 label?: string | undefined;
 view?: string | undefined;
 disabled?: boolean | undefined;
+autoComplete?: string | undefined;
 readOnly?: boolean | undefined;
 size?: string | undefined;
 contentLeft?: ReactNode;
@@ -3226,6 +3227,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3262,6 +3264,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3298,6 +3301,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -1574,6 +1574,7 @@ name?: string | undefined;
 label?: string | undefined;
 view?: string | undefined;
 disabled?: boolean | undefined;
+autoComplete?: string | undefined;
 readOnly?: boolean | undefined;
 size?: string | undefined;
 contentLeft?: ReactNode;
@@ -3320,6 +3321,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3356,6 +3358,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3392,6 +3395,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -1575,6 +1575,7 @@ name?: string | undefined;
 label?: string | undefined;
 view?: string | undefined;
 disabled?: boolean | undefined;
+autoComplete?: string | undefined;
 readOnly?: boolean | undefined;
 size?: string | undefined;
 contentLeft?: ReactNode;
@@ -3321,6 +3322,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3357,6 +3359,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3393,6 +3396,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -1574,6 +1574,7 @@ name?: string | undefined;
 label?: string | undefined;
 view?: string | undefined;
 disabled?: boolean | undefined;
+autoComplete?: string | undefined;
 readOnly?: boolean | undefined;
 size?: string | undefined;
 contentLeft?: ReactNode;
@@ -3320,6 +3321,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3356,6 +3358,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;
@@ -3392,6 +3395,7 @@ secondTextfieldContentLeft?: ReactElement<any, string | JSXElementConstructor<an
 secondTextfieldContentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefined;
 firstTextfieldTextAfter?: string | undefined;
 secondTextfieldTextAfter?: string | undefined;
+autoComplete?: string | undefined;
 view?: string | undefined;
 size?: string | undefined;
 readOnly?: boolean | undefined;


### PR DESCRIPTION
### Range, DatePickerRange

- добавлена возможность передать autoComplete в Range/DatePickerRange

### What/why changed

Добавлена возможность передать autoComplete в Range/DatePickerRange.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.194.0-canary.1530.11700796066.0
  npm install @salutejs/plasma-b2c@1.436.0-canary.1530.11700796066.0
  npm install @salutejs/plasma-new-hope@0.184.0-canary.1530.11700796066.0
  npm install @salutejs/plasma-web@1.438.0-canary.1530.11700796066.0
  npm install @salutejs/sdds-cs@0.166.0-canary.1530.11700796066.0
  npm install @salutejs/sdds-dfa@0.164.0-canary.1530.11700796066.0
  npm install @salutejs/sdds-finportal@0.158.0-canary.1530.11700796066.0
  npm install @salutejs/sdds-insol@0.157.0-canary.1530.11700796066.0
  npm install @salutejs/sdds-serv@0.165.0-canary.1530.11700796066.0
  # or 
  yarn add @salutejs/plasma-asdk@0.194.0-canary.1530.11700796066.0
  yarn add @salutejs/plasma-b2c@1.436.0-canary.1530.11700796066.0
  yarn add @salutejs/plasma-new-hope@0.184.0-canary.1530.11700796066.0
  yarn add @salutejs/plasma-web@1.438.0-canary.1530.11700796066.0
  yarn add @salutejs/sdds-cs@0.166.0-canary.1530.11700796066.0
  yarn add @salutejs/sdds-dfa@0.164.0-canary.1530.11700796066.0
  yarn add @salutejs/sdds-finportal@0.158.0-canary.1530.11700796066.0
  yarn add @salutejs/sdds-insol@0.157.0-canary.1530.11700796066.0
  yarn add @salutejs/sdds-serv@0.165.0-canary.1530.11700796066.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
