### PR TITLE
fix(plasma-new-hope): Fix DatePickerRange grid type prop

### DIFF
--- a/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDatePopover/RangeDatePopover.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDatePopover/RangeDatePopover.tsx
@@ -74,6 +74,7 @@ export const RangeDatePopover = ({
                         disabledYearList={disabledYearList}
                         min={min}
                         max={max}
+                        type={type}
                         locale={lang}
                         includeEdgeDates={includeEdgeDates}
                         onChangeValue={onChangeValue}


### PR DESCRIPTION
### DatePicker

- добавлен пропс type для двойного DatePickerRange

### What/why changed

Без этого пропса нельзя задать конечную сетку календаря для выбора даты.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.194.1-canary.1535.11702289511.0
  npm install @salutejs/plasma-b2c@1.436.1-canary.1535.11702289511.0
  npm install @salutejs/plasma-new-hope@0.184.1-canary.1535.11702289511.0
  npm install @salutejs/plasma-web@1.438.1-canary.1535.11702289511.0
  npm install @salutejs/sdds-cs@0.166.1-canary.1535.11702289511.0
  npm install @salutejs/sdds-dfa@0.164.1-canary.1535.11702289511.0
  npm install @salutejs/sdds-finportal@0.158.1-canary.1535.11702289511.0
  npm install @salutejs/sdds-insol@0.157.1-canary.1535.11702289511.0
  npm install @salutejs/sdds-serv@0.165.1-canary.1535.11702289511.0
  # or 
  yarn add @salutejs/plasma-asdk@0.194.1-canary.1535.11702289511.0
  yarn add @salutejs/plasma-b2c@1.436.1-canary.1535.11702289511.0
  yarn add @salutejs/plasma-new-hope@0.184.1-canary.1535.11702289511.0
  yarn add @salutejs/plasma-web@1.438.1-canary.1535.11702289511.0
  yarn add @salutejs/sdds-cs@0.166.1-canary.1535.11702289511.0
  yarn add @salutejs/sdds-dfa@0.164.1-canary.1535.11702289511.0
  yarn add @salutejs/sdds-finportal@0.158.1-canary.1535.11702289511.0
  yarn add @salutejs/sdds-insol@0.157.1-canary.1535.11702289511.0
  yarn add @salutejs/sdds-serv@0.165.1-canary.1535.11702289511.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
