### PR TITLE
feat(plasma-new-hope): Divide chip events

### DIFF
--- a/packages/plasma-b2c/src/components/Chip/Chip.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Chip/Chip.component-test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { IconDownload } from '@salutejs/plasma-icons';
 import { mount, CypressTestDecorator, getComponent, PadMe, SpaceMe } from '@salutejs/plasma-cy-utils';
 
@@ -106,5 +106,30 @@ describe('plasma-b2c: Chip', () => {
             </CypressTestDecorator>,
         );
         cy.matchImageSnapshot();
+    });
+
+    const Demo = () => {
+        const [isChipVisible, setIsChipVisible] = useState(true);
+
+        return isChipVisible ? (
+            <Chip className="chip" onClickClose={() => setIsChipVisible(false)}>
+                text
+            </Chip>
+        ) : (
+            <></>
+        );
+    };
+
+    it('click on close', () => {
+        mount(
+            <CypressTestDecorator>
+                <Demo />
+            </CypressTestDecorator>,
+        );
+
+        cy.get('.chip').click();
+        cy.get('.chip').should('exist');
+        cy.get('.chip div').last().click();
+        cy.get('.chip').should('not.exist');
     });
 });

--- a/packages/plasma-new-hope/src/components/Chip/Chip.tsx
+++ b/packages/plasma-new-hope/src/components/Chip/Chip.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo } from 'react';
+import React, { forwardRef, MouseEvent } from 'react';
 
 import type { RootProps } from '../../engines';
 import { IconClose } from '../_Icon/Icons/IconClose';
@@ -27,6 +27,7 @@ export const chipRoot = (Root: RootProps<HTMLButtonElement, ChipProps>) =>
             className,
             onClear,
             onClick,
+            onClickClose,
             pilled = false,
             readOnly = false,
             disabled = false,
@@ -36,7 +37,7 @@ export const chipRoot = (Root: RootProps<HTMLButtonElement, ChipProps>) =>
         const txt = !text && typeof children === 'string' ? children : text;
         const pilledClass = pilled ? classes.pilled : undefined;
 
-        const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
             if (disabled || readOnly) {
                 return;
             }
@@ -45,15 +46,14 @@ export const chipRoot = (Root: RootProps<HTMLButtonElement, ChipProps>) =>
             onClear?.();
         };
 
-        const ClearContent = useMemo(() => {
-            return (
-                contentClearButton || (
-                    <StyledContentClear>
-                        <IconClose sizeCustomProperty={tokens.closeIconSize} color="inherit" />
-                    </StyledContentClear>
-                )
-            );
-        }, [contentClearButton, tokens.closeIconSize]);
+        const handleClickClose = (event: MouseEvent<HTMLDivElement>) => {
+            if (disabled || readOnly || !onClickClose) {
+                return;
+            }
+
+            event.stopPropagation();
+            onClickClose(event);
+        };
 
         return (
             <Root
@@ -71,7 +71,12 @@ export const chipRoot = (Root: RootProps<HTMLButtonElement, ChipProps>) =>
                 {contentLeft && <StyledContentLeft>{contentLeft}</StyledContentLeft>}
                 {txt ? <StyledContentMain>{txt}</StyledContentMain> : children}
                 {contentRight && <StyledContentRight>{contentRight}</StyledContentRight>}
-                {hasClear && ClearContent}
+                {hasClear &&
+                    (contentClearButton || (
+                        <StyledContentClear onClick={handleClickClose}>
+                            <IconClose sizeCustomProperty={tokens.closeIconSize} color="inherit" />
+                        </StyledContentClear>
+                    ))}
             </Root>
         );
     });

--- a/packages/plasma-new-hope/src/components/Chip/Chip.types.ts
+++ b/packages/plasma-new-hope/src/components/Chip/Chip.types.ts
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, PropsWithChildren, ReactNode } from 'react';
+import type { ButtonHTMLAttributes, PropsWithChildren, ReactNode, MouseEvent } from 'react';
 
 type CustomChipProps = {
     /**
@@ -50,8 +50,14 @@ type CustomChipProps = {
     view?: string;
     /**
      *  Коллбек при взаимодействии с элементом
+     * @deprecated
+     * Использовать onClick для закрытия
      */
     onClear?: () => void;
+    /**
+     *  Коллбек при нажатии на крестик
+     */
+    onClickClose?: (event: MouseEvent<HTMLDivElement>) => void;
 } & PropsWithChildren;
 
 export interface ChipProps extends ButtonHTMLAttributes<HTMLButtonElement>, CustomChipProps {}

--- a/packages/plasma-web/src/components/Chip/Chip.component-test.tsx
+++ b/packages/plasma-web/src/components/Chip/Chip.component-test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { FC, PropsWithChildren } from 'react';
 import { createGlobalStyle } from 'styled-components';
 import { standard as standardTypo } from '@salutejs/plasma-typo';
@@ -117,5 +117,30 @@ describe('plasma-web: Chip', () => {
             </CypressTestDecoratorWithTypo>,
         );
         cy.matchImageSnapshot();
+    });
+
+    const Demo = () => {
+        const [isChipVisible, setIsChipVisible] = useState(true);
+
+        return isChipVisible ? (
+            <Chip className="chip" onClickClose={() => setIsChipVisible(false)}>
+                text
+            </Chip>
+        ) : (
+            <></>
+        );
+    };
+
+    it('click on close', () => {
+        mount(
+            <CypressTestDecorator>
+                <Demo />
+            </CypressTestDecorator>,
+        );
+
+        cy.get('.chip').click();
+        cy.get('.chip').should('exist');
+        cy.get('.chip div').last().click();
+        cy.get('.chip').should('not.exist');
     });
 });


### PR DESCRIPTION
### Chip

- добавлено событие onClickClose по клику на крестик
- onClear помечено как deprecated
- написан тест на onClickClose

### What/why changed

Появилась потребность разделить события клика по Chip и по крестику внутри Chip

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.195.0-canary.1536.11704107927.0
  npm install @salutejs/plasma-b2c@1.437.0-canary.1536.11704107927.0
  npm install @salutejs/plasma-new-hope@0.185.0-canary.1536.11704107927.0
  npm install @salutejs/plasma-web@1.439.0-canary.1536.11704107927.0
  npm install @salutejs/sdds-cs@0.167.0-canary.1536.11704107927.0
  npm install @salutejs/sdds-dfa@0.165.0-canary.1536.11704107927.0
  npm install @salutejs/sdds-finportal@0.159.0-canary.1536.11704107927.0
  npm install @salutejs/sdds-insol@0.158.0-canary.1536.11704107927.0
  npm install @salutejs/sdds-serv@0.166.0-canary.1536.11704107927.0
  # or 
  yarn add @salutejs/plasma-asdk@0.195.0-canary.1536.11704107927.0
  yarn add @salutejs/plasma-b2c@1.437.0-canary.1536.11704107927.0
  yarn add @salutejs/plasma-new-hope@0.185.0-canary.1536.11704107927.0
  yarn add @salutejs/plasma-web@1.439.0-canary.1536.11704107927.0
  yarn add @salutejs/sdds-cs@0.167.0-canary.1536.11704107927.0
  yarn add @salutejs/sdds-dfa@0.165.0-canary.1536.11704107927.0
  yarn add @salutejs/sdds-finportal@0.159.0-canary.1536.11704107927.0
  yarn add @salutejs/sdds-insol@0.158.0-canary.1536.11704107927.0
  yarn add @salutejs/sdds-serv@0.166.0-canary.1536.11704107927.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
