### PR TITLE
`plasma-*, sdds-*`: `TabItemProps`, `TabsProps` exported

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -288,9 +288,11 @@ import { SubtitleProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SwitchProps as SwitchProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { SyntheticEvent } from 'react';
 import { syntheticFocus } from '@salutejs/plasma-core';
+import { TabItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TabItemRefs } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsContext } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+import { TabsProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextareaHTMLAttributes } from '@salutejs/plasma-core';
 import { TextareaHTMLAttributes as TextareaHTMLAttributes_2 } from '@salutejs/plasma-new-hope/types/types';
 import type { TextAreaProps as TextAreaProps_2 } from '@salutejs/plasma-hope';
@@ -4023,17 +4025,19 @@ export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 
 export { syntheticFocus }
 
-// Warning: (ae-forgotten-export) The symbol "TabItemProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabItemProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const TabItem: (props: TabItemProps) => JSX.Element;
+export const TabItem: (props: TabItemProps_2) => JSX.Element;
+
+export { TabItemProps }
 
 export { TabItemRefs }
 
-// Warning: (ae-forgotten-export) The symbol "TabsProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabsProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const Tabs: (props: TabsProps) => JSX.Element;
+export const Tabs: (props: TabsProps_2) => JSX.Element;
 
 export { TabsContext }
 
@@ -4041,6 +4045,8 @@ export { TabsContext }
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }
+
+export { TabsProps }
 
 // @public
 export const TextArea: FunctionComponent<PropsType<    {

--- a/packages/plasma-b2c/src/components/Tabs/index.ts
+++ b/packages/plasma-b2c/src/components/Tabs/index.ts
@@ -1,6 +1,6 @@
 export { TabsController } from './TabsController';
 export { TabItemRefs, TabsContext } from '@salutejs/plasma-new-hope/styled-components';
-export type { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { TabItemProps, TabsProps, TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Tabs } from './Tabs';
 export { TabItem } from './TabItem';

--- a/packages/plasma-new-hope/src/components/Tabs/index.ts
+++ b/packages/plasma-new-hope/src/components/Tabs/index.ts
@@ -6,5 +6,5 @@ export { tokens as tabsTokens } from './tokens';
 export { TabItemRefs, TabsContext } from './TabsContext';
 export { createTabsController } from './createTabsController';
 export type { TabsControllerProps } from './createTabsController';
-export type { HorizontalTabsProps, BaseTabsProps } from './Tabs.types';
-export type { HorizontalTabItemProps, BaseTabItemProps, RightContent } from './TabItem.types';
+export type { HorizontalTabsProps, BaseTabsProps, TabsProps } from './Tabs.types';
+export type { HorizontalTabItemProps, BaseTabItemProps, RightContent, TabItemProps } from './TabItem.types';

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -288,9 +288,11 @@ import { SubtitleProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SwitchProps as SwitchProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { SyntheticEvent } from 'react';
 import { syntheticFocus } from '@salutejs/plasma-core';
+import { TabItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TabItemRefs } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsContext } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+import { TabsProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextareaHTMLAttributes } from '@salutejs/plasma-core';
 import { TextareaHTMLAttributes as TextareaHTMLAttributes_2 } from '@salutejs/plasma-new-hope/types/types';
 import type { TextAreaProps as TextAreaProps_2 } from '@salutejs/plasma-hope';
@@ -4025,17 +4027,19 @@ export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 
 export { syntheticFocus }
 
-// Warning: (ae-forgotten-export) The symbol "TabItemProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabItemProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const TabItem: (props: TabItemProps) => JSX.Element;
+export const TabItem: (props: TabItemProps_2) => JSX.Element;
+
+export { TabItemProps }
 
 export { TabItemRefs }
 
-// Warning: (ae-forgotten-export) The symbol "TabsProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabsProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const Tabs: (props: TabsProps) => JSX.Element;
+export const Tabs: (props: TabsProps_2) => JSX.Element;
 
 export { TabsContext }
 
@@ -4043,6 +4047,8 @@ export { TabsContext }
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }
+
+export { TabsProps }
 
 // @public
 export const TextArea: FunctionComponent<PropsType<    {

--- a/packages/plasma-web/src/components/Tabs/index.ts
+++ b/packages/plasma-web/src/components/Tabs/index.ts
@@ -1,6 +1,6 @@
 export { TabsController } from './TabsController';
 export { TabItemRefs, TabsContext } from '@salutejs/plasma-new-hope/styled-components';
-export type { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { TabItemProps, TabsProps, TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Tabs } from './Tabs';
 export { TabItem } from './TabItem';

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -196,9 +196,11 @@ import { StepsProps } from '@salutejs/plasma-new-hope/types/components/Steps/Ste
 import { StyledComponent } from 'styled-components';
 import { SwitchProps as SwitchProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { SyntheticEvent } from 'react';
+import { TabItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TabItemRefs } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsContext } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+import { TabsProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextareaHTMLAttributes } from '@salutejs/plasma-new-hope/types/types';
 import { TextFieldPrimitiveValue } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
 import { TextfieldPrimitiveValue } from '@salutejs/plasma-new-hope/types/components/Range/Range.types';
@@ -3753,17 +3755,19 @@ true: PolymorphicClassName;
 // @public (undocumented)
 export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 
-// Warning: (ae-forgotten-export) The symbol "TabItemProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabItemProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const TabItem: (props: TabItemProps) => JSX.Element;
+export const TabItem: (props: TabItemProps_2) => JSX.Element;
+
+export { TabItemProps }
 
 export { TabItemRefs }
 
-// Warning: (ae-forgotten-export) The symbol "TabsProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabsProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const Tabs: (props: TabsProps) => JSX.Element;
+export const Tabs: (props: TabsProps_2) => JSX.Element;
 
 export { TabsContext }
 
@@ -3771,6 +3775,8 @@ export { TabsContext }
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }
+
+export { TabsProps }
 
 // @public
 export const TextArea: FunctionComponent<PropsType<    {

--- a/packages/sdds-cs/src/components/Tabs/index.ts
+++ b/packages/sdds-cs/src/components/Tabs/index.ts
@@ -1,6 +1,6 @@
 export { TabsController } from './TabsController';
 export { TabItemRefs, TabsContext } from '@salutejs/plasma-new-hope/styled-components';
-export type { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { TabItemProps, TabsProps, TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Tabs } from './Tabs';
 export { TabItem } from './TabItem';

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -186,9 +186,11 @@ import { StepsProps } from '@salutejs/plasma-new-hope/types/components/Steps/Ste
 import { StyledComponent } from 'styled-components';
 import { SwitchProps as SwitchProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { SyntheticEvent } from 'react';
+import { TabItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TabItemRefs } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsContext } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+import { TabsProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextareaHTMLAttributes } from '@salutejs/plasma-new-hope/types/types';
 import { TextFieldGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextFieldPrimitiveValue } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -3908,17 +3910,19 @@ true: PolymorphicClassName;
 // @public (undocumented)
 export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 
-// Warning: (ae-forgotten-export) The symbol "TabItemProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabItemProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const TabItem: (props: TabItemProps) => JSX.Element;
+export const TabItem: (props: TabItemProps_2) => JSX.Element;
+
+export { TabItemProps }
 
 export { TabItemRefs }
 
-// Warning: (ae-forgotten-export) The symbol "TabsProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabsProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const Tabs: (props: TabsProps) => JSX.Element;
+export const Tabs: (props: TabsProps_2) => JSX.Element;
 
 export { TabsContext }
 
@@ -3926,6 +3930,8 @@ export { TabsContext }
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }
+
+export { TabsProps }
 
 // @public
 export const TextArea: FunctionComponent<PropsType<    {

--- a/packages/sdds-dfa/src/components/Tabs/index.ts
+++ b/packages/sdds-dfa/src/components/Tabs/index.ts
@@ -1,6 +1,6 @@
 export { TabsController } from './TabsController';
 export { TabItemRefs, TabsContext } from '@salutejs/plasma-new-hope/styled-components';
-export type { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { TabItemProps, TabsProps, TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Tabs } from './Tabs';
 export { TabItem } from './TabItem';

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -197,9 +197,11 @@ import { StepsProps } from '@salutejs/plasma-new-hope/types/components/Steps/Ste
 import { StyledComponent } from 'styled-components';
 import { SwitchProps as SwitchProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { SyntheticEvent } from 'react';
+import { TabItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TabItemRefs } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsContext } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+import { TabsProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextareaHTMLAttributes } from '@salutejs/plasma-new-hope/types/types';
 import { TextFieldGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextFieldPrimitiveValue } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -4004,17 +4006,19 @@ true: PolymorphicClassName;
 // @public (undocumented)
 export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 
-// Warning: (ae-forgotten-export) The symbol "TabItemProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabItemProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const TabItem: (props: TabItemProps) => JSX.Element;
+export const TabItem: (props: TabItemProps_2) => JSX.Element;
+
+export { TabItemProps }
 
 export { TabItemRefs }
 
-// Warning: (ae-forgotten-export) The symbol "TabsProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabsProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const Tabs: (props: TabsProps) => JSX.Element;
+export const Tabs: (props: TabsProps_2) => JSX.Element;
 
 export { TabsContext }
 
@@ -4022,6 +4026,8 @@ export { TabsContext }
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }
+
+export { TabsProps }
 
 // @public
 export const TextArea: FunctionComponent<PropsType<    {

--- a/packages/sdds-finportal/src/components/Tabs/index.ts
+++ b/packages/sdds-finportal/src/components/Tabs/index.ts
@@ -1,6 +1,6 @@
 export { TabsController } from './TabsController';
 export { TabItemRefs, TabsContext } from '@salutejs/plasma-new-hope/styled-components';
-export type { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { TabItemProps, TabsProps, TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Tabs } from './Tabs';
 export { TabItem } from './TabItem';

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -197,9 +197,11 @@ import { StepsProps } from '@salutejs/plasma-new-hope/types/components/Steps/Ste
 import { StyledComponent } from 'styled-components';
 import { SwitchProps as SwitchProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { SyntheticEvent } from 'react';
+import { TabItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TabItemRefs } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsContext } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+import { TabsProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextareaHTMLAttributes } from '@salutejs/plasma-new-hope/types/types';
 import { TextFieldGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextFieldPrimitiveValue } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -4005,17 +4007,19 @@ true: PolymorphicClassName;
 // @public (undocumented)
 export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 
-// Warning: (ae-forgotten-export) The symbol "TabItemProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabItemProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const TabItem: (props: TabItemProps) => JSX.Element;
+export const TabItem: (props: TabItemProps_2) => JSX.Element;
+
+export { TabItemProps }
 
 export { TabItemRefs }
 
-// Warning: (ae-forgotten-export) The symbol "TabsProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabsProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const Tabs: (props: TabsProps) => JSX.Element;
+export const Tabs: (props: TabsProps_2) => JSX.Element;
 
 export { TabsContext }
 
@@ -4023,6 +4027,8 @@ export { TabsContext }
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }
+
+export { TabsProps }
 
 // @public
 export const TextArea: FunctionComponent<PropsType<    {

--- a/packages/sdds-insol/src/components/Tabs/index.ts
+++ b/packages/sdds-insol/src/components/Tabs/index.ts
@@ -1,6 +1,6 @@
 export { TabsController } from './TabsController';
 export { TabItemRefs, TabsContext } from '@salutejs/plasma-new-hope/styled-components';
-export type { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { TabItemProps, TabsProps, TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Tabs } from './Tabs';
 export { TabItem } from './TabItem';

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -197,9 +197,11 @@ import { StepsProps } from '@salutejs/plasma-new-hope/types/components/Steps/Ste
 import { StyledComponent } from 'styled-components';
 import { SwitchProps as SwitchProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { SyntheticEvent } from 'react';
+import { TabItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TabItemRefs } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsContext } from '@salutejs/plasma-new-hope/styled-components';
 import { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+import { TabsProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextareaHTMLAttributes } from '@salutejs/plasma-new-hope/types/types';
 import { TextFieldGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { TextFieldPrimitiveValue } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -4004,17 +4006,19 @@ true: PolymorphicClassName;
 // @public (undocumented)
 export type SwitchProps = ComponentProps<typeof SwitchComponent>;
 
-// Warning: (ae-forgotten-export) The symbol "TabItemProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabItemProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const TabItem: (props: TabItemProps) => JSX.Element;
+export const TabItem: (props: TabItemProps_2) => JSX.Element;
+
+export { TabItemProps }
 
 export { TabItemRefs }
 
-// Warning: (ae-forgotten-export) The symbol "TabsProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "TabsProps_2" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const Tabs: (props: TabsProps) => JSX.Element;
+export const Tabs: (props: TabsProps_2) => JSX.Element;
 
 export { TabsContext }
 
@@ -4022,6 +4026,8 @@ export { TabsContext }
 export const TabsController: ForwardRefExoticComponent<TabsControllerProps & RefAttributes<HTMLDivElement>>;
 
 export { TabsControllerProps }
+
+export { TabsProps }
 
 // @public
 export const TextArea: FunctionComponent<PropsType<    {

--- a/packages/sdds-serv/src/components/Tabs/index.ts
+++ b/packages/sdds-serv/src/components/Tabs/index.ts
@@ -1,6 +1,6 @@
 export { TabsController } from './TabsController';
 export { TabItemRefs, TabsContext } from '@salutejs/plasma-new-hope/styled-components';
-export type { TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { TabItemProps, TabsProps, TabsControllerProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Tabs } from './Tabs';
 export { TabItem } from './TabItem';


### PR DESCRIPTION
### Tabs

- `TabItemProps`, `TabsProps` экспортируются во все пакеты

### What/why changed

`TabItemProps`, `TabsProps` экспортируются во все пакеты для поддержания обратной совместимости у пользователей, которые ранее использовали эти импорты. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.197.1-canary.1545.11773810119.0
  npm install @salutejs/plasma-b2c@1.439.1-canary.1545.11773810119.0
  npm install @salutejs/plasma-new-hope@0.187.1-canary.1545.11773810119.0
  npm install @salutejs/plasma-web@1.441.1-canary.1545.11773810119.0
  npm install @salutejs/sdds-cs@0.170.1-canary.1545.11773810119.0
  npm install @salutejs/sdds-dfa@0.167.1-canary.1545.11773810119.0
  npm install @salutejs/sdds-finportal@0.161.1-canary.1545.11773810119.0
  npm install @salutejs/sdds-insol@0.160.1-canary.1545.11773810119.0
  npm install @salutejs/sdds-serv@0.168.1-canary.1545.11773810119.0
  # or 
  yarn add @salutejs/plasma-asdk@0.197.1-canary.1545.11773810119.0
  yarn add @salutejs/plasma-b2c@1.439.1-canary.1545.11773810119.0
  yarn add @salutejs/plasma-new-hope@0.187.1-canary.1545.11773810119.0
  yarn add @salutejs/plasma-web@1.441.1-canary.1545.11773810119.0
  yarn add @salutejs/sdds-cs@0.170.1-canary.1545.11773810119.0
  yarn add @salutejs/sdds-dfa@0.167.1-canary.1545.11773810119.0
  yarn add @salutejs/sdds-finportal@0.161.1-canary.1545.11773810119.0
  yarn add @salutejs/sdds-insol@0.160.1-canary.1545.11773810119.0
  yarn add @salutejs/sdds-serv@0.168.1-canary.1545.11773810119.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
