### PR TITLE
fix(sdds-cs-docs): Edit docs components for correctly view

### DIFF
--- a/website/sdds-cs-docs/docs/components/Cell.mdx
+++ b/website/sdds-cs-docs/docs/components/Cell.mdx
@@ -51,7 +51,7 @@ export function App() {
     return (
         <>
             <Cell
-                contentLeft={ <Avatar size="xs" url="https://avatars.githubusercontent.com/u/1813468?v=4" /> }
+                contentLeft={ <Avatar size="m" url="https://avatars.githubusercontent.com/u/1813468?v=4" /> }
                 size="s"
                 contentRight={<IconChevronRight color="inheart" size="xs" />}
             >

--- a/website/sdds-cs-docs/docs/components/Chip.mdx
+++ b/website/sdds-cs-docs/docs/components/Chip.mdx
@@ -53,7 +53,6 @@ export function App() {
 ## Примеры
 
 ### Размер Chip
-Размер Chip задается с помощью свойства `size`. Возможные значения свойства: `"l"`, `"m"`, `"s"` или `"xs"`:
 
 ```tsx live
 import React from 'react';

--- a/website/sdds-cs-docs/docs/components/Mask.mdx
+++ b/website/sdds-cs-docs/docs/components/Mask.mdx
@@ -31,7 +31,7 @@ export function App() {
                 placeholder="Введите дату"
                 mask="00/00/0000"
                 maskString="DD/MM/YYYY"
-                size="l"
+                size="s"
             />
         </div>
     );

--- a/website/sdds-cs-docs/docs/components/Toast.mdx
+++ b/website/sdds-cs-docs/docs/components/Toast.mdx
@@ -134,7 +134,7 @@ export function App() {
             role: 'status',
             hasClose: true,
             fade: false,
-            size: 'm',
+            size: 's',
             view: 'dark',
             timeout: 3000,
             onShow,


### PR DESCRIPTION
### Edit docs components for correctly view

Изменена документация ( значения `size` ) для корректного отображения в документации в вертикали `sdds-cs`


### What/why changed (Это обязательный заголовок)

- Изменена документация к компонентам `Mask`, `Toast`, `Cell`, `Chip`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.201.2-canary.1557.11803291365.0
  npm install @salutejs/plasma-b2c@1.443.2-canary.1557.11803291365.0
  npm install @salutejs/plasma-new-hope@0.191.2-canary.1557.11803291365.0
  npm install @salutejs/plasma-web@1.445.2-canary.1557.11803291365.0
  npm install @salutejs/sdds-cs@0.174.2-canary.1557.11803291365.0
  npm install @salutejs/sdds-dfa@0.171.2-canary.1557.11803291365.0
  npm install @salutejs/sdds-finportal@0.165.2-canary.1557.11803291365.0
  npm install @salutejs/sdds-insol@0.164.2-canary.1557.11803291365.0
  npm install @salutejs/sdds-serv@0.172.2-canary.1557.11803291365.0
  # or 
  yarn add @salutejs/plasma-asdk@0.201.2-canary.1557.11803291365.0
  yarn add @salutejs/plasma-b2c@1.443.2-canary.1557.11803291365.0
  yarn add @salutejs/plasma-new-hope@0.191.2-canary.1557.11803291365.0
  yarn add @salutejs/plasma-web@1.445.2-canary.1557.11803291365.0
  yarn add @salutejs/sdds-cs@0.174.2-canary.1557.11803291365.0
  yarn add @salutejs/sdds-dfa@0.171.2-canary.1557.11803291365.0
  yarn add @salutejs/sdds-finportal@0.165.2-canary.1557.11803291365.0
  yarn add @salutejs/sdds-insol@0.164.2-canary.1557.11803291365.0
  yarn add @salutejs/sdds-serv@0.172.2-canary.1557.11803291365.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
