### PR TITLE
feat(plasma-new-hope): Add displaying date from min value in Calendar

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
@@ -60,7 +60,7 @@ export const calendarBaseRoot = (Root: RootProps<HTMLDivElement, HTMLAttributes<
             const [prevValue, setPrevValue] = useState(value);
             const [outOfRangeKey, setOutOfRangeKey] = useState<number>(0);
 
-            const [state, dispatch] = useReducer(reducer, getInitialState(value, type));
+            const [state, dispatch] = useReducer(reducer, getInitialState(value, min, type));
 
             const { date, calendarState, startYear, size } = state;
 

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
@@ -60,7 +60,7 @@ export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttribute
             const [prevValue, setPrevValue] = useState(value);
             const [outOfRangeKey, setOutOfRangeKey] = useState<number>(0);
 
-            const [state, dispatch] = useReducer(reducer, getInitialState(value, type, true));
+            const [state, dispatch] = useReducer(reducer, getInitialState(value, min, type, true));
 
             const { date, calendarState, startYear, size } = state;
 

--- a/packages/plasma-new-hope/src/components/Calendar/store/reducer.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/store/reducer.ts
@@ -23,10 +23,11 @@ export const sizeMap: SizeMap = {
 
 export const getInitialState = (
     value: Date | undefined,
+    min: Date | undefined,
     calendarState: CalendarStateType,
     isDouble?: boolean,
 ): InitialState => {
-    const initDate = value || new Date();
+    const initDate = value || min || new Date();
     const date = getDateFromValue(initDate);
 
     const resSize: [number, number] = isDouble ? sizeMap[calendarState].double : sizeMap[calendarState].single;


### PR DESCRIPTION
### Calendar

- при отсутствии значения календарная сетка отображается с минимальной даты

**Before**:
<img width="484" alt="image" src="https://github.com/user-attachments/assets/e3ea6e68-f8d4-4c9a-95ca-fba28ca282f5">

**After**:
<img width="464" alt="image" src="https://github.com/user-attachments/assets/d7a53b4b-4a28-4eda-9c91-7a82d9f03466">

### What/why changed

При отсутствии значения календарная сетка отображается с минимальной даты

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.208.0-canary.1572.11972038908.0
  npm install @salutejs/plasma-b2c@1.450.0-canary.1572.11972038908.0
  npm install @salutejs/plasma-new-hope@0.197.0-canary.1572.11972038908.0
  npm install @salutejs/plasma-web@1.452.0-canary.1572.11972038908.0
  npm install @salutejs/sdds-cs@0.181.0-canary.1572.11972038908.0
  npm install @salutejs/sdds-dfa@0.178.0-canary.1572.11972038908.0
  npm install @salutejs/sdds-finportal@0.172.0-canary.1572.11972038908.0
  npm install @salutejs/sdds-insol@0.172.0-canary.1572.11972038908.0
  npm install @salutejs/sdds-serv@0.180.0-canary.1572.11972038908.0
  # or 
  yarn add @salutejs/plasma-asdk@0.208.0-canary.1572.11972038908.0
  yarn add @salutejs/plasma-b2c@1.450.0-canary.1572.11972038908.0
  yarn add @salutejs/plasma-new-hope@0.197.0-canary.1572.11972038908.0
  yarn add @salutejs/plasma-web@1.452.0-canary.1572.11972038908.0
  yarn add @salutejs/sdds-cs@0.181.0-canary.1572.11972038908.0
  yarn add @salutejs/sdds-dfa@0.178.0-canary.1572.11972038908.0
  yarn add @salutejs/sdds-finportal@0.172.0-canary.1572.11972038908.0
  yarn add @salutejs/sdds-insol@0.172.0-canary.1572.11972038908.0
  yarn add @salutejs/sdds-serv@0.180.0-canary.1572.11972038908.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
