### PR TITLE
feat(new-hope): add react hook form support in autocomplite

### DIFF
--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.tsx
@@ -19,6 +19,7 @@ export const autocompleteRoot = (Root: RootProps<HTMLInputElement, AutocompleteP
         (
             {
                 value: outerValue,
+                defaultValue,
                 onChange,
                 suggestions,
                 view,
@@ -112,6 +113,12 @@ export const autocompleteRoot = (Root: RootProps<HTMLInputElement, AutocompleteP
             useDidMountEffect(() => {
                 dispatchFocused({ type: 'reset' });
             }, [value]);
+
+            useDidMountEffect(() => {
+                if (defaultValue) {
+                    setInnerValue(defaultValue);
+                }
+            }, [defaultValue]);
 
             return (
                 <Root view={view} size={size} labelPlacement={labelPlacement} disabled={disabled} readOnly={readOnly}>

--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
@@ -87,6 +87,10 @@ export type BaseProps = {
      * Коллбэк для рендера элемента в конце выпадающего списка.
      */
     renderListEnd?: () => ReactNode;
+    /**
+     * Изначальное значение.
+     */
+    defaultValue?: string;
 };
 
 export type AutocompleteProps = BaseProps &

--- a/scaffold/template-docs/docs/form/Components.mdx
+++ b/scaffold/template-docs/docs/form/Components.mdx
@@ -4,7 +4,7 @@ title: Поддержка компонентов
 sidebar_position: 4
 ---
 
-### TextField, TextArea, Radiobox, Checkbox и Switch
+### TextField, TextArea, Radiobox, Checkbox, Autocomplite и Switch
 
 #### React Hook Form
 

--- a/scaffold/template-docs/docs/form/NativeForm.mdx
+++ b/scaffold/template-docs/docs/form/NativeForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 3
 ```tsx live
 
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker } from "@salutejs/{{ name }}";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, Autocomplite } from "@salutejs{{ name }}";
 
 export function App() {
     const langName = 'language';
@@ -34,6 +34,59 @@ export function App() {
             console.log(name, value);
         }
     };
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
+    ];
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -56,6 +109,7 @@ export function App() {
             </RadioGroup>
             <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/scaffold/template-docs/docs/form/ReactHookForm.mdx
+++ b/scaffold/template-docs/docs/form/ReactHookForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 import { useForm } from 'react-hook-form';
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange } from "@salutejs/{{ name }}";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange, Autocomplete } from "@salutejs/{{ name }}";
 
 export function App() {
     const langName = 'language';
@@ -22,6 +22,59 @@ export function App() {
         { langName, value: 'c', label: 'C', disabled: false },
         { langName, value: 'cpp', label: 'C++', disabled: false },
         { langName, value: 'assembly', label: 'Assembly', disabled: false },
+    ];
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
     ];
 
     const { register, handleSubmit } = useForm();
@@ -51,6 +104,7 @@ export function App() {
             </RadioGroup>
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/plasma-b2c-docs/docs/form/Components.mdx
+++ b/website/plasma-b2c-docs/docs/form/Components.mdx
@@ -4,7 +4,7 @@ title: Поддержка компонентов
 sidebar_position: 4
 ---
 
-### TextField, TextArea, Radiobox, Checkbox и Switch
+### TextField, TextArea, Radiobox, Checkbox, Autocomplite и Switch
 
 #### React Hook Form
 

--- a/website/plasma-b2c-docs/docs/form/NativeForm.mdx
+++ b/website/plasma-b2c-docs/docs/form/NativeForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 3
 ```tsx live
 
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker } from "@salutejs/plasma-b2c";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, Autocomplite } from "@salutejs/plasma-b2c";
 
 export function App() {
     const langName = 'language';
@@ -34,6 +34,60 @@ export function App() {
             console.log(name, value);
         }
     };
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
+    ];
+
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -56,6 +110,7 @@ export function App() {
             </RadioGroup>
             <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/plasma-b2c-docs/docs/form/ReactHookForm.mdx
+++ b/website/plasma-b2c-docs/docs/form/ReactHookForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 import { useForm } from 'react-hook-form';
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange } from "@salutejs/plasma-b2c";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange, Autocomplete } from "@salutejs/plasma-b2c";
 
 export function App() {
     const langName = 'language';
@@ -22,6 +22,59 @@ export function App() {
         { langName, value: 'c', label: 'C', disabled: false },
         { langName, value: 'cpp', label: 'C++', disabled: false },
         { langName, value: 'assembly', label: 'Assembly', disabled: false },
+    ];
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
     ];
 
     const { register, handleSubmit } = useForm();
@@ -51,6 +104,7 @@ export function App() {
             </RadioGroup>
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/plasma-web-docs/docs/form/Components.mdx
+++ b/website/plasma-web-docs/docs/form/Components.mdx
@@ -4,7 +4,7 @@ title: Поддержка компонентов
 sidebar_position: 4
 ---
 
-### TextField, TextArea, Radiobox, Checkbox и Switch
+### TextField, TextArea, Radiobox, Checkbox, Autocomplite и Switch
 
 #### React Hook Form
 

--- a/website/plasma-web-docs/docs/form/NativeForm.mdx
+++ b/website/plasma-web-docs/docs/form/NativeForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 3
 ```tsx live
 
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker } from "@salutejs/plasma-web";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, Autocomplite } from "@salutejsplasma-web";
 
 export function App() {
     const langName = 'language';
@@ -34,6 +34,59 @@ export function App() {
             console.log(name, value);
         }
     };
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
+    ];
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -56,6 +109,7 @@ export function App() {
             </RadioGroup>
             <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/plasma-web-docs/docs/form/ReactHookForm.mdx
+++ b/website/plasma-web-docs/docs/form/ReactHookForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 import { useForm } from 'react-hook-form';
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange } from "@salutejs/plasma-web";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange, Autocomplete } from "@salutejs/plasma-web";
 
 export function App() {
     const langName = 'language';
@@ -22,6 +22,59 @@ export function App() {
         { langName, value: 'c', label: 'C', disabled: false },
         { langName, value: 'cpp', label: 'C++', disabled: false },
         { langName, value: 'assembly', label: 'Assembly', disabled: false },
+    ];
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
     ];
 
     const { register, handleSubmit } = useForm();
@@ -51,6 +104,7 @@ export function App() {
             </RadioGroup>
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-cs-docs/docs/form/Components.mdx
+++ b/website/sdds-cs-docs/docs/form/Components.mdx
@@ -4,7 +4,7 @@ title: Поддержка компонентов
 sidebar_position: 4
 ---
 
-### TextField, TextArea, Radiobox, Checkbox и Switch
+### TextField, TextArea, Radiobox, Checkbox, Autocomplite и Switch
 
 #### React Hook Form
 

--- a/website/sdds-cs-docs/docs/form/NativeForm.mdx
+++ b/website/sdds-cs-docs/docs/form/NativeForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 3
 ```tsx live
 
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker } from "@salutejs/sdds-cs";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, Autocomplite } from "@salutejssdds-cs";
 
 export function App() {
     const langName = 'language';
@@ -34,6 +34,59 @@ export function App() {
             console.log(name, value);
         }
     };
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
+    ];
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -56,6 +109,7 @@ export function App() {
             </RadioGroup>
             <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-cs-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-cs-docs/docs/form/ReactHookForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 import { useForm } from 'react-hook-form';
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange } from "@salutejs/sdds-cs";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange, Autocomplete } from "@salutejs/sdds-cs";
 
 export function App() {
     const langName = 'language';
@@ -22,6 +22,59 @@ export function App() {
         { langName, value: 'c', label: 'C', disabled: false },
         { langName, value: 'cpp', label: 'C++', disabled: false },
         { langName, value: 'assembly', label: 'Assembly', disabled: false },
+    ];
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
     ];
 
     const { register, handleSubmit } = useForm();
@@ -51,6 +104,7 @@ export function App() {
             </RadioGroup>
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-dfa-docs/docs/form/Components.mdx
+++ b/website/sdds-dfa-docs/docs/form/Components.mdx
@@ -4,7 +4,7 @@ title: Поддержка компонентов
 sidebar_position: 4
 ---
 
-### TextField, TextArea, Radiobox, Checkbox и Switch
+### TextField, TextArea, Radiobox, Checkbox, Autocomplite и Switch
 
 #### React Hook Form
 

--- a/website/sdds-dfa-docs/docs/form/NativeForm.mdx
+++ b/website/sdds-dfa-docs/docs/form/NativeForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 3
 ```tsx live
 
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker } from "@salutejs/sdds-dfa";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, Autocomplite } from "@salutejssdds-dfa";
 
 export function App() {
     const langName = 'language';
@@ -34,6 +34,59 @@ export function App() {
             console.log(name, value);
         }
     };
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
+    ];
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -56,6 +109,7 @@ export function App() {
             </RadioGroup>
             <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-dfa-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-dfa-docs/docs/form/ReactHookForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 import { useForm } from 'react-hook-form';
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange } from "@salutejs/sdds-dfa";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange, Autocomplete } from "@salutejs/sdds-dfa";
 
 export function App() {
     const langName = 'language';
@@ -22,6 +22,59 @@ export function App() {
         { langName, value: 'c', label: 'C', disabled: false },
         { langName, value: 'cpp', label: 'C++', disabled: false },
         { langName, value: 'assembly', label: 'Assembly', disabled: false },
+    ];
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
     ];
 
     const { register, handleSubmit } = useForm();
@@ -51,6 +104,7 @@ export function App() {
             </RadioGroup>
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-insol-docs/docs/form/Components.mdx
+++ b/website/sdds-insol-docs/docs/form/Components.mdx
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 # Поддержка компонентов 
 
-### TextField, TextArea, Radiobox, Checkbox и Switch
+### TextField, TextArea, Radiobox, Checkbox, Autocomplite и Switch
 
 #### React Hook Form
 

--- a/website/sdds-insol-docs/docs/form/NativeForm.mdx
+++ b/website/sdds-insol-docs/docs/form/NativeForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 3
 ```tsx live
 
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker } from "@salutejs/sdds-insol";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, Autocomplite } from "@salutejssdds-insol";
 
 export function App() {
     const langName = 'language';
@@ -34,6 +34,59 @@ export function App() {
             console.log(name, value);
         }
     };
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
+    ];
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -56,6 +109,7 @@ export function App() {
             </RadioGroup>
             <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-insol-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-insol-docs/docs/form/ReactHookForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 import { useForm } from 'react-hook-form';
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange } from "@salutejs/sdds-insol";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange, Autocomplete } from "@salutejs/sdds-insol";
 
 export function App() {
     const langName = 'language';
@@ -22,6 +22,59 @@ export function App() {
         { langName, value: 'c', label: 'C', disabled: false },
         { langName, value: 'cpp', label: 'C++', disabled: false },
         { langName, value: 'assembly', label: 'Assembly', disabled: false },
+    ];
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
     ];
 
     const { register, handleSubmit } = useForm();
@@ -51,6 +104,7 @@ export function App() {
             </RadioGroup>
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-serv-docs/docs/form/Components.mdx
+++ b/website/sdds-serv-docs/docs/form/Components.mdx
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 # Поддержка компонентов 
 
-### TextField, TextArea, Radiobox, Checkbox и Switch
+### TextField, TextArea, Radiobox, Checkbox, Autocomplite и Switch
 
 #### React Hook Form
 

--- a/website/sdds-serv-docs/docs/form/NativeForm.mdx
+++ b/website/sdds-serv-docs/docs/form/NativeForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 3
 ```tsx live
 
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker } from "@salutejs/sdds-serv";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, Autocomplite } from "@salutejssdds-serv";
 
 export function App() {
     const langName = 'language';
@@ -34,6 +34,59 @@ export function App() {
             console.log(name, value);
         }
     };
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
+    ];
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -56,6 +109,7 @@ export function App() {
             </RadioGroup>
             <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-serv-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-serv-docs/docs/form/ReactHookForm.mdx
@@ -14,7 +14,7 @@ sidebar_position: 2
 
 import { useForm } from 'react-hook-form';
 import React from 'react';
-import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange } from "@salutejs/sdds-serv";
+import { Button, TextField, TextArea, Checkbox, Switch, Radiobox, RadioGroup, Slider, DatePicker, DatePickerRange, Autocomplete } from "@salutejs/sdds-serv";
 
 export function App() {
     const langName = 'language';
@@ -22,6 +22,59 @@ export function App() {
         { langName, value: 'c', label: 'C', disabled: false },
         { langName, value: 'cpp', label: 'C++', disabled: false },
         { langName, value: 'assembly', label: 'Assembly', disabled: false },
+    ];
+
+    const mockData = [
+        { label: 'Алексей Смирнов' },
+        { label: 'Екатерина Иванова' },
+        { label: 'Дмитрий Петров' },
+        { label: 'Ольга Васильева' },
+        { label: 'Сергей Сидоров' },
+        { label: 'Мария Кузнецова' },
+        { label: 'Андрей Попов' },
+        { label: 'Анна Николаева' },
+        { label: 'Иван Федоров' },
+        { label: 'Наталья Морозова' },
+        { label: 'Михаил Павлов' },
+        { label: 'Елена Романова' },
+        { label: 'Владимир Киселев' },
+        { label: 'Татьяна Захарова' },
+        { label: 'Николай Семенов' },
+        { label: 'Юлия Белова' },
+        { label: 'Александр Гусев' },
+        { label: 'Оксана Яковлева' },
+        { label: 'Игорь Егорова' },
+        { label: 'Вера Тихомирова' },
+        { label: 'Артем Григорьев' },
+        { label: 'Евгения Козлова' },
+        { label: 'Максим Лебедев' },
+        { label: 'Виктория Калашникова' },
+        { label: 'Константин Абрамов' },
+        { label: 'Светлана Новикова' },
+        { label: 'Юрий Волков' },
+        { label: 'Валентина Воробьева' },
+        { label: 'Павел Сергеев' },
+        { label: 'Людмила Виноградова' },
+        { label: 'Антон Соловьев' },
+        { label: 'Маргарита Цветкова' },
+        { label: 'Роман Трофимов' },
+        { label: 'Лариса Зайцева' },
+        { label: 'Евгений Никитин' },
+        { label: 'Галина Михайлова' },
+        { label: 'Владислав Антонов' },
+        { label: 'Дарья Филатова' },
+        { label: 'Олег Буров' },
+        { label: 'Инна Медведева' },
+        { label: 'Вячеслав Крылов' },
+        { label: 'Тамара Беляева' },
+        { label: 'Кирилл Марков' },
+        { label: 'Марина Пономарева' },
+        { label: 'Борис Захаров' },
+        { label: 'Жанна Савельева' },
+        { label: 'Федор Жуков' },
+        { label: 'Елизавета Логинова' },
+        { label: 'Виктор Рыбаков' },
+        { label: 'Лилия Макарова' },
     ];
 
     const { register, handleSubmit } = useForm();
@@ -51,6 +104,7 @@ export function App() {
             </RadioGroup>
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
+            <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
             <Button type="submit">Отправить</Button>
         </form>
     );


### PR DESCRIPTION
### Add react hook form support in autocomplite

- Добавлена поддержка `react-hook-form` для `autocomplite`
- Добавлена документация по использованию `autocomplite` с нативной формой и `react-hook-form`

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.211.0-canary.1574.12018059654.0
  npm install @salutejs/plasma-b2c@1.453.0-canary.1574.12018059654.0
  npm install @salutejs/plasma-new-hope@0.200.0-canary.1574.12018059654.0
  npm install @salutejs/plasma-web@1.455.0-canary.1574.12018059654.0
  npm install @salutejs/sdds-cs@0.184.0-canary.1574.12018059654.0
  npm install @salutejs/sdds-dfa@0.181.0-canary.1574.12018059654.0
  npm install @salutejs/sdds-finportal@0.175.0-canary.1574.12018059654.0
  npm install @salutejs/sdds-insol@0.175.0-canary.1574.12018059654.0
  npm install @salutejs/sdds-serv@0.183.0-canary.1574.12018059654.0
  # or 
  yarn add @salutejs/plasma-asdk@0.211.0-canary.1574.12018059654.0
  yarn add @salutejs/plasma-b2c@1.453.0-canary.1574.12018059654.0
  yarn add @salutejs/plasma-new-hope@0.200.0-canary.1574.12018059654.0
  yarn add @salutejs/plasma-web@1.455.0-canary.1574.12018059654.0
  yarn add @salutejs/sdds-cs@0.184.0-canary.1574.12018059654.0
  yarn add @salutejs/sdds-dfa@0.181.0-canary.1574.12018059654.0
  yarn add @salutejs/sdds-finportal@0.175.0-canary.1574.12018059654.0
  yarn add @salutejs/sdds-insol@0.175.0-canary.1574.12018059654.0
  yarn add @salutejs/sdds-serv@0.183.0-canary.1574.12018059654.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
