### PR TITLE
plasma-infra: Handle build storybook draft component

### DIFF
--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -166,12 +166,17 @@ jobs:
                 run: |
                     npm run storybook:build --prefix="./packages/${{ matrix.package }}"
                     cp -R ./packages/${{ matrix.package }}/build-sb ./s3_build/${PR_NAME}/${{ env.SHORT_NAME }}-storybook
-            
-            -   name: Build storybook by draft components - "${{ matrix.package }}"
-                if: false
+
+            ## Проверяем если в пакете скрипт отвечающий за сборку компонентов на основе черновика
+            -   name: Build draft components storybook - "${{ matrix.package }}"
                 run: |
-                    npm run storybook:build:draft --prefix="./packages/${{ matrix.package }}"
-                    cp -R ./packages/${{ matrix.package }}/build-sb-draft ./s3_build/${PR_NAME}/${{ env.SHORT_NAME }}-draft-storybook
+                  if grep -q '"storybook:draft"' "./packages/${{ matrix.package }}/package.json"; then
+                   npm run storybook:build:draft --prefix="./packages/${{ matrix.package }}"
+                   cp -R ./packages/${{ matrix.package }}/build-sb-draft ./s3_build/${PR_NAME}/${{ env.SHORT_NAME }}-draft-storybook
+                   echo "HAS_DRAFT_COMPONENTS=true" >> $GITHUB_ENV
+                  else
+                   echo "Package not have draft components"
+                  fi
             
             -   name: Install s3cmd
                 run: pip3 install s3cmd
@@ -193,7 +198,7 @@ jobs:
                     s3://${{ secrets.AWS_S3_BUCKET_2 }}/pr/${PR_NAME}/${{ env.SHORT_NAME }}/
             
             -   name: s3 upload storybook by draft components
-                if: false
+                if: ${{ env.HAS_DRAFT_COMPONENTS == 'true' }}
                 run: >
                     s3cmd
                     --access_key ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
### What/why changed 

Продолжение истории из #1524

Проверка этой логики - https://github.com/Yakutoc/plasma-dev-stage/actions/runs/11908665607


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-finportal@0.168.2-canary.1575.11927224206.0
  # or 
  yarn add @salutejs/sdds-finportal@0.168.2-canary.1575.11927224206.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
