### PR TITLE
PLASMA-3873: Группировка stories по разделам как в макетах Figma 

### DIFF
--- a/packages/plasma-asdk/.storybook/preview.tsx
+++ b/packages/plasma-asdk/.storybook/preview.tsx
@@ -38,7 +38,7 @@ const preview: Preview = {
         options: {
             storySort: {
                 method: 'alphabetical',
-                order: ['About', 'Intro', 'Colors', 'Typography', 'Controls', 'Hooks'],
+                order: ['About', 'Layout', '*', 'Hooks'],
             },
         },
         viewport: {

--- a/packages/plasma-asdk/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-asdk/src/components/Button/Button.stories.tsx
@@ -29,7 +29,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     component: Button,
     args: {

--- a/packages/plasma-asdk/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-asdk/src/components/Checkbox/Checkbox.stories.tsx
@@ -35,7 +35,7 @@ const onBlur = action('onBlur');
 type CheckboxProps = Base;
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-asdk/src/components/Link/Link.stories.tsx
+++ b/packages/plasma-asdk/src/components/Link/Link.stories.tsx
@@ -9,7 +9,7 @@ import { Link } from '.';
 const views = ['default'] as const;
 
 const meta: Meta<typeof Link> = {
-    title: 'Content/Link',
+    title: 'Navigation/Link',
     decorators: [InSpacingDecorator],
     argTypes: {
         text: {

--- a/packages/plasma-asdk/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-asdk/src/components/Radiobox/Radiobox.stories.tsx
@@ -16,7 +16,7 @@ const onBlur = action('onBlur');
 type RadioboxProps = Base;
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     component: Radiobox,
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-asdk/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/plasma-asdk/src/components/Spinner/Spinner.stories.tsx
@@ -10,7 +10,7 @@ import { Spinner } from '.';
 import type { SpinnerProps } from '.';
 
 const meta: Meta<SpinnerProps> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     decorators: [InSpacingDecorator],
     component: Spinner,
     argTypes: {

--- a/packages/plasma-asdk/src/components/Switch/Switch.stories.tsx
+++ b/packages/plasma-asdk/src/components/Switch/Switch.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-asdk/src/components/Typography/Typography.stories.tsx
+++ b/packages/plasma-asdk/src/components/Typography/Typography.stories.tsx
@@ -39,7 +39,7 @@ import {
 } from '.';
 
 const meta: Meta = {
-    title: 'Content/Typography',
+    title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
         ...disableProps(['size']),

--- a/packages/plasma-b2c/.storybook/main.ts
+++ b/packages/plasma-b2c/.storybook/main.ts
@@ -3,7 +3,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
     staticDirs: ['public'],
-    stories: ['../src/**/*.stories.tsx'],
+    stories: ['../src/**/*.stories.tsx', '../README.stories.mdx'],
     addons: ['@storybook/addon-essentials'],
     framework: {
         name: '@storybook/react-vite',

--- a/packages/plasma-b2c/.storybook/preview.ts
+++ b/packages/plasma-b2c/.storybook/preview.ts
@@ -40,7 +40,7 @@ const preview: Preview = {
         options: {
             storySort: {
                 method: 'alphabetical',
-                order: ['About', 'Intro', 'Colors', 'Typography', 'Controls', 'Hooks'],
+                order: ['About', 'Layout', '*', 'Hooks'],
             },
         },
         docs: {

--- a/packages/plasma-b2c/README.stories.mdx
+++ b/packages/plasma-b2c/README.stories.mdx
@@ -1,0 +1,44 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="About" />
+
+# Библиотека компонентов Plasma B2C
+
+Реализация компонентов для создания веб-приложений.
+
+<p align="center">
+    <img width="800" src="https://user-images.githubusercontent.com/1813468/98609687-ea20fc80-22fe-11eb-8d84-cd26385f01ed.png" alt="plasma-ui" />
+</p>
+
+## Использование
+
+Компоненты реализованы на [typescript](https://www.typescriptlang.org/) с помощью [react](https://reactjs.org/) и [styled-components](https://styled-components.com/);
+
+Использование данного пакета предполагает использование `react` & `react-dom`;
+Использование `styled-components` на проект не обязательно, так же как и использование `typescript`.
+Но для того чтобы компоненты работали необходимо установить - `styled-components`.
+
+### Установка пакета
+
+```bash
+$ npm install --save react react-dom
+$ npm install --save styled-components
+$ npm install --save @salutejs/plasma-b2c @salutejs/plasma-core @salutejs/plasma-icons
+```
+
+### Использование компонентов
+
+Все компоненты доступны из папки `components` или напрямую из пакета:
+
+```jsx
+// App.tsx
+import { Button } from '@salutejs/plasma-b2c';
+
+export const App = () => {
+    return <Button>Hello, Plasma!</Button>;
+};
+```
+
+## Полезные ссылки:
+
+[Документация](https://plasma.sberdevices.ru/b2c/)

--- a/packages/plasma-b2c/src/components/Attach/Attach.stories.tsx
+++ b/packages/plasma-b2c/src/components/Attach/Attach.stories.tsx
@@ -32,7 +32,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'Controls/Attach',
+    title: 'Data Entry/Attach',
     decorators: [InSpacingDecorator],
     component: Attach,
     argTypes: {

--- a/packages/plasma-b2c/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/packages/plasma-b2c/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -7,7 +7,7 @@ import { AudioPlayer } from '.';
 import type { AudioPlayerProps } from '.';
 
 const meta: Meta<AudioPlayerProps> = {
-    title: 'Controls/AudioPlayer',
+    title: 'Data Entry/AudioPlayer',
     component: AudioPlayer,
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-b2c/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/plasma-b2c/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -69,7 +69,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Controls/Autocomplete',
+    title: 'Data Entry/Autocomplete',
     decorators: [InSpacingDecorator],
     component: Autocomplete,
     argTypes: {

--- a/packages/plasma-b2c/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/plasma-b2c/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from '.';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'Content/Breadcrumbs',
+    title: 'Navigation/Breadcrumbs',
     component: Breadcrumbs,
     args: {
         view: 'default',

--- a/packages/plasma-b2c/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-b2c/src/components/Button/Button.stories.tsx
@@ -29,7 +29,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     component: Button,
     args: {

--- a/packages/plasma-b2c/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/plasma-b2c/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'Controls/ButtonGroup',
+    title: 'Data Entry/ButtonGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/plasma-b2c/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-b2c/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<CalendarProps> = {
-    title: 'Controls/Calendar',
+    title: 'Data Entry/Calendar',
     decorators: [InSpacingDecorator],
     component: Calendar,
     argTypes: {

--- a/packages/plasma-b2c/src/components/Card/Card.stories.tsx
+++ b/packages/plasma-b2c/src/components/Card/Card.stories.tsx
@@ -17,7 +17,7 @@ const roundList = [250, 32, 28, 24, 20, 18, 16, 14, 12, 8, 0] as const;
 const ratios = ['1/1', '3/4', '4/3', '9/16', '16/9', '1/2', '2/1'] as const;
 
 const meta: Meta<StoryCardProps> = {
-    title: 'Content/Card',
+    title: 'Data Display/Card',
     decorators: [InSpacingDecorator],
     component: Card,
     argTypes: {

--- a/packages/plasma-b2c/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-b2c/src/components/Carousel/Carousel.stories.tsx
@@ -11,7 +11,7 @@ import { Headline4, Footnote1 } from '../Typography';
 import { Carousel, CarouselItem } from '.';
 
 const meta: Meta<typeof Carousel> = {
-    title: 'Controls/Carousel',
+    title: 'Navigation/Carousel',
     component: Carousel,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-b2c/src/components/Checkbox/Checkbox.stories.tsx
@@ -36,7 +36,7 @@ const sizes = ['m', 's'];
 const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-b2c/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/plasma-b2c/src/components/Combobox/Legacy/Combobox.stories.tsx
+++ b/packages/plasma-b2c/src/components/Combobox/Legacy/Combobox.stories.tsx
@@ -24,7 +24,7 @@ type ComboboxPrimitiveValue = string | number | boolean;
 type StorySelectProps = ComponentProps<typeof Combobox> & StorySelectPropsCustom;
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/plasma-b2c/src/components/Counter/Counter.stories.tsx
+++ b/packages/plasma-b2c/src/components/Counter/Counter.stories.tsx
@@ -7,7 +7,7 @@ const sizes = ['l', 'm', 's', 'xs', 'xxs'];
 const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'Content/Counter',
+    title: 'Data Display/Counter',
     component: Counter,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-b2c/src/components/DatePicker/DatePicker.stories.tsx
@@ -20,7 +20,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'Controls/DatePicker',
+    title: 'Data Entry/DatePicker',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/plasma-b2c/src/components/Divider/Divider.stories.tsx
+++ b/packages/plasma-b2c/src/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { BodyS } from '../Typography';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'Content/Divider',
+    title: 'Data Display/Divider',
     decorators: [InSpacingDecorator],
     argTypes: {
         orientation: {

--- a/packages/plasma-b2c/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-b2c/src/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '.';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
 export default {
-    title: 'Controls/Drawer',
+    title: 'Overlay/Drawer',
     decorators: [InSpacingDecorator],
     argTypes: {
         placement: {

--- a/packages/plasma-b2c/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-b2c/src/components/Dropdown/Dropdown.stories.tsx
@@ -16,7 +16,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<DropdownProps> = {
-    title: 'Controls/Dropdown',
+    title: 'Data Entry/Dropdown',
     component: Dropdown,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/plasma-b2c/src/components/Dropzone/Dropzone.stories.tsx
@@ -14,7 +14,7 @@ const onChoseFiles = action('onChoseFiles');
 const iconPlacements = ['top', 'left'];
 
 const meta: Meta<typeof Dropzone> = {
-    title: 'Controls/Dropzone',
+    title: 'Data Entry/Dropzone',
     component: Dropzone,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Editable/Editable.stories.tsx
+++ b/packages/plasma-b2c/src/components/Editable/Editable.stories.tsx
@@ -10,7 +10,7 @@ import { Editable } from '.';
 const iconSizes = ['s', 'xs'] as const;
 
 const meta: Meta<typeof Editable> = {
-    title: 'Controls/Editable',
+    title: 'Data Entry/Editable',
     decorators: [InSpacingDecorator],
     component: Editable,
     argTypes: {

--- a/packages/plasma-b2c/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/plasma-b2c/src/components/EmptyState/EmptyState.stories.tsx
@@ -13,7 +13,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Content/EmptyState',
+    title: 'Data Entry/EmptyState',
     decorators: [InSpacingDecorator],
     component: EmptyState,
     args: {

--- a/packages/plasma-b2c/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/plasma-b2c/src/components/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const pins = [
 ];
 
 const meta: Meta<StoryButtonProps> = {
-    title: 'Controls/IconButton',
+    title: 'Data Entry/IconButton',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/plasma-b2c/src/components/Image/Image.stories.tsx
+++ b/packages/plasma-b2c/src/components/Image/Image.stories.tsx
@@ -6,7 +6,7 @@ import { Image } from '.';
 import type { ImageProps } from '.';
 
 const meta: Meta<ImageProps> = {
-    title: 'Content/Image',
+    title: 'Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Indicator/Indicator.stories.tsx
+++ b/packages/plasma-b2c/src/components/Indicator/Indicator.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { Indicator } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'Content/Indicator',
+    title: 'Data Display/Indicator',
     component: Indicator,
     argTypes: {
         view: {

--- a/packages/plasma-b2c/src/components/Link/Link.stories.tsx
+++ b/packages/plasma-b2c/src/components/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ import { P1 } from '../Typography';
 import { Link } from '.';
 
 const meta: Meta<typeof Link> = {
-    title: 'Content/Link',
+    title: 'Navigation/Link',
     component: Link,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Mask/Mask.stories.tsx
+++ b/packages/plasma-b2c/src/components/Mask/Mask.stories.tsx
@@ -35,7 +35,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<typeof Mask> = {
-    title: 'Controls/Mask',
+    title: 'Data Display/Mask',
     component: Mask,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Modal/Modal.stories.tsx
+++ b/packages/plasma-b2c/src/components/Modal/Modal.stories.tsx
@@ -10,7 +10,7 @@ import { ModalsProvider, Modal } from '.';
 import type { ModalProps } from '.';
 
 const meta: Meta<ModalProps> = {
-    title: 'Controls/Modal',
+    title: 'Overlay/Modal',
     component: Modal,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/ModalBase/ModalBase.stories.tsx
+++ b/packages/plasma-b2c/src/components/ModalBase/ModalBase.stories.tsx
@@ -13,7 +13,7 @@ import { ModalBase, modalBaseClasses } from '.';
 import type { ModalBaseProps } from '.';
 
 const meta: Meta<ModalBaseProps> = {
-    title: 'Controls/ModalBase',
+    title: 'Overlay/ModalBase',
     component: ModalBase,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/plasma-b2c/src/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-b2c/src/components/Notification/Notification.stories.tsx
@@ -39,7 +39,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<NotificationProps> = {
-    title: 'Controls/Notification',
+    title: 'Overlay/Notification',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/plasma-b2c/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/plasma-b2c/src/components/NumberInput/NumberInput.stories.tsx
@@ -16,7 +16,7 @@ const inputBackgroundTypes = ['fill', 'clear'];
 const segmentation = ['default', 'segmented', 'solid'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'Controls/NumberInput',
+    title: 'Data Entry/NumberInput',
     component: NumberInput,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/plasma-b2c/src/components/Overlay/Overlay.stories.tsx
@@ -12,7 +12,7 @@ import { Overlay } from '.';
 const onOverlayClick = action('onOverlayClick');
 
 export default {
-    title: 'Controls/Overlay',
+    title: 'Overlay/Overlay',
     decorators: [InSpacingDecorator],
     argTypes: {
         isClickable: {

--- a/packages/plasma-b2c/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/plasma-b2c/src/components/Pagination/Pagination.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'Controls/Pagination',
+    title: 'Navigation/Pagination',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/plasma-b2c/src/components/PaginationDots/PaginationDots.stories.tsx
+++ b/packages/plasma-b2c/src/components/PaginationDots/PaginationDots.stories.tsx
@@ -10,7 +10,7 @@ import { SmartPaginationDots, PaginationDots, PaginationDot } from '.';
 import type { SmartPaginationDotsProps } from '.';
 
 const meta: Meta<SmartPaginationDotsProps> = {
-    title: 'Controls/PaginationDots',
+    title: 'Navigation/PaginationDots',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/plasma-b2c/src/components/Popover/Popover.stories.tsx
+++ b/packages/plasma-b2c/src/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from '../Button/Button';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'Controls/Popover',
+    title: 'Overlay/Popover',
     decorators: [InSpacingDecorator],
     component: Popover,
     argTypes: {

--- a/packages/plasma-b2c/src/components/PopupBase/PopupBase.stories.tsx
+++ b/packages/plasma-b2c/src/components/PopupBase/PopupBase.stories.tsx
@@ -11,7 +11,7 @@ import { PopupBase, popupBaseClasses, PopupBaseProvider } from '.';
 import type { PopupBaseProps } from '.';
 
 const meta: Meta<PopupBaseProps> = {
-    title: 'Controls/PopupBase',
+    title: 'Overlay/Popup',
     component: PopupBase,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/plasma-b2c/src/components/Portal/Portal.stories.tsx
+++ b/packages/plasma-b2c/src/components/Portal/Portal.stories.tsx
@@ -10,7 +10,7 @@ import { BodyM } from '../Typography';
 import { Portal } from '.';
 
 const meta: Meta<typeof Portal> = {
-    title: 'Controls/Portal',
+    title: 'Data Entry/Portal',
     decorators: [InSpacingDecorator],
     args: {
         disabled: false,

--- a/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.stories.tsx
+++ b/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.stories.tsx
@@ -9,7 +9,7 @@ import { arrayItemRemoving, arrayItemSelecting, arrayItemSwapping, PreviewGaller
 import type { PreviewGalleryItemProps, PreviewGalleryProps } from '.';
 
 const meta: Meta = {
-    title: 'Controls/PreviewGallery',
+    title: 'Layout/PreviewGallery',
     component: PreviewGallery,
     argTypes: {
         items: {

--- a/packages/plasma-b2c/src/components/Price/Price.stories.tsx
+++ b/packages/plasma-b2c/src/components/Price/Price.stories.tsx
@@ -5,7 +5,7 @@ import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import { Price } from '.';
 
 const meta: Meta<typeof Price> = {
-    title: 'Content/Price',
+    title: 'Data Display/Price',
     decorators: [InSpacingDecorator],
     argTypes: {
         currency: {

--- a/packages/plasma-b2c/src/components/Progress/Progress.stories.tsx
+++ b/packages/plasma-b2c/src/components/Progress/Progress.stories.tsx
@@ -7,7 +7,7 @@ import type { ProgressProps } from '.';
 const views = ['default', 'secondary', 'primary', 'accent', 'success', 'warning', 'error'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'Controls/Progress',
+    title: 'Overlay/Progress',
     component: Progress,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-b2c/src/components/Radiobox/Radiobox.stories.tsx
@@ -18,7 +18,7 @@ const sizes = ['m', 's'];
 const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     decorators: [InSpacingDecorator],
     component: Radiobox,
     argTypes: {

--- a/packages/plasma-b2c/src/components/Range/Range.stories.tsx
+++ b/packages/plasma-b2c/src/components/Range/Range.stories.tsx
@@ -22,7 +22,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'Controls/Range',
+    title: 'Data Entry/Range',
     component: Range,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Segment/Segment.stories.tsx
+++ b/packages/plasma-b2c/src/components/Segment/Segment.stories.tsx
@@ -49,7 +49,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'Controls/Segment',
+    title: 'Data Entry/Segment',
     decorators: [InSpacingDecorator],
     component: SegmentGroup,
     argTypes: {

--- a/packages/plasma-b2c/src/components/Select/Select.stories.tsx
+++ b/packages/plasma-b2c/src/components/Select/Select.stories.tsx
@@ -19,7 +19,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Select',
+    title: 'Data Entry/Select',
     decorators: [InSpacingDecorator],
     component: Select,
     argTypes: {

--- a/packages/plasma-b2c/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-b2c/src/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Sheet } from '.';
 import type { SheetProps } from '.';
 
 const meta: Meta<SheetProps> = {
-    title: 'Content/Sheet',
+    title: 'Overlay/Sheet',
     decorators: [InSpacingDecorator],
     args: {
         withBlur: false,

--- a/packages/plasma-b2c/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/plasma-b2c/src/components/Skeleton/Skeleton.stories.tsx
@@ -16,7 +16,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'Content/Skeleton',
+    title: 'Data Display/Skeleton',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/plasma-b2c/src/components/Slider/Slider.stories.tsx
+++ b/packages/plasma-b2c/src/components/Slider/Slider.stories.tsx
@@ -16,7 +16,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'Controls/Slider',
+    title: 'Data Entry/Slider',
     component: Slider,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/plasma-b2c/src/components/Spinner/Spinner.stories.tsx
@@ -5,7 +5,7 @@ import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 import { Spinner, SpinnerProps } from '.';
 
 const meta: Meta<SpinnerProps> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     component: Spinner,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Steps/Steps.stories.tsx
+++ b/packages/plasma-b2c/src/components/Steps/Steps.stories.tsx
@@ -9,7 +9,7 @@ import { Steps } from './Steps';
 import type { StepItemProps } from '.';
 
 const meta: Meta<typeof Steps> = {
-    title: 'Controls/Steps',
+    title: 'Navigation/Steps',
     decorators: [InSpacingDecorator],
     component: Steps,
 };

--- a/packages/plasma-b2c/src/components/Switch/Switch.stories.tsx
+++ b/packages/plasma-b2c/src/components/Switch/Switch.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-b2c/src/components/Tabs/Tabs.stories.tsx
@@ -55,7 +55,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'Controls/Tabs',
+    title: 'Navigation/Tabs',
     component: Tabs,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextArea/TextArea.stories.tsx
@@ -37,7 +37,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<TextAreaProps> = {
-    title: 'Controls/TextArea',
+    title: 'Data Entry/TextArea',
     component: TextArea,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
@@ -64,7 +64,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<TextFieldProps> = {
-    title: 'Controls/TextField',
+    title: 'Data Entry/TextField',
     component: TextField,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
@@ -22,7 +22,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof TextFieldGroup> = {
-    title: 'Controls/TextFieldGroup',
+    title: 'Data Entry/TextFieldGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/plasma-b2c/src/components/Toast/Toast.stories.tsx
+++ b/packages/plasma-b2c/src/components/Toast/Toast.stories.tsx
@@ -14,7 +14,7 @@ import { ToastController } from './Toast';
 import { Toast, useToast } from '.';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'Controls/Toast',
+    title: 'Overlay/Toast',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/plasma-b2c/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/plasma-b2c/src/components/Toolbar/Toolbar.stories.tsx
@@ -35,7 +35,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'Controls/Toolbar',
+    title: 'Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-b2c/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-b2c/src/components/Tooltip/Tooltip.stories.tsx
@@ -32,7 +32,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'Controls/Tooltip',
+    title: 'Overlay/Tooltip',
     decorators: [InSpacingDecorator],
     component: Tooltip,
 };

--- a/packages/plasma-b2c/src/components/Typography/Typography.stories.tsx
+++ b/packages/plasma-b2c/src/components/Typography/Typography.stories.tsx
@@ -40,7 +40,7 @@ import {
 } from '.';
 
 const meta: Meta<SpacingProps> = {
-    title: 'Content/Typography',
+    title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
         ...disableProps(['size']),

--- a/packages/plasma-b2c/src/components/Upload/Upload.stories.tsx
+++ b/packages/plasma-b2c/src/components/Upload/Upload.stories.tsx
@@ -7,7 +7,7 @@ import { Upload, ValidationResult } from '.';
 import type { UploadProps } from '.';
 
 const meta: Meta<UploadProps> = {
-    title: 'Controls/Upload',
+    title: 'Data Entry/Upload',
     component: Upload,
     argTypes: {
         content: {

--- a/packages/plasma-b2c/src/components/UploadAudio/UploadAudio.stories.tsx
+++ b/packages/plasma-b2c/src/components/UploadAudio/UploadAudio.stories.tsx
@@ -10,7 +10,7 @@ import { UploadAudio } from '.';
 import type { UploadAudioProps } from '.';
 
 const meta: Meta = {
-    title: 'Controls/UploadAudio',
+    title: 'Data Entry/UploadAudio',
     component: UploadAudio,
     argTypes: {
         content: {

--- a/packages/plasma-b2c/src/components/UploadVisual/UploadVisual.stories.tsx
+++ b/packages/plasma-b2c/src/components/UploadVisual/UploadVisual.stories.tsx
@@ -12,7 +12,7 @@ import type { UploadVisualProps } from '.';
 import { UploadVisual } from '.';
 
 const meta: Meta = {
-    title: 'Controls/UploadVisual',
+    title: 'Data Entry/UploadVisual',
     component: UploadVisual,
     argTypes: {
         content: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Accordion/Accordion.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Accordion/Accordion.stories.tsx
@@ -24,7 +24,7 @@ type AccordionItemCustomProps = {
 type AccordionProps = ComponentProps<typeof Accordion> & AccordionItemCustomProps;
 
 const meta: Meta<AccordionProps> = {
-    title: 'plasma_b2c/Accordion',
+    title: 'b2c/Data Display/Accordion',
     decorators: [WithTheme],
     component: Accordion,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Attach/Attach.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Attach/Attach.stories.tsx
@@ -47,7 +47,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'plasma_b2c/Attach',
+    title: 'b2c/Data Entry/Attach',
     decorators: [WithTheme],
     component: Attach,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Autocomplete/Autocomplete.stories.tsx
@@ -70,7 +70,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'plasma_b2c/Autocomplete',
+    title: 'b2c/Data Entry/Autocomplete',
     decorators: [WithTheme],
     component: Autocomplete,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Avatar/Avatar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Avatar/Avatar.stories.tsx
@@ -7,7 +7,7 @@ import { argTypesFromConfig, WithTheme } from '../../../_helpers';
 import { Avatar, mergedConfig } from './Avatar';
 
 const meta: Meta<typeof Avatar> = {
-    title: 'plasma_b2c/Avatar',
+    title: 'b2c/Data Display/Avatar',
     decorators: [WithTheme],
     component: Avatar,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<ComponentProps<typeof AvatarGroup>>;
 type Avatar = ComponentProps<typeof Avatar>;
 
 const meta: Meta<typeof AvatarGroup> = {
-    title: 'plasma_b2c/AvatarGroup',
+    title: 'b2c/Data Display/AvatarGroup',
     decorators: [WithTheme],
     component: AvatarGroup,
 };

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Badge/Badge.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Badge/Badge.stories.tsx
@@ -7,7 +7,7 @@ import { WithTheme } from '../../../_helpers';
 import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
-    title: 'plasma_b2c/Badge',
+    title: 'b2c/Data Display/Badge',
     component: Badge,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -13,7 +13,7 @@ import { Breadcrumbs } from './Breadcrumbs';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'plasma_b2c/Breadcrumbs',
+    title: 'b2c/Navigation/Breadcrumbs',
     decorators: [WithTheme],
     component: Breadcrumbs,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.stories.tsx
@@ -24,7 +24,7 @@ const pinValues = [
 const contentPlacinValues = ['default', 'relaxed'];
 
 const meta: Meta<typeof Button> = {
-    title: 'plasma_b2c/Button',
+    title: 'b2c/Data Entry/Button',
     decorators: [WithTheme],
     component: Button,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -19,7 +19,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'plasma_b2c/ButtonGroup',
+    title: 'b2c/Data Entry/ButtonGroup',
     decorators: [WithTheme],
     argTypes: {
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/Calendar.stories.tsx
@@ -13,7 +13,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<typeof CalendarBase> = {
-    title: 'plasma_b2c/Calendar',
+    title: 'b2c/Data Entry/Calendar',
     decorators: [WithTheme],
     argTypes: {
         min: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Cell/Cell.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Cell/Cell.stories.tsx
@@ -33,7 +33,7 @@ const getSize = (size: SizesCell): SizesAvatar => {
 };
 
 const meta: Meta<typeof Cell> = {
-    title: 'plasma_b2c/Cell',
+    title: 'b2c/Data Display/Cell',
     decorators: [WithTheme],
     argTypes: {
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Checkbox/Checkbox.stories.tsx
@@ -16,7 +16,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<typeof Checkbox> = {
-    title: 'plasma_b2c/Checkbox',
+    title: 'b2c/Data Entry/Checkbox',
     decorators: [WithTheme],
     component: Checkbox,
     argTypes: argTypesFromConfig(mergeConfig(checkboxConfig, config)),

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Chip/Chip.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Chip/Chip.stories.tsx
@@ -13,7 +13,7 @@ const views = ['default', 'accent', 'secondary', 'positive', 'warning', 'negativ
 const sizes = ['l', 'm', 's', 'xs'];
 
 const meta: Meta<typeof Chip> = {
-    title: 'plasma_b2c/Chip',
+    title: 'b2c/Data Display/Chip',
     decorators: [WithTheme],
     component: Chip,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/ChipGroup /ChipGroup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/ChipGroup /ChipGroup.stories.tsx
@@ -16,7 +16,7 @@ const sizes = ['l', 'm', 's', 'xs'];
 const gapValues = ['dense', 'wide'];
 
 const meta: Meta<typeof ChipGroup> = {
-    title: 'plasma_b2c/ChipGroup',
+    title: 'b2c/Data Display/ChipGroup',
     decorators: [WithTheme],
     argTypes: {
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Combobox.stories.tsx
@@ -17,7 +17,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'plasma_b2c/Combobox',
+    title: 'b2c/Data Entry/Combobox',
     decorators: [WithTheme],
     component: Combobox,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Legacy/Combobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Legacy/Combobox.stories.tsx
@@ -25,7 +25,7 @@ type StorySelectPropsCustom = {
 type StorySelectProps = ComponentProps<typeof Combobox> & StorySelectPropsCustom;
 
 const meta: Meta<StorySelectProps> = {
-    title: 'plasma_b2c/Combobox',
+    title: 'b2c/Data Entry/Combobox',
     decorators: [WithTheme],
     component: Combobox,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Counter/Counter.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Counter/Counter.stories.tsx
@@ -9,7 +9,7 @@ const sizes = ['l', 'm', 's', 'xs', 'xxs'];
 const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'plasma_b2c/Counter',
+    title: 'b2c/Data Display/Counter',
     component: Counter,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
@@ -22,7 +22,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'plasma_b2c/DatePicker',
+    title: 'b2c/Data Entry/DatePicker',
     decorators: [WithTheme],
     argTypes: {
         view: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Divider/Divider.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { bodyS } from '../../../../mixins';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'plasma_b2c/Divider',
+    title: 'b2c/Data Display/Divider',
     decorators: [WithTheme],
     argTypes: {
         orientation: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '../../../../components/Drawer';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from './Drawer';
 
 export default {
-    title: 'plasma_b2c/Drawer',
+    title: 'b2c/Overlay/Divider',
     decorators: [WithTheme],
     argTypes: {
         placement: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Dropdown/Dropdown.stories.tsx
@@ -17,7 +17,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StoryDropdownProps> = {
-    title: 'plasma_b2c/Dropdown',
+    title: 'b2c/Data Entry/Dropdown',
     decorators: [WithTheme],
     component: Dropdown,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Editable/Editable.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Editable/Editable.stories.tsx
@@ -11,7 +11,7 @@ import { Editable, typographyVariants } from './Editable';
 const iconSizes = ['s', 'xs'] as const;
 
 const meta: Meta<typeof Editable> = {
-    title: 'plasma_b2c/Editable',
+    title: 'b2c/Data Entry/Editable',
     decorators: [WithTheme],
     component: Editable,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/EmptyState/EmptyState.stories.tsx
@@ -14,7 +14,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'plasma_b2c/EmptyState',
+    title: 'b2c/Data Entry/EmptyState',
     decorators: [WithTheme],
     component: EmptyState,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Grid/Grid.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Grid/Grid.stories.tsx
@@ -7,7 +7,7 @@ import { WithTheme } from '../../../_helpers';
 import { Col, Grid, Row } from './Grid';
 
 const meta: Meta = {
-    title: 'plasma_b2c/Grid',
+    title: 'b2c/Layout/Grid',
     decorators: [WithTheme],
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/IconButton/IconButton.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/IconButton/IconButton.stories.tsx
@@ -11,7 +11,7 @@ import { config } from './IconButton.config';
 import { IconButton } from './IconButton';
 
 const meta: Meta<typeof IconButton> = {
-    title: 'plasma_b2c/IconButton',
+    title: 'b2c/Data Entry/IconButton',
     decorators: [WithTheme],
     component: IconButton,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Image/Image.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Image/Image.stories.tsx
@@ -10,7 +10,7 @@ const bases = ['div', 'img'];
 const ratios = ['1/1', '3/4', '4/3', '9/16', '16/9', '1/2', '2/1'];
 
 const meta: Meta<ImageProps> = {
-    title: 'plasma_b2c/Image',
+    title: 'b2c/Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Indicator/Indicator.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Indicator/Indicator.stories.tsx
@@ -6,7 +6,7 @@ import { argTypesFromConfig, WithTheme } from '../../../_helpers';
 import { Indicator, mergedConfig } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'plasma_b2c/Indicator',
+    title: 'b2c/Data Display/Indicator',
     decorators: [WithTheme],
     component: Indicator,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Link/Link.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Link/Link.stories.tsx
@@ -10,7 +10,7 @@ import { config } from './Link.config';
 import { Link } from './Link';
 
 const meta: Meta<typeof Link> = {
-    title: 'plasma_b2c/Link',
+    title: 'b2c/Navigation/Link',
     decorators: [WithTheme],
     component: Link,
     argTypes: argTypesFromConfig(mergeConfig(linkConfig, config)),

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Mask/Mask.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Mask/Mask.stories.tsx
@@ -13,7 +13,7 @@ const sizes = ['l', 'm', 's', 'xs'];
 const views = ['default', 'positive', 'warning', 'negative'];
 
 const meta: Meta<typeof Mask> = {
-    title: 'plasma_b2c/Mask',
+    title: 'b2c/Data Display/Mask',
     component: Mask,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Modal/Modal.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Modal/Modal.stories.tsx
@@ -13,7 +13,7 @@ import { WithTheme } from '../../../_helpers';
 import { Modal, modalClasses } from './Modal';
 
 export default {
-    title: 'plasma_b2c/Modal',
+    title: 'b2c/Overlay/Modal',
     decorators: [WithTheme],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Notification/Notification.stories.tsx
@@ -37,7 +37,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<NotificationProps> = {
-    title: 'plasma_b2c/Notification',
+    title: 'b2c/Overlay/Notification',
     decorators: [WithTheme],
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/NumberInput/NumberInput.stories.tsx
@@ -17,7 +17,7 @@ const inputBackgroundTypes = ['fill', 'clear'];
 const segmentation = ['default', 'segmented', 'solid'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'plasma_b2c/NumberInput',
+    title: 'b2c/Data Entry/NumberInput',
     component: NumberInput,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Overlay/Overlay.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Overlay/Overlay.stories.tsx
@@ -14,7 +14,7 @@ const onOverlayClick = action('onOverlayClick');
 type StoryOverlayProps = ComponentProps<typeof Overlay>;
 
 const meta: Meta<StoryOverlayProps> = {
-    title: 'plasma_b2c/Overlay',
+    title: 'b2c/Overlay/Overlay',
     decorators: [WithTheme],
     argTypes: {
         isClickable: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Pagination/Pagination.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Pagination/Pagination.stories.tsx
@@ -8,7 +8,7 @@ import { Button } from '../Button/Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'plasma_b2c/Pagination',
+    title: 'b2c/Navigation/Pagination',
     component: Pagination,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Panel/Panel.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Panel/Panel.stories.tsx
@@ -13,7 +13,7 @@ import { SSRProvider } from '../../../../components/SSRProvider';
 import { Panel, PanelContent, PanelFooter, PanelHeader } from './Panel';
 
 export default {
-    title: 'plasma_b2c/Panel',
+    title: 'b2c/Overlay/Panel',
     decorators: [WithTheme],
     argTypes: {
         borderRadius: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Popover/Popover.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { WithTheme } from '../../../_helpers';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'plasma_b2c/Popover',
+    title: 'b2c/Overlay/Popover',
     decorators: [WithTheme],
     component: Popover,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Popup/Popup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Popup/Popup.stories.tsx
@@ -10,7 +10,7 @@ import { WithTheme } from '../../../_helpers';
 import { Popup, popupClasses, PopupProvider } from './Popup';
 
 const meta: Meta<typeof Popup> = {
-    title: 'plasma_b2c/Popup',
+    title: 'b2c/Overlay/Popup',
     decorators: [WithTheme],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Portal/Portal.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Portal/Portal.stories.tsx
@@ -9,7 +9,7 @@ import { Body } from '../../../typography/components/Body/Body';
 import { Portal } from '../../../../components/Portal';
 
 const meta: Meta<typeof Portal> = {
-    title: 'plasma_b2c/Portal',
+    title: 'b2c/Data Entry/Portal',
     decorators: [WithTheme],
     args: {
         disabled: false,

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Price/Price.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Price/Price.stories.tsx
@@ -9,7 +9,7 @@ import { Price } from './Price';
 const currencies = ['rub', 'usd', 'eur', 'inr'];
 
 const meta: Meta<typeof Price> = {
-    title: 'plasma_b2c/Price',
+    title: 'b2c/Data Display/Price',
     decorators: [WithTheme],
     argTypes: {
         currency: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Progress/Progress.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Progress/Progress.stories.tsx
@@ -9,7 +9,7 @@ import { Progress } from './Progress';
 const views = ['default', 'secondary', 'primary', 'accent', 'success', 'warning', 'error'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'plasma_b2c/Progress',
+    title: 'b2c/Overlay/Progress',
     component: Progress,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Radiobox/Radiobox.stories.tsx
@@ -16,7 +16,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<typeof Radiobox> = {
-    title: 'plasma_b2c/Radiobox',
+    title: 'b2c/Data Entry/Radiobox',
     decorators: [WithTheme],
     component: Radiobox,
     argTypes: argTypesFromConfig(mergeConfig(radioboxConfig, config)),

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Range/Range.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Range/Range.stories.tsx
@@ -23,7 +23,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'plasma_b2c/Range',
+    title: 'b2c/Data Entry/Range',
     component: Range,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Segment/Segment.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Segment/Segment.stories.tsx
@@ -52,7 +52,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'plasma_b2c/Segment',
+    title: 'b2c/Data Entry/Segment',
     decorators: [WithTheme],
     component: SegmentGroup,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Select/Select.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Select/Select.stories.tsx
@@ -20,7 +20,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'plasma_b2c/Select',
+    title: 'b2c/Data Entry/Select',
     decorators: [WithTheme],
     component: Select,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Body } from '../../../typography/components/Body/Body';
 import { Sheet } from './Sheet';
 
 const meta: Meta<typeof Sheet> = {
-    title: 'plasma_b2c/Sheet',
+    title: 'b2c/Overlay/Select',
     decorators: [WithTheme],
     args: {
         withBlur: false,

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Skeleton/Skeleton.stories.tsx
@@ -18,7 +18,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'plasma_b2c/Skeleton',
+    title: 'b2c/Data Display/Skeleton',
     decorators: [WithTheme],
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Slider/Slider.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Slider/Slider.stories.tsx
@@ -18,7 +18,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'plasma_b2c/Slider',
+    title: 'b2c/Data Entry/Slider',
     component: Slider,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Spinner/Spinner.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Spinner/Spinner.stories.tsx
@@ -10,7 +10,7 @@ import { config } from './Spinner.config';
 import { Spinner } from './Spinner';
 
 const meta: Meta<typeof Spinner> = {
-    title: 'plasma_b2c/Spinner',
+    title: 'b2c/Data Display/Spinner',
     decorators: [WithTheme],
     component: Spinner,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Steps/Steps.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Steps/Steps.stories.tsx
@@ -10,7 +10,7 @@ import { StepItemProps } from '../../../../components/Steps/ui';
 import { Steps, mergedConfig } from './Steps';
 
 const meta: Meta<typeof Steps> = {
-    title: 'plasma_b2c/Steps',
+    title: 'b2c/Navigation/Steps',
     decorators: [WithTheme],
     component: Steps,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Switch/Switch.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Switch/Switch.stories.tsx
@@ -14,7 +14,7 @@ import { Switch, SwitchOutline } from './Switch';
 type SwitchProps = ComponentProps<typeof Switch>;
 
 const meta: Meta<SwitchProps> = {
-    title: 'plasma_b2c/Switch',
+    title: 'b2c/Data Entry/Switch',
     decorators: [WithTheme],
     component: Switch,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tabs/Tabs.stories.tsx
@@ -56,7 +56,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'plasma_b2c/Tabs',
+    title: 'b2c/Navigation/Tabs',
     component: Tabs,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextArea/TextArea.stories.tsx
@@ -44,7 +44,7 @@ type StoryTextAreaPropsCustom = {
 type StoryTextAreaProps = ComponentProps<typeof TextArea> & StoryTextAreaPropsCustom;
 
 const meta: Meta<StoryTextAreaProps> = {
-    title: 'plasma_b2c/TextArea',
+    title: 'b2c/Data Entry/TextArea',
     decorators: [WithTheme],
     component: TextArea,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextField/TextField.stories.tsx
@@ -43,7 +43,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<typeof TextField> = {
-    title: 'plasma_b2c/TextField',
+    title: 'b2c/Data Entry/TextField',
     component: TextField,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextFieldGroup/TextFieldGroup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextFieldGroup/TextFieldGroup.stories.tsx
@@ -23,7 +23,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof TextFieldGroup> = {
-    title: 'plasma_b2c/TextFieldGroup',
+    title: 'b2c/Data Entry/TextFieldGroup',
     decorators: [WithTheme],
     argTypes: {
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Toast/Toast.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Toast/Toast.stories.tsx
@@ -17,7 +17,7 @@ import { config } from './Toast.config';
 import { Toast, ToastController, ToastProvider, useToast } from './Toast';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'plasma_b2c/Toast',
+    title: 'b2c/Overlay/Toast',
     decorators: [WithTheme],
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'plasma_b2c/Toolbar',
+    title: 'b2c/Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tooltip/Tooltip.stories.tsx
@@ -31,7 +31,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'plasma_b2c/Tooltip',
+    title: 'b2c/Overlay/Tooltip',
     decorators: [WithTheme],
     component: Tooltip,
     parameters: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/ViewContainer/ViewContainer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/ViewContainer/ViewContainer.stories.tsx
@@ -10,7 +10,7 @@ import { ViewContainer } from './ViewContainer';
 type StoryViewProps = ComponentProps<typeof ViewContainer>;
 
 const meta: Meta<StoryViewProps> = {
-    title: 'plasma_b2c/ViewContainer',
+    title: 'b2c/Data Display/ViewContainer',
 };
 
 export default meta;

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Accordion/Accordion.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Accordion/Accordion.stories.tsx
@@ -24,7 +24,7 @@ type AccordionItemCustomProps = {
 type AccordionProps = ComponentProps<typeof Accordion> & AccordionItemCustomProps;
 
 const meta: Meta<AccordionProps> = {
-    title: 'plasma_web/Accordion',
+    title: 'web/Data Display/Accordion',
     decorators: [WithTheme],
     component: Accordion,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Attach/Attach.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Attach/Attach.stories.tsx
@@ -47,7 +47,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'plasma_web/Attach',
+    title: 'web/Data Entry/Attach',
     decorators: [WithTheme],
     component: Attach,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Autocomplete/Autocomplete.stories.tsx
@@ -70,7 +70,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'plasma_web/Autocomplete',
+    title: 'web/Data Entry/Autocomplete',
     decorators: [WithTheme],
     component: Autocomplete,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Avatar/Avatar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Avatar/Avatar.stories.tsx
@@ -7,7 +7,7 @@ import { argTypesFromConfig, WithTheme } from '../../../_helpers';
 import { Avatar, mergedConfig } from './Avatar';
 
 const meta: Meta<typeof Avatar> = {
-    title: 'plasma_web/Avatar',
+    title: 'web/Data Display/Avatar',
     decorators: [WithTheme],
     component: Avatar,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -10,7 +10,7 @@ import { AvatarGroup } from './AvatarGroup';
 type Story = StoryObj<ComponentProps<typeof AvatarGroup>>;
 
 const meta: Meta<typeof AvatarGroup> = {
-    title: 'plasma_web/AvatarGroup',
+    title: 'web/Data Display/AvatarGroup',
     decorators: [WithTheme],
     component: AvatarGroup,
 };

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Badge/Badge.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Badge/Badge.stories.tsx
@@ -7,7 +7,7 @@ import { WithTheme } from '../../../_helpers';
 import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
-    title: 'plasma_web/Badge',
+    title: 'web/Data Display/Badge',
     component: Badge,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -13,7 +13,7 @@ import { Breadcrumbs } from './Breadcrumbs';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'plasma_web/Breadcrumbs',
+    title: 'web/Navigation/Breadcrumbs',
     decorators: [WithTheme],
     component: Breadcrumbs,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.stories.tsx
@@ -24,7 +24,7 @@ const pinValues = [
 const contentPlacinValues = ['default', 'relaxed'];
 
 const meta: Meta<typeof Button> = {
-    title: 'plasma_web/Button',
+    title: 'web/Data Entry/Button',
     decorators: [WithTheme],
     component: Button,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -19,7 +19,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'plasma_web/ButtonGroup',
+    title: 'web/Data Entry/ButtonGroup',
     decorators: [WithTheme],
     argTypes: {
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/Calendar.stories.tsx
@@ -13,7 +13,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<typeof CalendarBase> = {
-    title: 'plasma_web/Calendar',
+    title: 'web/Data Entry/Calendar',
     decorators: [WithTheme],
     argTypes: {
         min: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Cell/Cell.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Cell/Cell.stories.tsx
@@ -33,7 +33,7 @@ const getSize = (size: SizesCell): SizesAvatar => {
 };
 
 const meta: Meta<typeof Cell> = {
-    title: 'plasma_web/Cell',
+    title: 'web/Data Display/Cell',
     decorators: [WithTheme],
     argTypes: {
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Checkbox/Checkbox.stories.tsx
@@ -16,7 +16,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<typeof Checkbox> = {
-    title: 'plasma_web/Checkbox',
+    title: 'web/Data Entry/Checkbox',
     decorators: [WithTheme],
     component: Checkbox,
     argTypes: argTypesFromConfig(mergeConfig(checkboxConfig, config)),

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Chip/Chip.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Chip/Chip.stories.tsx
@@ -13,7 +13,7 @@ const views = ['default', 'accent', 'secondary', 'positive', 'warning', 'negativ
 const sizes = ['l', 'm', 's', 'xs'];
 
 const meta: Meta<typeof Chip> = {
-    title: 'plasma_web/Chip',
+    title: 'web/Data Display/Chip',
     decorators: [WithTheme],
     component: Chip,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/ChipGroup /ChipGroup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/ChipGroup /ChipGroup.stories.tsx
@@ -16,7 +16,7 @@ const sizes = ['l', 'm', 's', 'xs'];
 const gapValues = ['dense', 'wide'];
 
 const meta: Meta<typeof ChipGroup> = {
-    title: 'plasma_web/ChipGroup',
+    title: 'web/Data Display/ChipGroup',
     decorators: [WithTheme],
     argTypes: {
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Combobox/Combobox.stories.tsx
@@ -17,7 +17,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'plasma_web/Combobox',
+    title: 'web/Data Entry/Combobox',
     decorators: [WithTheme],
     component: Combobox,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Combobox/Legacy/Combobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Combobox/Legacy/Combobox.stories.tsx
@@ -25,7 +25,7 @@ type StorySelectPropsCustom = {
 type StorySelectProps = ComponentProps<typeof Combobox> & StorySelectPropsCustom;
 
 const meta: Meta<StorySelectProps> = {
-    title: 'plasma_web/Combobox',
+    title: 'web/Data Entry/Combobox',
     decorators: [WithTheme],
     component: Combobox,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Counter/Counter.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Counter/Counter.stories.tsx
@@ -9,7 +9,7 @@ const sizes = ['l', 'm', 's', 'xs', 'xxs'];
 const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'plasma_web/Counter',
+    title: 'web/Data Display/Counter',
     component: Counter,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/DatePicker/DatePicker.stories.tsx
@@ -22,7 +22,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'plasma_web/DatePicker',
+    title: 'web/Data Entry/DatePicker',
     decorators: [WithTheme],
     argTypes: {
         view: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Divider/Divider.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { bodyS } from '../../../../mixins';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'plasma_web/Divider',
+    title: 'web/Data Display/Divider',
     decorators: [WithTheme],
     argTypes: {
         orientation: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '../../../../components/Drawer';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from './Drawer';
 
 export default {
-    title: 'plasma_web/Drawer',
+    title: 'web/Overlay/Divider',
     decorators: [WithTheme],
     argTypes: {
         placement: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Dropdown/Dropdown.stories.tsx
@@ -17,7 +17,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StoryDropdownProps> = {
-    title: 'plasma_web/Dropdown',
+    title: 'web/Data Entry/Dropdown',
     decorators: [WithTheme],
     component: Dropdown,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Editable/Editable.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Editable/Editable.stories.tsx
@@ -11,7 +11,7 @@ import { Editable, typographyVariants } from './Editable';
 const iconSizes = ['s', 'xs'] as const;
 
 const meta: Meta<typeof Editable> = {
-    title: 'plasma_web/Editable',
+    title: 'web/Data Entry/Editable',
     decorators: [WithTheme],
     component: Editable,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/EmptyState/EmptyState.stories.tsx
@@ -14,7 +14,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'plasma_web/EmptyState',
+    title: 'web/Data Entry/EmptyState',
     decorators: [WithTheme],
     component: EmptyState,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Grid/Grid.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Grid/Grid.stories.tsx
@@ -7,7 +7,7 @@ import { WithTheme } from '../../../_helpers';
 import { Col, Grid, Row } from './Grid';
 
 const meta: Meta = {
-    title: 'plasma_web/Grid',
+    title: 'web/Layout/Grid',
     decorators: [WithTheme],
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/IconButton/IconButton.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/IconButton/IconButton.stories.tsx
@@ -11,7 +11,7 @@ import { config } from './IconButton.config';
 import { IconButton } from './IconButton';
 
 const meta: Meta<typeof IconButton> = {
-    title: 'plasma_web/IconButton',
+    title: 'web/Data Entry/IconButton',
     decorators: [WithTheme],
     component: IconButton,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Image/Image.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Image/Image.stories.tsx
@@ -10,7 +10,7 @@ const bases = ['div', 'img'];
 const ratios = ['1/1', '3/4', '4/3', '9/16', '16/9', '1/2', '2/1'];
 
 const meta: Meta<ImageProps> = {
-    title: 'plasma_web/Image',
+    title: 'web/Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Indicator/Indicator.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Indicator/Indicator.stories.tsx
@@ -6,7 +6,7 @@ import { argTypesFromConfig, WithTheme } from '../../../_helpers';
 import { Indicator, mergedConfig } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'plasma_web/Indicator',
+    title: 'web/Data Display/Indicator',
     decorators: [WithTheme],
     component: Indicator,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Link/Link.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Link/Link.stories.tsx
@@ -10,7 +10,7 @@ import { config } from './Link.config';
 import { Link } from './Link';
 
 const meta: Meta<typeof Link> = {
-    title: 'plasma_web/Link',
+    title: 'web/Navigation/Link',
     decorators: [WithTheme],
     component: Link,
     argTypes: argTypesFromConfig(mergeConfig(linkConfig, config)),

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Mask/Mask.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Mask/Mask.stories.tsx
@@ -13,7 +13,7 @@ const sizes = ['l', 'm', 's', 'xs'];
 const views = ['default', 'positive', 'warning', 'negative'];
 
 const meta: Meta<typeof Mask> = {
-    title: 'plasma_web/Mask',
+    title: 'web/Data Display/Mask',
     component: Mask,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Modal/Modal.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Modal/Modal.stories.tsx
@@ -13,7 +13,7 @@ import { WithTheme } from '../../../_helpers';
 import { Modal, modalClasses } from './Modal';
 
 export default {
-    title: 'plasma_web/Modal',
+    title: 'web/Overlay/Modal',
     decorators: [WithTheme],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Notification/Notification.stories.tsx
@@ -37,7 +37,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<NotificationProps> = {
-    title: 'plasma_web/Notification',
+    title: 'web/Overlay/Notification',
     decorators: [WithTheme],
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/NumberInput/NumberInput.stories.tsx
@@ -17,7 +17,7 @@ const inputBackgroundTypes = ['fill', 'clear'];
 const segmentation = ['default', 'segmented', 'solid'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'plasma_web/NumberInput',
+    title: 'web/Data Entry/NumberInput',
     component: NumberInput,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Overlay/Overlay.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Overlay/Overlay.stories.tsx
@@ -14,7 +14,7 @@ const onOverlayClick = action('onOverlayClick');
 type StoryOverlayProps = ComponentProps<typeof Overlay>;
 
 const meta: Meta<StoryOverlayProps> = {
-    title: 'plasma_web/Overlay',
+    title: 'web/Overlay/Overlay',
     decorators: [WithTheme],
     argTypes: {
         isClickable: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Pagination/Pagination.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Pagination/Pagination.stories.tsx
@@ -8,7 +8,7 @@ import { Button } from '../Button/Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'plasma_web/Pagination',
+    title: 'web/Navigation/Pagination',
     component: Pagination,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Panel/Panel.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Panel/Panel.stories.tsx
@@ -13,7 +13,7 @@ import { SSRProvider } from '../../../../components/SSRProvider';
 import { Panel, PanelContent, PanelFooter, PanelHeader } from './Panel';
 
 export default {
-    title: 'plasma_web/Panel',
+    title: 'web/Overlay/Panel',
     decorators: [WithTheme],
     argTypes: {
         borderRadius: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Popover/Popover.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { WithTheme } from '../../../_helpers';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'plasma_web/Popover',
+    title: 'web/Overlay/Popover',
     decorators: [WithTheme],
     component: Popover,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Popup/Popup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Popup/Popup.stories.tsx
@@ -10,7 +10,7 @@ import { WithTheme } from '../../../_helpers';
 import { Popup, popupClasses, PopupProvider } from './Popup';
 
 const meta: Meta<typeof Popup> = {
-    title: 'plasma_web/Popup',
+    title: 'web/Overlay/Popup',
     decorators: [WithTheme],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Portal/Portal.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Portal/Portal.stories.tsx
@@ -9,7 +9,7 @@ import { Body } from '../../../typography/components/Body/Body';
 import { Portal } from '../../../../components/Portal';
 
 const meta: Meta<typeof Portal> = {
-    title: 'plasma_web/Portal',
+    title: 'web/Data Entry/Portal',
     decorators: [WithTheme],
     args: {
         disabled: false,

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Price/Price.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Price/Price.stories.tsx
@@ -9,7 +9,7 @@ import { Price } from './Price';
 const currencies = ['rub', 'usd', 'eur', 'inr'];
 
 const meta: Meta<typeof Price> = {
-    title: 'plasma_web/Price',
+    title: 'web/Data Display/Price',
     decorators: [WithTheme],
     argTypes: {
         currency: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Progress/Progress.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Progress/Progress.stories.tsx
@@ -8,7 +8,7 @@ import { Progress } from './Progress';
 const views = ['default', 'secondary', 'primary', 'accent', 'success', 'warning', 'error'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'plasma_web/Progress',
+    title: 'web/Overlay/Progress',
     component: Progress,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Radiobox/Radiobox.stories.tsx
@@ -16,7 +16,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<typeof Radiobox> = {
-    title: 'plasma_web/Radiobox',
+    title: 'web/Data Entry/Radiobox',
     decorators: [WithTheme],
     component: Radiobox,
     argTypes: argTypesFromConfig(mergeConfig(radioboxConfig, config)),

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Range/Range.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Range/Range.stories.tsx
@@ -23,7 +23,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'plasma_web/Range',
+    title: 'web/Data Entry/Range',
     component: Range,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Segment/Segment.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Segment/Segment.stories.tsx
@@ -52,7 +52,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'plasma_web/Segment',
+    title: 'web/Data Entry/Segment',
     decorators: [WithTheme],
     component: SegmentGroup,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Select/Select.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Select/Select.stories.tsx
@@ -20,7 +20,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'plasma_web/Select',
+    title: 'web/Data Entry/Select',
     decorators: [WithTheme],
     component: Select,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Body } from '../../../typography/components/Body/Body';
 import { Sheet } from './Sheet';
 
 const meta: Meta<typeof Sheet> = {
-    title: 'plasma_web/Sheet',
+    title: 'web/Overlay/Select',
     decorators: [WithTheme],
     args: {
         withBlur: false,

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Skeleton/Skeleton.stories.tsx
@@ -18,7 +18,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'plasma_web/Skeleton',
+    title: 'web/Data Display/Skeleton',
     decorators: [WithTheme],
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Slider/Slider.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Slider/Slider.stories.tsx
@@ -18,7 +18,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'plasma_web/Slider',
+    title: 'web/Data Entry/Slider',
     component: Slider,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Spinner/Spinner.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Spinner/Spinner.stories.tsx
@@ -10,7 +10,7 @@ import { config } from './Spinner.config';
 import { Spinner } from './Spinner';
 
 const meta: Meta<typeof Spinner> = {
-    title: 'plasma_web/Spinner',
+    title: 'web/Data Display/Spinner',
     decorators: [WithTheme],
     component: Spinner,
     args: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Steps/Steps.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Steps/Steps.stories.tsx
@@ -10,7 +10,7 @@ import { StepItemProps } from '../../../../components/Steps/ui';
 import { Steps, mergedConfig } from './Steps';
 
 const meta: Meta<typeof Steps> = {
-    title: 'plasma_web/Steps',
+    title: 'web/Navigation/Steps',
     decorators: [WithTheme],
     component: Steps,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Switch/Switch.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Switch/Switch.stories.tsx
@@ -14,7 +14,7 @@ import { Switch, SwitchOutline } from './Switch';
 type SwitchProps = ComponentProps<typeof Switch>;
 
 const meta: Meta<SwitchProps> = {
-    title: 'plasma_web/Switch',
+    title: 'web/Data Entry/Switch',
     decorators: [WithTheme],
     component: Switch,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Tabs/Tabs.stories.tsx
@@ -56,7 +56,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'plasma_web/Tabs',
+    title: 'web/Navigation/Tabs',
     component: Tabs,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/TextArea/TextArea.stories.tsx
@@ -44,7 +44,7 @@ type StoryTextAreaPropsCustom = {
 type StoryTextAreaProps = ComponentProps<typeof TextArea> & StoryTextAreaPropsCustom;
 
 const meta: Meta<StoryTextAreaProps> = {
-    title: 'plasma_web/TextArea',
+    title: 'web/Data Entry/TextArea',
     decorators: [WithTheme],
     component: TextArea,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/TextField/TextField.stories.tsx
@@ -43,7 +43,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<typeof TextField> = {
-    title: 'plasma_web/TextField',
+    title: 'web/Data Entry/TextField',
     component: TextField,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/TextFieldGroup/TextFieldGroup.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/TextFieldGroup/TextFieldGroup.stories.tsx
@@ -23,7 +23,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof TextFieldGroup> = {
-    title: 'plasma_web/TextFieldGroup',
+    title: 'web/Data Entry/TextFieldGroup',
     decorators: [WithTheme],
     argTypes: {
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Toast/Toast.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Toast/Toast.stories.tsx
@@ -17,7 +17,7 @@ import { config } from './Toast.config';
 import { Toast, ToastController, ToastProvider, useToast } from './Toast';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'plasma_web/Toast',
+    title: 'web/Overlay/Toast',
     decorators: [WithTheme],
 };
 

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'plasma_web/Toolbar',
+    title: 'web/Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [WithTheme],
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Tooltip/Tooltip.stories.tsx
@@ -31,7 +31,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'plasma_web/Tooltip',
+    title: 'web/Overlay/Tooltip',
     decorators: [WithTheme],
     component: Tooltip,
     parameters: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/ViewContainer/ViewContainer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/ViewContainer/ViewContainer.stories.tsx
@@ -10,7 +10,7 @@ import { ViewContainer } from './ViewContainer';
 type StoryViewProps = ComponentProps<typeof ViewContainer>;
 
 const meta: Meta<StoryViewProps> = {
-    title: 'plasma_web/ViewContainer',
+    title: 'web/Data Display/ViewContainer',
 };
 
 export default meta;

--- a/packages/plasma-new-hope/src/examples/typography/components/Body/Body.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Body/Body.stories.tsx
@@ -9,7 +9,7 @@ import { Body } from './Body';
 import { config } from './Body.config';
 
 const meta: Meta<typeof Body> = {
-    title: 'typography/Body',
+    title: 'Data Display/Typography/Body',
     decorators: [WithTheme],
     component: Body,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Dspl/Dspl.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Dspl/Dspl.stories.tsx
@@ -9,7 +9,7 @@ import { Dspl } from './Dspl';
 import { config } from './Dspl.config';
 
 const meta: Meta<typeof Dspl> = {
-    title: 'typography/Dspl',
+    title: 'Data Display/Typography/Dspl',
     decorators: [WithTheme],
     component: Dspl,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Heading/Heading.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Heading/Heading.stories.tsx
@@ -9,7 +9,7 @@ import { Heading } from './Heading';
 import { config } from './Heading.config';
 
 const meta: Meta<typeof Heading> = {
-    title: 'typography/Heading',
+    title: 'Data Display/Typography/Heading',
     decorators: [WithTheme],
     component: Heading,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Body/Body.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Body/Body.stories.tsx
@@ -9,7 +9,7 @@ import { OldBody } from './Body';
 import { config } from './Body.config';
 
 const meta: Meta<typeof OldBody> = {
-    title: 'typography/Old/Body',
+    title: 'Data Display/Typography/Old/Body',
     decorators: [WithTheme],
     component: OldBody,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Button/Button.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Button/Button.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from './Button';
 import { config } from './Button.config';
 
 const meta: Meta<typeof Button> = {
-    title: 'typography/Old/Button',
+    title: 'Data Display/Typography/Old/Button',
     decorators: [WithTheme],
     component: Button,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Caption/Caption.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Caption/Caption.stories.tsx
@@ -9,7 +9,7 @@ import { Caption } from './Caption';
 import { config } from './Caption.config';
 
 const meta: Meta<typeof Caption> = {
-    title: 'typography/Old/Caption',
+    title: 'Data Display/Typography/Old/Caption',
     decorators: [WithTheme],
     component: Caption,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Display/Display.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Display/Display.stories.tsx
@@ -9,7 +9,7 @@ import { Display } from './Display';
 import { config } from './Display.config';
 
 const meta: Meta<typeof Display> = {
-    title: 'typography/Old/Display',
+    title: 'Data Display/Typography/Old/Display',
     decorators: [WithTheme],
     component: Display,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Footnote/Footnote.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Footnote/Footnote.stories.tsx
@@ -9,7 +9,7 @@ import { Footnote } from './Footnote';
 import { config } from './Footnote.config';
 
 const meta: Meta<typeof Footnote> = {
-    title: 'typography/Old/Footnote',
+    title: 'Data Display/Typography/Old/Footnote',
     decorators: [WithTheme],
     component: Footnote,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Headline/Headline.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Headline/Headline.stories.tsx
@@ -9,7 +9,7 @@ import { Headline } from './Headline';
 import { config } from './Headline.config';
 
 const meta: Meta<typeof Headline> = {
-    title: 'typography/Old/Headline',
+    title: 'Data Display/Typography/Old/Headline',
     decorators: [WithTheme],
     component: Headline,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Paragraph/Paragraph.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Paragraph/Paragraph.stories.tsx
@@ -9,7 +9,7 @@ import { Paragraph } from './Paragraph';
 import { config } from './Paragraph.config';
 
 const meta: Meta<typeof Paragraph> = {
-    title: 'typography/Old/Paragraph',
+    title: 'Data Display/Typography/Old/Paragraph',
     decorators: [WithTheme],
     component: Paragraph,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Subtitle/Subtitle.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Subtitle/Subtitle.stories.tsx
@@ -9,7 +9,7 @@ import { Subtitle } from './Subtitle';
 import { config } from './Subtitle.config';
 
 const meta: Meta<typeof Subtitle> = {
-    title: 'typography/Old/Subtitle',
+    title: 'Data Display/Typography/Old/Subtitle',
     decorators: [WithTheme],
     component: Subtitle,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Old/Underline/Underline.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Old/Underline/Underline.stories.tsx
@@ -9,7 +9,7 @@ import { Underline } from './Underline';
 import { config } from './Underline.config';
 
 const meta: Meta<typeof Underline> = {
-    title: 'typography/Old/Underline',
+    title: 'Data Display/Typography/Old/Underline',
     decorators: [WithTheme],
     component: Underline,
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/typography/components/Text/Text.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Text/Text.stories.tsx
@@ -9,7 +9,7 @@ import { Text } from './Text';
 import { config } from './Text.config';
 
 const meta: Meta<typeof Text> = {
-    title: 'typography/Text',
+    title: 'Data Display/Typography/Text',
     decorators: [WithTheme],
     component: Text,
     argTypes: {

--- a/packages/plasma-ui/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-ui/src/components/Button/Button.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = actionWithPersistedEvent('onFocus');
 const onBlur = actionWithPersistedEvent('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     argTypes: {
         text: {

--- a/packages/plasma-ui/src/components/Card/Card.stories.tsx
+++ b/packages/plasma-ui/src/components/Card/Card.stories.tsx
@@ -15,7 +15,7 @@ import type { CardProps } from '.';
 import { CardParagraph1 } from '.';
 
 const meta: Meta<CardProps> = {
-    title: 'Content/Card',
+    title: 'Data Display/Card',
     decorators: [InSpacingDecorator],
     parameters: {
         performance: {

--- a/packages/plasma-ui/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.stories.tsx
@@ -31,7 +31,7 @@ import {
 import type { CarouselProps, CarouselColProps } from '.';
 
 const meta: Meta<CarouselProps> = {
-    title: 'Controls/Carousel',
+    title: 'Navigation/Carousel',
     component: Carousel,
     decorators: [WithGridLines, InContainer],
 };

--- a/packages/plasma-ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -14,7 +14,7 @@ const onFocus = actionWithPersistedEvent('onFocus');
 const onBlur = actionWithPersistedEvent('onBlur');
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [
         InSpacingDecorator,

--- a/packages/plasma-ui/src/components/Image/Image.stories.tsx
+++ b/packages/plasma-ui/src/components/Image/Image.stories.tsx
@@ -12,7 +12,7 @@ const bases = ['div', 'img'];
 const ratios = ['1/1', '3/4', '4/3', '9/16', '16/9', '1/2', '2/1'];
 
 const meta: Meta<ImageProps> = {
-    title: 'Content/Image',
+    title: 'Data Display/Image',
     component: Image,
     decorators: [InSpacing],
     argTypes: {

--- a/packages/plasma-ui/src/components/PaginationDots/PaginationDots.stories.tsx
+++ b/packages/plasma-ui/src/components/PaginationDots/PaginationDots.stories.tsx
@@ -11,7 +11,7 @@ import { SmartPaginationDots, PaginationDots, PaginationDot } from '.';
 import type { SmartPaginationDotsProps, PaginationDotProps } from '.';
 
 const meta: Meta<PaginationDotProps> = {
-    title: 'Controls/PaginationDots',
+    title: 'Navigation/PaginationDots',
     component: PaginationDots,
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-ui/src/components/Price/Price.stories.tsx
+++ b/packages/plasma-ui/src/components/Price/Price.stories.tsx
@@ -10,7 +10,7 @@ import type { PriceProps } from '.';
 type StoryPriceProps = PriceProps & { priceLabel: number; withCustomPeriodicity?: boolean };
 
 const meta: Meta<StoryPriceProps> = {
-    title: 'Content/Price',
+    title: 'Data Display/Price',
     component: Price,
     decorators: [InSpacing],
     argTypes: {

--- a/packages/plasma-ui/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-ui/src/components/Radiobox/Radiobox.stories.tsx
@@ -13,7 +13,7 @@ const onFocus = actionWithPersistedEvent('onFocus');
 const onBlur = actionWithPersistedEvent('onBlur');
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     component: Radiobox,
     decorators: [
         InSpacingDecorator,

--- a/packages/plasma-ui/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-ui/src/components/Sheet/Sheet.stories.tsx
@@ -9,7 +9,7 @@ import { Sheet } from './Sheet';
 import type { SheetProps } from './Sheet';
 
 const meta: Meta<SheetProps> = {
-    title: 'Content/Sheet',
+    title: 'Overlay/Sheet',
     decorators: [InSpacing],
     component: Sheet,
     parameters: { viewport: { defaultViewport: '860' } },

--- a/packages/plasma-ui/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/plasma-ui/src/components/Skeleton/Skeleton.stories.tsx
@@ -12,7 +12,7 @@ import { LineSkeleton, TextSkeleton, RectSkeleton } from '.';
 import type { LineSkeletonProps, TextSkeletonProps, RectSkeletonProps } from '.';
 
 const meta: Meta = {
-    title: 'Content/Skeleton',
+    title: 'Data Display/Skeleton',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/plasma-ui/src/components/Slider/Slider.stories.tsx
+++ b/packages/plasma-ui/src/components/Slider/Slider.stories.tsx
@@ -9,7 +9,7 @@ import { Slider } from '.';
 import type { SliderProps } from '.';
 
 const meta: Meta<SliderProps> = {
-    title: 'Controls/Slider',
+    title: 'Data Entry/Slider',
     component: Slider,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-ui/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/plasma-ui/src/components/Spinner/Spinner.stories.tsx
@@ -9,7 +9,7 @@ import { Spinner } from './Spinner';
 import type { SpinnerProps } from '.';
 
 const meta: Meta<SpinnerProps> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     decorators: [InSpacing],
     component: Spinner,
     argTypes: {

--- a/packages/plasma-ui/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/plasma-ui/src/components/Stepper/Stepper.stories.tsx
@@ -15,7 +15,7 @@ const onFocusAction = actionWithPersistedEvent('onFocus');
 const onBlurAction = actionWithPersistedEvent('onBlur');
 
 const meta: Meta<StepperProps> = {
-    title: 'Controls/Stepper',
+    title: 'Data Entry/Stepper',
     component: Stepper,
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-ui/src/components/Switch/Switch.stories.tsx
+++ b/packages/plasma-ui/src/components/Switch/Switch.stories.tsx
@@ -11,7 +11,7 @@ const onFocus = actionWithPersistedEvent('onFocus');
 const onBlur = actionWithPersistedEvent('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
@@ -12,7 +12,7 @@ import type { TabsProps, TabsControllerProps } from '.';
 const icons = ['clock', 'settings', 'house', 'trash'];
 
 const meta: Meta<TabsProps> = {
-    title: 'Controls/Tabs',
+    title: 'Navigation/Tabs',
     component: Tabs,
     decorators: [InContainerDecorator],
     argTypes: {

--- a/packages/plasma-ui/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-ui/src/components/TextArea/TextArea.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<TextAreaProps> = {
-    title: 'Controls/TextArea',
+    title: 'Data Entry/TextArea',
     component: TextArea,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-ui/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-ui/src/components/TextField/TextField.stories.tsx
@@ -11,7 +11,7 @@ import { TextField } from '.';
 import type { TextFieldProps } from '.';
 
 const meta: Meta<TextFieldProps> = {
-    title: 'Controls/TextField',
+    title: 'Data Entry/TextField',
     component: TextField,
     decorators: [InSpacing],
     argTypes: {

--- a/packages/plasma-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/plasma-ui/src/components/Toast/Toast.stories.tsx
@@ -12,7 +12,7 @@ import { Toast, useToast, ToastPosition } from '.';
 import type { ToastProps } from '.';
 
 const meta: Meta<ToastProps> = {
-    title: 'Controls/Toast',
+    title: 'Overlay/Toast',
     component: Toast,
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-web/.storybook/preview.ts
+++ b/packages/plasma-web/.storybook/preview.ts
@@ -39,7 +39,7 @@ const preview: Preview = {
         options: {
             storySort: {
                 method: 'alphabetical',
-                order: ['About', 'Intro', 'Colors', 'Typography', 'Controls', 'Hooks'],
+                order: ['About', 'Layout', '*', 'Hooks'],
             },
         },
         viewport: {

--- a/packages/plasma-web/src/components/Attach/Attach.stories.tsx
+++ b/packages/plasma-web/src/components/Attach/Attach.stories.tsx
@@ -32,7 +32,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'Controls/Attach',
+    title: 'Data Entry/Attach',
     decorators: [InSpacingDecorator],
     component: Attach,
     argTypes: {

--- a/packages/plasma-web/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/packages/plasma-web/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -7,7 +7,7 @@ import { AudioPlayer } from '.';
 import type { AudioPlayerProps } from '.';
 
 const meta: Meta<AudioPlayerProps> = {
-    title: 'Controls/AudioPlayer',
+    title: 'Data Entry/AudioPlayer',
     component: AudioPlayer,
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-web/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/plasma-web/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -69,7 +69,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Controls/Autocomplete',
+    title: 'Data Entry/Autocomplete',
     decorators: [InSpacingDecorator],
     component: Autocomplete,
     argTypes: {

--- a/packages/plasma-web/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/plasma-web/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from '.';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'Content/Breadcrumbs',
+    title: 'Navigation/Breadcrumbs',
     component: Breadcrumbs,
     args: {
         view: 'default',

--- a/packages/plasma-web/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-web/src/components/Button/Button.stories.tsx
@@ -29,7 +29,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     component: Button,
     args: {

--- a/packages/plasma-web/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/plasma-web/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'Controls/ButtonGroup',
+    title: 'Data Entry/ButtonGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/plasma-web/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-web/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<CalendarProps> = {
-    title: 'Controls/Calendar',
+    title: 'Data Entry/Calendar',
     decorators: [InSpacingDecorator],
     component: Calendar,
     argTypes: {

--- a/packages/plasma-web/src/components/Card/Card.stories.tsx
+++ b/packages/plasma-web/src/components/Card/Card.stories.tsx
@@ -25,7 +25,7 @@ type StoryDefaultProps = CardProps & {
 };
 
 const meta: Meta<StoryDefaultProps> = {
-    title: 'Content/Card',
+    title: 'Data Display/Card',
     component: Card,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-web/src/components/Carousel/Carousel.stories.tsx
@@ -14,7 +14,7 @@ import { Carousel, CarouselItem } from '.';
 import type { CarouselProps } from '.';
 
 const meta: Meta<typeof Carousel> = {
-    title: 'Controls/Carousel',
+    title: 'Navigation/Carousel',
     component: Carousel,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-web/src/components/Checkbox/Checkbox.stories.tsx
@@ -36,7 +36,7 @@ const sizes = ['m', 's'];
 const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-web/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/plasma-web/src/components/Combobox/Legacy/Combobox.stories.tsx
+++ b/packages/plasma-web/src/components/Combobox/Legacy/Combobox.stories.tsx
@@ -24,7 +24,7 @@ type ComboboxPrimitiveValue = string | number | boolean;
 type StorySelectProps = ComponentProps<typeof Combobox> & StorySelectPropsCustom;
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/plasma-web/src/components/Counter/Counter.stories.tsx
+++ b/packages/plasma-web/src/components/Counter/Counter.stories.tsx
@@ -7,7 +7,7 @@ const sizes = ['l', 'm', 's', 'xs', 'xxs'];
 const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'Content/Counter',
+    title: 'Data Display/Counter',
     component: Counter,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-web/src/components/DatePicker/DatePicker.stories.tsx
@@ -20,7 +20,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'Controls/DatePicker',
+    title: 'Data Entry/DatePicker',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/plasma-web/src/components/Divider/Divider.stories.tsx
+++ b/packages/plasma-web/src/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { BodyS } from '../Typography';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'Content/Divider',
+    title: 'Data Display/Divider',
     decorators: [InSpacingDecorator],
     argTypes: {
         orientation: {

--- a/packages/plasma-web/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-web/src/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '.';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
 export default {
-    title: 'Controls/Drawer',
+    title: 'Overlay/Drawer',
     decorators: [InSpacingDecorator],
     argTypes: {
         placement: {

--- a/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
@@ -16,7 +16,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<DropdownProps> = {
-    title: 'Controls/Dropdown',
+    title: 'Data Entry/Dropdown',
     component: Dropdown,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/plasma-web/src/components/Dropzone/Dropzone.stories.tsx
@@ -14,7 +14,7 @@ const onChoseFiles = action('onChoseFiles');
 const iconPlacements = ['top', 'left'];
 
 const meta: Meta<typeof Dropzone> = {
-    title: 'Controls/Dropzone',
+    title: 'Data Entry/Dropzone',
     component: Dropzone,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Editable/Editable.stories.tsx
+++ b/packages/plasma-web/src/components/Editable/Editable.stories.tsx
@@ -10,7 +10,7 @@ import { Editable } from '.';
 const iconSizes = ['s', 'xs'] as const;
 
 const meta: Meta<typeof Editable> = {
-    title: 'Controls/Editable',
+    title: 'Data Entry/Editable',
     decorators: [InSpacingDecorator],
     component: Editable,
     argTypes: {

--- a/packages/plasma-web/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/plasma-web/src/components/EmptyState/EmptyState.stories.tsx
@@ -13,7 +13,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Content/EmptyState',
+    title: 'Data Entry/EmptyState',
     decorators: [InSpacingDecorator],
     component: EmptyState,
     args: {

--- a/packages/plasma-web/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/plasma-web/src/components/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const pins = [
 ];
 
 const meta: Meta<StoryButtonProps> = {
-    title: 'Controls/IconButton',
+    title: 'Data Entry/IconButton',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/plasma-web/src/components/Image/Image.stories.tsx
+++ b/packages/plasma-web/src/components/Image/Image.stories.tsx
@@ -6,7 +6,7 @@ import { Image, Ratio } from '.';
 import type { ImageProps } from '.';
 
 const meta: Meta<ImageProps> = {
-    title: 'Content/Image',
+    title: 'Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Indicator/Indicator.stories.tsx
+++ b/packages/plasma-web/src/components/Indicator/Indicator.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { Indicator } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'Content/Indicator',
+    title: 'Data Display/Indicator',
     component: Indicator,
     argTypes: {
         view: {

--- a/packages/plasma-web/src/components/Link/Link.stories.tsx
+++ b/packages/plasma-web/src/components/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ import { P1 } from '../Typography';
 import { Link } from '.';
 
 const meta: Meta<typeof Link> = {
-    title: 'Content/Link',
+    title: 'Navigation/Link',
     decorators: [InSpacingDecorator],
     component: Link,
     argTypes: {

--- a/packages/plasma-web/src/components/Mask/Mask.stories.tsx
+++ b/packages/plasma-web/src/components/Mask/Mask.stories.tsx
@@ -35,7 +35,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<typeof Mask> = {
-    title: 'Controls/Mask',
+    title: 'Data Display/Mask',
     component: Mask,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Modal/Modal.stories.tsx
+++ b/packages/plasma-web/src/components/Modal/Modal.stories.tsx
@@ -19,7 +19,7 @@ const longText = `Если после применения правила Лоп
 type StoryModalProps = ModalProps & { heading: string; text: string; withBlur?: boolean };
 
 const meta: Meta<StoryModalProps> = {
-    title: 'Controls/Modal',
+    title: 'Overlay/Modal',
     component: Modal,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/ModalBase/ModalBase.stories.tsx
+++ b/packages/plasma-web/src/components/ModalBase/ModalBase.stories.tsx
@@ -13,7 +13,7 @@ import { ModalBase, modalBaseClasses } from '.';
 import type { ModalBaseProps } from '.';
 
 const meta: Meta<ModalBaseProps> = {
-    title: 'Controls/ModalBase',
+    title: 'Overlay/ModalBase',
     component: ModalBase,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/plasma-web/src/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-web/src/components/Notification/Notification.stories.tsx
@@ -39,7 +39,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<NotificationProps> = {
-    title: 'Controls/Notification',
+    title: 'Overlay/Notification',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/plasma-web/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/plasma-web/src/components/NumberInput/NumberInput.stories.tsx
@@ -16,7 +16,7 @@ const inputBackgroundTypes = ['fill', 'clear'];
 const segmentation = ['default', 'segmented', 'solid'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'Controls/NumberInput',
+    title: 'Data Entry/NumberInput',
     component: NumberInput,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/plasma-web/src/components/Overlay/Overlay.stories.tsx
@@ -12,7 +12,7 @@ import { Overlay } from '.';
 const onOverlayClick = action('onOverlayClick');
 
 export default {
-    title: 'Controls/Overlay',
+    title: 'Overlay/Overlay',
     decorators: [InSpacingDecorator],
     argTypes: {
         isClickable: {

--- a/packages/plasma-web/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/plasma-web/src/components/Pagination/Pagination.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'Controls/Pagination',
+    title: 'Navigation/Pagination',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/plasma-web/src/components/PaginationDots/PaginationDots.stories.tsx
+++ b/packages/plasma-web/src/components/PaginationDots/PaginationDots.stories.tsx
@@ -10,7 +10,7 @@ import { SmartPaginationDots, PaginationDots, PaginationDot } from '.';
 import type { SmartPaginationDotsProps } from '.';
 
 const meta: Meta<SmartPaginationDotsProps> = {
-    title: 'Controls/PaginationDots',
+    title: 'Navigation/PaginationDots',
     component: PaginationDots,
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-web/src/components/Popover/Popover.stories.tsx
+++ b/packages/plasma-web/src/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from '../Button/Button';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'Controls/Popover',
+    title: 'Overlay/Popover',
     decorators: [InSpacingDecorator],
     component: Popover,
     argTypes: {

--- a/packages/plasma-web/src/components/PopupBase/PopupBase.stories.tsx
+++ b/packages/plasma-web/src/components/PopupBase/PopupBase.stories.tsx
@@ -11,7 +11,7 @@ import { PopupBase, popupBaseClasses, PopupBaseProvider } from '.';
 import type { PopupBaseProps } from '.';
 
 const meta: Meta<PopupBaseProps> = {
-    title: 'Controls/PopupBase',
+    title: 'Overlay/Popup',
     component: PopupBase,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/plasma-web/src/components/Portal/Portal.stories.tsx
+++ b/packages/plasma-web/src/components/Portal/Portal.stories.tsx
@@ -10,7 +10,7 @@ import { BodyM } from '../Typography';
 import { Portal } from '.';
 
 const meta: Meta<typeof Portal> = {
-    title: 'Controls/Portal',
+    title: 'Data Entry/Portal',
     decorators: [InSpacingDecorator],
     args: {
         disabled: false,

--- a/packages/plasma-web/src/components/PreviewGallery/PreviewGallery.stories.tsx
+++ b/packages/plasma-web/src/components/PreviewGallery/PreviewGallery.stories.tsx
@@ -9,7 +9,7 @@ import { arrayItemRemoving, arrayItemSelecting, arrayItemSwapping, PreviewGaller
 import type { PreviewGalleryProps, PreviewGalleryItemProps } from '.';
 
 const meta: Meta<PreviewGalleryProps> = {
-    title: 'Controls/PreviewGallery',
+    title: 'Layout/PreviewGallery',
     component: PreviewGallery,
     argTypes: {
         items: {

--- a/packages/plasma-web/src/components/Price/Price.stories.tsx
+++ b/packages/plasma-web/src/components/Price/Price.stories.tsx
@@ -5,7 +5,7 @@ import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import { Price } from '.';
 
 const meta: Meta<typeof Price> = {
-    title: 'Content/Price',
+    title: 'Data Display/Price',
     decorators: [InSpacingDecorator],
     argTypes: {
         currency: {

--- a/packages/plasma-web/src/components/Progress/Progress.stories.tsx
+++ b/packages/plasma-web/src/components/Progress/Progress.stories.tsx
@@ -7,7 +7,7 @@ import type { ProgressProps } from '.';
 const views = ['default', 'secondary', 'primary', 'accent', 'success', 'warning', 'error'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'Controls/Progress',
+    title: 'Overlay/Progress',
     component: Progress,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-web/src/components/Radiobox/Radiobox.stories.tsx
@@ -18,7 +18,7 @@ const sizes = ['m', 's'];
 const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     decorators: [InSpacingDecorator],
     component: Radiobox,
     argTypes: {

--- a/packages/plasma-web/src/components/Range/Range.stories.tsx
+++ b/packages/plasma-web/src/components/Range/Range.stories.tsx
@@ -22,7 +22,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'Controls/Range',
+    title: 'Data Entry/Range',
     component: Range,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Segment/Segment.stories.tsx
+++ b/packages/plasma-web/src/components/Segment/Segment.stories.tsx
@@ -49,7 +49,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'Controls/Segment',
+    title: 'Data Entry/Segment',
     decorators: [InSpacingDecorator],
     component: SegmentGroup,
     argTypes: {

--- a/packages/plasma-web/src/components/Select/Select.stories.tsx
+++ b/packages/plasma-web/src/components/Select/Select.stories.tsx
@@ -19,7 +19,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Select',
+    title: 'Data Entry/Select',
     decorators: [InSpacingDecorator],
     component: Select,
     argTypes: {

--- a/packages/plasma-web/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/plasma-web/src/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Sheet } from '.';
 import type { SheetProps } from '.';
 
 const meta: Meta<SheetProps> = {
-    title: 'Content/Sheet',
+    title: 'Overlay/Sheet',
     decorators: [InSpacingDecorator],
     args: {
         withBlur: false,

--- a/packages/plasma-web/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/plasma-web/src/components/Skeleton/Skeleton.stories.tsx
@@ -16,7 +16,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'Content/Skeleton',
+    title: 'Data Display/Skeleton',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/plasma-web/src/components/Slider/Slider.stories.tsx
+++ b/packages/plasma-web/src/components/Slider/Slider.stories.tsx
@@ -16,7 +16,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'Controls/Slider',
+    title: 'Data Entry/Slider',
     component: Slider,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/plasma-web/src/components/Spinner/Spinner.stories.tsx
@@ -11,7 +11,7 @@ import { Spinner } from '.';
 import type { SpinnerProps } from '.';
 
 const meta: Meta<SpinnerProps> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     component: Spinner,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Steps/Steps.stories.tsx
+++ b/packages/plasma-web/src/components/Steps/Steps.stories.tsx
@@ -9,7 +9,7 @@ import { Steps } from './Steps';
 import type { StepItemProps } from '.';
 
 const meta: Meta<typeof Steps> = {
-    title: 'Controls/Steps',
+    title: 'Navigation/Steps',
     decorators: [InSpacingDecorator],
     component: Steps,
 };

--- a/packages/plasma-web/src/components/Switch/Switch.stories.tsx
+++ b/packages/plasma-web/src/components/Switch/Switch.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-web/src/components/Tabs/Tabs.stories.tsx
@@ -55,7 +55,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'Controls/Tabs',
+    title: 'Navigation/Tabs',
     component: Tabs,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-web/src/components/TextArea/TextArea.stories.tsx
@@ -38,7 +38,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<TextAreaProps> = {
-    title: 'Controls/TextArea',
+    title: 'Data Entry/TextArea',
     component: TextArea,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.stories.tsx
@@ -64,7 +64,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<TextFieldProps> = {
-    title: 'Controls/TextField',
+    title: 'Data Entry/TextField',
     component: TextField,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
+++ b/packages/plasma-web/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
@@ -22,7 +22,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof TextFieldGroup> = {
-    title: 'Controls/TextFieldGroup',
+    title: 'Data Entry/TextFieldGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/plasma-web/src/components/Toast/Toast.stories.tsx
+++ b/packages/plasma-web/src/components/Toast/Toast.stories.tsx
@@ -14,7 +14,7 @@ import { ToastController } from './Toast';
 import { Toast, useToast } from '.';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'Controls/Toast',
+    title: 'Overlay/Toast',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/plasma-web/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/plasma-web/src/components/Toolbar/Toolbar.stories.tsx
@@ -35,7 +35,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'Controls/Toolbar',
+    title: 'Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/plasma-web/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-web/src/components/Tooltip/Tooltip.stories.tsx
@@ -32,7 +32,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'Controls/Tooltip',
+    title: 'Overlay/Tooltip',
     decorators: [InSpacingDecorator],
     component: Tooltip,
 };

--- a/packages/plasma-web/src/components/Typography/Typography.stories.tsx
+++ b/packages/plasma-web/src/components/Typography/Typography.stories.tsx
@@ -41,7 +41,7 @@ import {
 } from '.';
 
 const meta: Meta = {
-    title: 'Content/Typography',
+    title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
         ...disableProps(['size']),

--- a/packages/plasma-web/src/components/Upload/Upload.stories.tsx
+++ b/packages/plasma-web/src/components/Upload/Upload.stories.tsx
@@ -7,7 +7,7 @@ import { Upload, ValidationResult } from '.';
 import type { UploadProps } from '.';
 
 const meta: Meta<UploadProps> = {
-    title: 'Controls/Upload',
+    title: 'Data Entry/Upload',
     component: Upload,
     argTypes: {
         content: {

--- a/packages/plasma-web/src/components/UploadAudio/UploadAudio.stories.tsx
+++ b/packages/plasma-web/src/components/UploadAudio/UploadAudio.stories.tsx
@@ -10,7 +10,7 @@ import { UploadAudio } from '.';
 import type { UploadAudioProps } from '.';
 
 const meta: Meta<UploadAudioProps> = {
-    title: 'Controls/UploadAudio',
+    title: 'Data Entry/UploadAudio',
     component: UploadAudio,
     argTypes: {
         content: {

--- a/packages/plasma-web/src/components/UploadVisual/UploadVisual.stories.tsx
+++ b/packages/plasma-web/src/components/UploadVisual/UploadVisual.stories.tsx
@@ -12,7 +12,7 @@ import { UploadVisual } from '.';
 import type { UploadVisualProps } from '.';
 
 const meta: Meta<UploadVisualProps> = {
-    title: 'Controls/UploadVisual',
+    title: 'Data Entry/UploadVisual',
     component: UploadVisual,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/.storybook/preview.tsx
+++ b/packages/sdds-cs/.storybook/preview.tsx
@@ -39,7 +39,7 @@ const preview: Preview = {
         options: {
             storySort: {
                 method: 'alphabetical',
-                order: ['About', 'Intro', 'Colors', 'Typography', 'Controls', 'Hooks'],
+                order: ['About', 'Layout', '*', 'Hooks'],
             },
         },
         viewport: {

--- a/packages/sdds-cs/src/components/Attach/Attach.stories.tsx
+++ b/packages/sdds-cs/src/components/Attach/Attach.stories.tsx
@@ -21,7 +21,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'Controls/Attach',
+    title: 'Data Entry/Attach',
     decorators: [InSpacingDecorator],
     component: Attach,
     argTypes: {

--- a/packages/sdds-cs/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/sdds-cs/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -67,7 +67,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Controls/Autocomplete',
+    title: 'Data Entry/Autocomplete',
     decorators: [InSpacingDecorator],
     component: Autocomplete,
     argTypes: {

--- a/packages/sdds-cs/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/sdds-cs/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from '.';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'Content/Breadcrumbs',
+    title: 'Navigation/Breadcrumbs',
     component: Breadcrumbs,
     args: {
         view: 'default',

--- a/packages/sdds-cs/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-cs/src/components/Button/Button.stories.tsx
@@ -31,7 +31,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     component: Button,
     args: {

--- a/packages/sdds-cs/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/sdds-cs/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'Controls/ButtonGroup',
+    title: 'Data Entry/ButtonGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-cs/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/sdds-cs/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<CalendarProps> = {
-    title: 'Controls/Calendar',
+    title: 'Data Entry/Calendar',
     decorators: [InSpacingDecorator],
     component: Calendar,
     argTypes: {

--- a/packages/sdds-cs/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-cs/src/components/Checkbox/Checkbox.stories.tsx
@@ -34,7 +34,7 @@ const sizes = ['s'];
 const views = ['accent'];
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-cs/src/components/Combobox/Combobox.stories.tsx
@@ -15,7 +15,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/sdds-cs/src/components/Counter/Counter.stories.tsx
+++ b/packages/sdds-cs/src/components/Counter/Counter.stories.tsx
@@ -6,7 +6,7 @@ import { Counter } from './Counter';
 const views = ['default', 'accent', 'positive', 'negative'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'Content/Counter',
+    title: 'Data Display/Counter',
     component: Counter,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-cs/src/components/DatePicker/DatePicker.stories.tsx
@@ -21,7 +21,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'Controls/DatePicker',
+    title: 'Data Entry/DatePicker',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-cs/src/components/Divider/Divider.stories.tsx
+++ b/packages/sdds-cs/src/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { BodyS } from '../Typography';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'Content/Divider',
+    title: 'Data Display/Divider',
     decorators: [InSpacingDecorator],
     argTypes: {
         orientation: {

--- a/packages/sdds-cs/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-cs/src/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '.';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
 export default {
-    title: 'Controls/Drawer',
+    title: 'Overlay/Drawer',
     decorators: [InSpacingDecorator],
     argTypes: {
         ...disableProps(['view', 'size']),

--- a/packages/sdds-cs/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-cs/src/components/Dropdown/Dropdown.stories.tsx
@@ -16,7 +16,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<DropdownProps> = {
-    title: 'Controls/Dropdown',
+    title: 'Data Entry/Dropdown',
     component: Dropdown,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/sdds-cs/src/components/Dropzone/Dropzone.stories.tsx
@@ -14,7 +14,7 @@ const onChoseFiles = action('onChoseFiles');
 const iconPlacements = ['top', 'left'];
 
 const meta: Meta<typeof Dropzone> = {
-    title: 'Controls/Dropzone',
+    title: 'Data Entry/Dropzone',
     component: Dropzone,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/sdds-cs/src/components/EmptyState/EmptyState.stories.tsx
@@ -13,7 +13,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Content/EmptyState',
+    title: 'Data Entry/EmptyState',
     decorators: [InSpacingDecorator],
     component: EmptyState,
     args: {

--- a/packages/sdds-cs/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/sdds-cs/src/components/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const pins = [
 ];
 
 const meta: Meta<StoryButtonProps> = {
-    title: 'Controls/IconButton',
+    title: 'Data Entry/IconButton',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-cs/src/components/Image/Image.stories.tsx
+++ b/packages/sdds-cs/src/components/Image/Image.stories.tsx
@@ -6,7 +6,7 @@ import { Image, Ratio } from '.';
 import type { ImageProps } from '.';
 
 const meta: Meta<ImageProps> = {
-    title: 'Content/Image',
+    title: 'Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Indicator/Indicator.stories.tsx
+++ b/packages/sdds-cs/src/components/Indicator/Indicator.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { Indicator } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'Content/Indicator',
+    title: 'Data Display/Indicator',
     component: Indicator,
     argTypes: {
         view: {

--- a/packages/sdds-cs/src/components/Link/Link.stories.tsx
+++ b/packages/sdds-cs/src/components/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ import { TextM } from '../Typography';
 import { Link } from '.';
 
 const meta: Meta<typeof Link> = {
-    title: 'Content/Link',
+    title: 'Navigation/Link',
     decorators: [InSpacingDecorator],
     component: Link,
     argTypes: {

--- a/packages/sdds-cs/src/components/Mask/Mask.stories.tsx
+++ b/packages/sdds-cs/src/components/Mask/Mask.stories.tsx
@@ -34,7 +34,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<typeof Mask> = {
-    title: 'Controls/Mask',
+    title: 'Data Display/Mask',
     component: Mask,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-cs/src/components/Modal/Modal.stories.tsx
@@ -13,7 +13,7 @@ import { Modal, modalClasses } from '.';
 import type { ModalProps } from '.';
 
 const meta: Meta<ModalProps> = {
-    title: 'Controls/Modal',
+    title: 'Overlay/Modal',
     decorators: [InSpacingDecorator],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/sdds-cs/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-cs/src/components/Notification/Notification.stories.tsx
@@ -37,7 +37,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<typeof Notification> = {
-    title: 'Controls/Notification',
+    title: 'Overlay/Notification',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-cs/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/sdds-cs/src/components/NumberInput/NumberInput.stories.tsx
@@ -13,7 +13,7 @@ const onIncrement = action('onIncrement');
 const shapes = ['cornered', 'pilled'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'Controls/NumberInput',
+    title: 'Data Entry/NumberInput',
     component: NumberInput,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/sdds-cs/src/components/Overlay/Overlay.stories.tsx
@@ -12,7 +12,7 @@ import { Overlay } from '.';
 const onOverlayClick = action('onOverlayClick');
 
 export default {
-    title: 'Controls/Overlay',
+    title: 'Overlay/Overlay',
     decorators: [InSpacingDecorator],
     argTypes: {
         isClickable: {

--- a/packages/sdds-cs/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/sdds-cs/src/components/Pagination/Pagination.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'Controls/Pagination',
+    title: 'Navigation/Pagination',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-cs/src/components/Popover/Popover.stories.tsx
+++ b/packages/sdds-cs/src/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from '../Button/Button';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'Controls/Popover',
+    title: 'Overlay/Popover',
     decorators: [InSpacingDecorator],
     component: Popover,
     argTypes: {

--- a/packages/sdds-cs/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-cs/src/components/Popup/Popup.stories.tsx
@@ -10,7 +10,7 @@ import { Popup, popupClasses, PopupProvider } from '.';
 import type { PopupProps } from '.';
 
 const meta: Meta<PopupProps> = {
-    title: 'Controls/Popup',
+    title: 'Overlay/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/sdds-cs/src/components/Portal/Portal.stories.tsx
+++ b/packages/sdds-cs/src/components/Portal/Portal.stories.tsx
@@ -10,7 +10,7 @@ import { BodyM } from '../Typography';
 import { Portal } from '.';
 
 const meta: Meta<typeof Portal> = {
-    title: 'Controls/Portal',
+    title: 'Data Entry/Portal',
     decorators: [InSpacingDecorator],
     args: {
         disabled: false,

--- a/packages/sdds-cs/src/components/Price/Price.stories.tsx
+++ b/packages/sdds-cs/src/components/Price/Price.stories.tsx
@@ -5,7 +5,7 @@ import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import { Price } from '.';
 
 const meta: Meta<typeof Price> = {
-    title: 'Content/Price',
+    title: 'Data Display/Price',
     decorators: [InSpacingDecorator],
     argTypes: {
         currency: {

--- a/packages/sdds-cs/src/components/Progress/Progress.stories.tsx
+++ b/packages/sdds-cs/src/components/Progress/Progress.stories.tsx
@@ -7,7 +7,7 @@ import type { ProgressProps } from '.';
 const views = ['default', 'accent', 'positive', 'negative'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'Controls/Progress',
+    title: 'Overlay/Progress',
     component: Progress,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/sdds-cs/src/components/Radiobox/Radiobox.stories.tsx
@@ -13,7 +13,7 @@ const sizes = ['s'];
 const views = ['accent'];
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     component: Radiobox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Range/Range.stories.tsx
+++ b/packages/sdds-cs/src/components/Range/Range.stories.tsx
@@ -22,7 +22,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'Controls/Range',
+    title: 'Data Entry/Range',
     component: Range,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Segment/Segment.stories.tsx
+++ b/packages/sdds-cs/src/components/Segment/Segment.stories.tsx
@@ -46,7 +46,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'Controls/Segment',
+    title: 'Data Entry/Segment',
     decorators: [InSpacingDecorator],
     component: SegmentGroup,
     argTypes: {

--- a/packages/sdds-cs/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-cs/src/components/Select/Select.stories.tsx
@@ -16,7 +16,7 @@ const view = ['default', 'negative'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Select',
+    title: 'Data Entry/Select',
     decorators: [InSpacingDecorator],
     component: Select,
     argTypes: {

--- a/packages/sdds-cs/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/sdds-cs/src/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Sheet } from '.';
 import type { SheetProps } from '.';
 
 const meta: Meta<SheetProps> = {
-    title: 'Content/Sheet',
+    title: 'Overlay/Sheet',
     decorators: [InSpacingDecorator],
     args: {
         withBlur: false,

--- a/packages/sdds-cs/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/sdds-cs/src/components/Skeleton/Skeleton.stories.tsx
@@ -14,7 +14,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'Content/Skeleton',
+    title: 'Data Display/Skeleton',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-cs/src/components/Slider/Slider.stories.tsx
+++ b/packages/sdds-cs/src/components/Slider/Slider.stories.tsx
@@ -16,7 +16,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'Controls/Slider',
+    title: 'Data Entry/Slider',
     component: Slider,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/sdds-cs/src/components/Spinner/Spinner.stories.tsx
@@ -9,7 +9,7 @@ import { BodyL } from '../Typography';
 import { Spinner } from '.';
 
 const meta: Meta<typeof Spinner> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     decorators: [InSpacingDecorator],
     component: Spinner,
     argTypes: {

--- a/packages/sdds-cs/src/components/Steps/Steps.stories.tsx
+++ b/packages/sdds-cs/src/components/Steps/Steps.stories.tsx
@@ -9,7 +9,7 @@ import { Steps } from './Steps';
 import type { StepItemProps } from '.';
 
 const meta: Meta<typeof Steps> = {
-    title: 'Controls/Steps',
+    title: 'Navigation/Steps',
     decorators: [InSpacingDecorator],
     component: Steps,
 };

--- a/packages/sdds-cs/src/components/Switch/Switch.stories.tsx
+++ b/packages/sdds-cs/src/components/Switch/Switch.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/sdds-cs/src/components/Tabs/Tabs.stories.tsx
@@ -53,7 +53,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'Controls/Tabs',
+    title: 'Navigation/Tabs',
     component: Tabs,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-cs/src/components/TextArea/TextArea.stories.tsx
@@ -42,7 +42,7 @@ const hintPlacements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<StoryTextAreaProps> = {
-    title: 'Controls/TextArea',
+    title: 'Data Entry/TextArea',
     decorators: [InSpacingDecorator],
     component: TextArea,
     argTypes: {

--- a/packages/sdds-cs/src/components/TextField/TextField.stories.tsx
+++ b/packages/sdds-cs/src/components/TextField/TextField.stories.tsx
@@ -40,7 +40,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<typeof TextField> = {
-    title: 'Controls/TextField',
+    title: 'Data Entry/TextField',
     component: TextField,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Toast/Toast.stories.tsx
+++ b/packages/sdds-cs/src/components/Toast/Toast.stories.tsx
@@ -11,7 +11,7 @@ import { ToastController, ToastProvider } from './Toast';
 import { Toast, useToast } from '.';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'Controls/Toast',
+    title: 'Overlay/Toast',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-cs/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/sdds-cs/src/components/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'Controls/Toolbar',
+    title: 'Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-cs/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-cs/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,7 +30,7 @@ const placements: Array<string> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'Controls/Tooltip',
+    title: 'Overlay/Tooltip',
     decorators: [InSpacingDecorator],
     component: Tooltip,
 };

--- a/packages/sdds-cs/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-cs/src/components/Typography/Typography.stories.tsx
@@ -23,7 +23,7 @@ import {
 } from '.';
 
 const meta: Meta = {
-    title: 'Content/Typography',
+    title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
         ...disableProps(['size']),

--- a/packages/sdds-cs/src/components/ViewContainer/ViewContainer.stories.tsx
+++ b/packages/sdds-cs/src/components/ViewContainer/ViewContainer.stories.tsx
@@ -11,7 +11,7 @@ import { ViewContainer } from './ViewContainer';
 type StoryViewProps = ComponentProps<typeof ViewContainer>;
 
 const meta: Meta<StoryViewProps> = {
-    title: 'Layout/ViewContainer',
+    title: 'Data Display/ViewContainer',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-dfa/.storybook/preview.tsx
+++ b/packages/sdds-dfa/.storybook/preview.tsx
@@ -46,7 +46,7 @@ const preview: Preview = {
         options: {
             storySort: {
                 method: 'alphabetical',
-                order: ['About', 'Intro', 'Colors', 'Typography', 'Controls', 'Hooks'],
+                order: ['About', 'Layout', '*', 'Hooks'],
             },
         },
         viewport: {

--- a/packages/sdds-dfa/src/components/Attach/Attach.stories.tsx
+++ b/packages/sdds-dfa/src/components/Attach/Attach.stories.tsx
@@ -32,7 +32,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'Controls/Attach',
+    title: 'Data Entry/Attach',
     decorators: [InSpacingDecorator],
     component: Attach,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/sdds-dfa/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -69,7 +69,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Controls/Autocomplete',
+    title: 'Data Entry/Autocomplete',
     decorators: [InSpacingDecorator],
     component: Autocomplete,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/sdds-dfa/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from '.';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'Content/Breadcrumbs',
+    title: 'Navigation/Breadcrumbs',
     component: Breadcrumbs,
     args: {
         view: 'default',

--- a/packages/sdds-dfa/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-dfa/src/components/Button/Button.stories.tsx
@@ -31,7 +31,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     component: Button,
     args: {

--- a/packages/sdds-dfa/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/sdds-dfa/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'Controls/ButtonGroup',
+    title: 'Data Entry/ButtonGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-dfa/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/sdds-dfa/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<CalendarProps> = {
-    title: 'Controls/Calendar',
+    title: 'Data Entry/Calendar',
     decorators: [InSpacingDecorator],
     component: Calendar,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-dfa/src/components/Checkbox/Checkbox.stories.tsx
@@ -34,7 +34,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-dfa/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Counter/Counter.stories.tsx
+++ b/packages/sdds-dfa/src/components/Counter/Counter.stories.tsx
@@ -7,7 +7,7 @@ const sizes = ['l', 'm', 's', 'xs', 'xxs'];
 const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'Content/Counter',
+    title: 'Data Display/Counter',
     component: Counter,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-dfa/src/components/DatePicker/DatePicker.stories.tsx
@@ -20,7 +20,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'Controls/DatePicker',
+    title: 'Data Entry/DatePicker',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-dfa/src/components/Divider/Divider.stories.tsx
+++ b/packages/sdds-dfa/src/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { BodyS } from '../Typography';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'Content/Divider',
+    title: 'Data Display/Divider',
     decorators: [InSpacingDecorator],
     argTypes: {
         orientation: {

--- a/packages/sdds-dfa/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-dfa/src/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '.';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
 export default {
-    title: 'Controls/Drawer',
+    title: 'Overlay/Drawer',
     decorators: [InSpacingDecorator],
     argTypes: {
         placement: {

--- a/packages/sdds-dfa/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-dfa/src/components/Dropdown/Dropdown.stories.tsx
@@ -16,7 +16,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<DropdownProps> = {
-    title: 'Controls/Dropdown',
+    title: 'Data Entry/Dropdown',
     component: Dropdown,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/sdds-dfa/src/components/Dropzone/Dropzone.stories.tsx
@@ -14,7 +14,7 @@ const onChoseFiles = action('onChoseFiles');
 const iconPlacements = ['top', 'left'];
 
 const meta: Meta<typeof Dropzone> = {
-    title: 'Controls/Dropzone',
+    title: 'Data Entry/Dropzone',
     component: Dropzone,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/sdds-dfa/src/components/EmptyState/EmptyState.stories.tsx
@@ -13,7 +13,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Content/EmptyState',
+    title: 'Data Entry/EmptyState',
     decorators: [InSpacingDecorator],
     component: EmptyState,
     args: {

--- a/packages/sdds-dfa/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/sdds-dfa/src/components/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const pins = [
 ];
 
 const meta: Meta<StoryButtonProps> = {
-    title: 'Controls/IconButton',
+    title: 'Data Entry/IconButton',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-dfa/src/components/Image/Image.stories.tsx
+++ b/packages/sdds-dfa/src/components/Image/Image.stories.tsx
@@ -6,7 +6,7 @@ import { Image, Ratio } from '.';
 import type { ImageProps } from '.';
 
 const meta: Meta<ImageProps> = {
-    title: 'Content/Image',
+    title: 'Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Indicator/Indicator.stories.tsx
+++ b/packages/sdds-dfa/src/components/Indicator/Indicator.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { Indicator } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'Content/Indicator',
+    title: 'Data Display/Indicator',
     component: Indicator,
     argTypes: {
         view: {

--- a/packages/sdds-dfa/src/components/Link/Link.stories.tsx
+++ b/packages/sdds-dfa/src/components/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ import { TextM } from '../Typography';
 import { Link } from '.';
 
 const meta: Meta<typeof Link> = {
-    title: 'Content/Link',
+    title: 'Navigation/Link',
     decorators: [InSpacingDecorator],
     component: Link,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Mask/Mask.stories.tsx
+++ b/packages/sdds-dfa/src/components/Mask/Mask.stories.tsx
@@ -35,7 +35,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<typeof Mask> = {
-    title: 'Controls/Mask',
+    title: 'Data Display/Mask',
     component: Mask,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-dfa/src/components/Modal/Modal.stories.tsx
@@ -13,7 +13,7 @@ import { Modal, modalClasses } from '.';
 import type { ModalProps } from '.';
 
 const meta: Meta<ModalProps> = {
-    title: 'Controls/Modal',
+    title: 'Overlay/Modal',
     decorators: [InSpacingDecorator],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/sdds-dfa/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-dfa/src/components/Notification/Notification.stories.tsx
@@ -37,7 +37,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<typeof Notification> = {
-    title: 'Controls/Notification',
+    title: 'Overlay/Notification',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-dfa/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/sdds-dfa/src/components/NumberInput/NumberInput.stories.tsx
@@ -16,7 +16,7 @@ const inputBackgroundTypes = ['fill', 'clear'];
 const segmentation = ['default', 'segmented', 'solid'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'Controls/NumberInput',
+    title: 'Data Entry/NumberInput',
     component: NumberInput,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/sdds-dfa/src/components/Overlay/Overlay.stories.tsx
@@ -12,7 +12,7 @@ import { Overlay } from '.';
 const onOverlayClick = action('onOverlayClick');
 
 export default {
-    title: 'Controls/Overlay',
+    title: 'Overlay/Overlay',
     decorators: [InSpacingDecorator],
     argTypes: {
         isClickable: {

--- a/packages/sdds-dfa/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/sdds-dfa/src/components/Pagination/Pagination.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'Controls/Pagination',
+    title: 'Navigation/Pagination',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-dfa/src/components/Popover/Popover.stories.tsx
+++ b/packages/sdds-dfa/src/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from '../Button/Button';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'Controls/Popover',
+    title: 'Overlay/Popover',
     decorators: [InSpacingDecorator],
     component: Popover,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-dfa/src/components/Popup/Popup.stories.tsx
@@ -10,7 +10,7 @@ import { Popup, popupClasses, PopupProvider } from '.';
 import type { PopupProps } from '.';
 
 const meta: Meta<PopupProps> = {
-    title: 'Controls/Popup',
+    title: 'Overlay/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/sdds-dfa/src/components/Portal/Portal.stories.tsx
+++ b/packages/sdds-dfa/src/components/Portal/Portal.stories.tsx
@@ -10,7 +10,7 @@ import { BodyM } from '../Typography';
 import { Portal } from '.';
 
 const meta: Meta<typeof Portal> = {
-    title: 'Controls/Portal',
+    title: 'Data Entry/Portal',
     decorators: [InSpacingDecorator],
     args: {
         disabled: false,

--- a/packages/sdds-dfa/src/components/Price/Price.stories.tsx
+++ b/packages/sdds-dfa/src/components/Price/Price.stories.tsx
@@ -5,7 +5,7 @@ import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import { Price } from '.';
 
 const meta: Meta<typeof Price> = {
-    title: 'Content/Price',
+    title: 'Data Display/Price',
     decorators: [InSpacingDecorator],
     argTypes: {
         currency: {

--- a/packages/sdds-dfa/src/components/Progress/Progress.stories.tsx
+++ b/packages/sdds-dfa/src/components/Progress/Progress.stories.tsx
@@ -7,7 +7,7 @@ import type { ProgressProps } from '.';
 const views = ['default', 'secondary', 'primary', 'accent', 'success', 'warning', 'error'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'Controls/Progress',
+    title: 'Overlay/Progress',
     component: Progress,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/sdds-dfa/src/components/Radiobox/Radiobox.stories.tsx
@@ -13,7 +13,7 @@ const sizes = ['m', 's'];
 const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     component: Radiobox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Range/Range.stories.tsx
+++ b/packages/sdds-dfa/src/components/Range/Range.stories.tsx
@@ -22,7 +22,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'Controls/Range',
+    title: 'Data Entry/Range',
     component: Range,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Segment/Segment.stories.tsx
+++ b/packages/sdds-dfa/src/components/Segment/Segment.stories.tsx
@@ -49,7 +49,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'Controls/Segment',
+    title: 'Data Entry/Segment',
     decorators: [InSpacingDecorator],
     component: SegmentGroup,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-dfa/src/components/Select/Select.stories.tsx
@@ -19,7 +19,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Select',
+    title: 'Data Entry/Select',
     decorators: [InSpacingDecorator],
     component: Select,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/sdds-dfa/src/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Sheet } from '.';
 import type { SheetProps } from '.';
 
 const meta: Meta<SheetProps> = {
-    title: 'Content/Sheet',
+    title: 'Overlay/Sheet',
     decorators: [InSpacingDecorator],
     args: {
         withBlur: false,

--- a/packages/sdds-dfa/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/sdds-dfa/src/components/Skeleton/Skeleton.stories.tsx
@@ -14,7 +14,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'Content/Skeleton',
+    title: 'Data Display/Skeleton',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-dfa/src/components/Slider/Slider.stories.tsx
+++ b/packages/sdds-dfa/src/components/Slider/Slider.stories.tsx
@@ -16,7 +16,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'Controls/Slider',
+    title: 'Data Entry/Slider',
     component: Slider,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/sdds-dfa/src/components/Spinner/Spinner.stories.tsx
@@ -9,7 +9,7 @@ import { BodyL } from '../Typography';
 import { Spinner } from '.';
 
 const meta: Meta<typeof Spinner> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     decorators: [InSpacingDecorator],
     component: Spinner,
     argTypes: {

--- a/packages/sdds-dfa/src/components/Steps/Steps.stories.tsx
+++ b/packages/sdds-dfa/src/components/Steps/Steps.stories.tsx
@@ -9,7 +9,7 @@ import { Steps } from './Steps';
 import type { StepItemProps } from '.';
 
 const meta: Meta<typeof Steps> = {
-    title: 'Controls/Steps',
+    title: 'Navigation/Steps',
     decorators: [InSpacingDecorator],
     component: Steps,
 };

--- a/packages/sdds-dfa/src/components/Switch/Switch.stories.tsx
+++ b/packages/sdds-dfa/src/components/Switch/Switch.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/sdds-dfa/src/components/Tabs/Tabs.stories.tsx
@@ -55,7 +55,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'Controls/Tabs',
+    title: 'Navigation/Tabs',
     component: Tabs,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-dfa/src/components/TextArea/TextArea.stories.tsx
@@ -43,7 +43,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<StoryTextAreaProps> = {
-    title: 'Controls/TextArea',
+    title: 'Data Entry/TextArea',
     decorators: [InSpacingDecorator],
     component: TextArea,
     argTypes: {

--- a/packages/sdds-dfa/src/components/TextField/TextField.stories.tsx
+++ b/packages/sdds-dfa/src/components/TextField/TextField.stories.tsx
@@ -42,7 +42,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<typeof TextField> = {
-    title: 'Controls/TextField',
+    title: 'Data Entry/TextField',
     component: TextField,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
+++ b/packages/sdds-dfa/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
@@ -22,7 +22,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof TextFieldGroup> = {
-    title: 'Controls/TextFieldGroup',
+    title: 'Data Entry/TextFieldGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-dfa/src/components/Toast/Toast.stories.tsx
+++ b/packages/sdds-dfa/src/components/Toast/Toast.stories.tsx
@@ -11,7 +11,7 @@ import { ToastController, ToastProvider } from './Toast';
 import { Toast, useToast } from '.';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'Controls/Toast',
+    title: 'Overlay/Toast',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-dfa/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/sdds-dfa/src/components/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'Controls/Toolbar',
+    title: 'Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-dfa/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-dfa/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,7 +30,7 @@ const placements: Array<string> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'Controls/Tooltip',
+    title: 'Overlay/Tooltip',
     decorators: [InSpacingDecorator],
     component: Tooltip,
 };

--- a/packages/sdds-dfa/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-dfa/src/components/Typography/Typography.stories.tsx
@@ -23,7 +23,7 @@ import {
 } from '.';
 
 const meta: Meta = {
-    title: 'Content/Typography',
+    title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
         ...disableProps(['size']),

--- a/packages/sdds-dfa/src/components/ViewContainer/ViewContainer.stories.tsx
+++ b/packages/sdds-dfa/src/components/ViewContainer/ViewContainer.stories.tsx
@@ -11,7 +11,7 @@ import { ViewContainer } from './ViewContainer';
 type StoryViewProps = ComponentProps<typeof ViewContainer>;
 
 const meta: Meta<StoryViewProps> = {
-    title: 'Layout/ViewContainer',
+    title: 'Data Display/ViewContainer',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-finportal/.storybook/preview.tsx
+++ b/packages/sdds-finportal/.storybook/preview.tsx
@@ -46,7 +46,7 @@ const preview: Preview = {
         options: {
             storySort: {
                 method: 'alphabetical',
-                order: ['About', 'Intro', 'Colors', 'Typography', 'Controls', 'Hooks'],
+                order: ['About', 'Layout', '*', 'Hooks'],
             },
         },
         viewport: {

--- a/packages/sdds-finportal/src/components/Attach/Attach.stories.tsx
+++ b/packages/sdds-finportal/src/components/Attach/Attach.stories.tsx
@@ -32,7 +32,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'Controls/Attach',
+    title: 'Data Entry/Attach',
     decorators: [InSpacingDecorator],
     component: Attach,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/sdds-finportal/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -69,7 +69,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Controls/Autocomplete',
+    title: 'Data Entry/Autocomplete',
     decorators: [InSpacingDecorator],
     component: Autocomplete,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/sdds-finportal/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from '.';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'Content/Breadcrumbs',
+    title: 'Navigation/Breadcrumbs',
     component: Breadcrumbs,
     args: {
         view: 'default',

--- a/packages/sdds-finportal/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-finportal/src/components/Button/Button.stories.tsx
@@ -31,7 +31,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     component: Button,
     args: {

--- a/packages/sdds-finportal/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/sdds-finportal/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'Controls/ButtonGroup',
+    title: 'Data Entry/ButtonGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-finportal/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/sdds-finportal/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<CalendarProps> = {
-    title: 'Controls/Calendar',
+    title: 'Data Entry/Calendar',
     decorators: [InSpacingDecorator],
     component: Calendar,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-finportal/src/components/Checkbox/Checkbox.stories.tsx
@@ -34,7 +34,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-finportal/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Counter/Counter.stories.tsx
+++ b/packages/sdds-finportal/src/components/Counter/Counter.stories.tsx
@@ -7,7 +7,7 @@ const sizes = ['l', 'm', 's', 'xs', 'xxs'];
 const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'Content/Counter',
+    title: 'Data Display/Counter',
     component: Counter,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-finportal/src/components/DatePicker/DatePicker.stories.tsx
@@ -20,7 +20,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'Controls/DatePicker',
+    title: 'Data Entry/DatePicker',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-finportal/src/components/Divider/Divider.stories.tsx
+++ b/packages/sdds-finportal/src/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { BodyS } from '../Typography';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'Content/Divider',
+    title: 'Data Display/Divider',
     decorators: [InSpacingDecorator],
     argTypes: {
         orientation: {

--- a/packages/sdds-finportal/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-finportal/src/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '.';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
 export default {
-    title: 'Controls/Drawer',
+    title: 'Overlay/Drawer',
     decorators: [InSpacingDecorator],
     argTypes: {
         placement: {

--- a/packages/sdds-finportal/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-finportal/src/components/Dropdown/Dropdown.stories.tsx
@@ -16,7 +16,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<DropdownProps> = {
-    title: 'Controls/Dropdown',
+    title: 'Data Entry/Dropdown',
     component: Dropdown,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/sdds-finportal/src/components/Dropzone/Dropzone.stories.tsx
@@ -14,7 +14,7 @@ const onChoseFiles = action('onChoseFiles');
 const iconPlacements = ['top', 'left'];
 
 const meta: Meta<typeof Dropzone> = {
-    title: 'Controls/Dropzone',
+    title: 'Data Entry/Dropzone',
     component: Dropzone,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/sdds-finportal/src/components/EmptyState/EmptyState.stories.tsx
@@ -13,7 +13,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Content/EmptyState',
+    title: 'Data Entry/EmptyState',
     decorators: [InSpacingDecorator],
     component: EmptyState,
     args: {

--- a/packages/sdds-finportal/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/sdds-finportal/src/components/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const pins = [
 ];
 
 const meta: Meta<StoryButtonProps> = {
-    title: 'Controls/IconButton',
+    title: 'Data Entry/IconButton',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-finportal/src/components/Image/Image.stories.tsx
+++ b/packages/sdds-finportal/src/components/Image/Image.stories.tsx
@@ -6,7 +6,7 @@ import { Image, Ratio } from '.';
 import type { ImageProps } from '.';
 
 const meta: Meta<ImageProps> = {
-    title: 'Content/Image',
+    title: 'Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Indicator/Indicator.stories.tsx
+++ b/packages/sdds-finportal/src/components/Indicator/Indicator.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { Indicator } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'Content/Indicator',
+    title: 'Data Display/Indicator',
     component: Indicator,
     argTypes: {
         view: {

--- a/packages/sdds-finportal/src/components/Link/Link.stories.tsx
+++ b/packages/sdds-finportal/src/components/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ import { TextM } from '../Typography';
 import { Link } from '.';
 
 const meta: Meta<typeof Link> = {
-    title: 'Content/Link',
+    title: 'Navigation/Link',
     decorators: [InSpacingDecorator],
     component: Link,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Mask/Mask.stories.tsx
+++ b/packages/sdds-finportal/src/components/Mask/Mask.stories.tsx
@@ -35,7 +35,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<typeof Mask> = {
-    title: 'Controls/Mask',
+    title: 'Data Display/Mask',
     component: Mask,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-finportal/src/components/Modal/Modal.stories.tsx
@@ -13,7 +13,7 @@ import { Modal, modalClasses } from '.';
 import type { ModalProps } from '.';
 
 const meta: Meta<ModalProps> = {
-    title: 'Controls/Modal',
+    title: 'Overlay/Modal',
     decorators: [InSpacingDecorator],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/sdds-finportal/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-finportal/src/components/Notification/Notification.stories.tsx
@@ -37,7 +37,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<typeof Notification> = {
-    title: 'Controls/Notification',
+    title: 'Overlay/Notification',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-finportal/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/sdds-finportal/src/components/NumberInput/NumberInput.stories.tsx
@@ -16,7 +16,7 @@ const inputBackgroundTypes = ['fill', 'clear'];
 const segmentation = ['default', 'segmented', 'solid'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'Controls/NumberInput',
+    title: 'Data Entry/NumberInput',
     component: NumberInput,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/sdds-finportal/src/components/Overlay/Overlay.stories.tsx
@@ -12,7 +12,7 @@ import { Overlay } from '.';
 const onOverlayClick = action('onOverlayClick');
 
 export default {
-    title: 'Controls/Overlay',
+    title: 'Overlay/Overlay',
     decorators: [InSpacingDecorator],
     argTypes: {
         isClickable: {

--- a/packages/sdds-finportal/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/sdds-finportal/src/components/Pagination/Pagination.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'Controls/Pagination',
+    title: 'Navigation/Pagination',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-finportal/src/components/Popover/Popover.stories.tsx
+++ b/packages/sdds-finportal/src/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from '../Button/Button';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'Controls/Popover',
+    title: 'Overlay/Popover',
     decorators: [InSpacingDecorator],
     component: Popover,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-finportal/src/components/Popup/Popup.stories.tsx
@@ -10,7 +10,7 @@ import { Popup, popupClasses, PopupProvider } from '.';
 import type { PopupProps } from '.';
 
 const meta: Meta<PopupProps> = {
-    title: 'Controls/Popup',
+    title: 'Overlay/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/sdds-finportal/src/components/Portal/Portal.stories.tsx
+++ b/packages/sdds-finportal/src/components/Portal/Portal.stories.tsx
@@ -10,7 +10,7 @@ import { BodyM } from '../Typography';
 import { Portal } from '.';
 
 const meta: Meta<typeof Portal> = {
-    title: 'Controls/Portal',
+    title: 'Data Entry/Portal',
     decorators: [InSpacingDecorator],
     args: {
         disabled: false,

--- a/packages/sdds-finportal/src/components/Price/Price.stories.tsx
+++ b/packages/sdds-finportal/src/components/Price/Price.stories.tsx
@@ -5,7 +5,7 @@ import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import { Price } from '.';
 
 const meta: Meta<typeof Price> = {
-    title: 'Content/Price',
+    title: 'Data Display/Price',
     decorators: [InSpacingDecorator],
     argTypes: {
         currency: {

--- a/packages/sdds-finportal/src/components/Progress/Progress.stories.tsx
+++ b/packages/sdds-finportal/src/components/Progress/Progress.stories.tsx
@@ -7,7 +7,7 @@ import type { ProgressProps } from '.';
 const views = ['default', 'secondary', 'primary', 'accent', 'success', 'warning', 'error'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'Controls/Progress',
+    title: 'Overlay/Progress',
     component: Progress,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/sdds-finportal/src/components/Radiobox/Radiobox.stories.tsx
@@ -13,7 +13,7 @@ const sizes = ['m', 's'];
 const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     component: Radiobox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Range/Range.stories.tsx
+++ b/packages/sdds-finportal/src/components/Range/Range.stories.tsx
@@ -22,7 +22,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'Controls/Range',
+    title: 'Data Entry/Range',
     component: Range,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Segment/Segment.stories.tsx
+++ b/packages/sdds-finportal/src/components/Segment/Segment.stories.tsx
@@ -49,7 +49,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'Controls/Segment',
+    title: 'Data Entry/Segment',
     decorators: [InSpacingDecorator],
     component: SegmentGroup,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-finportal/src/components/Select/Select.stories.tsx
@@ -19,7 +19,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Select',
+    title: 'Data Entry/Select',
     decorators: [InSpacingDecorator],
     component: Select,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/sdds-finportal/src/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Sheet } from '.';
 import type { SheetProps } from '.';
 
 const meta: Meta<SheetProps> = {
-    title: 'Content/Sheet',
+    title: 'Overlay/Sheet',
     decorators: [InSpacingDecorator],
     args: {
         withBlur: false,

--- a/packages/sdds-finportal/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/sdds-finportal/src/components/Skeleton/Skeleton.stories.tsx
@@ -14,7 +14,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'Content/Skeleton',
+    title: 'Data Display/Skeleton',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-finportal/src/components/Slider/Slider.stories.tsx
+++ b/packages/sdds-finportal/src/components/Slider/Slider.stories.tsx
@@ -16,7 +16,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'Controls/Slider',
+    title: 'Data Entry/Slider',
     component: Slider,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/sdds-finportal/src/components/Spinner/Spinner.stories.tsx
@@ -9,7 +9,7 @@ import { BodyL } from '../Typography';
 import { Spinner } from '.';
 
 const meta: Meta<typeof Spinner> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     decorators: [InSpacingDecorator],
     component: Spinner,
     argTypes: {

--- a/packages/sdds-finportal/src/components/Steps/Steps.stories.tsx
+++ b/packages/sdds-finportal/src/components/Steps/Steps.stories.tsx
@@ -9,7 +9,7 @@ import { Steps } from './Steps';
 import type { StepItemProps } from '.';
 
 const meta: Meta<typeof Steps> = {
-    title: 'Controls/Steps',
+    title: 'Navigation/Steps',
     decorators: [InSpacingDecorator],
     component: Steps,
 };

--- a/packages/sdds-finportal/src/components/Switch/Switch.stories.tsx
+++ b/packages/sdds-finportal/src/components/Switch/Switch.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/sdds-finportal/src/components/Tabs/Tabs.stories.tsx
@@ -55,7 +55,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'Controls/Tabs',
+    title: 'Navigation/Tabs',
     component: Tabs,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-finportal/src/components/TextArea/TextArea.stories.tsx
@@ -43,7 +43,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<StoryTextAreaProps> = {
-    title: 'Controls/TextArea',
+    title: 'Data Entry/TextArea',
     decorators: [InSpacingDecorator],
     component: TextArea,
     argTypes: {

--- a/packages/sdds-finportal/src/components/TextField/TextField.stories.tsx
+++ b/packages/sdds-finportal/src/components/TextField/TextField.stories.tsx
@@ -42,7 +42,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<typeof TextField> = {
-    title: 'Controls/TextField',
+    title: 'Data Entry/TextField',
     component: TextField,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
+++ b/packages/sdds-finportal/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
@@ -22,7 +22,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof TextFieldGroup> = {
-    title: 'Controls/TextFieldGroup',
+    title: 'Data Entry/TextFieldGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-finportal/src/components/Toast/Toast.stories.tsx
+++ b/packages/sdds-finportal/src/components/Toast/Toast.stories.tsx
@@ -11,7 +11,7 @@ import { ToastController, ToastProvider } from './Toast';
 import { Toast, useToast } from '.';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'Controls/Toast',
+    title: 'Overlay/Toast',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-finportal/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/sdds-finportal/src/components/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'Controls/Toolbar',
+    title: 'Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-finportal/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-finportal/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,7 +30,7 @@ const placements: Array<string> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'Controls/Tooltip',
+    title: 'Overlay/Tooltip',
     decorators: [InSpacingDecorator],
     component: Tooltip,
 };

--- a/packages/sdds-finportal/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-finportal/src/components/Typography/Typography.stories.tsx
@@ -23,7 +23,7 @@ import {
 } from '.';
 
 const meta: Meta = {
-    title: 'Content/Typography',
+    title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
         ...disableProps(['size']),

--- a/packages/sdds-finportal/src/components/ViewContainer/ViewContainer.stories.tsx
+++ b/packages/sdds-finportal/src/components/ViewContainer/ViewContainer.stories.tsx
@@ -11,7 +11,7 @@ import { ViewContainer } from './ViewContainer';
 type StoryViewProps = ComponentProps<typeof ViewContainer>;
 
 const meta: Meta<StoryViewProps> = {
-    title: 'Layout/ViewContainer',
+    title: 'Data Display/ViewContainer',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-insol/.storybook/preview.tsx
+++ b/packages/sdds-insol/.storybook/preview.tsx
@@ -46,7 +46,7 @@ const preview: Preview = {
         options: {
             storySort: {
                 method: 'alphabetical',
-                order: ['About', 'Intro', 'Colors', 'Typography', 'Controls', 'Hooks'],
+                order: ['About', 'Layout', '*', 'Hooks'],
             },
         },
         viewport: {

--- a/packages/sdds-insol/src/components/Attach/Attach.stories.tsx
+++ b/packages/sdds-insol/src/components/Attach/Attach.stories.tsx
@@ -32,7 +32,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'Controls/Attach',
+    title: 'Data Entry/Attach',
     decorators: [InSpacingDecorator],
     component: Attach,
     argTypes: {

--- a/packages/sdds-insol/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/sdds-insol/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -69,7 +69,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Controls/Autocomplete',
+    title: 'Data Entry/Autocomplete',
     decorators: [InSpacingDecorator],
     component: Autocomplete,
     argTypes: {

--- a/packages/sdds-insol/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/sdds-insol/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from '.';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'Content/Breadcrumbs',
+    title: 'Navigation/Breadcrumbs',
     component: Breadcrumbs,
     decorators: [InSpacingDecorator],
     args: {

--- a/packages/sdds-insol/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-insol/src/components/Button/Button.stories.tsx
@@ -32,7 +32,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     component: Button,
     args: {

--- a/packages/sdds-insol/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/sdds-insol/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'Controls/ButtonGroup',
+    title: 'Data Entry/ButtonGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-insol/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/sdds-insol/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<CalendarProps> = {
-    title: 'Controls/Calendar',
+    title: 'Data Entry/Calendar',
     decorators: [InSpacingDecorator],
     component: Calendar,
     argTypes: {

--- a/packages/sdds-insol/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-insol/src/components/Checkbox/Checkbox.stories.tsx
@@ -34,7 +34,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-insol/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/sdds-insol/src/components/Counter/Counter.stories.tsx
+++ b/packages/sdds-insol/src/components/Counter/Counter.stories.tsx
@@ -7,7 +7,7 @@ const sizes = ['l', 'm', 's', 'xs', 'xxs'];
 const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'Content/Counter',
+    title: 'Data Display/Counter',
     component: Counter,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-insol/src/components/DatePicker/DatePicker.stories.tsx
@@ -20,7 +20,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'Controls/DatePicker',
+    title: 'Data Entry/DatePicker',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-insol/src/components/Divider/Divider.stories.tsx
+++ b/packages/sdds-insol/src/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { BodyS } from '../Typography';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'Content/Divider',
+    title: 'Data Display/Divider',
     decorators: [InSpacingDecorator],
     argTypes: {
         orientation: {

--- a/packages/sdds-insol/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-insol/src/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '.';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
 export default {
-    title: 'Controls/Drawer',
+    title: 'Overlay/Drawer',
     decorators: [InSpacingDecorator],
     argTypes: {
         placement: {

--- a/packages/sdds-insol/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-insol/src/components/Dropdown/Dropdown.stories.tsx
@@ -16,7 +16,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<DropdownProps> = {
-    title: 'Controls/Dropdown',
+    title: 'Data Entry/Dropdown',
     component: Dropdown,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/sdds-insol/src/components/Dropzone/Dropzone.stories.tsx
@@ -14,7 +14,7 @@ const onChoseFiles = action('onChoseFiles');
 const iconPlacements = ['top', 'left'];
 
 const meta: Meta<typeof Dropzone> = {
-    title: 'Controls/Dropzone',
+    title: 'Data Entry/Dropzone',
     component: Dropzone,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/sdds-insol/src/components/EmptyState/EmptyState.stories.tsx
@@ -13,7 +13,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Content/EmptyState',
+    title: 'Data Entry/EmptyState',
     decorators: [InSpacingDecorator],
     component: EmptyState,
     args: {

--- a/packages/sdds-insol/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/sdds-insol/src/components/IconButton/IconButton.stories.tsx
@@ -22,7 +22,7 @@ const pins = [
 ];
 
 const meta: Meta<StoryButtonProps> = {
-    title: 'Controls/IconButton',
+    title: 'Data Entry/IconButton',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-insol/src/components/Image/Image.stories.tsx
+++ b/packages/sdds-insol/src/components/Image/Image.stories.tsx
@@ -6,7 +6,7 @@ import { Image, Ratio } from '.';
 import type { ImageProps } from '.';
 
 const meta: Meta<ImageProps> = {
-    title: 'Content/Image',
+    title: 'Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Indicator/Indicator.stories.tsx
+++ b/packages/sdds-insol/src/components/Indicator/Indicator.stories.tsx
@@ -5,7 +5,7 @@ import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import { Indicator } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'Content/Indicator',
+    title: 'Data Display/Indicator',
     component: Indicator,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Link/Link.stories.tsx
+++ b/packages/sdds-insol/src/components/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ import { TextM } from '../Typography';
 import { Link } from '.';
 
 const meta: Meta<typeof Link> = {
-    title: 'Content/Link',
+    title: 'Navigation/Link',
     decorators: [InSpacingDecorator],
     component: Link,
     argTypes: {

--- a/packages/sdds-insol/src/components/Mask/Mask.stories.tsx
+++ b/packages/sdds-insol/src/components/Mask/Mask.stories.tsx
@@ -35,7 +35,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<typeof Mask> = {
-    title: 'Controls/Mask',
+    title: 'Data Display/Mask',
     component: Mask,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-insol/src/components/Modal/Modal.stories.tsx
@@ -13,7 +13,7 @@ import { Modal, modalClasses } from '.';
 import type { ModalProps } from '.';
 
 const meta: Meta<ModalProps> = {
-    title: 'Controls/Modal',
+    title: 'Overlay/Modal',
     decorators: [InSpacingDecorator],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/sdds-insol/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-insol/src/components/Notification/Notification.stories.tsx
@@ -37,7 +37,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<typeof Notification> = {
-    title: 'Controls/Notification',
+    title: 'Overlay/Notification',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-insol/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/sdds-insol/src/components/NumberInput/NumberInput.stories.tsx
@@ -16,7 +16,7 @@ const inputBackgroundTypes = ['fill', 'clear'];
 const segmentation = ['default', 'segmented', 'solid'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'Controls/NumberInput',
+    title: 'Data Entry/NumberInput',
     component: NumberInput,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/sdds-insol/src/components/Overlay/Overlay.stories.tsx
@@ -12,7 +12,7 @@ import { Overlay } from '.';
 const onOverlayClick = action('onOverlayClick');
 
 export default {
-    title: 'Controls/Overlay',
+    title: 'Overlay/Overlay',
     decorators: [InSpacingDecorator],
     argTypes: {
         isClickable: {

--- a/packages/sdds-insol/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/sdds-insol/src/components/Pagination/Pagination.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'Controls/Pagination',
+    title: 'Navigation/Pagination',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-insol/src/components/Popover/Popover.stories.tsx
+++ b/packages/sdds-insol/src/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from '../Button/Button';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'Controls/Popover',
+    title: 'Overlay/Popover',
     decorators: [InSpacingDecorator],
     component: Popover,
     argTypes: {

--- a/packages/sdds-insol/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-insol/src/components/Popup/Popup.stories.tsx
@@ -10,7 +10,7 @@ import { Popup, popupClasses, PopupProvider } from '.';
 import type { PopupProps } from '.';
 
 const meta: Meta<PopupProps> = {
-    title: 'Controls/Popup',
+    title: 'Overlay/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/sdds-insol/src/components/Portal/Portal.stories.tsx
+++ b/packages/sdds-insol/src/components/Portal/Portal.stories.tsx
@@ -10,7 +10,7 @@ import { BodyM } from '../Typography';
 import { Portal } from '.';
 
 const meta: Meta<typeof Portal> = {
-    title: 'Controls/Portal',
+    title: 'Data Entry/Portal',
     decorators: [InSpacingDecorator],
     args: {
         disabled: false,

--- a/packages/sdds-insol/src/components/Price/Price.stories.tsx
+++ b/packages/sdds-insol/src/components/Price/Price.stories.tsx
@@ -5,7 +5,7 @@ import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import { Price } from '.';
 
 const meta: Meta<typeof Price> = {
-    title: 'Content/Price',
+    title: 'Data Display/Price',
     decorators: [InSpacingDecorator],
     argTypes: {
         currency: {

--- a/packages/sdds-insol/src/components/Progress/Progress.stories.tsx
+++ b/packages/sdds-insol/src/components/Progress/Progress.stories.tsx
@@ -7,7 +7,7 @@ import type { ProgressProps } from '.';
 const views = ['default', 'secondary', 'primary', 'accent', 'success', 'warning', 'error'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'Controls/Progress',
+    title: 'Overlay/Progress',
     component: Progress,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/sdds-insol/src/components/Radiobox/Radiobox.stories.tsx
@@ -13,7 +13,7 @@ const sizes = ['m', 's'];
 const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     component: Radiobox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Range/Range.stories.tsx
+++ b/packages/sdds-insol/src/components/Range/Range.stories.tsx
@@ -22,7 +22,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'Controls/Range',
+    title: 'Data Entry/Range',
     component: Range,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Segment/Segment.stories.tsx
+++ b/packages/sdds-insol/src/components/Segment/Segment.stories.tsx
@@ -49,7 +49,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'Controls/Segment',
+    title: 'Data Entry/Segment',
     decorators: [InSpacingDecorator],
     component: SegmentGroup,
     argTypes: {

--- a/packages/sdds-insol/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-insol/src/components/Select/Select.stories.tsx
@@ -19,7 +19,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Select',
+    title: 'Data Entry/Select',
     decorators: [InSpacingDecorator],
     component: Select,
     argTypes: {

--- a/packages/sdds-insol/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/sdds-insol/src/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Sheet } from '.';
 import type { SheetProps } from '.';
 
 const meta: Meta<SheetProps> = {
-    title: 'Content/Sheet',
+    title: 'Overlay/Sheet',
     decorators: [InSpacingDecorator],
     args: {
         withBlur: false,

--- a/packages/sdds-insol/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/sdds-insol/src/components/Skeleton/Skeleton.stories.tsx
@@ -14,7 +14,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'Content/Skeleton',
+    title: 'Data Display/Skeleton',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-insol/src/components/Slider/Slider.stories.tsx
+++ b/packages/sdds-insol/src/components/Slider/Slider.stories.tsx
@@ -16,7 +16,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'Controls/Slider',
+    title: 'Data Entry/Slider',
     component: Slider,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/sdds-insol/src/components/Spinner/Spinner.stories.tsx
@@ -9,7 +9,7 @@ import { BodyL } from '../Typography';
 import { Spinner } from '.';
 
 const meta: Meta<typeof Spinner> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     decorators: [InSpacingDecorator],
     component: Spinner,
     argTypes: {

--- a/packages/sdds-insol/src/components/Steps/Steps.stories.tsx
+++ b/packages/sdds-insol/src/components/Steps/Steps.stories.tsx
@@ -9,7 +9,7 @@ import { Steps } from './Steps';
 import type { StepItemProps } from '.';
 
 const meta: Meta<typeof Steps> = {
-    title: 'Controls/Steps',
+    title: 'Navigation/Steps',
     decorators: [InSpacingDecorator],
     component: Steps,
 };

--- a/packages/sdds-insol/src/components/Switch/Switch.stories.tsx
+++ b/packages/sdds-insol/src/components/Switch/Switch.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/sdds-insol/src/components/Tabs/Tabs.stories.tsx
@@ -55,7 +55,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'Controls/Tabs',
+    title: 'Navigation/Tabs',
     component: Tabs,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-insol/src/components/TextArea/TextArea.stories.tsx
@@ -44,7 +44,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<StoryTextAreaProps> = {
-    title: 'Controls/TextArea',
+    title: 'Data Entry/TextArea',
     decorators: [InSpacingDecorator],
     component: TextArea,
     argTypes: {

--- a/packages/sdds-insol/src/components/TextField/TextField.stories.tsx
+++ b/packages/sdds-insol/src/components/TextField/TextField.stories.tsx
@@ -43,7 +43,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<typeof TextField> = {
-    title: 'Controls/TextField',
+    title: 'Data Entry/TextField',
     component: TextField,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
+++ b/packages/sdds-insol/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
@@ -22,7 +22,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof TextFieldGroup> = {
-    title: 'Controls/TextFieldGroup',
+    title: 'Data Entry/TextFieldGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-insol/src/components/Toast/Toast.stories.tsx
+++ b/packages/sdds-insol/src/components/Toast/Toast.stories.tsx
@@ -11,7 +11,7 @@ import { ToastController, ToastProvider } from './Toast';
 import { Toast, useToast } from '.';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'Controls/Toast',
+    title: 'Overlay/Toast',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-insol/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/sdds-insol/src/components/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'Controls/Toolbar',
+    title: 'Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-insol/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-insol/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,7 +30,7 @@ const placements: Array<string> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'Controls/Tooltip',
+    title: 'Overlay/Tooltip',
     decorators: [InSpacingDecorator],
     component: Tooltip,
 };

--- a/packages/sdds-insol/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-insol/src/components/Typography/Typography.stories.tsx
@@ -23,7 +23,7 @@ import {
 } from '.';
 
 const meta: Meta = {
-    title: 'Content/Typography',
+    title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
         ...disableProps(['size']),

--- a/packages/sdds-insol/src/components/ViewContainer/ViewContainer.stories.tsx
+++ b/packages/sdds-insol/src/components/ViewContainer/ViewContainer.stories.tsx
@@ -11,7 +11,7 @@ import { ViewContainer } from './ViewContainer';
 type StoryViewProps = ComponentProps<typeof ViewContainer>;
 
 const meta: Meta<StoryViewProps> = {
-    title: 'Layout/ViewContainer',
+    title: 'Data Display/ViewContainer',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-serv/.storybook/preview.tsx
+++ b/packages/sdds-serv/.storybook/preview.tsx
@@ -46,7 +46,7 @@ const preview: Preview = {
         options: {
             storySort: {
                 method: 'alphabetical',
-                order: ['About', 'Intro', 'Colors', 'Typography', 'Controls', 'Hooks'],
+                order: ['About', 'Layout', '*', 'Hooks'],
             },
         },
         viewport: {

--- a/packages/sdds-serv/src/components/Attach/Attach.stories.tsx
+++ b/packages/sdds-serv/src/components/Attach/Attach.stories.tsx
@@ -32,7 +32,7 @@ type StoryAttachProps = ComponentProps<typeof Attach> & {
 };
 
 const meta: Meta<StoryAttachProps> = {
-    title: 'Controls/Attach',
+    title: 'Data Entry/Attach',
     decorators: [InSpacingDecorator],
     component: Attach,
     argTypes: {

--- a/packages/sdds-serv/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/sdds-serv/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -69,7 +69,7 @@ type StoryProps = ComponentProps<typeof Autocomplete> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Controls/Autocomplete',
+    title: 'Data Entry/Autocomplete',
     decorators: [InSpacingDecorator],
     component: Autocomplete,
     argTypes: {

--- a/packages/sdds-serv/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/sdds-serv/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -10,7 +10,7 @@ import { Breadcrumbs } from '.';
 type BreadcrumbsProps = ComponentProps<typeof Breadcrumbs>;
 
 const meta: Meta<BreadcrumbsProps> = {
-    title: 'Content/Breadcrumbs',
+    title: 'Navigation/Breadcrumbs',
     component: Breadcrumbs,
     args: {
         view: 'default',

--- a/packages/sdds-serv/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-serv/src/components/Button/Button.stories.tsx
@@ -31,7 +31,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<ButtonProps> = {
-    title: 'Controls/Button',
+    title: 'Data Entry/Button',
     decorators: [InSpacingDecorator],
     component: Button,
     args: {

--- a/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/sdds-serv/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof ButtonGroup> = {
-    title: 'Controls/ButtonGroup',
+    title: 'Data Entry/ButtonGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-serv/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/sdds-serv/src/components/Calendar/Calendar.stories.tsx
@@ -12,7 +12,7 @@ import { Calendar, CalendarBase, CalendarBaseRange, CalendarDouble, CalendarDoub
 const onChangeValue = action('onChangeValue');
 
 const meta: Meta<CalendarProps> = {
-    title: 'Controls/Calendar',
+    title: 'Data Entry/Calendar',
     decorators: [InSpacingDecorator],
     component: Calendar,
     argTypes: {

--- a/packages/sdds-serv/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-serv/src/components/Checkbox/Checkbox.stories.tsx
@@ -34,7 +34,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<CheckboxProps> = {
-    title: 'Controls/Checkbox',
+    title: 'Data Entry/Checkbox',
     component: Checkbox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-serv/src/components/Combobox/Combobox.stories.tsx
@@ -16,7 +16,7 @@ const labelPlacement = ['inner', 'outer'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Combobox',
+    title: 'Data Entry/Combobox',
     decorators: [InSpacingDecorator],
     component: Combobox,
     argTypes: {

--- a/packages/sdds-serv/src/components/Counter/Counter.stories.tsx
+++ b/packages/sdds-serv/src/components/Counter/Counter.stories.tsx
@@ -7,7 +7,7 @@ const sizes = ['l', 'm', 's', 'xs', 'xxs'];
 const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
 
 const meta: Meta<typeof Counter> = {
-    title: 'Content/Counter',
+    title: 'Data Display/Counter',
     component: Counter,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-serv/src/components/DatePicker/DatePicker.stories.tsx
@@ -20,7 +20,7 @@ const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
 
 const meta: Meta = {
-    title: 'Controls/DatePicker',
+    title: 'Data Entry/DatePicker',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-serv/src/components/Divider/Divider.stories.tsx
+++ b/packages/sdds-serv/src/components/Divider/Divider.stories.tsx
@@ -9,7 +9,7 @@ import { BodyS } from '../Typography';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {
-    title: 'Content/Divider',
+    title: 'Data Display/Divider',
     decorators: [InSpacingDecorator],
     argTypes: {
         orientation: {

--- a/packages/sdds-serv/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-serv/src/components/Drawer/Drawer.stories.tsx
@@ -14,7 +14,7 @@ import type { ClosePlacementType } from '.';
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
 export default {
-    title: 'Controls/Drawer',
+    title: 'Overlay/Drawer',
     decorators: [InSpacingDecorator],
     argTypes: {
         placement: {

--- a/packages/sdds-serv/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-serv/src/components/Dropdown/Dropdown.stories.tsx
@@ -16,7 +16,7 @@ const size = ['xs', 's', 'm', 'l'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<DropdownProps> = {
-    title: 'Controls/Dropdown',
+    title: 'Data Entry/Dropdown',
     component: Dropdown,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Dropzone/Dropzone.stories.tsx
+++ b/packages/sdds-serv/src/components/Dropzone/Dropzone.stories.tsx
@@ -14,7 +14,7 @@ const onChoseFiles = action('onChoseFiles');
 const iconPlacements = ['top', 'left'];
 
 const meta: Meta<typeof Dropzone> = {
-    title: 'Controls/Dropzone',
+    title: 'Data Entry/Dropzone',
     component: Dropzone,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/sdds-serv/src/components/EmptyState/EmptyState.stories.tsx
@@ -13,7 +13,7 @@ type StoryProps = ComponentProps<typeof EmptyState> & {
 };
 
 const meta: Meta<StoryProps> = {
-    title: 'Content/EmptyState',
+    title: 'Data Entry/EmptyState',
     decorators: [InSpacingDecorator],
     component: EmptyState,
     args: {

--- a/packages/sdds-serv/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/sdds-serv/src/components/IconButton/IconButton.stories.tsx
@@ -21,7 +21,7 @@ const pins = [
 ];
 
 const meta: Meta<StoryButtonProps> = {
-    title: 'Controls/IconButton',
+    title: 'Data Entry/IconButton',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-serv/src/components/Image/Image.stories.tsx
+++ b/packages/sdds-serv/src/components/Image/Image.stories.tsx
@@ -6,7 +6,7 @@ import { Image, Ratio } from '.';
 import type { ImageProps } from '.';
 
 const meta: Meta<ImageProps> = {
-    title: 'Content/Image',
+    title: 'Data Display/Image',
     component: Image,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Indicator/Indicator.stories.tsx
+++ b/packages/sdds-serv/src/components/Indicator/Indicator.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { Indicator } from './Indicator';
 
 const meta: Meta<typeof Indicator> = {
-    title: 'Content/Indicator',
+    title: 'Data Display/Indicator',
     component: Indicator,
     argTypes: {
         view: {

--- a/packages/sdds-serv/src/components/Link/Link.stories.tsx
+++ b/packages/sdds-serv/src/components/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ import { TextM } from '../Typography';
 import { Link } from '.';
 
 const meta: Meta<typeof Link> = {
-    title: 'Content/Link',
+    title: 'Navigation/Link',
     decorators: [InSpacingDecorator],
     component: Link,
     argTypes: {

--- a/packages/sdds-serv/src/components/Mask/Mask.stories.tsx
+++ b/packages/sdds-serv/src/components/Mask/Mask.stories.tsx
@@ -35,7 +35,7 @@ const propsToDisable = [
 ];
 
 const meta: Meta<typeof Mask> = {
-    title: 'Controls/Mask',
+    title: 'Data Display/Mask',
     component: Mask,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-serv/src/components/Modal/Modal.stories.tsx
@@ -13,7 +13,7 @@ import { Modal, modalClasses } from '.';
 import type { ModalProps } from '.';
 
 const meta: Meta<ModalProps> = {
-    title: 'Controls/Modal',
+    title: 'Overlay/Modal',
     decorators: [InSpacingDecorator],
     parameters: {
         docs: { story: { inline: false, iframeHeight: '30rem' } },

--- a/packages/sdds-serv/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-serv/src/components/Notification/Notification.stories.tsx
@@ -37,7 +37,7 @@ const getNotificationProps = (i: number) => ({
 const placements = ['top', 'left'];
 
 const meta: Meta<typeof Notification> = {
-    title: 'Controls/Notification',
+    title: 'Overlay/Notification',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-serv/src/components/NumberInput/NumberInput.stories.tsx
+++ b/packages/sdds-serv/src/components/NumberInput/NumberInput.stories.tsx
@@ -16,7 +16,7 @@ const inputBackgroundTypes = ['fill', 'clear'];
 const segmentation = ['default', 'segmented', 'solid'];
 
 const meta: Meta<typeof NumberInput> = {
-    title: 'Controls/NumberInput',
+    title: 'Data Entry/NumberInput',
     component: NumberInput,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Overlay/Overlay.stories.tsx
+++ b/packages/sdds-serv/src/components/Overlay/Overlay.stories.tsx
@@ -12,7 +12,7 @@ import { Overlay } from '.';
 const onOverlayClick = action('onOverlayClick');
 
 export default {
-    title: 'Controls/Overlay',
+    title: 'Overlay/Overlay',
     decorators: [InSpacingDecorator],
     argTypes: {
         isClickable: {

--- a/packages/sdds-serv/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/sdds-serv/src/components/Pagination/Pagination.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-    title: 'Controls/Pagination',
+    title: 'Navigation/Pagination',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-serv/src/components/Popover/Popover.stories.tsx
+++ b/packages/sdds-serv/src/components/Popover/Popover.stories.tsx
@@ -9,7 +9,7 @@ import { Button } from '../Button/Button';
 import { Popover } from './Popover';
 
 const meta: Meta<typeof Popover> = {
-    title: 'Controls/Popover',
+    title: 'Overlay/Popover',
     decorators: [InSpacingDecorator],
     component: Popover,
     argTypes: {

--- a/packages/sdds-serv/src/components/Popup/Popup.stories.tsx
+++ b/packages/sdds-serv/src/components/Popup/Popup.stories.tsx
@@ -10,7 +10,7 @@ import { Popup, popupClasses, PopupProvider } from '.';
 import type { PopupProps } from '.';
 
 const meta: Meta<PopupProps> = {
-    title: 'Controls/Popup',
+    title: 'Overlay/Popup',
     component: Popup,
     decorators: [InSpacingDecorator],
     parameters: {

--- a/packages/sdds-serv/src/components/Portal/Portal.stories.tsx
+++ b/packages/sdds-serv/src/components/Portal/Portal.stories.tsx
@@ -10,7 +10,7 @@ import { BodyM } from '../Typography';
 import { Portal } from '.';
 
 const meta: Meta<typeof Portal> = {
-    title: 'Controls/Portal',
+    title: 'Data Entry/Portal',
     decorators: [InSpacingDecorator],
     args: {
         disabled: false,

--- a/packages/sdds-serv/src/components/Price/Price.stories.tsx
+++ b/packages/sdds-serv/src/components/Price/Price.stories.tsx
@@ -5,7 +5,7 @@ import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import { Price } from '.';
 
 const meta: Meta<typeof Price> = {
-    title: 'Content/Price',
+    title: 'Data Display/Price',
     decorators: [InSpacingDecorator],
     argTypes: {
         currency: {

--- a/packages/sdds-serv/src/components/Progress/Progress.stories.tsx
+++ b/packages/sdds-serv/src/components/Progress/Progress.stories.tsx
@@ -7,7 +7,7 @@ import type { ProgressProps } from '.';
 const views = ['default', 'secondary', 'primary', 'accent', 'success', 'warning', 'error'];
 
 const meta: Meta<typeof Progress> = {
-    title: 'Controls/Progress',
+    title: 'Overlay/Progress',
     component: Progress,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/sdds-serv/src/components/Radiobox/Radiobox.stories.tsx
@@ -13,7 +13,7 @@ const sizes = ['m', 's'];
 const views = ['default', 'secondary', 'tertiary', 'paragraph', 'accent', 'positive', 'warning', 'negative'];
 
 const meta: Meta<RadioboxProps> = {
-    title: 'Controls/Radiobox',
+    title: 'Data Entry/Radiobox',
     component: Radiobox,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Range/Range.stories.tsx
+++ b/packages/sdds-serv/src/components/Range/Range.stories.tsx
@@ -22,7 +22,7 @@ const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 
 const meta: Meta<typeof Range> = {
-    title: 'Controls/Range',
+    title: 'Data Entry/Range',
     component: Range,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Segment/Segment.stories.tsx
+++ b/packages/sdds-serv/src/components/Segment/Segment.stories.tsx
@@ -49,7 +49,7 @@ const getContentRight = (contentRightOption: string, size: Size) => {
 };
 
 const meta: Meta<StorySegmentProps> = {
-    title: 'Controls/Segment',
+    title: 'Data Entry/Segment',
     decorators: [InSpacingDecorator],
     component: SegmentGroup,
     argTypes: {

--- a/packages/sdds-serv/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-serv/src/components/Select/Select.stories.tsx
@@ -19,7 +19,7 @@ const chip = ['default', 'secondary', 'accent'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<StorySelectProps> = {
-    title: 'Controls/Select',
+    title: 'Data Entry/Select',
     decorators: [InSpacingDecorator],
     component: Select,
     argTypes: {

--- a/packages/sdds-serv/src/components/Sheet/Sheet.stories.tsx
+++ b/packages/sdds-serv/src/components/Sheet/Sheet.stories.tsx
@@ -10,7 +10,7 @@ import { Sheet } from '.';
 import type { SheetProps } from '.';
 
 const meta: Meta<SheetProps> = {
-    title: 'Content/Sheet',
+    title: 'Overlay/Sheet',
     decorators: [InSpacingDecorator],
     args: {
         withBlur: false,

--- a/packages/sdds-serv/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/sdds-serv/src/components/Skeleton/Skeleton.stories.tsx
@@ -14,7 +14,7 @@ type StoryRectSkeletonProps = ComponentProps<typeof RectSkeleton>;
 type BasicButtonProps = ComponentProps<typeof BasicButton>;
 
 const meta: Meta = {
-    title: 'Content/Skeleton',
+    title: 'Data Display/Skeleton',
     decorators: [InSpacingDecorator],
 };
 

--- a/packages/sdds-serv/src/components/Slider/Slider.stories.tsx
+++ b/packages/sdds-serv/src/components/Slider/Slider.stories.tsx
@@ -16,7 +16,7 @@ const scaleAligns = ['side', 'bottom'];
 const orientations: Array<string> = ['vertical', 'horizontal'];
 
 const meta: Meta<typeof Slider> = {
-    title: 'Controls/Slider',
+    title: 'Data Entry/Slider',
     component: Slider,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/sdds-serv/src/components/Spinner/Spinner.stories.tsx
@@ -9,7 +9,7 @@ import { BodyL } from '../Typography';
 import { Spinner } from '.';
 
 const meta: Meta<typeof Spinner> = {
-    title: 'Content/Spinner',
+    title: 'Data Display/Spinner',
     decorators: [InSpacingDecorator],
     component: Spinner,
     argTypes: {

--- a/packages/sdds-serv/src/components/Steps/Steps.stories.tsx
+++ b/packages/sdds-serv/src/components/Steps/Steps.stories.tsx
@@ -9,7 +9,7 @@ import { Steps } from './Steps';
 import type { StepItemProps } from '.';
 
 const meta: Meta<typeof Steps> = {
-    title: 'Controls/Steps',
+    title: 'Navigation/Steps',
     decorators: [InSpacingDecorator],
     component: Steps,
 };

--- a/packages/sdds-serv/src/components/Switch/Switch.stories.tsx
+++ b/packages/sdds-serv/src/components/Switch/Switch.stories.tsx
@@ -12,7 +12,7 @@ const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
 const meta: Meta<SwitchProps> = {
-    title: 'Controls/Switch',
+    title: 'Data Entry/Switch',
     component: Switch,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/sdds-serv/src/components/Tabs/Tabs.stories.tsx
@@ -55,7 +55,7 @@ type HorizontalStoryTabsProps = StoryTabsProps & { width: string };
 type VerticalStoryTabsProps = StoryTabsProps & { height: string };
 
 const meta: Meta<StoryTabsProps> = {
-    title: 'Controls/Tabs',
+    title: 'Navigation/Tabs',
     component: Tabs,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-serv/src/components/TextArea/TextArea.stories.tsx
@@ -43,7 +43,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<StoryTextAreaProps> = {
-    title: 'Controls/TextArea',
+    title: 'Data Entry/TextArea',
     decorators: [InSpacingDecorator],
     component: TextArea,
     argTypes: {

--- a/packages/sdds-serv/src/components/TextField/TextField.stories.tsx
+++ b/packages/sdds-serv/src/components/TextField/TextField.stories.tsx
@@ -42,7 +42,7 @@ const placements: Array<PopoverPlacement> = [
 ];
 
 const meta: Meta<typeof TextField> = {
-    title: 'Controls/TextField',
+    title: 'Data Entry/TextField',
     component: TextField,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
+++ b/packages/sdds-serv/src/components/TextFieldGroup/TextFieldGroup.stories.tsx
@@ -22,7 +22,7 @@ const shapeValues = ['segmented', 'default'];
 const stretchingValues = ['auto', 'filled'];
 
 const meta: Meta<typeof TextFieldGroup> = {
-    title: 'Controls/TextFieldGroup',
+    title: 'Data Entry/TextFieldGroup',
     decorators: [InSpacingDecorator],
     argTypes: {
         size: {

--- a/packages/sdds-serv/src/components/Toast/Toast.stories.tsx
+++ b/packages/sdds-serv/src/components/Toast/Toast.stories.tsx
@@ -11,7 +11,7 @@ import { ToastController, ToastProvider } from './Toast';
 import { Toast, useToast } from '.';
 
 const meta: Meta<typeof ToastController> = {
-    title: 'Controls/Toast',
+    title: 'Overlay/Toast',
     decorators: [InSpacingDecorator],
     argTypes: {
         view: {

--- a/packages/sdds-serv/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/sdds-serv/src/components/Toolbar/Toolbar.stories.tsx
@@ -25,7 +25,7 @@ const ToolbarWrapper = (props: ComponentProps<typeof Toolbar>) => {
 };
 
 const meta: Meta<typeof Toolbar> = {
-    title: 'Controls/Toolbar',
+    title: 'Overlay/Toolbar',
     component: ToolbarWrapper,
     decorators: [InSpacingDecorator],
     argTypes: {

--- a/packages/sdds-serv/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-serv/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,7 +30,7 @@ const placements: Array<string> = [
 ];
 
 const meta: Meta<TooltipProps> = {
-    title: 'Controls/Tooltip',
+    title: 'Overlay/Tooltip',
     decorators: [InSpacingDecorator],
     component: Tooltip,
 };

--- a/packages/sdds-serv/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-serv/src/components/Typography/Typography.stories.tsx
@@ -23,7 +23,7 @@ import {
 } from '.';
 
 const meta: Meta = {
-    title: 'Content/Typography',
+    title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
         ...disableProps(['size']),

--- a/packages/sdds-serv/src/components/ViewContainer/ViewContainer.stories.tsx
+++ b/packages/sdds-serv/src/components/ViewContainer/ViewContainer.stories.tsx
@@ -11,7 +11,7 @@ import { ViewContainer } from './ViewContainer';
 type StoryViewProps = ComponentProps<typeof ViewContainer>;
 
 const meta: Meta<StoryViewProps> = {
-    title: 'Layout/ViewContainer',
+    title: 'Data Display/ViewContainer',
     decorators: [InSpacingDecorator],
 };
 

--- a/website/plasma-b2c-docs/docs/components/ModalBase.mdx
+++ b/website/plasma-b2c-docs/docs/components/ModalBase.mdx
@@ -68,7 +68,7 @@ export function App() {
 Для использования стилизованного модального окна с отступами и крестиком для закрытия, добавьте свойство `hasBody`.
 ```tsx live
 import React, { useState } from 'react';
-import { SSRProvider, Button, Modal, PopupProvider } from '@salutejs/plasma-b2c';
+import { SSRProvider, Button, ModalBase, PopupBaseProvider } from '@salutejs/plasma-b2c';
 
 export function App() {
     const [isOpenA, setIsOpenA] = useState(false);
@@ -76,9 +76,9 @@ export function App() {
 
     return (
         <SSRProvider>
-            <PopupProvider>
-                <div style=\{{ height: "300px" }}>
-                    <div style=\{{ display: 'flex', flexDirection: 'column' }}>
+            <PopupBaseProvider>
+                <div style={{ height: "300px" }}>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
                         <Button text="Открыть A" onClick={() => setIsOpenA(true)} />
                     </div>
                     <ModalBase
@@ -92,7 +92,7 @@ export function App() {
                         <Button onClick={() => setIsOpenA(false)}>Close</Button>
                         <Button text="Открыть B" onClick={() => setIsOpenB(true)} />
                         Content
-                        <Modal
+                        <ModalBase
                             id="modalB"
                             onClose={() => setIsOpenB(false)}
                             opened={isOpenB}
@@ -101,10 +101,10 @@ export function App() {
                         >
                             <Button onClick={() => setIsOpenB(false)}>Close</Button>
                             Content
-                        </Modal>
+                        </ModalBase>
                     </ModalBase>
                 </div>
-            </PopupProvider>
+            </PopupBaseProvider>
         </SSRProvider>
     );
 }

--- a/website/plasma-web-docs/docs/components/ModalBase.mdx
+++ b/website/plasma-web-docs/docs/components/ModalBase.mdx
@@ -70,7 +70,7 @@ export function App() {
 Для использования стилизованного модального окна с отступами и крестиком для закрытия, добавьте свойство `hasBody`.
 ```tsx live
 import React, { useState } from 'react';
-import { SSRProvider, Button, Modal, PopupProvider } from '@salutejs/plasma-web';
+import { SSRProvider, Button, ModalBase, PopupBaseProvider } from '@salutejs/plasma-web';
 
 export function App() {
     const [isOpenA, setIsOpenA] = useState(false);
@@ -78,9 +78,9 @@ export function App() {
 
     return (
         <SSRProvider>
-            <PopupProvider>
-                <div style=\{{ height: "300px" }}>
-                    <div style=\{{ display: 'flex', flexDirection: 'column' }}>
+            <PopupBaseProvider>
+                <div style={{ height: "300px" }}>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
                         <Button text="Открыть A" onClick={() => setIsOpenA(true)} />
                     </div>
                     <ModalBase
@@ -94,7 +94,7 @@ export function App() {
                         <Button onClick={() => setIsOpenA(false)}>Close</Button>
                         <Button text="Открыть B" onClick={() => setIsOpenB(true)} />
                         Content
-                        <Modal
+                        <ModalBase
                             id="modalB"
                             onClose={() => setIsOpenB(false)}
                             opened={isOpenB}
@@ -103,10 +103,10 @@ export function App() {
                         >
                             <Button onClick={() => setIsOpenB(false)}>Close</Button>
                             Content
-                        </Modal>
+                        </ModalBase>
                     </ModalBase>
                 </div>
-            </PopupProvider>
+            </PopupBaseProvider>
         </SSRProvider>
     );
 }

--- a/website/sdds-cs-docs/docs/components/Modal.mdx
+++ b/website/sdds-cs-docs/docs/components/Modal.mdx
@@ -76,8 +76,8 @@ export function App() {
     return (
         <SSRProvider>
             <PopupProvider>
-                <div style=\{{ height: "300px" }}>
-                    <div style=\{{ display: 'flex', flexDirection: 'column' }}>
+                <div style={{ height: "300px" }}>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
                         <Button text="Открыть A" onClick={() => setIsOpenA(true)} />
                     </div>
                     <Modal

--- a/website/sdds-dfa-docs/docs/components/Modal.mdx
+++ b/website/sdds-dfa-docs/docs/components/Modal.mdx
@@ -76,8 +76,8 @@ export function App() {
     return (
         <SSRProvider>
             <PopupProvider>
-                <div style=\{{ height: "300px" }}>
-                    <div style=\{{ display: 'flex', flexDirection: 'column' }}>
+                <div style={{ height: "300px" }}>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
                         <Button text="Открыть A" onClick={() => setIsOpenA(true)} />
                     </div>
                     <Modal

--- a/website/sdds-insol-docs/docs/components/Modal.mdx
+++ b/website/sdds-insol-docs/docs/components/Modal.mdx
@@ -76,8 +76,8 @@ export function App() {
     return (
         <SSRProvider>
             <PopupProvider>
-                <div style=\{{ height: "300px" }}>
-                    <div style=\{{ display: 'flex', flexDirection: 'column' }}>
+                <div style={{ height: "300px" }}>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
                         <Button text="Открыть A" onClick={() => setIsOpenA(true)} />
                     </div>
                     <Modal

--- a/website/sdds-serv-docs/docs/components/Modal.mdx
+++ b/website/sdds-serv-docs/docs/components/Modal.mdx
@@ -76,8 +76,8 @@ export function App() {
     return (
         <SSRProvider>
             <PopupProvider>
-                <div style=\{{ height: "300px" }}>
-                    <div style=\{{ display: 'flex', flexDirection: 'column' }}>
+                <div style={{ height: "300px" }}>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
                         <Button text="Открыть A" onClick={() => setIsOpenA(true)} />
                     </div>
                     <Modal


### PR DESCRIPTION
### What/why changed

компоненты в storybook сгруппированы как в макетах, то есть разделам Data Display, Data Entry, etc
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.218.2-canary.1580.12153203342.0
  npm install @salutejs/plasma-b2c@1.460.2-canary.1580.12153203342.0
  npm install @salutejs/plasma-new-hope@0.207.2-canary.1580.12153203342.0
  npm install @salutejs/plasma-ui@1.296.1-canary.1580.12153203342.0
  npm install @salutejs/plasma-web@1.462.2-canary.1580.12153203342.0
  npm install @salutejs/sdds-cs@0.191.2-canary.1580.12153203342.0
  npm install @salutejs/sdds-dfa@0.188.2-canary.1580.12153203342.0
  npm install @salutejs/sdds-finportal@0.182.2-canary.1580.12153203342.0
  npm install @salutejs/sdds-insol@0.183.2-canary.1580.12153203342.0
  npm install @salutejs/sdds-serv@0.190.2-canary.1580.12153203342.0
  # or 
  yarn add @salutejs/plasma-asdk@0.218.2-canary.1580.12153203342.0
  yarn add @salutejs/plasma-b2c@1.460.2-canary.1580.12153203342.0
  yarn add @salutejs/plasma-new-hope@0.207.2-canary.1580.12153203342.0
  yarn add @salutejs/plasma-ui@1.296.1-canary.1580.12153203342.0
  yarn add @salutejs/plasma-web@1.462.2-canary.1580.12153203342.0
  yarn add @salutejs/sdds-cs@0.191.2-canary.1580.12153203342.0
  yarn add @salutejs/sdds-dfa@0.188.2-canary.1580.12153203342.0
  yarn add @salutejs/sdds-finportal@0.182.2-canary.1580.12153203342.0
  yarn add @salutejs/sdds-insol@0.183.2-canary.1580.12153203342.0
  yarn add @salutejs/sdds-serv@0.190.2-canary.1580.12153203342.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
