### PR TITLE
feat(sdds-serv): Add switch to linaria build

### DIFF
--- a/packages/sdds-insol/scripts/copy-linaria-components.sh
+++ b/packages/sdds-insol/scripts/copy-linaria-components.sh
@@ -7,12 +7,10 @@ mkdir -p src-css/components/
 touch src-css/index.ts
 touch src-css/index.d.ts
 for component in $components; do
-    if [[ "$component" != "Switch" ]]; then
         cp -R src/components/$component src-css/components/;
         grep -E "\<$component\>" src/index.ts >> src-css/index.ts
         echo "export * from '../components/$component';" >> css/index.d.ts;
 
-    fi
 done;
 
 # remove unused tests

--- a/packages/sdds-serv/scripts/copy-linaria-components.sh
+++ b/packages/sdds-serv/scripts/copy-linaria-components.sh
@@ -7,12 +7,10 @@ mkdir -p src-css/components/
 touch src-css/index.ts
 touch src-css/index.d.ts
 for component in $components; do
-    if [[ "$component" != "Switch" ]]; then
-        cp -R src/components/$component src-css/components/;
-        grep -E "\<$component\>" src/index.ts >> src-css/index.ts
-        echo "export * from '../components/$component';" >> css/index.d.ts;
-
-    fi
+    cp -R src/components/$component src-css/components/;
+    grep -E "\<$component\>" src/index.ts >> src-css/index.ts
+    echo "export * from '../components/$component';" >> css/index.d.ts;
+    
 done;
 
 # remove unused tests


### PR DESCRIPTION
### Add switch to linaria build

- Добавлен `switch` в поставку `sdds-serv` для сборки `linaria`

### What/why changed (Это обязательный заголовок)

Вариант до: https://codesandbox.io/p/sandbox/lwkjwy?file=%2Fsrc%2Findex.js
Вариант после: https://codesandbox.io/p/sandbox/plasma-sdds-serv-example-forked-s9drhh?file=%2Fpackage.json%3A13%2C1

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-insol@0.170.0-canary.1583.11968748564.0
  npm install @salutejs/sdds-serv@0.178.0-canary.1583.11968748564.0
  # or 
  yarn add @salutejs/sdds-insol@0.170.0-canary.1583.11968748564.0
  yarn add @salutejs/sdds-serv@0.178.0-canary.1583.11968748564.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
