### PR TITLE
feat(plasma-new-hope): listHeight prop stands for a css maxHeight now

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.styles.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.styles.ts
@@ -24,7 +24,7 @@ export const Ul = styled.ul<{
 
     border-radius: var(${tokens.borderRadius});
     width: ${({ listWidth }) => listWidth || '100%'};
-    height: ${({ listHeight }) => listHeight || 'auto'};
+    max-height: ${({ listHeight }) => listHeight || 'auto'};
     overflow: ${({ listOverflow }) => listOverflow || 'initial'};
 
     border: var(${tokens.dropdownBorderWidth}) solid var(${tokens.dropdownBorderColor});

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
@@ -138,6 +138,7 @@ type BasicProps<T extends ItemOption = ItemOption> = {
      * @example listOverflow="scroll"
      */
     listOverflow?: CSSProperties['overflow'];
+    // TODO: #1584
     /**
      * Значение css height для выпадающего меню.
      */

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.styles.ts
@@ -13,7 +13,7 @@ export const Ul = styled.ul<{
 }>`
     box-sizing: border-box;
     width: ${({ listWidth }) => listWidth || `var(${tokens.width})`};
-    height: ${({ listHeight }) => (listHeight ? getCorrectHeight(listHeight) : 'auto')};
+    max-height: ${({ listHeight }) => (listHeight ? getCorrectHeight(listHeight) : 'auto')};
     margin: ${({ isInnerUl }) => (isInnerUl ? `calc(var(${tokens.padding}) * -1) 0.125rem 0` : 0)};
     padding: var(${tokens.padding}) 0;
     overflow: ${({ listOverflow }) => listOverflow || 'initial'};

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
@@ -101,13 +101,14 @@ export type DropdownProps<T extends DropdownItemOption = DropdownItemOption> = {
      * @example listOverflow="scroll"
      */
     listOverflow?: CSSProperties['overflow'];
+    // TODO: #1584
     /**
      * Значение css height для выпадающего меню.
      * @default initial
      * @deprecated
      * @example listHeight="11", listHeight="auto", listHeight={11}
      */
-    listHeight?: number | CSSProperties['height'];
+    listHeight?: CSSProperties['height'];
     /**
      * Индекс элемента при наведении
      * @deprecated использовать onHover

--- a/packages/plasma-new-hope/src/components/Select/Select.styles.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.styles.ts
@@ -19,7 +19,7 @@ export const Ul = styled.ul<{
 
     border-radius: var(${tokens.borderRadius});
     width: ${({ listWidth }) => listWidth || '100%'};
-    height: ${({ listHeight }) => (listHeight ? getCorrectHeight(listHeight) : 'auto')};
+    max-height: ${({ listHeight }) => (listHeight ? getCorrectHeight(listHeight) : 'auto')};
     overflow: ${({ listOverflow }) => listOverflow || 'initial'};
 
     margin: ${({ isInnerUl }) => (isInnerUl ? `calc(var(${tokens.padding}) * -1) 0 0 0` : 0)};

--- a/packages/plasma-new-hope/src/components/Select/Select.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.types.ts
@@ -122,11 +122,12 @@ export interface BasicProps<K extends ItemOption> {
      * @example listOverflow="scroll"
      */
     listOverflow?: CSSProperties['overflow'];
+    // TODO: #1584
     /**
      * Значение css height для выпадающего меню.
      * @example listHeight="11", listHeight="auto", listHeight={11}
      */
-    listHeight?: number | CSSProperties['height'];
+    listHeight?: CSSProperties['height'];
     /**
      * Значение css width для выпадающего списка.
      * @example width="200px"
@@ -242,11 +243,12 @@ export type MergedSelectProps<T = any, K extends DropdownNode = DropdownNode> = 
          * @example listOverflow="scroll"
          */
         listOverflow?: CSSProperties['overflow'];
+        // TODO: #1584
         /**
          * Значение css height для выпадающего меню.
          * @example listHeight="11", listHeight="auto", listHeight={11}
          */
-        listHeight?: number | CSSProperties['height'];
+        listHeight?: CSSProperties['height'];
 
         /**
          * Placeholder.


### PR DESCRIPTION
### Select, Combobox, Dropdown

- исправлен баг, возникающий когда проп `listHeight` был больше, чем актуальная высота списка, что приводило к пустым пробелам в этом же выпадающем списке.

### What/why changed
Поправили `listHeight` в Select, Combobox, Dropdown, теперь высота списка обрезается по высоте этого списка, либо по listHeight в случаях, когда оно меньше чем высота списка.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.210.0-canary.1585.12012734025.0
  npm install @salutejs/plasma-b2c@1.452.0-canary.1585.12012734025.0
  npm install @salutejs/plasma-new-hope@0.199.0-canary.1585.12012734025.0
  npm install @salutejs/plasma-web@1.454.0-canary.1585.12012734025.0
  npm install @salutejs/sdds-cs@0.183.0-canary.1585.12012734025.0
  npm install @salutejs/sdds-dfa@0.180.0-canary.1585.12012734025.0
  npm install @salutejs/sdds-finportal@0.174.0-canary.1585.12012734025.0
  npm install @salutejs/sdds-insol@0.174.0-canary.1585.12012734025.0
  npm install @salutejs/sdds-serv@0.182.0-canary.1585.12012734025.0
  # or 
  yarn add @salutejs/plasma-asdk@0.210.0-canary.1585.12012734025.0
  yarn add @salutejs/plasma-b2c@1.452.0-canary.1585.12012734025.0
  yarn add @salutejs/plasma-new-hope@0.199.0-canary.1585.12012734025.0
  yarn add @salutejs/plasma-web@1.454.0-canary.1585.12012734025.0
  yarn add @salutejs/sdds-cs@0.183.0-canary.1585.12012734025.0
  yarn add @salutejs/sdds-dfa@0.180.0-canary.1585.12012734025.0
  yarn add @salutejs/sdds-finportal@0.174.0-canary.1585.12012734025.0
  yarn add @salutejs/sdds-insol@0.174.0-canary.1585.12012734025.0
  yarn add @salutejs/sdds-serv@0.182.0-canary.1585.12012734025.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
