### PR TITLE
fix: TextArea auto scroll on focus

### DIFF
--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -225,12 +225,6 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaRootPr
                 return;
             }
 
-            outerRef.current.scrollTo({
-                top: 0,
-                left: outerRef.current.offsetLeft,
-                behavior: 'smooth',
-            });
-
             outerRef.current.focus();
         };
 


### PR DESCRIPTION
### TextArea

- убран автоподскролл по фокусу

### What/why changed

Убран автоподскролл по фокусу.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.208.2-canary.1590.12000699920.0
  npm install @salutejs/plasma-b2c@1.450.2-canary.1590.12000699920.0
  npm install @salutejs/plasma-new-hope@0.197.2-canary.1590.12000699920.0
  npm install @salutejs/plasma-web@1.452.2-canary.1590.12000699920.0
  npm install @salutejs/sdds-cs@0.181.2-canary.1590.12000699920.0
  npm install @salutejs/sdds-dfa@0.178.2-canary.1590.12000699920.0
  npm install @salutejs/sdds-finportal@0.172.2-canary.1590.12000699920.0
  npm install @salutejs/sdds-insol@0.172.2-canary.1590.12000699920.0
  npm install @salutejs/sdds-serv@0.180.2-canary.1590.12000699920.0
  # or 
  yarn add @salutejs/plasma-asdk@0.208.2-canary.1590.12000699920.0
  yarn add @salutejs/plasma-b2c@1.450.2-canary.1590.12000699920.0
  yarn add @salutejs/plasma-new-hope@0.197.2-canary.1590.12000699920.0
  yarn add @salutejs/plasma-web@1.452.2-canary.1590.12000699920.0
  yarn add @salutejs/sdds-cs@0.181.2-canary.1590.12000699920.0
  yarn add @salutejs/sdds-dfa@0.178.2-canary.1590.12000699920.0
  yarn add @salutejs/sdds-finportal@0.172.2-canary.1590.12000699920.0
  yarn add @salutejs/sdds-insol@0.172.2-canary.1590.12000699920.0
  yarn add @salutejs/sdds-serv@0.180.2-canary.1590.12000699920.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
