### PR TITLE
fix(sdds-cs): Set tokens in drawer and datepicker

### DIFF
--- a/packages/plasma-new-hope/src/components/Drawer/Drawer.styles.ts
+++ b/packages/plasma-new-hope/src/components/Drawer/Drawer.styles.ts
@@ -1,10 +1,20 @@
 import { styled } from '@linaria/react';
 
-import { component } from '../../engines';
+import { component, mergeConfig } from '../../engines';
 import { popupClasses, popupConfig } from '../Popup';
+import { panelTokens, panelConfig } from '../Panel';
 
 import type { DrawerPlacement } from './Drawer.types';
 import { classes } from './Drawer.tokens';
+
+import { drawerTokens } from '.';
+
+const mergedPanelConfig = mergeConfig(panelConfig);
+const Panel = component(mergedPanelConfig);
+
+export const StyledPanel = styled(Panel)`
+    ${panelTokens.closeColor}: var(${drawerTokens.closeIconColor});
+`;
 
 const Popup = component(popupConfig);
 

--- a/packages/plasma-new-hope/src/components/Drawer/Drawer.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Drawer/Drawer.tokens.ts
@@ -20,4 +20,5 @@ export const tokens = {
     contentBackgroundColor: '--plasma-drawer-content-background-color',
     padding: '--plasma-drawer-padding',
     borderRadius: '--plasma-drawer-border-radius',
+    closeIconColor: '--plasma-drawer-close-icon-color',
 };

--- a/packages/plasma-new-hope/src/components/Drawer/Drawer.tsx
+++ b/packages/plasma-new-hope/src/components/Drawer/Drawer.tsx
@@ -1,12 +1,10 @@
 import React, { forwardRef, useMemo } from 'react';
 import { useForkRef, safeUseId } from '@salutejs/plasma-core';
 
-import { component, mergeConfig } from '../../engines';
 import type { RootProps } from '../../engines';
 import { usePopupContext } from '../Popup';
 import { Overlay } from '../Overlay';
 import { DEFAULT_Z_INDEX } from '../Popup/utils';
-import { panelConfig } from '../Panel';
 import { cx, getSizeValueFromProp } from '../../utils';
 import { useFocusTrap } from '../../hooks';
 
@@ -15,13 +13,11 @@ import type { DrawerProps } from './Drawer.types';
 import { base as viewCSS } from './variations/_view/base';
 import { base as sizeCSS } from './variations/_size/base';
 import { base as borderRadiusCSS } from './variations/_borderRadius/base';
-import { StyledPopup } from './Drawer.styles';
+import { StyledPopup, StyledPanel } from './Drawer.styles';
 import { getIdLastDrawer } from './DrawerContext';
 import { useDrawer } from './hooks';
 
 // issue #823
-const mergedPanelConfig = mergeConfig(panelConfig);
-const Panel = component(mergedPanelConfig);
 
 export const drawerRoot = (Root: RootProps<HTMLDivElement, DrawerProps>) =>
     forwardRef<HTMLDivElement, DrawerProps>(
@@ -134,9 +130,9 @@ export const drawerRoot = (Root: RootProps<HTMLDivElement, DrawerProps>) =>
                         style={{ width: innerWidth, height: innerHeight }}
                         borderRadius={borderRadius}
                     >
-                        <Panel width={innerWidth} height={innerHeight} className={className}>
+                        <StyledPanel width={innerWidth} height={innerHeight} className={className}>
                             {children}
-                        </Panel>
+                        </StyledPanel>
                     </Root>
                 </StyledPopup>
             );

--- a/packages/plasma-new-hope/src/components/Panel/Panel.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Panel/Panel.tokens.ts
@@ -13,4 +13,5 @@ export const tokens = {
     contentBackgroundColor: '--plasma-panel-content-background-color',
     padding: '--plasma-panel-padding',
     borderRadius: '--plasma-panel-border-radius',
+    closeColor: '--plasma-panel-close-color',
 };

--- a/packages/plasma-new-hope/src/components/Panel/ui/PanelHeader/PanelHeader.styles.ts
+++ b/packages/plasma-new-hope/src/components/Panel/ui/PanelHeader/PanelHeader.styles.ts
@@ -26,4 +26,5 @@ export const CloseIconWrapper = styled(Button)`
     position: relative;
     width: 1.5rem;
     min-height: 1.5rem;
+    color: var(${tokens.closeColor});
 `;

--- a/packages/plasma-new-hope/src/components/Panel/ui/PanelHeader/PanelHeader.tsx
+++ b/packages/plasma-new-hope/src/components/Panel/ui/PanelHeader/PanelHeader.tsx
@@ -24,7 +24,7 @@ export const panelHeaderRoot = (Root: RootProps<HTMLDivElement, PanelHeaderProps
                     {actions && <ButtonWrapper>{actions}</ButtonWrapper>}
                     {hasClose && (
                         <ButtonWrapper placement={closePlacement}>
-                            <CloseIconWrapper view="clear" size="s" onClick={onClose}>
+                            <CloseIconWrapper view="clear" size="s" onClick={onClose} color="inherit">
                                 <IconClose size="s" color="inherit" />
                             </CloseIconWrapper>
                         </ButtonWrapper>

--- a/packages/sdds-cs/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-cs/src/components/DatePicker/DatePicker.stories.tsx
@@ -2,7 +2,7 @@ import React, { ComponentProps, useRef, useState } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { IconPlaceholder, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import { IconPlasma, IconDisclosureDown } from '@salutejs/plasma-icons';
+import { IconPlasma, IconDisclosureDown, IconCalendarOutline } from '@salutejs/plasma-icons';
 
 import { IconButton } from '../IconButton/IconButton';
 
@@ -87,7 +87,7 @@ const StoryDefault = ({
             valueError={valueError}
             valueSuccess={valueSuccess}
             contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
-            contentRight={enableContentRight ? <IconDisclosureDown size={iconSize} /> : undefined}
+            contentRight={enableContentRight ? <IconCalendarOutline size={iconSize} /> : undefined}
             onBlur={onBlur}
             onFocus={onFocus}
             onToggle={(is) => setIsOpen(is)}
@@ -130,7 +130,7 @@ export const Default: StoryObj<StoryPropsDefault> = {
         disabled: false,
         readOnly: false,
         textBefore: '',
-        enableContentLeft: true,
+        enableContentLeft: false,
         enableContentRight: true,
         valueError: false,
         valueSuccess: false,
@@ -151,7 +151,7 @@ const ActionButton = ({ size }) => {
     const iconSize = size === 'xs' ? 'xs' : 's';
     return (
         <IconButton view="clear" size={size}>
-            <IconDisclosureDown size={iconSize} color="var(--text-accent)" />
+            <IconCalendarOutline size={iconSize} color="var(--text-accent)" />
         </IconButton>
     );
 };
@@ -260,7 +260,7 @@ export const Range: StoryObj<StoryPropsRange> = {
         maskWithFormat: false,
         disabled: false,
         readOnly: false,
-        enableContentLeft: true,
+        enableContentLeft: false,
         enableContentRight: true,
         enableFirstTextfieldContentLeft: false,
         enableFirstTextfieldContentRight: false,

--- a/packages/sdds-cs/src/components/Drawer/Drawer.config.ts
+++ b/packages/sdds-cs/src/components/Drawer/Drawer.config.ts
@@ -13,6 +13,7 @@ export const config = {
                 ${drawerTokens.contentBackgroundColor}: var(--surface-transparent-primary);
                 ${drawerTokens.drawerOverlayWithBlurColor}: var(--overlay-blur);
                 ${drawerTokens.drawerOverlayColor}: var(--overlay-soft);
+                ${drawerTokens.closeIconColor}: var(--text-accent);
             `,
         },
         size: {

--- a/packages/sdds-cs/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-cs/src/components/Drawer/Drawer.stories.tsx
@@ -131,6 +131,7 @@ const StyledIconButton = styled(Button)`
     position: relative;
     width: 1.5rem;
     height: 1.5rem;
+    color: var(--text-secondary);
 `;
 
 const StoryDrawerDemo = ({


### PR DESCRIPTION
### Set tokens in `drawer` and `datepicker`

- Изменен storybook в `datepicker` для вертикали `sdds-cs`
- Изменен компонент `drawer`, добавлена возможность изменить цвет закрывающей иконки ( также затронут компонент `Panel` ) 

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.214.1-canary.1594.12049220457.0
  npm install @salutejs/plasma-b2c@1.456.1-canary.1594.12049220457.0
  npm install @salutejs/plasma-new-hope@0.203.1-canary.1594.12049220457.0
  npm install @salutejs/plasma-web@1.458.1-canary.1594.12049220457.0
  npm install @salutejs/sdds-cs@0.187.1-canary.1594.12049220457.0
  npm install @salutejs/sdds-dfa@0.184.1-canary.1594.12049220457.0
  npm install @salutejs/sdds-finportal@0.178.1-canary.1594.12049220457.0
  npm install @salutejs/sdds-insol@0.179.1-canary.1594.12049220457.0
  npm install @salutejs/sdds-serv@0.186.1-canary.1594.12049220457.0
  # or 
  yarn add @salutejs/plasma-asdk@0.214.1-canary.1594.12049220457.0
  yarn add @salutejs/plasma-b2c@1.456.1-canary.1594.12049220457.0
  yarn add @salutejs/plasma-new-hope@0.203.1-canary.1594.12049220457.0
  yarn add @salutejs/plasma-web@1.458.1-canary.1594.12049220457.0
  yarn add @salutejs/sdds-cs@0.187.1-canary.1594.12049220457.0
  yarn add @salutejs/sdds-dfa@0.184.1-canary.1594.12049220457.0
  yarn add @salutejs/sdds-finportal@0.178.1-canary.1594.12049220457.0
  yarn add @salutejs/sdds-insol@0.179.1-canary.1594.12049220457.0
  yarn add @salutejs/sdds-serv@0.186.1-canary.1594.12049220457.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
