### PR TITLE
PLASMA-4067: Popup hydration issues [FIX]

### DIFF
--- a/packages/plasma-new-hope/src/components/Popup/ClientOnlyPortal.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/ClientOnlyPortal.tsx
@@ -1,0 +1,23 @@
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { ReactNode, FC } from 'react';
+
+import { useIsomorphicLayoutEffect } from '../../hooks';
+
+// Полиморфная версия портала для рендера как на сервере, так и на клиенте.
+// Позволяет избежать ошибок, связанных с гидрацией.
+const ClientOnlyPortal: FC<{ children: ReactNode }> = ({ children }) => {
+    const ref = useRef<HTMLElement | null>(null);
+
+    const [mounted, setMounted] = useState(false);
+
+    useIsomorphicLayoutEffect(() => {
+        ref.current = document.body;
+
+        setMounted(true);
+    }, []);
+
+    return mounted && ref.current ? createPortal(children, ref.current) : null;
+};
+
+export { ClientOnlyPortal };


### PR DESCRIPTION
### Popup
- добавлено небезопасное свойство `UNSAFE_SSR_ENABLED` в компонент `PopupProvider` для корректной гидрации компонента;

### What/why changed
Пока решили рефакторинг попапов отложить, ограничились вводом нового временного свойства `UNSAFE_SSR_ENABLED` для тех, кто использует попапы в нексте. Также создано ишью: [1599](https://github.com/salute-developers/plasma/issues/1599)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.218.1-canary.1596.12137404478.0
  npm install @salutejs/plasma-b2c@1.460.1-canary.1596.12137404478.0
  npm install @salutejs/plasma-new-hope@0.207.1-canary.1596.12137404478.0
  npm install @salutejs/plasma-web@1.462.1-canary.1596.12137404478.0
  npm install @salutejs/sdds-cs@0.191.1-canary.1596.12137404478.0
  npm install @salutejs/sdds-dfa@0.188.1-canary.1596.12137404478.0
  npm install @salutejs/sdds-finportal@0.182.1-canary.1596.12137404478.0
  npm install @salutejs/sdds-insol@0.183.1-canary.1596.12137404478.0
  npm install @salutejs/sdds-serv@0.190.1-canary.1596.12137404478.0
  # or 
  yarn add @salutejs/plasma-asdk@0.218.1-canary.1596.12137404478.0
  yarn add @salutejs/plasma-b2c@1.460.1-canary.1596.12137404478.0
  yarn add @salutejs/plasma-new-hope@0.207.1-canary.1596.12137404478.0
  yarn add @salutejs/plasma-web@1.462.1-canary.1596.12137404478.0
  yarn add @salutejs/sdds-cs@0.191.1-canary.1596.12137404478.0
  yarn add @salutejs/sdds-dfa@0.188.1-canary.1596.12137404478.0
  yarn add @salutejs/sdds-finportal@0.182.1-canary.1596.12137404478.0
  yarn add @salutejs/sdds-insol@0.183.1-canary.1596.12137404478.0
  yarn add @salutejs/sdds-serv@0.190.1-canary.1596.12137404478.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
