### PR TITLE
PLASMA-3619: add 'hover' trigger to Tooltip

### DIFF
--- a/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
@@ -35,6 +35,14 @@ export const StyledPopover = styled.div<Pick<PopoverProps, 'zIndex'>>`
     position: absolute;
     z-index: ${({ zIndex }) => zIndex || DEFAULT_Z_INDEX};
 
+    /* пустой блок между target и popover, чтобы ловить onMouseEnter */
+    &:before {
+        content: '';
+        display: block;
+        position: absolute;
+        background: transparent;
+    }
+
     &[data-popper-placement^='top'] > .${classes.arrow} {
         bottom: calc(0px - var(${String(tokens.arrowHeight)}));
     }
@@ -109,5 +117,53 @@ export const StyledPopover = styled.div<Pick<PopoverProps, 'zIndex'>>`
         top: unset !important;
         bottom: var(${String(tokens.arrowEdgeMargin)}) !important;
         transform: unset !important;
+    }
+
+    &[data-popper-placement^='top'],
+    &[data-popper-placement^='top-start'],
+    &[data-popper-placement^='top-end'] {
+        &:before {
+            top: unset;
+            left: 0;
+            right: 0;
+            height: var(${String(tokens.arrowHeight)});
+            bottom: calc(-1 * var(${String(tokens.arrowHeight)}));
+        }
+    }
+
+    &[data-popper-placement^='bottom'],
+    &[data-popper-placement^='bottom-start'],
+    &[data-popper-placement^='bottom-end'] {
+        &:before {
+            top: calc(-1 * var(${String(tokens.arrowHeight)}));
+            left: 0;
+            right: 0;
+            bottom: var(${String(tokens.arrowHeight)});
+            height: var(${String(tokens.arrowHeight)});
+        }
+    }
+
+    &[data-popper-placement^='left'],
+    &[data-popper-placement^='left-start'],
+    &[data-popper-placement^='left-end'] {
+        &:before {
+            width: var(${String(tokens.arrowHeight)});
+            height: 100%;
+            top: 0;
+            right: calc(-1 * var(${String(tokens.arrowHeight)}));
+            bottom: 0;
+        }
+    }
+
+    &[data-popper-placement^='right'],
+    &[data-popper-placement^='right-start'],
+    &[data-popper-placement^='right-end'] {
+        &:before {
+            width: var(${String(tokens.arrowHeight)});
+            height: 100%;
+            top: 0;
+            left: calc(-1 * var(${String(tokens.arrowHeight)}));
+            bottom: 0;
+        }
     }
 `;

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.template-doc.mdx
@@ -28,3 +28,24 @@ export function App() {
     );
 }
 ```
+
+## Отображение при взаимодействии с `target`
+
+Помимо выставления `opened` в `true/false` можно управлять отображением по ховеру или клику через свойство `trigger`.
+
+При открытии по клику доступны свойства из `Popover`, такие как `closeOnEsc` и `closeOnOverlayClick`.
+
+```tsx live
+import React from 'react';
+import { Tooltip, Button } from '@salutejs/{{ package }}';
+
+export function App() {
+    return (
+        <>
+            <Tooltip target={(<Button>trigger: hover</Button>)} text="По ховеру" placement="right" hasArrow trigger="hover" hoverTimeout={500} />
+            <br />
+            <Tooltip target={(<Button>trigger: click</Button>)} text="По клику" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+        </>
+    );
+}
+```

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, forwardRef, useState } from 'react';
+import React, { useEffect, forwardRef, useState, useRef } from 'react';
 import { styled } from '@linaria/react';
 
 import { RootProps, component } from '../../engines';
@@ -62,16 +62,21 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                 zIndex = '9200',
                 className,
                 style,
+                hoverTimeout = 300,
+                trigger,
                 ...rest
             },
             outerRef,
         ) => {
             const [ref, setRef] = useState<HTMLDivElement | null>(null);
+            const timeoutRef = useRef<number | undefined>();
+            const [isOpened, setIsOpened] = useState(false);
+            const [isHovered, setIsHovered] = useState(false);
 
             // TODO убрать после отказа от старого API
             const innerIsOpen = Boolean(isVisible || isOpen || opened);
             const innerHasArrow = arrow || hasArrow;
-            const showTooltip = innerIsOpen && Boolean(text?.length);
+            const showTooltip = innerIsOpen && Boolean(text);
 
             const animatedClass = animated ? classes.animated : undefined;
 
@@ -89,9 +94,39 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                 };
             }, []);
 
+            const onMouseEnter = () => {
+                clearTimeout(timeoutRef.current);
+                setIsHovered(true);
+            };
+
+            const onMouseLeave = () => {
+                timeoutRef.current = setTimeout(() => {
+                    setIsHovered(false);
+                }, hoverTimeout);
+            };
+
+            useEffect(() => {
+                return () => clearTimeout(timeoutRef.current);
+            }, [trigger]);
+
+            const onToggle = (isOpen: boolean) => {
+                if (trigger === 'hover') {
+                    if (isOpen) {
+                        clearTimeout(timeoutRef.current);
+                        setIsOpened(true);
+                    } else {
+                        timeoutRef.current = setTimeout(() => {
+                            setIsOpened(false);
+                        }, hoverTimeout);
+                    }
+                } else {
+                    setIsOpened(isOpen);
+                }
+            };
+
             return (
                 <StyledPopover
-                    opened={showTooltip}
+                    opened={showTooltip || isOpened || isHovered}
                     placement={placement}
                     offset={offset}
                     zIndex={zIndex}
@@ -102,9 +137,17 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                     aria-live="polite"
                     role="tooltip"
                     className={cx(ref?.classList.toString(), animatedClass)}
+                    {...((trigger === 'hover' || trigger === 'click') && { trigger, onToggle })}
                     {...rest}
                 >
-                    <Root view={view} size={size} ref={setRef} className={className} style={style}>
+                    <Root
+                        view={view}
+                        size={size}
+                        ref={setRef}
+                        className={className}
+                        style={style}
+                        {...(trigger === 'hover' && { onMouseEnter, onMouseLeave })}
+                    >
                         <TooltipRoot
                             ref={outerRef}
                             id={id}

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.types.ts
@@ -6,7 +6,7 @@ export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
     /**
      * Текст тултипа.
      */
-    text: string;
+    text: ReactNode;
     /**
      * Видимость тултипа.
      */
@@ -94,4 +94,13 @@ export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
      * @deprecated
      */
     children?: ReactNode;
+    /**
+     * Действие по target для отображения тултипа
+     */
+    trigger?: 'click' | 'hover' | 'none';
+    /**
+     * Время автоматического скрытия тултипа по ховеру в ms
+     * @default 300
+     */
+    hoverTimeout?: number;
 }

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { styled } from '@linaria/react';
 import type { StoryObj, Meta } from '@storybook/react';
+import { disableProps } from '@salutejs/plasma-sb-utils';
 
 import { WithTheme } from '../../../_helpers';
 import { Button } from '../Button/Button';
@@ -34,6 +35,9 @@ const meta: Meta<TooltipProps> = {
     title: 'b2c/Overlay/Tooltip',
     decorators: [WithTheme],
     component: Tooltip,
+    argTypes: {
+        ...disableProps(['isVisible', 'isOpen', 'onDismiss']),
+    },
     parameters: {
         docs: { story: { inline: false, iframeHeight: '20rem' } },
     },
@@ -147,7 +151,7 @@ export const Default: StoryObj<TooltipProps> = {
 const StyledRow = styled.div`
     display: flex;
     width: 150vw;
-    height: 150vh;
+    height: auto;
     padding: 10rem;
 `;
 
@@ -170,7 +174,6 @@ const StoryLive = (args: TooltipProps) => {
                     {...args}
                     id="example-tooltip-firstname"
                     text={text}
-                    opened
                     frame="theme-root"
                 />
             </StyledRow>
@@ -193,12 +196,22 @@ export const Live: StoryObj<TooltipProps> = {
                 type: 'select',
             },
         },
+        trigger: {
+            options: ['click', 'hover', 'none'],
+            control: {
+                type: 'select',
+            },
+        },
     },
     args: {
         placement: 'bottom',
         maxWidth: 10,
         minWidth: 3,
         hasArrow: true,
+        trigger: 'hover',
+        hoverTimeout: 300,
+        closeOnOverlayClick: true,
+        closeOnEsc: true,
         size: 'm',
     },
     render: (args) => <StoryLive {...args} />,

--- a/packages/plasma-web/src/components/Tooltip/Tooltip.component-test.tsx
+++ b/packages/plasma-web/src/components/Tooltip/Tooltip.component-test.tsx
@@ -319,4 +319,67 @@ describe('plasma-web: Tooltip', () => {
 
         cy.matchImageSnapshot('multiple');
     });
+
+    describe('trigger', () => {
+        it('trigger:click', () => {
+            mount(
+                <CypressTestDecoratorWithTypo>
+                    <span id="outer" />
+                    <Tooltip
+                        target={<Button text="hello" />}
+                        text="World"
+                        placement="bottom"
+                        trigger="click"
+                        closeOnOverlayClick
+                    />
+                </CypressTestDecoratorWithTypo>,
+            );
+
+            cy.contains('World').should('not.visible');
+
+            cy.contains('hello').click();
+            cy.contains('World').should('be.visible');
+
+            cy.contains('hello').click();
+            cy.contains('World').should('not.visible');
+
+            cy.contains('hello').click();
+            cy.contains('World').should('be.visible');
+            cy.get('#outer').click({ force: true });
+
+            cy.matchImageSnapshot();
+        });
+
+        it('trigger:hover', () => {
+            mount(
+                <CypressTestDecoratorWithTypo>
+                    <Tooltip target={<Button text="hello" />} text="World" placement="bottom" trigger="hover" />
+                </CypressTestDecoratorWithTypo>,
+            );
+
+            cy.contains('World').should('not.visible');
+
+            cy.get('button').first().trigger('mouseover', { force: true });
+            cy.contains('World').should('be.visible');
+
+            cy.get('button').first().trigger('mouseout', { force: true });
+            cy.contains('World').should('not.visible');
+        });
+
+        it('trigger:none', () => {
+            mount(
+                <CypressTestDecoratorWithTypo>
+                    <Tooltip target={<Button text="hello" />} text="World" placement="bottom" trigger="none" />
+                </CypressTestDecoratorWithTypo>,
+            );
+
+            cy.contains('World').should('not.visible');
+
+            cy.get('button').first().trigger('mouseover', { force: true });
+            cy.contains('World').should('not.visible');
+
+            cy.contains('hello').click();
+            cy.contains('World').should('not.visible');
+        });
+    });
 });

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -510,7 +510,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -540,7 +540,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -634,7 +634,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -664,7 +664,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -1884,7 +1884,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -1946,7 +1946,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2136,7 +2136,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2198,7 +2198,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3068,7 +3068,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3111,7 +3111,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3154,7 +3154,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3197,7 +3197,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3443,7 +3443,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3478,7 +3478,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3587,7 +3587,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3622,7 +3622,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -489,7 +489,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -519,7 +519,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -613,7 +613,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -643,7 +643,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -1928,7 +1928,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2004,7 +2004,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2236,7 +2236,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2312,7 +2312,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3237,7 +3237,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3280,7 +3280,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3323,7 +3323,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3366,7 +3366,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3626,7 +3626,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3661,7 +3661,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3770,7 +3770,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3805,7 +3805,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -530,7 +530,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -560,7 +560,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -654,7 +654,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -684,7 +684,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2005,7 +2005,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2081,7 +2081,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2313,7 +2313,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2389,7 +2389,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3333,7 +3333,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3376,7 +3376,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3419,7 +3419,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3462,7 +3462,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3722,7 +3722,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3757,7 +3757,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3866,7 +3866,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3901,7 +3901,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -530,7 +530,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -560,7 +560,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -654,7 +654,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -684,7 +684,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2010,7 +2010,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2087,7 +2087,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2322,7 +2322,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2399,7 +2399,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3347,7 +3347,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3390,7 +3390,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3433,7 +3433,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3476,7 +3476,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3737,7 +3737,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3772,7 +3772,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3881,7 +3881,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3916,7 +3916,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -530,7 +530,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -560,7 +560,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -654,7 +654,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -684,7 +684,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2005,7 +2005,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2081,7 +2081,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2313,7 +2313,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -2389,7 +2389,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3333,7 +3333,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3376,7 +3376,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3419,7 +3419,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3462,7 +3462,7 @@ requiredPlacement?: "right" | "left" | undefined;
 optional?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintOpened?: boolean | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
@@ -3722,7 +3722,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3757,7 +3757,7 @@ clear?: boolean | undefined;
 hasDivider?: boolean | undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3866,7 +3866,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;
@@ -3901,7 +3901,7 @@ clear?: false | undefined;
 hasDivider?: undefined;
 } & {
 hintText: string;
-hintTrigger?: "hover" | "click" | undefined;
+hintTrigger?: "click" | "hover" | undefined;
 hintView?: string | undefined;
 hintSize?: string | undefined;
 hintTargetIcon?: ReactNode;

--- a/website/plasma-b2c-docs/docs/components/Tooltip.mdx
+++ b/website/plasma-b2c-docs/docs/components/Tooltip.mdx
@@ -29,3 +29,24 @@ export function App() {
     );
 }
 ```
+
+## Отображение при взаимодействии с `target`
+
+Помимо выставления `opened` в `true/false` можно управлять отображением по ховеру или клику через свойство `trigger`.
+
+При открытии по клику доступны свойства из `Popover`, такие как `closeOnEsc` и `closeOnOverlayClick`.
+
+```tsx live
+import React from 'react';
+import { Tooltip, Button } from '@salutejs/plasma-b2c';
+
+export function App() {
+    return (
+        <>
+            <Tooltip target={(<Button>trigger: hover</Button>)} text="По ховеру" placement="right" hasArrow trigger="hover" hoverTimeout={500} />
+            <br />
+            <Tooltip target={(<Button>trigger: click</Button>)} text="По клику" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+        </>
+    );
+}
+```

--- a/website/plasma-web-docs/docs/components/Tooltip.mdx
+++ b/website/plasma-web-docs/docs/components/Tooltip.mdx
@@ -23,9 +23,30 @@ import { IconApps } from '@salutejs/plasma-icons';
 
 export function App() {
     return (
-        <div style={{marginLeft: '100px',marginBottom: '35px'}}>
+        <div style={{marginLeft: '100px', marginBottom: '35px'}}>
             <Tooltip target={( <IconApps />)} text="Высокое качество воспроизведения" placement="bottom" hasArrow opened />
         </div>
+    );
+}
+```
+
+## Отображение при взаимодействии с `target`
+
+Помимо выставления `opened` в `true/false` можно управлять отображением по ховеру или клику через свойство `trigger`.
+
+При открытии по клику доступны свойства из `Popover`, такие как `closeOnEsc` и `closeOnOverlayClick`.
+
+```tsx live
+import React from 'react';
+import { Tooltip, Button } from '@salutejs/plasma-web';
+
+export function App() {
+    return (
+        <>
+            <Tooltip target={(<Button>trigger: hover</Button>)} text="По ховеру" placement="right" hasArrow trigger="hover" hoverTimeout={500} />
+            <br />
+            <Tooltip target={(<Button>trigger: click</Button>)} text="По клику" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+        </>
     );
 }
 ```

--- a/website/sdds-cs-docs/docs/components/Tooltip.mdx
+++ b/website/sdds-cs-docs/docs/components/Tooltip.mdx
@@ -28,3 +28,24 @@ export function App() {
     );
 }
 ```
+
+## Отображение при взаимодействии с `target`
+
+Помимо выставления `opened` в `true/false` можно управлять отображением по ховеру или клику через свойство `trigger`.
+
+При открытии по клику доступны свойства из `Popover`, такие как `closeOnEsc` и `closeOnOverlayClick`.
+
+```tsx live
+import React from 'react';
+import { Tooltip, Button } from '@salutejs/sdds-cs';
+
+export function App() {
+    return (
+        <>
+            <Tooltip target={(<Button>trigger: hover</Button>)} text="По ховеру" placement="right" hasArrow trigger="hover" hoverTimeout={500} />
+            <br />
+            <Tooltip target={(<Button>trigger: click</Button>)} text="По клику" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+        </>
+    );
+}
+```

--- a/website/sdds-dfa-docs/docs/components/Tooltip.mdx
+++ b/website/sdds-dfa-docs/docs/components/Tooltip.mdx
@@ -28,3 +28,24 @@ export function App() {
     );
 }
 ```
+
+## Отображение при взаимодействии с `target`
+
+Помимо выставления `opened` в `true/false` можно управлять отображением по ховеру или клику через свойство `trigger`.
+
+При открытии по клику доступны свойства из `Popover`, такие как `closeOnEsc` и `closeOnOverlayClick`.
+
+```tsx live
+import React from 'react';
+import { Tooltip, Button } from '@salutejs/sdds-dfa';
+
+export function App() {
+    return (
+        <>
+            <Tooltip target={(<Button>trigger: hover</Button>)} text="По ховеру" placement="right" hasArrow trigger="hover" hoverTimeout={500} />
+            <br />
+            <Tooltip target={(<Button>trigger: click</Button>)} text="По клику" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+        </>
+    );
+}
+```

--- a/website/sdds-insol-docs/docs/components/Tooltip.mdx
+++ b/website/sdds-insol-docs/docs/components/Tooltip.mdx
@@ -28,3 +28,24 @@ export function App() {
     );
 }
 ```
+
+## Отображение при взаимодействии с `target`
+
+Помимо выставления `opened` в `true/false` можно управлять отображением по ховеру или клику через свойство `trigger`.
+
+При открытии по клику доступны свойства из `Popover`, такие как `closeOnEsc` и `closeOnOverlayClick`.
+
+```tsx live
+import React from 'react';
+import { Tooltip, Button } from '@salutejs/sdds-insol';
+
+export function App() {
+    return (
+        <>
+            <Tooltip target={(<Button>trigger: hover</Button>)} text="По ховеру" placement="right" hasArrow trigger="hover" hoverTimeout={500} />
+            <br />
+            <Tooltip target={(<Button>trigger: click</Button>)} text="По клику" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+        </>
+    );
+}
+```

--- a/website/sdds-serv-docs/docs/components/Tooltip.mdx
+++ b/website/sdds-serv-docs/docs/components/Tooltip.mdx
@@ -28,3 +28,24 @@ export function App() {
     );
 }
 ```
+
+## Отображение при взаимодействии с `target`
+
+Помимо выставления `opened` в `true/false` можно управлять отображением по ховеру или клику через свойство `trigger`.
+
+При открытии по клику доступны свойства из `Popover`, такие как `closeOnEsc` и `closeOnOverlayClick`.
+
+```tsx live
+import React from 'react';
+import { Tooltip, Button } from '@salutejs/sdds-serv';
+
+export function App() {
+    return (
+        <>
+            <Tooltip target={(<Button>trigger: hover</Button>)} text="По ховеру" placement="right" hasArrow trigger="hover" hoverTimeout={500} />
+            <br />
+            <Tooltip target={(<Button>trigger: click</Button>)} text="По клику" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+        </>
+    );
+}
+```


### PR DESCRIPTION
## Core
### Tooltip, Popover

- добавлена возможность открывать по `hover`

### What/why changed

Добавлено внутреннее состояния для тултипа: isOpen
Прокинуты свойства в Popover: trigger, closeOnEsc, closeOnOverlayClick. Так же, невидимый блок между target и контентом
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.227.0-canary.1625.12267028714.0
  npm install @salutejs/plasma-b2c@1.469.0-canary.1625.12267028714.0
  npm install @salutejs/plasma-new-hope@0.216.0-canary.1625.12267028714.0
  npm install @salutejs/plasma-web@1.471.0-canary.1625.12267028714.0
  npm install @salutejs/sdds-cs@0.200.0-canary.1625.12267028714.0
  npm install @salutejs/sdds-dfa@0.197.0-canary.1625.12267028714.0
  npm install @salutejs/sdds-finportal@0.191.0-canary.1625.12267028714.0
  npm install @salutejs/sdds-insol@0.192.0-canary.1625.12267028714.0
  npm install @salutejs/sdds-serv@0.199.0-canary.1625.12267028714.0
  # or 
  yarn add @salutejs/plasma-asdk@0.227.0-canary.1625.12267028714.0
  yarn add @salutejs/plasma-b2c@1.469.0-canary.1625.12267028714.0
  yarn add @salutejs/plasma-new-hope@0.216.0-canary.1625.12267028714.0
  yarn add @salutejs/plasma-web@1.471.0-canary.1625.12267028714.0
  yarn add @salutejs/sdds-cs@0.200.0-canary.1625.12267028714.0
  yarn add @salutejs/sdds-dfa@0.197.0-canary.1625.12267028714.0
  yarn add @salutejs/sdds-finportal@0.191.0-canary.1625.12267028714.0
  yarn add @salutejs/sdds-insol@0.192.0-canary.1625.12267028714.0
  yarn add @salutejs/sdds-serv@0.199.0-canary.1625.12267028714.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
