### PR TITLE
PLASMA-4108: add zIndex prop in Dropdown, Select, Combobox

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -1896,6 +1896,7 @@ default: PolymorphicClassName;
     variant?: "normal" | "tight" | undefined;
     portal?: string | React_2.RefObject<HTMLElement> | undefined;
     renderItem?: ((item: DropdownItemOption) => React_2.ReactNode) | undefined;
+    zIndex?: Property.ZIndex | undefined;
     onItemClick?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     listOverflow?: Property.Overflow | undefined;
     listHeight?: Property.Height<string | number> | undefined;

--- a/packages/plasma-b2c/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Combobox/Combobox.component-test.tsx
@@ -1185,6 +1185,18 @@ describe('plasma-b2c: Combobox', () => {
         cy.get('[id$="north_america"]').should('have.attr', 'data-name', 'test-data-name');
     });
 
+    it('prop: zIndex', () => {
+        mount(
+            <div style={{ width: '300px' }}>
+                <Combobox id="single" items={items} label="Label" placeholder="Placeholder" zIndex={10000} />
+            </div>,
+        );
+
+        cy.get('#single').realClick();
+
+        cy.get('[data-floating-ui-portal] > div').should('have.css', 'z-index', '10000');
+    });
+
     it('flow: single uncontrolled', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-b2c/src/components/Dropdown/Dropdown.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Dropdown/Dropdown.component-test.tsx
@@ -568,6 +568,20 @@ describe('plasma-b2c: Dropdown', () => {
         cy.get('[id$="north_america"]').should('have.attr', 'data-name', 'test-data-name');
     });
 
+    it('prop: zIndex', () => {
+        mount(
+            <CypressTestDecoratorWithTypo>
+                <Dropdown items={items} zIndex={10000}>
+                    <Button text="Список стран" />
+                </Dropdown>
+            </CypressTestDecoratorWithTypo>,
+        );
+
+        cy.get('button').realClick();
+
+        cy.get('[data-floating-ui-portal] > div').should('have.css', 'z-index', '10000');
+    });
+
     it('keyboard interactions', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-b2c/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Select/Select.component-test.tsx
@@ -781,6 +781,18 @@ describe('plasma-b2c: Select', () => {
         cy.get('[id$="north_america"]').should('have.attr', 'data-name', 'test-data-name');
     });
 
+    it('prop: zIndex', () => {
+        mount(
+            <div style={{ width: '300px' }}>
+                <Select id="single" items={items} label="Label" placeholder="Placeholder" zIndex={10000} />
+            </div>,
+        );
+
+        cy.get('#single').realClick();
+
+        cy.get('[data-floating-ui-portal] > div').should('have.css', 'z-index', '10000');
+    });
+
     it('basic logic', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
@@ -69,6 +69,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             filter,
             closeAfterSelect: outerCloseAfterSelect,
             renderValue,
+            zIndex,
             ...rest
         } = props;
 
@@ -453,6 +454,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
                                     onEnterDisabled // Пропс для отключения обработчика Enter внутри Textfield
                                 />
                             )}
+                            zIndex={zIndex}
                         >
                             <Root
                                 size={size}

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
@@ -2,6 +2,7 @@ import type { CSSProperties, ButtonHTMLAttributes, ChangeEventHandler } from 're
 import React from 'react';
 
 import { RequiredProps, LabelProps } from '../../TextField/TextField.types';
+import { DropdownProps } from '../../Dropdown/Dropdown.types';
 
 import { FocusedPathState } from './reducers';
 import { ItemOption, ItemOptionTransformed } from './ui/Inner/ui/Item/Item.types';
@@ -164,6 +165,10 @@ type BasicProps<T extends ItemOption = ItemOption> = {
      */
     variant?: 'normal' | 'tight';
     /**
+     * CSS-свойство z-index для выпадающего списка.
+     */
+    zIndex?: CSSProperties['zIndex'];
+    /**
      * Значение css overflow для выпадающего меню.
      * @example listOverflow="scroll"
      */
@@ -221,6 +226,7 @@ export type FloatingPopoverProps = {
     portal?: ComboboxProps['portal'];
     listWidth?: ComboboxProps['listWidth'];
     offset?: number;
+    zIndex?: DropdownProps['zIndex'];
 };
 
 export type ItemContext = {

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/FloatingPopover.tsx
@@ -5,7 +5,7 @@ import { safeUseId } from '@salutejs/plasma-core';
 import type { FloatingPopoverProps } from './Combobox.types';
 
 const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
-    ({ target, children, opened, onToggle, placement, portal, listWidth, offset = 0 }, ref) => {
+    ({ target, children, opened, onToggle, placement, portal, listWidth, offset = 0, zIndex }, ref) => {
         const { refs, floatingStyles } = useFloating({
             placement,
             open: opened,
@@ -47,7 +47,7 @@ const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
                     // root - принимает ref контейнера портала.
                     // id - если есть портал - не используется, если портала нет - подставляется 'wrappedId'.
                     <FloatingPortal {...getFloatingPortalProps(portal, wrappedId)}>
-                        <div ref={refs.setFloating} style={{ ...floatingStyles, zIndex: 1 }}>
+                        <div ref={refs.setFloating} style={{ ...floatingStyles, zIndex: zIndex || 1000 }}>
                             {children}
                         </div>
                     </FloatingPortal>

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tsx
@@ -50,6 +50,7 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, Omit<DropdownProps,
                 alwaysOpened = false,
                 portal,
                 renderItem,
+                zIndex,
                 ...rest
             },
             ref,
@@ -141,6 +142,7 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, Omit<DropdownProps,
                                 : '',
                             onKeyDown,
                         })}
+                        zIndex={zIndex}
                     >
                         <Root
                             className={cx(className, classes.dropdownRoot)}

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
@@ -88,6 +88,10 @@ export type DropdownProps<T extends DropdownItemOption = DropdownItemOption> = {
      * Callback для кастомной настройки айтема в выпадающем списке.
      */
     renderItem?: (item: T) => React.ReactNode;
+    /**
+     * CSS-свойство z-index для выпадающего списка.
+     */
+    zIndex?: CSSProperties['zIndex'];
 
     /**
      * Обработчик клика по item.
@@ -130,6 +134,7 @@ export type FloatingPopoverProps = {
     isInner?: boolean;
     portal?: DropdownProps['portal'];
     offset?: [number, number];
+    zIndex?: DropdownProps['zIndex'];
 };
 
 export type ItemContext = {

--- a/packages/plasma-new-hope/src/components/Dropdown/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/FloatingPopover.tsx
@@ -12,7 +12,7 @@ import { safeUseId } from '@salutejs/plasma-core';
 import { FloatingPopoverProps } from './Dropdown.types';
 
 const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
-    ({ target, children, opened, onToggle, placement, portal, offset = [0, 0], isInner, trigger }, ref) => {
+    ({ target, children, opened, onToggle, placement, portal, offset = [0, 0], isInner, trigger, zIndex }, ref) => {
         const { refs, floatingStyles } = useFloating({
             placement: placement === 'auto' ? undefined : placement,
             open: opened,
@@ -96,7 +96,7 @@ const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
                             onMouseLeave={handleFloatingMouseLeave}
                             style={{
                                 ...floatingStyles,
-                                zIndex: 1,
+                                zIndex: zIndex || 1000,
                             }}
                         >
                             {children}

--- a/packages/plasma-new-hope/src/components/Select/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Select/FloatingPopover.tsx
@@ -6,7 +6,7 @@ import { getPlacement, getFallbackPlacements } from './utils';
 import type { FloatingPopoverProps } from './Select.types';
 
 const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
-    ({ target, children, opened, onToggle, placement, portal, listWidth, offset = 0 }, ref) => {
+    ({ target, children, opened, onToggle, placement, portal, listWidth, offset = 0, zIndex }, ref) => {
         const { refs, floatingStyles } = useFloating({
             placement: getPlacement(placement),
             open: opened,
@@ -48,7 +48,7 @@ const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
                     // root - принимает ref контейнера портала.
                     // id - если есть портал - не используется, если портала нет - подставляется 'wrappedId'.
                     <FloatingPortal {...getFloatingPortalProps(portal, wrappedId)}>
-                        <div ref={refs.setFloating} style={{ ...floatingStyles, zIndex: 1 }}>
+                        <div ref={refs.setFloating} style={{ ...floatingStyles, zIndex: zIndex || 1000 }}>
                             {children}
                         </div>
                     </FloatingPortal>

--- a/packages/plasma-new-hope/src/components/Select/Select.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.tsx
@@ -59,6 +59,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
             isTargetAmount,
             beforeList,
             afterList,
+            zIndex,
             ...rest
         } = props;
         const transformedItems = useMemo(() => initialItemsTransform(items || []), [items]);
@@ -329,6 +330,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
                                 requiredProps={requiredProps}
                             />
                         )}
+                        zIndex={zIndex}
                     >
                         <Root
                             view={view}

--- a/packages/plasma-new-hope/src/components/Select/Select.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.types.ts
@@ -2,6 +2,7 @@ import type { CSSProperties, ButtonHTMLAttributes, SyntheticEvent } from 'react'
 import React from 'react';
 
 import type { RequiredProps, LabelProps } from '../TextField/TextField.types';
+import { DropdownProps } from '../Dropdown/Dropdown.types';
 
 import { FocusedPathState } from './reducers';
 import {
@@ -109,6 +110,10 @@ export interface BasicProps<K extends ItemOption> {
      * @default normal
      */
     variant?: 'normal' | 'tight';
+    /**
+     * CSS-свойство z-index для выпадающего списка.
+     */
+    zIndex?: CSSProperties['zIndex'];
     /**
      * Значение css overflow для выпадающего меню.
      * @example listOverflow="scroll"
@@ -295,6 +300,10 @@ export type MergedSelectProps<T = any, K extends DropdownNode = DropdownNode> = 
          */
         variant?: 'normal' | 'tight';
         /**
+         * CSS-свойство z-index для выпадающего списка.
+         */
+        zIndex?: CSSProperties['zIndex'];
+        /**
          * Значение css width для выпадающего списка.
          * @example width="200px"
          */
@@ -363,4 +372,5 @@ export type FloatingPopoverProps = {
     portal?: MergedSelectProps['portal'];
     listWidth?: MergedSelectProps['listWidth'];
     offset?: number;
+    zIndex?: DropdownProps['zIndex'];
 };

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Combobox.stories.tsx
@@ -361,6 +361,7 @@ const SingleStory = (args: StorySelectProps) => {
                 value={value}
                 onChange={setValue}
                 contentLeft={args.enableContentLeft ? <IconDone size="s" /> : undefined}
+                onToggle={(e) => console.log(e)}
             />
         </div>
     );

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -1898,6 +1898,7 @@ default: PolymorphicClassName;
     variant?: "normal" | "tight" | undefined;
     portal?: string | React_2.RefObject<HTMLElement> | undefined;
     renderItem?: ((item: DropdownItemOption) => React_2.ReactNode) | undefined;
+    zIndex?: Property.ZIndex | undefined;
     onItemClick?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     listOverflow?: Property.Overflow | undefined;
     listHeight?: Property.Height<string | number> | undefined;

--- a/packages/plasma-web/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-web/src/components/Combobox/Combobox.component-test.tsx
@@ -1185,6 +1185,18 @@ describe('plasma-web: Combobox', () => {
         cy.get('[id$="north_america"]').should('have.attr', 'data-name', 'test-data-name');
     });
 
+    it('prop: zIndex', () => {
+        mount(
+            <div style={{ width: '300px' }}>
+                <Combobox id="single" items={items} label="Label" placeholder="Placeholder" zIndex={10000} />
+            </div>,
+        );
+
+        cy.get('#single').realClick();
+
+        cy.get('[data-floating-ui-portal] > div').should('have.css', 'z-index', '10000');
+    });
+
     it('flow: single uncontrolled', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-web/src/components/Dropdown/Dropdown.component-test.tsx
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.component-test.tsx
@@ -568,6 +568,20 @@ describe('plasma-web: Dropdown', () => {
         cy.get('[id$="north_america"]').should('have.attr', 'data-name', 'test-data-name');
     });
 
+    it('prop: zIndex', () => {
+        mount(
+            <CypressTestDecoratorWithTypo>
+                <Dropdown items={items} zIndex={10000}>
+                    <Button text="Список стран" />
+                </Dropdown>
+            </CypressTestDecoratorWithTypo>,
+        );
+
+        cy.get('button').realClick();
+
+        cy.get('[data-floating-ui-portal] > div').should('have.css', 'z-index', '10000');
+    });
+
     it('keyboard interactions', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-web/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-web/src/components/Select/Select.component-test.tsx
@@ -781,6 +781,18 @@ describe('plasma-web: Select', () => {
         cy.get('[id$="north_america"]').should('have.attr', 'data-name', 'test-data-name');
     });
 
+    it('prop: zIndex', () => {
+        mount(
+            <div style={{ width: '300px' }}>
+                <Select id="single" items={items} label="Label" placeholder="Placeholder" zIndex={10000} />
+            </div>,
+        );
+
+        cy.get('#single').realClick();
+
+        cy.get('[data-floating-ui-portal] > div').should('have.css', 'z-index', '10000');
+    });
+
     it('basic logic', () => {
         cy.viewport(1000, 500);
 

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -1509,6 +1509,7 @@ default: PolymorphicClassName;
     variant?: "normal" | "tight" | undefined;
     portal?: string | React_2.RefObject<HTMLElement> | undefined;
     renderItem?: ((item: DropdownItemOption) => React_2.ReactNode) | undefined;
+    zIndex?: Property.ZIndex | undefined;
     onItemClick?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     listOverflow?: Property.Overflow | undefined;
     listHeight?: Property.Height<string | number> | undefined;

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -1555,6 +1555,7 @@ default: PolymorphicClassName;
     variant?: "normal" | "tight" | undefined;
     portal?: string | React_2.RefObject<HTMLElement> | undefined;
     renderItem?: ((item: DropdownItemOption) => React_2.ReactNode) | undefined;
+    zIndex?: Property.ZIndex | undefined;
     onItemClick?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     listOverflow?: Property.Overflow | undefined;
     listHeight?: Property.Height<string | number> | undefined;

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -1606,6 +1606,7 @@ default: PolymorphicClassName;
     variant?: "normal" | "tight" | undefined;
     portal?: string | React_2.RefObject<HTMLElement> | undefined;
     renderItem?: ((item: DropdownItemOption) => React_2.ReactNode) | undefined;
+    zIndex?: Property.ZIndex | undefined;
     onItemClick?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     listOverflow?: Property.Overflow | undefined;
     listHeight?: Property.Height<string | number> | undefined;

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -1608,6 +1608,7 @@ default: PolymorphicClassName;
     variant?: "normal" | "tight" | undefined;
     portal?: string | React_2.RefObject<HTMLElement> | undefined;
     renderItem?: ((item: DropdownItemOption) => React_2.ReactNode) | undefined;
+    zIndex?: Property.ZIndex | undefined;
     onItemClick?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     listOverflow?: Property.Overflow | undefined;
     listHeight?: Property.Height<string | number> | undefined;

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -1606,6 +1606,7 @@ default: PolymorphicClassName;
     variant?: "normal" | "tight" | undefined;
     portal?: string | React_2.RefObject<HTMLElement> | undefined;
     renderItem?: ((item: DropdownItemOption) => React_2.ReactNode) | undefined;
+    zIndex?: Property.ZIndex | undefined;
     onItemClick?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     listOverflow?: Property.Overflow | undefined;
     listHeight?: Property.Height<string | number> | undefined;


### PR DESCRIPTION
## Core
### Dropdown, Select, Combobox

- добавлено свойство `zIndex`;

### What/why changed
По просьбам нуждающихся и облегчения работы со слоями мы вынесли управление слоями выпадающих меню наружу. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.223.2-canary.1631.12232898742.0
  npm install @salutejs/plasma-b2c@1.465.2-canary.1631.12232898742.0
  npm install @salutejs/plasma-new-hope@0.212.2-canary.1631.12232898742.0
  npm install @salutejs/plasma-web@1.467.2-canary.1631.12232898742.0
  npm install @salutejs/sdds-cs@0.196.2-canary.1631.12232898742.0
  npm install @salutejs/sdds-dfa@0.193.2-canary.1631.12232898742.0
  npm install @salutejs/sdds-finportal@0.187.2-canary.1631.12232898742.0
  npm install @salutejs/sdds-insol@0.188.2-canary.1631.12232898742.0
  npm install @salutejs/sdds-serv@0.195.2-canary.1631.12232898742.0
  # or 
  yarn add @salutejs/plasma-asdk@0.223.2-canary.1631.12232898742.0
  yarn add @salutejs/plasma-b2c@1.465.2-canary.1631.12232898742.0
  yarn add @salutejs/plasma-new-hope@0.212.2-canary.1631.12232898742.0
  yarn add @salutejs/plasma-web@1.467.2-canary.1631.12232898742.0
  yarn add @salutejs/sdds-cs@0.196.2-canary.1631.12232898742.0
  yarn add @salutejs/sdds-dfa@0.193.2-canary.1631.12232898742.0
  yarn add @salutejs/sdds-finportal@0.187.2-canary.1631.12232898742.0
  yarn add @salutejs/sdds-insol@0.188.2-canary.1631.12232898742.0
  yarn add @salutejs/sdds-serv@0.195.2-canary.1631.12232898742.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
