### PR TITLE
PLASMA-4011: изменение типа leftHelper для TextField и TextArea

### DIFF
--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.types.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.types.tsx
@@ -192,7 +192,7 @@ export type TextAreaPropsBase = {
     /**
      * Вспомогательный текст снизу слева для поля ввода.
      */
-    leftHelper?: string;
+    leftHelper?: ReactNode;
     /**
      * Вспомогательный текст снизу справа для поля ввода.
      */

--- a/packages/plasma-new-hope/src/components/TextField/TextField.types.ts
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.types.ts
@@ -200,7 +200,7 @@ export type TextFieldPropsBase = {
     /**
      * Вспомогательный текст снизу слева для поля ввода.
      */
-    leftHelper?: string;
+    leftHelper?: ReactNode;
     /**
      * Слот для контента слева.
      */


### PR DESCRIPTION
## Core

### TextField, TextArea
- тип `leftHelper` изменен с `string` на `ReactNode`

### What/why changed

Необходима возможность прокинуть ссылку в helperText
