### PR TITLE
PLASMA-4116: изменен уровень передачи rest в Popup

### DIFF
--- a/packages/plasma-b2c/src/components/Drawer/Drawer.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Drawer/Drawer.component-test.tsx
@@ -15,6 +15,7 @@ type DrawerDemoProps = {
     closePlacement?: string;
     hasClose?: boolean;
     asModal?: boolean;
+    'data-testid'?: string;
 };
 
 const Icon = () => <IconDone color="inherit" size="s" />;
@@ -50,6 +51,7 @@ describe('plasma-b2c: Drawer', () => {
             asModal = true,
             closeOnEsc = false,
             closeOnOverlayClick = false,
+            'data-testid': testId,
         } = props;
 
         return (
@@ -65,6 +67,7 @@ describe('plasma-b2c: Drawer', () => {
                     closeOnOverlayClick={closeOnOverlayClick}
                     width={width}
                     height={height}
+                    data-testid={testId}
                 >
                     <DrawerHeader
                         closePlacement={closePlacement}
@@ -271,5 +274,21 @@ describe('plasma-b2c: Drawer', () => {
         cy.get('button').click();
 
         cy.matchImageSnapshot();
+    });
+
+    it('prop: data-attrs', () => {
+        mount(
+            <CypressTestDecorator>
+                <NoAnimationStyle />
+
+                <PopupBaseProvider>
+                    <Demo data-testid="test-data-id" />
+                </PopupBaseProvider>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('button').click();
+
+        cy.get('.popup-base-root').should('have.attr', 'data-testid', 'test-data-id');
     });
 });

--- a/packages/plasma-new-hope/src/components/Popup/Popup.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.tsx
@@ -131,7 +131,7 @@ export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
             );
 
             const rootNode = (
-                <Root className={cls} {...rest}>
+                <Root className={cls}>
                     {overlay}
                     <PopupRoot
                         id={innerId}
@@ -141,6 +141,7 @@ export const popupRoot = (Root: RootProps<HTMLDivElement, PopupProps>) =>
                         frame={frame}
                         animationInfo={animationInfo}
                         setVisible={setVisible}
+                        {...rest}
                     >
                         {children}
                     </PopupRoot>

--- a/packages/plasma-web/src/components/Drawer/Drawer.component-test.tsx
+++ b/packages/plasma-web/src/components/Drawer/Drawer.component-test.tsx
@@ -17,6 +17,7 @@ type DrawerDemoProps = {
     closePlacement?: string;
     hasClose?: boolean;
     asModal?: boolean;
+    'data-testid'?: string;
 };
 
 const StandardTypoStyle = createGlobalStyle(standardTypo);
@@ -60,6 +61,7 @@ describe('plasma-b2c: Drawer', () => {
             asModal = true,
             closeOnEsc = false,
             closeOnOverlayClick = false,
+            'data-testid': testId,
         } = props;
 
         return (
@@ -75,6 +77,7 @@ describe('plasma-b2c: Drawer', () => {
                     closeOnOverlayClick={closeOnOverlayClick}
                     width={width}
                     height={height}
+                    data-testid={testId}
                 >
                     <DrawerHeader
                         closePlacement={closePlacement}
@@ -281,5 +284,21 @@ describe('plasma-b2c: Drawer', () => {
         cy.get('button').click();
 
         cy.matchImageSnapshot();
+    });
+
+    it('prop: data-attrs', () => {
+        mount(
+            <CypressTestDecorator>
+                <NoAnimationStyle />
+
+                <PopupBaseProvider>
+                    <Demo data-testid="test-data-id" />
+                </PopupBaseProvider>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('button').click();
+
+        cy.get('.popup-base-root').should('have.attr', 'data-testid', 'test-data-id');
     });
 });

--- a/packages/plasma-web/src/components/PopupBase/PopupBase.component-test.tsx
+++ b/packages/plasma-web/src/components/PopupBase/PopupBase.component-test.tsx
@@ -185,4 +185,20 @@ describe('plasma-web: PopupBase', () => {
         cy.get('button').contains('Open popup B').click();
         cy.matchImageSnapshot();
     });
+
+    it('prop: data-attrs', () => {
+        mount(
+            <CypressTestDecorator>
+                <PopupBaseProvider>
+                    <PopupBase opened data-testid="test-data-id">
+                        <Content>
+                            <Headline3>Popup</Headline3>
+                        </Content>
+                    </PopupBase>
+                </PopupBaseProvider>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('.popup-base-root').should('have.attr', 'data-testid', 'test-data-id');
+    });
 });


### PR DESCRIPTION
## Core

### Popup, Drawer

- rest аргументы прокидываются на уровень `.popup-base-root` элемента 

### What/why changed

Нужно пробрасывать data-аттрибуты на уровень ниже в Popup
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.228.0-canary.1636.12271985293.0
  npm install @salutejs/plasma-b2c@1.470.0-canary.1636.12271985293.0
  npm install @salutejs/plasma-new-hope@0.217.0-canary.1636.12271985293.0
  npm install @salutejs/plasma-web@1.472.0-canary.1636.12271985293.0
  npm install @salutejs/sdds-cs@0.201.0-canary.1636.12271985293.0
  npm install @salutejs/sdds-dfa@0.198.0-canary.1636.12271985293.0
  npm install @salutejs/sdds-finportal@0.192.0-canary.1636.12271985293.0
  npm install @salutejs/sdds-insol@0.193.0-canary.1636.12271985293.0
  npm install @salutejs/sdds-serv@0.200.0-canary.1636.12271985293.0
  # or 
  yarn add @salutejs/plasma-asdk@0.228.0-canary.1636.12271985293.0
  yarn add @salutejs/plasma-b2c@1.470.0-canary.1636.12271985293.0
  yarn add @salutejs/plasma-new-hope@0.217.0-canary.1636.12271985293.0
  yarn add @salutejs/plasma-web@1.472.0-canary.1636.12271985293.0
  yarn add @salutejs/sdds-cs@0.201.0-canary.1636.12271985293.0
  yarn add @salutejs/sdds-dfa@0.198.0-canary.1636.12271985293.0
  yarn add @salutejs/sdds-finportal@0.192.0-canary.1636.12271985293.0
  yarn add @salutejs/sdds-insol@0.193.0-canary.1636.12271985293.0
  yarn add @salutejs/sdds-serv@0.200.0-canary.1636.12271985293.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
