### PR TITLE
Plasma 3734: Support React-hook-form select

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/SelectNative/SelectNative.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/SelectNative/SelectNative.tsx
@@ -21,13 +21,6 @@ export const SelectNative = forwardRef<HTMLInputElement, Props>(
         const options = Array.from(items.keys());
 
         useLayoutEffect(() => {
-            const event = createEvent(selectRef);
-            if (onChange) {
-                onChange(event);
-            }
-        }, [values]);
-
-        useLayoutEffect(() => {
             if (selectRef.current && !multiple) {
                 const valueInit = selectRef.current.value;
 
@@ -43,6 +36,13 @@ export const SelectNative = forwardRef<HTMLInputElement, Props>(
                 }
             }
         }, []);
+
+        useLayoutEffect(() => {
+            const event = createEvent(selectRef);
+            if (onChange) {
+                onChange(event);
+            }
+        }, [values]);
 
         return (
             <>

--- a/packages/plasma-new-hope/src/components/Select/Select.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.types.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, ButtonHTMLAttributes, SyntheticEvent } from 'react';
+import type { CSSProperties, ButtonHTMLAttributes, SyntheticEvent, ChangeEventHandler } from 'react';
 import React from 'react';
 
 import type { RequiredProps, LabelProps } from '../TextField/TextField.types';
@@ -63,28 +63,69 @@ type Target = LabelProps &
           }
     );
 
+// type IsMultiselect<K extends ItemOption> =
+//     | {
+//           multiselect?: false;
+//           value?: string;
+//           onChange?: (value: string) => void;
+//           /**
+//            * Если включено - будет выведено общее количество выбранных элементов вместо перечисления.
+//            * @default false
+//            */
+//           isTargetAmount?: never | false;
+//           /**
+//            * Callback для кастомной настройки таргета целиком.
+//            */
+//           renderTarget?: (value: K) => React.ReactNode;
+//       }
+//     | {
+//           multiselect: true;
+//           value?: Array<string>;
+//           onChange?: (value: Array<string>) => void;
+//           isTargetAmount?: boolean;
+//           renderTarget?: (value: K[]) => React.ReactNode;
+//       };
+
 type IsMultiselect<K extends ItemOption> =
-    | {
-          multiselect?: false;
-          value?: string;
-          onChange?: (value: string) => void;
-          /**
-           * Если включено - будет выведено общее количество выбранных элементов вместо перечисления.
-           * @default false
-           */
-          isTargetAmount?: never | false;
-          /**
-           * Callback для кастомной настройки таргета целиком.
-           */
-          renderTarget?: (value: K) => React.ReactNode;
-      }
-    | {
-          multiselect: true;
-          value?: Array<string>;
-          onChange?: (value: Array<string>) => void;
-          isTargetAmount?: boolean;
-          renderTarget?: (value: K[]) => React.ReactNode;
-      };
+    | ({ name?: never; defaultValue?: never } & (
+          | {
+                multiselect?: false;
+                value?: string;
+                onChange?: (value: string) => void;
+                /**
+                 * Если включено - будет выведено общее количество выбранных элементов вместо перечисления.
+                 * @default false
+                 */
+                isTargetAmount?: never | false;
+                /**
+                 * Callback для кастомной настройки значения в селекте.
+                 */
+                renderTarget?: (value: K) => React.ReactNode;
+            }
+          | {
+                multiselect: true;
+                value?: Array<string>;
+                onChange?: (value: string[]) => void;
+                isTargetAmount?: true;
+                renderTarget?: (value: K[]) => React.ReactNode;
+            }
+      ))
+    | ({ name: string; onChange?: ChangeEventHandler } & (
+          | {
+                multiselect?: false;
+                defaultValue?: string;
+                value?: never;
+                isTargetAmount?: never | false;
+                renderTarget?: (value: K) => React.ReactNode;
+            }
+          | {
+                multiselect: true;
+                defaultValue?: Array<string>;
+                value?: never;
+                isTargetAmount?: true;
+                renderTarget?: (value: K[]) => React.ReactNode;
+            }
+      ));
 
 export interface BasicProps<K extends ItemOption> {
     /**
@@ -174,7 +215,10 @@ export interface BasicProps<K extends ItemOption> {
 export type SelectProps<K extends ItemOption = ItemOption> = BasicProps<K> &
     IsMultiselect<K> &
     Target &
-    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'onChange' | 'onResize' | 'onResizeCapture' | 'nonce'>;
+    Omit<
+        ButtonHTMLAttributes<HTMLButtonElement>,
+        'value' | 'onChange' | 'onResize' | 'onResizeCapture' | 'nonce' | 'name' | 'defaultValue'
+    >;
 
 export type { ItemOption as ItemOptionSelect };
 

--- a/packages/plasma-new-hope/src/components/Select/Select.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.types.ts
@@ -63,29 +63,6 @@ type Target = LabelProps &
           }
     );
 
-// type IsMultiselect<K extends ItemOption> =
-//     | {
-//           multiselect?: false;
-//           value?: string;
-//           onChange?: (value: string) => void;
-//           /**
-//            * Если включено - будет выведено общее количество выбранных элементов вместо перечисления.
-//            * @default false
-//            */
-//           isTargetAmount?: never | false;
-//           /**
-//            * Callback для кастомной настройки таргета целиком.
-//            */
-//           renderTarget?: (value: K) => React.ReactNode;
-//       }
-//     | {
-//           multiselect: true;
-//           value?: Array<string>;
-//           onChange?: (value: Array<string>) => void;
-//           isTargetAmount?: boolean;
-//           renderTarget?: (value: K[]) => React.ReactNode;
-//       };
-
 type IsMultiselect<K extends ItemOption> =
     | ({ name?: never; defaultValue?: never } & (
           | {

--- a/packages/plasma-new-hope/src/components/Select/ui/SelectNative/SelectNative.styles.ts
+++ b/packages/plasma-new-hope/src/components/Select/ui/SelectNative/SelectNative.styles.ts
@@ -1,0 +1,7 @@
+import { styled } from '@linaria/react';
+
+import { applyHidden } from '../../../../mixins';
+
+export const SelectHidden = styled.select`
+    ${applyHidden()};
+`;

--- a/packages/plasma-new-hope/src/components/Select/ui/SelectNative/SelectNative.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/SelectNative/SelectNative.tsx
@@ -1,0 +1,66 @@
+import React, { ChangeEvent, forwardRef, useLayoutEffect, useRef } from 'react';
+import { useForkRef } from '@salutejs/plasma-core';
+
+import { createEvent } from '../../../../utils';
+import { SelectProps } from '../../Select.types';
+import { ValueToItemMapType } from '../../hooks/usePathMaps';
+
+import { SelectHidden } from './SelectNative.styles';
+
+type Props = Pick<SelectProps, 'name' | 'multiselect'> & {
+    onChange: (newValue: ChangeEvent<HTMLSelectElement> | null) => void;
+    onSetValue: (value: string | string[]) => void;
+    items: ValueToItemMapType;
+    value: string | number | Array<string | number>;
+};
+
+export const SelectNative = forwardRef<HTMLButtonElement, Props>(
+    ({ name, multiselect, items, value, onChange, onSetValue }, ref) => {
+        const values = (multiselect ? value : [value]) as string[];
+        const selectRef = useRef<HTMLSelectElement>(null);
+        const forkRef = useForkRef(selectRef, ref as any);
+        const options = Array.from(items.keys());
+
+        useLayoutEffect(() => {
+            const event = createEvent(selectRef);
+            if (onChange) {
+                onChange(event);
+            }
+        }, [values]);
+
+        useLayoutEffect(() => {
+            if (selectRef.current && !multiselect) {
+                const valueInit = selectRef.current.value;
+
+                if (valueInit) {
+                    onSetValue(valueInit);
+                }
+            }
+
+            if (selectRef.current && multiselect) {
+                const valuesInit = Array.from(selectRef.current.selectedOptions).map((v) => v.value);
+                if (valuesInit.length !== 0) {
+                    onSetValue(valuesInit);
+                }
+            }
+        }, []);
+
+        return (
+            <>
+                <SelectHidden
+                    ref={forkRef}
+                    multiple={multiselect}
+                    name={name}
+                    hidden
+                    value={multiselect ? values : values[0]}
+                >
+                    {options.map((v) => (
+                        <option key={v} value={v}>
+                            {v}
+                        </option>
+                    ))}
+                </SelectHidden>
+            </>
+        );
+    },
+);

--- a/packages/plasma-new-hope/src/components/Select/ui/SelectNative/SelectNative.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/SelectNative/SelectNative.tsx
@@ -22,13 +22,6 @@ export const SelectNative = forwardRef<HTMLButtonElement, Props>(
         const options = Array.from(items.keys());
 
         useLayoutEffect(() => {
-            const event = createEvent(selectRef);
-            if (onChange) {
-                onChange(event);
-            }
-        }, [values]);
-
-        useLayoutEffect(() => {
             if (selectRef.current && !multiselect) {
                 const valueInit = selectRef.current.value;
 
@@ -44,6 +37,13 @@ export const SelectNative = forwardRef<HTMLButtonElement, Props>(
                 }
             }
         }, []);
+
+        useLayoutEffect(() => {
+            const event = createEvent(selectRef);
+            if (onChange) {
+                onChange(event);
+            }
+        }, [values]);
 
         return (
             <>

--- a/scaffold/template-docs/docs/form/Components.mdx
+++ b/scaffold/template-docs/docs/form/Components.mdx
@@ -76,7 +76,7 @@ sidebar_position: 4
 
 
 
-### Combobox
+### Combobox и Select
 
 #### React Hook Form
 
@@ -87,7 +87,7 @@ sidebar_position: 4
 Изначальные значения задаются в defaultValue через параметр в компоненте. Возвращаемый и изначальный тип `string`.
 
 
-### Combobox Multiple
+### Combobox Multiple и Select Multi
 
 #### React Hook Form
 
@@ -103,6 +103,9 @@ sidebar_position: 4
     ...
     ['combobox': 'test_1'],
     ['combobox': 'test_2'],
+    ...
+    ['select': 'test_1'],
+    ['select': 'test_2'],
     ...
     ['textfield2': 'test'],
 ]

--- a/scaffold/template-docs/docs/form/NativeForm.mdx
+++ b/scaffold/template-docs/docs/form/NativeForm.mdx
@@ -87,6 +87,219 @@ export function App() {
         { label: 'Виктор Рыбаков' },
         { label: 'Лилия Макарова' },
     ];
+
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />

--- a/scaffold/template-docs/docs/form/ReactHookForm.mdx
+++ b/scaffold/template-docs/docs/form/ReactHookForm.mdx
@@ -77,6 +77,218 @@ export function App() {
         { label: 'Лилия Макарова' },
     ];
 
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     const { register, handleSubmit } = useForm();
     const onSubmit = (data) => {
         console.log(data);
@@ -105,8 +317,10 @@ export function App() {
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox {...register('combobox')} />
-            <Combobox {...register('comboboxMultiple')} />
+            <Combobox {...register('combobox')} items={items} />
+            <Combobox {...register('comboboxMultiple')} items={items} />
+            <Select {...register('select')} items={items} />
+            <Select {...register('selectMulti')} items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/plasma-b2c-docs/docs/form/Components.mdx
+++ b/website/plasma-b2c-docs/docs/form/Components.mdx
@@ -76,7 +76,7 @@ sidebar_position: 4
 
 
 
-### Combobox
+### Combobox и Select
 
 #### React Hook Form
 
@@ -87,7 +87,7 @@ sidebar_position: 4
 Изначальные значения задаются в defaultValue через параметр в компоненте. Возвращаемый и изначальный тип `string`.
 
 
-### Combobox Multiple
+### Combobox Multiple и Multiselect
 
 #### React Hook Form
 
@@ -103,6 +103,9 @@ sidebar_position: 4
     ...
     ['combobox': 'test_1'],
     ['combobox': 'test_2'],
+    ...
+    ['select': 'test_1'],
+    ['select': 'test_2'],
     ...
     ['textfield2': 'test'],
 ]

--- a/website/plasma-b2c-docs/docs/form/NativeForm.mdx
+++ b/website/plasma-b2c-docs/docs/form/NativeForm.mdx
@@ -88,6 +88,218 @@ export function App() {
         { label: 'Лилия Макарова' },
     ];
 
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -111,7 +323,8 @@ export function App() {
              <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox label="Combobox" name="combobox" />
+            <Combobox label="Combobox" name="combobox" items={items} />
+            <Select label="Combobox" name="combobox" items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/plasma-b2c-docs/docs/form/ReactHookForm.mdx
+++ b/website/plasma-b2c-docs/docs/form/ReactHookForm.mdx
@@ -77,6 +77,218 @@ export function App() {
         { label: 'Лилия Макарова' },
     ];
 
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     const { register, handleSubmit } = useForm();
     const onSubmit = (data) => {
         console.log(data);
@@ -105,8 +317,10 @@ export function App() {
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox {...register('combobox')} />
-            <Combobox {...register('comboboxMultiple')} />
+            <Combobox {...register('combobox')} items={items} />
+            <Combobox {...register('comboboxMultiple')} items={items} />
+            <Select {...register('select')} items={items} />
+            <Select {...register('selectMulti')} items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/plasma-web-docs/docs/form/Components.mdx
+++ b/website/plasma-web-docs/docs/form/Components.mdx
@@ -76,7 +76,7 @@ sidebar_position: 4
 
 
 
-### Combobox
+### Combobox и Select
 
 #### React Hook Form
 
@@ -87,7 +87,7 @@ sidebar_position: 4
 Изначальные значения задаются в defaultValue через параметр в компоненте. Возвращаемый и изначальный тип `string`.
 
 
-### Combobox Multiple
+### Combobox Multiple и Select Multi
 
 #### React Hook Form
 
@@ -103,6 +103,9 @@ sidebar_position: 4
     ...
     ['combobox': 'test_1'],
     ['combobox': 'test_2'],
+    ...
+    ['select': 'test_1'],
+    ['select': 'test_2'],
     ...
     ['textfield2': 'test'],
 ]

--- a/website/plasma-web-docs/docs/form/NativeForm.mdx
+++ b/website/plasma-web-docs/docs/form/NativeForm.mdx
@@ -87,6 +87,219 @@ export function App() {
         { label: 'Виктор Рыбаков' },
         { label: 'Лилия Макарова' },
     ];
+
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -110,7 +323,8 @@ export function App() {
              <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox label="Combobox" name="combobox" />
+            <Combobox label="Combobox" name="combobox" items={items} />
+            <Select label="Combobox" name="combobox" items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/plasma-web-docs/docs/form/ReactHookForm.mdx
+++ b/website/plasma-web-docs/docs/form/ReactHookForm.mdx
@@ -77,6 +77,218 @@ export function App() {
         { label: 'Лилия Макарова' },
     ];
 
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     const { register, handleSubmit } = useForm();
     const onSubmit = (data) => {
         console.log(data);
@@ -105,8 +317,10 @@ export function App() {
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox {...register('combobox')} />
-            <Combobox {...register('comboboxMultiple')} />
+            <Combobox {...register('combobox')} items={items} />
+            <Combobox {...register('comboboxMultiple')} items={items} />
+            <Select {...register('select')} items={items} />
+            <Select {...register('selectMulti')} items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-cs-docs/docs/form/Components.mdx
+++ b/website/sdds-cs-docs/docs/form/Components.mdx
@@ -76,7 +76,7 @@ sidebar_position: 4
 
 
 
-### Combobox
+### Combobox и Select
 
 #### React Hook Form
 
@@ -87,7 +87,7 @@ sidebar_position: 4
 Изначальные значения задаются в defaultValue через параметр в компоненте. Возвращаемый и изначальный тип `string`.
 
 
-### Combobox Multiple
+### Combobox Multiple и Select Multi
 
 #### React Hook Form
 
@@ -103,6 +103,9 @@ sidebar_position: 4
     ...
     ['combobox': 'test_1'],
     ['combobox': 'test_2'],
+    ...
+    ['select': 'test_1'],
+    ['select': 'test_2'],
     ...
     ['textfield2': 'test'],
 ]

--- a/website/sdds-cs-docs/docs/form/NativeForm.mdx
+++ b/website/sdds-cs-docs/docs/form/NativeForm.mdx
@@ -87,6 +87,219 @@ export function App() {
         { label: 'Виктор Рыбаков' },
         { label: 'Лилия Макарова' },
     ];
+
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -110,7 +323,8 @@ export function App() {
              <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox label="Combobox" name="combobox" />
+            <Combobox label="Combobox" name="combobox" items={items} />
+            <Select label="Combobox" name="combobox" items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-cs-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-cs-docs/docs/form/ReactHookForm.mdx
@@ -77,6 +77,218 @@ export function App() {
         { label: 'Лилия Макарова' },
     ];
 
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     const { register, handleSubmit } = useForm();
     const onSubmit = (data) => {
         console.log(data);
@@ -105,8 +317,10 @@ export function App() {
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox {...register('combobox')} />
-            <Combobox {...register('comboboxMultiple')} />
+            <Combobox {...register('combobox')} items={items} />
+            <Combobox {...register('comboboxMultiple')} items={items} />
+            <Select {...register('select')} items={items} />
+            <Select {...register('selectMulti')} items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-dfa-docs/docs/form/Components.mdx
+++ b/website/sdds-dfa-docs/docs/form/Components.mdx
@@ -76,7 +76,7 @@ sidebar_position: 4
 
 
 
-### Combobox
+### Combobox и Select
 
 #### React Hook Form
 
@@ -87,7 +87,7 @@ sidebar_position: 4
 Изначальные значения задаются в defaultValue через параметр в компоненте. Возвращаемый и изначальный тип `string`.
 
 
-### Combobox Multiple
+### Combobox Multiple и Select Multi
 
 #### React Hook Form
 
@@ -103,6 +103,9 @@ sidebar_position: 4
     ...
     ['combobox': 'test_1'],
     ['combobox': 'test_2'],
+    ...
+    ['select': 'test_1'],
+    ['select': 'test_2'],
     ...
     ['textfield2': 'test'],
 ]

--- a/website/sdds-dfa-docs/docs/form/NativeForm.mdx
+++ b/website/sdds-dfa-docs/docs/form/NativeForm.mdx
@@ -87,6 +87,219 @@ export function App() {
         { label: 'Виктор Рыбаков' },
         { label: 'Лилия Макарова' },
     ];
+
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -110,7 +323,8 @@ export function App() {
              <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox label="Combobox" name="combobox" />
+            <Combobox label="Combobox" name="combobox" items={items} />
+            <Select label="Combobox" name="combobox" items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-dfa-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-dfa-docs/docs/form/ReactHookForm.mdx
@@ -75,6 +75,218 @@ export function App() {
         { label: 'Лилия Макарова' },
     ];
 
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     const { register, handleSubmit } = useForm();
     const onSubmit = (data) => {
         console.log(data);
@@ -103,8 +315,10 @@ export function App() {
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox {...register('combobox')} />
-            <Combobox {...register('comboboxMultiple')} />
+            <Combobox {...register('combobox')} items={items} />
+            <Combobox {...register('comboboxMultiple')} items={items} />
+            <Select {...register('select')} items={items} />
+            <Select {...register('selectMulti')} items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-insol-docs/docs/form/NativeForm.mdx
+++ b/website/sdds-insol-docs/docs/form/NativeForm.mdx
@@ -87,6 +87,219 @@ export function App() {
         { label: 'Виктор Рыбаков' },
         { label: 'Лилия Макарова' },
     ];
+
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -110,7 +323,8 @@ export function App() {
              <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox label="Combobox" name="combobox" />
+            <Combobox label="Combobox" name="combobox" items={items} />
+            <Select label="Combobox" name="combobox" items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-insol-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-insol-docs/docs/form/ReactHookForm.mdx
@@ -75,6 +75,218 @@ export function App() {
         { label: 'Лилия Макарова' },
     ];
 
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     const { register, handleSubmit } = useForm();
     const onSubmit = (data) => {
         console.log(data);
@@ -103,8 +315,10 @@ export function App() {
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox {...register('combobox')} />
-            <Combobox {...register('comboboxMultiple')} />
+            <Combobox {...register('combobox')} items={items} />
+            <Combobox {...register('comboboxMultiple')} items={items} />
+            <Select {...register('select')} items={items} />
+            <Select {...register('selectMulti')} items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-serv-docs/docs/form/NativeForm.mdx
+++ b/website/sdds-serv-docs/docs/form/NativeForm.mdx
@@ -87,6 +87,219 @@ export function App() {
         { label: 'Виктор Рыбаков' },
         { label: 'Лилия Макарова' },
     ];
+
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     return (
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <TextField name="textfield" placeholder="Textfield" />
@@ -110,7 +323,8 @@ export function App() {
              <Slider name="slider" label="Slider" type="single" min={0} max={100} />
             <DatePicker label="DatePicker" name="datepicker" />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox label="Combobox" name="combobox" />
+            <Combobox label="Combobox" name="combobox" items={items} />
+            <Select label="Combobox" name="combobox" items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );

--- a/website/sdds-serv-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-serv-docs/docs/form/ReactHookForm.mdx
@@ -77,6 +77,218 @@ export function App() {
         { label: 'Лилия Макарова' },
     ];
 
+    const items = [
+        {
+            value: 'north_america',
+            label: 'Северная Америка',
+        },
+        {
+            value: 'south_america',
+            label: 'Южная Америка',
+            items: [
+                {
+                    value: 'brazil',
+                    label: 'Бразилия',
+                    items: [
+                        {
+                            value: 'rio_de_janeiro',
+                            label: 'Рио-де-Жанейро',
+                        },
+                        {
+                            value: 'sao_paulo',
+                            label: 'Сан-Паулу',
+                        },
+                    ],
+                },
+                {
+                    value: 'argentina',
+                    label: 'Аргентина',
+                    items: [
+                        {
+                            value: 'buenos_aires',
+                            label: 'Буэнос-Айрес',
+                        },
+                        {
+                            value: 'cordoba',
+                            label: 'Кордова',
+                        },
+                    ],
+                },
+                {
+                    value: 'colombia',
+                    label: 'Колумбия',
+                    items: [
+                        {
+                            value: 'bogota',
+                            label: 'Богота',
+                        },
+                        {
+                            value: 'medellin',
+                            label: 'Медельин',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'europe',
+            label: 'Европа',
+            items: [
+                {
+                    value: 'france',
+                    label: 'Франция',
+                    items: [
+                        {
+                            value: 'paris',
+                            label: 'Париж',
+                        },
+                        {
+                            value: 'lyon',
+                            label: 'Лион',
+                        },
+                    ],
+                },
+                {
+                    value: 'germany',
+                    label: 'Германия',
+                    items: [
+                        {
+                            value: 'berlin',
+                            label: 'Берлин',
+                        },
+                        {
+                            value: 'munich',
+                            label: 'Мюнхен',
+                        },
+                    ],
+                },
+                {
+                    value: 'italy',
+                    label: 'Италия',
+                    items: [
+                        {
+                            value: 'rome',
+                            label: 'Рим',
+                        },
+                        {
+                            value: 'milan',
+                            label: 'Милан',
+                        },
+                    ],
+                },
+                {
+                    value: 'spain',
+                    label: 'Испания',
+                    items: [
+                        {
+                            value: 'madrid',
+                            label: 'Мадрид',
+                        },
+                        {
+                            value: 'barcelona',
+                            label: 'Барселона',
+                        },
+                    ],
+                },
+                {
+                    value: 'united_kingdom',
+                    label: 'Великобритания',
+                    items: [
+                        {
+                            value: 'london',
+                            label: 'Лондон',
+                        },
+                        {
+                            value: 'manchester',
+                            label: 'Манчестер',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'asia',
+            label: 'Азия',
+            items: [
+                {
+                    value: 'china',
+                    label: 'Китай',
+                    items: [
+                        {
+                            value: 'beijing',
+                            label: 'Пекин',
+                        },
+                        {
+                            value: 'shanghai',
+                            label: 'Шанхай',
+                        },
+                    ],
+                },
+                {
+                    value: 'japan',
+                    label: 'Япония',
+                    items: [
+                        {
+                            value: 'tokyo',
+                            label: 'Токио',
+                        },
+                        {
+                            value: 'osaka',
+                            label: 'Осака',
+                        },
+                    ],
+                },
+                {
+                    value: 'india',
+                    label: 'Индия',
+                    items: [
+                        {
+                            value: 'delhi',
+                            label: 'Дели',
+                        },
+                        {
+                            value: 'mumbai',
+                            label: 'Мумбаи',
+                        },
+                    ],
+                },
+                {
+                    value: 'south_korea',
+                    label: 'Южная Корея',
+                    items: [
+                        {
+                            value: 'seoul',
+                            label: 'Сеул',
+                        },
+                        {
+                            value: 'busan',
+                            label: 'Пусан',
+                        },
+                    ],
+                },
+                {
+                    value: 'thailand',
+                    label: 'Таиланд',
+                    items: [
+                        {
+                            value: 'bangkok',
+                            label: 'Бангкок',
+                        },
+                        {
+                            value: 'phuket',
+                            label: 'Пхукет',
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            value: 'africa',
+            label: 'Африка',
+            isDisabled: true,
+        },
+    ];
+
     const { register, handleSubmit } = useForm();
     const onSubmit = (data) => {
         console.log(data);
@@ -105,8 +317,10 @@ export function App() {
             <Slider {...register('slider')} label="Slider" type="single" min={0} max={100} />
             <Slider {...register('sliderdouble')} label="Slider Double" type="double" min={0} max={100} />
             <Autocomplete suggestions={mockData} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите имя Алексей" />
-            <Combobox {...register('combobox')} />
-            <Combobox {...register('comboboxMultiple')} />
+            <Combobox {...register('combobox')} items={items} />
+            <Combobox {...register('comboboxMultiple')} items={items} />
+            <Select {...register('select')} items={items} />
+            <Select {...register('selectMulti')} items={items} />
             <Button type="submit">Отправить</Button>
         </form>
     );


### PR DESCRIPTION
## Core

### Select

- Добавлена поддержка `react-hook-form` для компонента `select`
- Обновлена документация 

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.234.0-canary.1639.12362024619.0
  npm install @salutejs/plasma-b2c@1.476.0-canary.1639.12362024619.0
  npm install @salutejs/plasma-new-hope@0.223.0-canary.1639.12362024619.0
  npm install @salutejs/plasma-web@1.478.0-canary.1639.12362024619.0
  npm install @salutejs/sdds-cs@0.208.0-canary.1639.12362024619.0
  npm install @salutejs/sdds-dfa@0.204.0-canary.1639.12362024619.0
  npm install @salutejs/sdds-finportal@0.198.0-canary.1639.12362024619.0
  npm install @salutejs/sdds-insol@0.199.0-canary.1639.12362024619.0
  npm install @salutejs/sdds-serv@0.206.0-canary.1639.12362024619.0
  # or 
  yarn add @salutejs/plasma-asdk@0.234.0-canary.1639.12362024619.0
  yarn add @salutejs/plasma-b2c@1.476.0-canary.1639.12362024619.0
  yarn add @salutejs/plasma-new-hope@0.223.0-canary.1639.12362024619.0
  yarn add @salutejs/plasma-web@1.478.0-canary.1639.12362024619.0
  yarn add @salutejs/sdds-cs@0.208.0-canary.1639.12362024619.0
  yarn add @salutejs/sdds-dfa@0.204.0-canary.1639.12362024619.0
  yarn add @salutejs/sdds-finportal@0.198.0-canary.1639.12362024619.0
  yarn add @salutejs/sdds-insol@0.199.0-canary.1639.12362024619.0
  yarn add @salutejs/sdds-serv@0.206.0-canary.1639.12362024619.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
