### PR TITLE
Plasma-4158: change rightHelper type for TextArea

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -3844,7 +3844,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3887,7 +3887,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3930,7 +3930,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3973,7 +3973,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -4016,7 +4016,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -4059,7 +4059,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -4102,7 +4102,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -4145,7 +4145,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.types.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.types.tsx
@@ -196,7 +196,7 @@ export type TextAreaPropsBase = {
     /**
      * Вспомогательный текст снизу справа для поля ввода.
      */
-    rightHelper?: string;
+    rightHelper?: ReactNode;
     /**
      * Расположение вспомогательного текста слева
      * @default 'inner'

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -3846,7 +3846,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3889,7 +3889,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3932,7 +3932,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3975,7 +3975,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -4018,7 +4018,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -4061,7 +4061,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -4104,7 +4104,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -4147,7 +4147,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -3062,7 +3062,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3105,7 +3105,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3148,7 +3148,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3191,7 +3191,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3234,7 +3234,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3277,7 +3277,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3320,7 +3320,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3363,7 +3363,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -3274,7 +3274,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3317,7 +3317,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3360,7 +3360,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3403,7 +3403,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3446,7 +3446,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3489,7 +3489,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3532,7 +3532,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3575,7 +3575,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -3327,7 +3327,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3370,7 +3370,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3413,7 +3413,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3456,7 +3456,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3499,7 +3499,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3542,7 +3542,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3585,7 +3585,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3628,7 +3628,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -3384,7 +3384,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3427,7 +3427,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3470,7 +3470,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3513,7 +3513,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3556,7 +3556,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3599,7 +3599,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3642,7 +3642,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3685,7 +3685,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -3370,7 +3370,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3413,7 +3413,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3456,7 +3456,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3499,7 +3499,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3542,7 +3542,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3585,7 +3585,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3628,7 +3628,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;
@@ -3671,7 +3671,7 @@ contentRight?: ReactElement<any, string | JSXElementConstructor<any>> | undefine
 resize?: "none" | "both" | "horizontal" | "vertical" | undefined;
 helperText?: string | undefined;
 leftHelper?: ReactNode;
-rightHelper?: string | undefined;
+rightHelper?: ReactNode;
 leftHelperPlacement?: "outer" | "inner" | undefined;
 } & {
 required?: boolean | undefined;


### PR DESCRIPTION
## Core

### TextArea

- изменен тип rightHelper с string на ReactNode

### What/why changed

Изменен тип rightHelper с string на ReactNode для TextArea

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.233.0-canary.1642.12348263740.0
  npm install @salutejs/plasma-b2c@1.475.0-canary.1642.12348263740.0
  npm install @salutejs/plasma-new-hope@0.222.0-canary.1642.12348263740.0
  npm install @salutejs/plasma-web@1.477.0-canary.1642.12348263740.0
  npm install @salutejs/sdds-cs@0.206.0-canary.1642.12348263740.0
  npm install @salutejs/sdds-dfa@0.203.0-canary.1642.12348263740.0
  npm install @salutejs/sdds-finportal@0.197.0-canary.1642.12348263740.0
  npm install @salutejs/sdds-insol@0.198.0-canary.1642.12348263740.0
  npm install @salutejs/sdds-serv@0.205.0-canary.1642.12348263740.0
  # or 
  yarn add @salutejs/plasma-asdk@0.233.0-canary.1642.12348263740.0
  yarn add @salutejs/plasma-b2c@1.475.0-canary.1642.12348263740.0
  yarn add @salutejs/plasma-new-hope@0.222.0-canary.1642.12348263740.0
  yarn add @salutejs/plasma-web@1.477.0-canary.1642.12348263740.0
  yarn add @salutejs/sdds-cs@0.206.0-canary.1642.12348263740.0
  yarn add @salutejs/sdds-dfa@0.203.0-canary.1642.12348263740.0
  yarn add @salutejs/sdds-finportal@0.197.0-canary.1642.12348263740.0
  yarn add @salutejs/sdds-insol@0.198.0-canary.1642.12348263740.0
  yarn add @salutejs/sdds-serv@0.205.0-canary.1642.12348263740.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
