### PR TITLE
PLASMA-4139: change accent hover from token to hex

### DIFF
--- a/packages/sdds-cs/src/components/Attach/Attach.config.ts
+++ b/packages/sdds-cs/src/components/Attach/Attach.config.ts
@@ -54,7 +54,7 @@ export const config = {
                 ${attachTokens.buttonValueColor}: var(--text-secondary);
                 ${attachTokens.buttonBackgroundColor}: var(--surface-solid-primary);
                 ${attachTokens.buttonLoadingBackgroundColor}: var(${attachTokens.buttonBackgroundColor});
-                ${attachTokens.buttonColorHover}: var(--text-accent-hover);
+                ${attachTokens.buttonColorHover}: #1A9E32;
                 ${attachTokens.buttonBackgroundColorHover}: var(--surface-solid-primary-hover);
                 ${attachTokens.buttonColorActive}: var(--text-accent-active);
                 ${attachTokens.buttonBackgroundColorActive}: var(--surface-solid-primary-active);
@@ -71,9 +71,9 @@ export const config = {
                 ${attachTokens.iconButtonColor}: var(--text-accent);
                 ${attachTokens.iconButtonBackgroundColor}: var(--surface-solid-primary);
                 ${attachTokens.iconButtonLoadingBackgroundColor}: var(${attachTokens.iconButtonBackgroundColor});
-                ${attachTokens.iconButtonColorHover}: var(--text-accent-hover);
+                ${attachTokens.iconButtonColorHover}: #1A9E32;
                 ${attachTokens.iconButtonBackgroundColorHover}: var(--surface-solid-primary-hover);
-                ${attachTokens.iconButtonColorActive}: var(--text-accent-hover);
+                ${attachTokens.iconButtonColorActive}: #1A9E32;
                 ${attachTokens.iconButtonBackgroundColorActive}: var(--surface-solid-primary-active);
 
                 ${attachTokens.iconButtonDisabledOpacity}: 0.4;

--- a/packages/sdds-cs/src/components/Autocomplete/Autocomplete.config.ts
+++ b/packages/sdds-cs/src/components/Autocomplete/Autocomplete.config.ts
@@ -30,7 +30,7 @@ export const config = {
                 ${tokens.textFieldContentSlotColorHover}: var(--text-secondary-hover);
                 ${tokens.textFieldContentSlotColorActive}: var(--text-secondary-active);
                 ${tokens.textFieldContentSlotRightColor}: var(--text-accent);
-                ${tokens.textFieldContentSlotRightColorHover}: var(--text-accent-hover);
+                ${tokens.textFieldContentSlotRightColorHover}: #1A9E32;
                 ${tokens.textFieldContentSlotRightColorActive}: var(--text-accent-active);
 
                 ${tokens.focusColor}: var(--surface-accent);
@@ -73,7 +73,7 @@ export const config = {
                 ${tokens.textFieldContentSlotColorHover}: var(--text-secondary-hover);
                 ${tokens.textFieldContentSlotColorActive}: var(--text-secondary-active);
                 ${tokens.textFieldContentSlotRightColor}: var(--text-accent);
-                ${tokens.textFieldContentSlotRightColorHover}: var(--text-accent-hover);
+                ${tokens.textFieldContentSlotRightColorHover}: #1A9E32;
                 ${tokens.textFieldContentSlotRightColorActive}: var(--text-accent-active);
 
                 ${tokens.focusColor}: var(--surface-accent);

--- a/packages/sdds-cs/src/components/Button/Button.config.ts
+++ b/packages/sdds-cs/src/components/Button/Button.config.ts
@@ -20,7 +20,7 @@ export const config = {
             `,
             secondary: css`
                 ${buttonTokens.buttonColor}: var(--text-accent);
-                ${buttonTokens.buttonColorHover}: var(--text-accent-hover);
+                ${buttonTokens.buttonColorHover}: #1A9E32;
                 ${buttonTokens.buttonColorActive}: var(--text-accent-active);
                 
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);

--- a/packages/sdds-cs/src/components/Combobox/Combobox.config.ts
+++ b/packages/sdds-cs/src/components/Combobox/Combobox.config.ts
@@ -34,7 +34,7 @@ export const config = {
                 ${tokens.textFieldContentSlotColorHover}: var(--text-secondary-hover);
                 ${tokens.textFieldContentSlotColorActive}: var(--text-secondary-active);
                 ${tokens.textFieldContentSlotRightColor}: var(--text-accent);
-                ${tokens.textFieldContentSlotRightColorHover}: var(--text-accent-hover);
+                ${tokens.textFieldContentSlotRightColorHover}: #1A9E32;
                 ${tokens.textFieldContentSlotRightColorActive}: var(--text-accent-active);
 
                 ${tokens.textFieldIndicatorColor}: var(--surface-negative);
@@ -55,7 +55,7 @@ export const config = {
                 ${tokens.dropdownBorderColor}: var(--surface-solid-primary);
 
                 ${tokens.disclosureIconColor}: var(--text-accent);
-                ${tokens.disclosureIconColorHover}: var(--text-accent-hover);
+                ${tokens.disclosureIconColorHover}: #1A9E32;
                 ${tokens.itemBackgroundHover}: var(--surface-transparent-accent);
             `,
             negative: css`
@@ -84,7 +84,7 @@ export const config = {
                 ${tokens.textFieldContentSlotColorHover}: var(--text-secondary-hover);
                 ${tokens.textFieldContentSlotColorActive}: var(--text-secondary-active);
                 ${tokens.textFieldContentSlotRightColor}: var(--text-accent);
-                ${tokens.textFieldContentSlotRightColorHover}: var(--text-accent-hover);
+                ${tokens.textFieldContentSlotRightColorHover}: #1A9E32;
                 ${tokens.textFieldContentSlotRightColorActive}: var(--text-accent-active);
 
                 ${tokens.textFieldIndicatorColor}: var(--surface-negative);
@@ -105,7 +105,7 @@ export const config = {
                 ${tokens.dropdownBorderColor}: var(--surface-solid-primary);
 
                 ${tokens.disclosureIconColor}: var(--text-accent);
-                ${tokens.disclosureIconColorHover}: var(--text-accent-hover);
+                ${tokens.disclosureIconColorHover}: #1A9E32;
                 ${tokens.itemBackgroundHover}: var(--surface-transparent-accent);
             `,
         },

--- a/packages/sdds-cs/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/sdds-cs/src/components/DatePicker/DatePicker.config.ts
@@ -79,7 +79,7 @@ export const config = {
                 ${tokens.iconButtonFocusColor}: var(--surface-accent);
 
                 ${tokens.textFieldContentRightSlotColor}: var(--text-accent);
-                ${tokens.textFieldContentRightSlotColorHover}: var(--text-accent-hover);
+                ${tokens.textFieldContentRightSlotColorHover}: #1A9E32;
             `,
         },
         size: {

--- a/packages/sdds-cs/src/components/IconButton/IconButton.config.ts
+++ b/packages/sdds-cs/src/components/IconButton/IconButton.config.ts
@@ -21,7 +21,7 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--text-accent);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-primary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-accent-hover);
+                ${iconButtonTokens.iconButtonColorHover}: #1A9E32;
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-primary-hover);
                 ${iconButtonTokens.iconButtonColorActive}: var(--text-accent-active);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-primary-active);

--- a/packages/sdds-cs/src/components/Link/Link.config.tsx
+++ b/packages/sdds-cs/src/components/Link/Link.config.tsx
@@ -50,10 +50,10 @@ export const config = {
             accent: css`
                 --plasma-link-font-family: var(--plasma-typo-text-m-font-family);
                 --plasma-link-color: var(--text-accent);
-                --plasma-link-color-hover: var(--text-accent-hover);
+                --plasma-link-color-hover: #1a9e32;
                 --plasma-link-color-active: var(--text-accent-active);
                 --plasma-link-color-visited: var(--text-accent);
-                --plasma-link-color-visited-hover: var(--text-accent-hover);
+                --plasma-link-color-visited-hover: #1a9e32;
                 --plasma-link-color-visited-active: var(--text-accent-active);
                 --plasma-link-underline-border: 0;
             `,

--- a/packages/sdds-cs/src/components/Notification/Notification.config.ts
+++ b/packages/sdds-cs/src/components/Notification/Notification.config.ts
@@ -54,7 +54,7 @@ export const config = {
                 ${notificationTokens.titleFontLineHeight}: var(--plasma-typo-body-m-line-height);
 
                 ${notificationTokens.closeIconColor}: var(--text-accent);
-                ${notificationTokens.closeIconColorOnHover}: var(--text-accent-hover);
+                ${notificationTokens.closeIconColorOnHover}: #1A9E32;
 
                 ${notificationTokens.horizontalLayoutGap}: 0.5rem;
                 ${notificationTokens.horizontalLayoutLeftIconMargin}: 0.75rem;

--- a/packages/sdds-cs/src/components/NumberInput/NumberInput.config.ts
+++ b/packages/sdds-cs/src/components/NumberInput/NumberInput.config.ts
@@ -22,7 +22,7 @@ export const config = {
 
                 ${tokens.iconButtonColor}: var(--text-accent);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-solid-card);
-                ${tokens.iconButtonColorSolidHover}: var(--text-accent-hover);
+                ${tokens.iconButtonColorSolidHover}: #1A9E32;
                 ${tokens.iconButtonColorSolidActive}: var(--text-accent-active);
 
                 ${tokens.actionButtonDisabledOpacity}: 0.4;

--- a/packages/sdds-cs/src/components/Segment/SegmentItem.config.ts
+++ b/packages/sdds-cs/src/components/Segment/SegmentItem.config.ts
@@ -10,7 +10,7 @@ export const config = {
             default: css`
                 ${segmentTokens.itemColor}: var(--text-accent);
                 ${segmentTokens.itemBackgroundColor}: transparent;
-                ${segmentTokens.itemColorHover}: var(--text-accent-hover);
+                ${segmentTokens.itemColorHover}: #1A9E32;
                 ${segmentTokens.itemBackgroundColorHover}: transparent;
                 ${segmentTokens.itemAdditionalColor}: var(--text-accent-minor);
                 ${segmentTokens.itemAdditionalColorHover}: var(--text-accent-minor);
@@ -26,7 +26,7 @@ export const config = {
             secondary: css`
                 ${segmentTokens.itemColor}: var(--text-accent);
                 ${segmentTokens.itemBackgroundColor}: transparent;
-                ${segmentTokens.itemColorHover}: var(--text-accent-hover);
+                ${segmentTokens.itemColorHover}: #1A9E32;
                 ${segmentTokens.itemBackgroundColorHover}: transparent;
                 ${segmentTokens.itemAdditionalColor}: var(--text-accent-minor);
                 ${segmentTokens.itemAdditionalColorHover}: var(--text-accent-minor);

--- a/packages/sdds-cs/src/components/Select/Select.config.ts
+++ b/packages/sdds-cs/src/components/Select/Select.config.ts
@@ -26,7 +26,7 @@ export const config = {
                 ${tokens.textFieldOptionalColor}: var(--text-tertiary);
 
                 ${selectTokens.buttonColor}: var(--text-accent);
-                ${selectTokens.buttonColorHover}: var(--text-accent-hover);
+                ${selectTokens.buttonColorHover}: #1A9E32;
                 ${selectTokens.buttonColorActive}: var(--text-accent-active);
                 ${selectTokens.buttonArrowColor}: var(--text-primary);
                 ${selectTokens.buttonArrowColorHover}: var(--text-primary-hover);
@@ -36,7 +36,7 @@ export const config = {
                 ${selectTokens.buttonBackgroundColorActive}: var(--surface-solid-primary-active);
 
                 ${selectTokens.disclosureIconColor}: var(--text-accent);
-                ${selectTokens.disclosureIconColorHover}: var(--text-accent-hover);
+                ${selectTokens.disclosureIconColorHover}: #1A9E32;
                 ${selectTokens.itemBackgroundHover}: var(--surface-transparent-accent);
 
                 ${selectTokens.dropdownBorderColor}: var(--outline-solid-primary);
@@ -58,7 +58,7 @@ export const config = {
                 ${tokens.textFieldOptionalColor}: var(--text-tertiary);
 
                 ${selectTokens.buttonColor}: var(--text-accent);
-                ${selectTokens.buttonColorHover}: var(--text-accent-hover);
+                ${selectTokens.buttonColorHover}: #1A9E32;
                 ${selectTokens.buttonColorActive}: var(--text-accent-active);
                 ${selectTokens.buttonArrowColor}: var(--text-primary);
                 ${selectTokens.buttonArrowColorHover}: var(--text-primary-hover);
@@ -68,7 +68,7 @@ export const config = {
                 ${selectTokens.buttonBackgroundColorActive}: var(--surface-solid-primary-active);
 
                 ${selectTokens.disclosureIconColor}: var(--text-accent);
-                ${selectTokens.disclosureIconColorHover}: var(--text-accent-hover);
+                ${selectTokens.disclosureIconColorHover}: #1A9E32;
                 ${selectTokens.itemBackgroundHover}: var(--surface-transparent-accent);
 
                 ${selectTokens.dropdownBorderColor}: var(--outline-solid-primary);

--- a/packages/sdds-cs/src/components/Tabs/horizontal/HorizontalTabItem.config.ts
+++ b/packages/sdds-cs/src/components/Tabs/horizontal/HorizontalTabItem.config.ts
@@ -62,7 +62,7 @@ export const config = {
                 ${tabsTokens.itemColor}: var(--text-accent);
                 ${tabsTokens.itemValueColor}: var(--text-secondary);
                 ${tabsTokens.itemBackgroundColor}: transparent;
-                ${tabsTokens.itemColorHover}: var(--text-accent-hover);
+                ${tabsTokens.itemColorHover}: #1A9E32;
                 ${tabsTokens.itemValueColorHover}: var(--text-secondary);
                 ${tabsTokens.itemColorActive}: var(--text-accent-active);
                 ${tabsTokens.itemValueColorActive}: var(--text-secondary);

--- a/packages/sdds-cs/src/components/Tabs/horizontal/HorizontalTabs.config.ts
+++ b/packages/sdds-cs/src/components/Tabs/horizontal/HorizontalTabs.config.ts
@@ -31,7 +31,7 @@ export const config = {
             `,
             divider: css`
                 ${tabsTokens.arrowColor}: var(--text-accent);
-                ${tabsTokens.arrowColorHover}: var(--text-accent-hover);
+                ${tabsTokens.arrowColorHover}: #1A9E32;
                 ${tabsTokens.arrowColorActive}: var(--text-accent-active);
                 ${tabsTokens.tabsBackgroundColor}: transparent;
                 ${tabsTokens.outlineFocusColor}: var(--surface-accent);

--- a/packages/sdds-cs/src/components/Tabs/vertical/VerticalTabItem.config.ts
+++ b/packages/sdds-cs/src/components/Tabs/vertical/VerticalTabItem.config.ts
@@ -11,7 +11,7 @@ export const config = {
                 ${tabsTokens.itemColor}: var(--text-accent);
                 ${tabsTokens.itemValueColor}: var(--text-secondary);
                 ${tabsTokens.itemBackgroundColor}: transparent;
-                ${tabsTokens.itemColorHover}: var(--text-accent-hover);
+                ${tabsTokens.itemColorHover}: #1A9E32;
                 ${tabsTokens.itemValueColorHover}: var(--text-secondary);
                 ${tabsTokens.itemColorActive}: var(--text-accent-active);
                 ${tabsTokens.itemValueColorActive}: var(--text-secondary);

--- a/packages/sdds-cs/src/components/Tabs/vertical/VerticalTabs.config.ts
+++ b/packages/sdds-cs/src/components/Tabs/vertical/VerticalTabs.config.ts
@@ -9,7 +9,7 @@ export const config = {
         view: {
             divider: css`
                 ${tabsTokens.arrowColor}: var(--text-accent);
-                ${tabsTokens.arrowColorHover}: var(--text-accent-hover);
+                ${tabsTokens.arrowColorHover}: #1A9E32;
                 ${tabsTokens.arrowColorActive}: var(--text-accent-active);
                 ${tabsTokens.tabsBackgroundColor}: transparent;
                 ${tabsTokens.outlineFocusColor}: var(--surface-accent);

--- a/packages/sdds-cs/src/components/TextField/TextField.config.ts
+++ b/packages/sdds-cs/src/components/TextField/TextField.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${tokens.contentSlotColorHover}: var(--text-secondary-hover);
                 ${tokens.contentSlotColorActive}: var(--text-secondary-active);
                 ${tokens.contentSlotRightColor}: var(--text-accent);
-                ${tokens.contentSlotRightColorHover}: var(--text-accent-hover);
+                ${tokens.contentSlotRightColorHover}: #1A9E32;
                 ${tokens.contentSlotRightColorActive}: var(--text-accent-active);
 
                 ${tokens.dividerColor}: var(--outline-solid-primary);

--- a/packages/sdds-cs/src/components/Toast/Toast.config.ts
+++ b/packages/sdds-cs/src/components/Toast/Toast.config.ts
@@ -13,7 +13,7 @@ export const config = {
                 ${toastTokens.background}: var(--surface-solid-card-brightness);
 
                 ${toastTokens.closeIconColor}: var(--text-accent);
-                ${toastTokens.closeIconColorOnHover}: var(--text-accent-hover);
+                ${toastTokens.closeIconColorOnHover}: #1A9E32;
             `,
             dark: css`
                 ${toastTokens.color}: var(--on-dark-text-primary);


### PR DESCRIPTION
## SDDS-CS

### Text accent hover

- изменено значение на `#1A9E32`

### What/why changed

Изменен токен --text-accent-hover на hex #1A9E32

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-cs@0.207.0-canary.1643.12352980035.0
  # or 
  yarn add @salutejs/sdds-cs@0.207.0-canary.1643.12352980035.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
