### PR TITLE
PLASMA-4102: expand target prop to ref in Popover

### DIFF
--- a/packages/plasma-b2c/src/components/Popover/Popover.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Popover/Popover.component-test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { RefObject, useRef } from 'react';
 import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
 
 import type { PopoverTrigger } from '.';
@@ -98,6 +98,45 @@ describe('plasma-b2c: Popover', () => {
         mount(
             <CypressTestDecorator>
                 <Demo trigger="click" closeOnEsc />
+            </CypressTestDecorator>,
+        );
+
+        cy.get('button').first().click();
+        cy.get('p').contains(text).should('be.visible');
+
+        cy.get('body').type('{esc}');
+        cy.get('p').contains(text).should('not.be.visible');
+    });
+
+    const TargetAsRef = () => {
+        const [isOpen, setIsOpen] = React.useState(false);
+        const targetRef = useRef<HTMLButtonElement>(null);
+
+        return (
+            <>
+                <Button ref={targetRef}>Target</Button>
+                <Popover
+                    opened={isOpen}
+                    onToggle={(is) => setIsOpen(is)}
+                    role="presentation"
+                    id="popover"
+                    target={targetRef}
+                    trigger="click"
+                    closeOnEsc
+                >
+                    <div>
+                        <P1>{text}</P1>
+                        <Button onClick={() => setIsOpen(!isOpen)}>close</Button>
+                    </div>
+                </Popover>
+            </>
+        );
+    };
+
+    it('target as ref', () => {
+        mount(
+            <CypressTestDecorator>
+                <TargetAsRef />
             </CypressTestDecorator>,
         );
 

--- a/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
@@ -5,14 +5,28 @@ import { DEFAULT_Z_INDEX } from '../Popup/utils';
 import { classes, tokens } from './Popover.tokens';
 import { PopoverProps } from './Popover.types';
 
-export const StyledWrapper = styled.div`
-    display: inline-block;
-`;
-
 export const StyledRoot = styled.div`
     display: inline-flex;
     box-sizing: border-box;
     position: relative;
+`;
+
+export const StyledWrapper = styled.div`
+    display: inline-block;
+
+    &.${classes.targetAsRef} {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+
+        ${StyledRoot} {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
+    }
 `;
 
 export const StyledArrow = styled.div`

--- a/packages/plasma-new-hope/src/components/Popover/Popover.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.template-doc.mdx
@@ -9,46 +9,131 @@ import { PropsTable, Description } from '@site/src/components';
 <Description name="Popover" />
 <PropsTable name="Popover" />
 
-```tsx live
-import React from 'react';
-import styled from "styled-components";
-import { surfaceSolidTertiary } from "@salutejs/{{ vertical }}/tokens";
-import { Popover, Button } from '@salutejs/{{ package }}';
+:::info
+`target` может быть как ReactNode, так и RefObject:
+:::
 
-export function App() {
-    const [isOpen, setIsOpen] = React.useState(false);
+<Tabs>
+    <TabItem value="reactNode" label="React Node" default>
+        ```tsx live
+        import React from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/{{ vertical }}/tokens";
+        import { Popover, Button } from '@salutejs/{{ package }}';
 
-    const StyledContent = styled.div`
-        background: ${surfaceSolidTertiary};
-        padding: 1rem;
+        export function App() {
+            const [isOpen, setIsOpen] = React.useState(false);
 
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    `;
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
 
-    return (
-        <section style=\{{width: '20rem', height: '15rem'}}>
-            <Popover
-                opened={isOpen}
-                onToggle={(is) => setIsOpen(is)}
-                role="presentation"
-                id="popover"
-                target={<Button>Target</Button>}
-                offset={[0, 6]}
-                hasArrow
-                placement='bottom'
-                trigger='click'
-                closeOnOverlayClick
-                closeOnEsc
-                isFocusTrapped
-            >
-                <StyledContent>
-                    <>Content</>
-                    <Button onClick={() => setIsOpen(false)}>close</Button>
-                </StyledContent>
-            </Popover>
-        </section>
-    );
-}
-```
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <section style=\{{width: '20rem', height: '15rem'}}>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={<Button>Target</Button>}
+                        offset={[0, 6]}
+                        hasArrow
+                        placement='bottom'
+                        trigger='click'
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>close</Button>
+                        </StyledContent>
+                    </Popover>
+                </section>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="refObject" label="RefObject">
+        ```tsx live
+        import React, { useRef, useState } from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/{{ vertical }}/tokens";
+        import { Popover, Button } from '@salutejs/{{ package }}';
+
+        export function App() {
+            const { skidding = 0, distance = 6 } = args;
+
+            const [isOpen, setIsOpen] = useState(false);
+
+            const targetRef = useRef<HTMLButtonElement | null>(null);
+            const targetRef2 = useRef<HTMLButtonElement | null>(null);
+            const targetRef3 = useRef<HTMLButtonElement | null>(null);
+
+            const refs = [targetRef, targetRef2, targetRef3];
+
+            const [currRefIndex, setCurrentRefIndex] = useState(0);
+            const [currentRef, setCurrentRef] = useState(targetRef);
+
+            const changeRef = () => {
+                let ind = currRefIndex + 1;
+
+                if (ind > refs.length - 1) {
+                    setCurrentRefIndex(0);
+                    ind = 0;
+                }
+
+                setCurrentRefIndex(ind);
+                setCurrentRef(refs[ind]);
+            };
+            
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
+
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <>
+                    <Button ref={targetRef}>Target 0</Button>
+                    <Button style={{ margin: ' 0 5rem' }} onClick={changeRef}>
+                        Change targetAsRef to Target {currRefIndex + 1 > refs.length - 1 ? 0 : currRefIndex + 1}
+                    </Button>
+                    <Button ref={targetRef2}>Target 1</Button>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={currentRef}
+                        offset={[0, 6]}
+                        hasArrow
+                        placement='bottom'
+                        trigger='click'
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>Close</Button>
+                        </StyledContent>
+                    </Popover>
+
+                    <div style={{ padding: '5rem' }}>Lorem ipsum</div>
+                    <Button ref={targetRef3}>Target 2</Button>
+                </>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+

--- a/packages/plasma-new-hope/src/components/Popover/Popover.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.template-doc.mdx
@@ -4,6 +4,8 @@ title: Popover
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Popover
 <Description name="Popover" />
@@ -42,9 +44,9 @@ import { PropsTable, Description } from '@site/src/components';
                         id="popover"
                         target={<Button>Target</Button>}
                         offset={[0, 6]}
-                        hasArrow
                         placement='bottom'
                         trigger='click'
+                        hasArrow
                         closeOnOverlayClick
                         closeOnEsc
                         isFocusTrapped
@@ -67,8 +69,6 @@ import { PropsTable, Description } from '@site/src/components';
         import { Popover, Button } from '@salutejs/{{ package }}';
 
         export function App() {
-            const { skidding = 0, distance = 6 } = args;
-
             const [isOpen, setIsOpen] = useState(false);
 
             const targetRef = useRef<HTMLButtonElement | null>(null);
@@ -104,7 +104,7 @@ import { PropsTable, Description } from '@site/src/components';
             return (
                 <>
                     <Button ref={targetRef}>Target 0</Button>
-                    <Button style={{ margin: ' 0 5rem' }} onClick={changeRef}>
+                    <Button style=\{{ margin: '0 5rem' }} onClick={changeRef}>
                         Change targetAsRef to Target {currRefIndex + 1 > refs.length - 1 ? 0 : currRefIndex + 1}
                     </Button>
                     <Button ref={targetRef2}>Target 1</Button>
@@ -115,9 +115,9 @@ import { PropsTable, Description } from '@site/src/components';
                         id="popover"
                         target={currentRef}
                         offset={[0, 6]}
-                        hasArrow
                         placement='bottom'
                         trigger='click'
+                        hasArrow
                         closeOnOverlayClick
                         closeOnEsc
                         isFocusTrapped
@@ -128,7 +128,7 @@ import { PropsTable, Description } from '@site/src/components';
                         </StyledContent>
                     </Popover>
 
-                    <div style={{ padding: '5rem' }}>Lorem ipsum</div>
+                    <div style=\{{ padding: '5rem' }}>Current Target: {currRefIndex}</div>
                     <Button ref={targetRef3}>Target 2</Button>
                 </>
             );

--- a/packages/plasma-new-hope/src/components/Popover/Popover.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.tokens.ts
@@ -3,6 +3,7 @@ export const classes = {
     root: 'popover-root',
     target: 'popover-target',
     arrow: 'popover-arrow',
+    targetAsRef: 'popover-target-as-ref',
 };
 
 export const tokens = {

--- a/packages/plasma-new-hope/src/components/Popover/Popover.types.ts
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode, SyntheticEvent } from 'react';
+import type { HTMLAttributes, ReactNode, RefObject, SyntheticEvent } from 'react';
 import { Placement as PopoverPlacement, ComputedPlacement as PopoverPlacementBasic } from '@popperjs/core';
 
 export type { Placement as PopoverPlacement, ComputedPlacement as PopoverPlacementBasic } from '@popperjs/core';
@@ -34,11 +34,11 @@ export type CustomPopoverProps = {
     /**
      * В каком контейнере позиционируется(по умолчанию document), можно также указать id элемента или ref для него.
      */
-    frame?: 'document' | string | React.RefObject<HTMLElement>;
+    frame?: 'document' | string | RefObject<HTMLElement>;
     /**
-     * Элемент, рядом с которым произойдет вызов всплывающего окна.
+     * Элемент или ref на элемент, рядом с которым произойдет вызов всплывающего окна.
      */
-    target?: ReactNode;
+    target?: ReactNode | RefObject<HTMLElement>;
     /**
      * Есть ли стрелка над элементом.
      */

--- a/packages/plasma-new-hope/src/components/Portal/Portal.tsx
+++ b/packages/plasma-new-hope/src/components/Portal/Portal.tsx
@@ -18,8 +18,8 @@ export const Portal: FC<PortalProps> = ({ children, container, disabled = false 
 
     return (
         <>
-            {disabled && children}
-            {!disabled && ReactDOM.createPortal(children, portalContainer)}
+            {(disabled || !portalContainer) && children}
+            {!disabled && portalContainer && ReactDOM.createPortal(children, portalContainer)}
         </>
     );
 };

--- a/packages/plasma-new-hope/src/components/Portal/Portal.types.ts
+++ b/packages/plasma-new-hope/src/components/Portal/Portal.types.ts
@@ -4,7 +4,7 @@ export type PortalProps = {
     /**
      * Элемент, в который добавится содержимое портала.
      */
-    container: HTMLElement | (() => HTMLElement);
+    container?: HTMLElement | (() => HTMLElement);
     /**
      * Содержимое портала.
      */

--- a/packages/plasma-web/src/components/Popover/Popover.component-test.tsx
+++ b/packages/plasma-web/src/components/Popover/Popover.component-test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
 
 import type { PopoverTrigger } from '.';
@@ -98,6 +98,45 @@ describe('plasma-web: Popover', () => {
         mount(
             <CypressTestDecorator>
                 <Demo trigger="click" closeOnEsc />
+            </CypressTestDecorator>,
+        );
+
+        cy.get('button').first().click();
+        cy.get('p').contains(text).should('be.visible');
+
+        cy.get('body').type('{esc}');
+        cy.get('p').contains(text).should('not.be.visible');
+    });
+
+    const TargetAsRef = () => {
+        const [isOpen, setIsOpen] = React.useState(false);
+        const targetRef = useRef<HTMLButtonElement>(null);
+
+        return (
+            <>
+                <Button ref={targetRef}>Target</Button>
+                <Popover
+                    opened={isOpen}
+                    onToggle={(is) => setIsOpen(is)}
+                    role="presentation"
+                    id="popover"
+                    target={targetRef}
+                    trigger="click"
+                    closeOnEsc
+                >
+                    <div>
+                        <P1>{text}</P1>
+                        <Button onClick={() => setIsOpen(!isOpen)}>close</Button>
+                    </div>
+                </Popover>
+            </>
+        );
+    };
+
+    it('target as ref', () => {
+        mount(
+            <CypressTestDecorator>
+                <TargetAsRef />
             </CypressTestDecorator>,
         );
 

--- a/website/plasma-b2c-docs/docs/components/Popover.mdx
+++ b/website/plasma-b2c-docs/docs/components/Popover.mdx
@@ -3,53 +3,137 @@ id: popover
 title: Popover
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Popover
 <Description name="Popover" />
 <PropsTable name="Popover" />
-<StorybookLink name="Popover" />
 
-```tsx live
-import React from 'react';
-import styled from "styled-components";
-import { surfaceSolid03 } from "@salutejs/plasma-tokens-b2c";
-import { Popover, Button } from '@salutejs/plasma-b2c';
+:::info
+`target` может быть как ReactNode, так и RefObject:
+:::
 
-export function App() {
-    const [isOpen, setIsOpen] = React.useState(false);
+<Tabs>
+    <TabItem value="reactNode" label="React Node" default>
+        ```tsx live
+        import React from 'react';
+        import styled from "styled-components";
+        import { surfaceSolid03 } from "@salutejs/plasma-tokens-b2c";
+        import { Popover, Button } from '@salutejs/plasma-b2c';
 
-    const StyledContent = styled.div`
-        background: ${surfaceSolid03};
-        padding: 1rem;
+        export function App() {
+            const [isOpen, setIsOpen] = React.useState(false);
 
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    `;
+            const StyledContent = styled.div`
+                background: ${surfaceSolid03};
+                padding: 1rem;
 
-    return (
-        <section style={{width: '20rem', height: '15rem'}}>
-            <Popover
-                isOpen={isOpen}
-                onToggle={(is) => setIsOpen(is)}
-                role="presentation"
-                id="popover"
-                target={<Button>Target</Button>}
-                offset={[0, 6]}
-                hasArrow
-                placement='bottom'
-                trigger='click'
-                closeOnOverlayClick
-                closeOnEsc
-                isFocusTrapped
-            >
-                <StyledContent>
-                    <>Content</>
-                    <Button onClick={() => setIsOpen(false)}>close</Button>
-                </StyledContent>
-            </Popover>
-        </section>
-    );
-}
-```
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <section style={{width: '20rem', height: '15rem'}}>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={<Button>Target</Button>}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>close</Button>
+                        </StyledContent>
+                    </Popover>
+                </section>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="refObject" label="RefObject">
+        ```tsx live
+        import React, { useRef, useState } from 'react';
+        import styled from "styled-components";
+        import { surfaceSolid03 } from "@salutejs/plasma-tokens-b2c";
+        import { Popover, Button } from '@salutejs/plasma-b2c';
+
+        export function App() {
+            const [isOpen, setIsOpen] = useState(false);
+
+            const targetRef = useRef<HTMLButtonElement | null>(null);
+            const targetRef2 = useRef<HTMLButtonElement | null>(null);
+            const targetRef3 = useRef<HTMLButtonElement | null>(null);
+
+            const refs = [targetRef, targetRef2, targetRef3];
+
+            const [currRefIndex, setCurrentRefIndex] = useState(0);
+            const [currentRef, setCurrentRef] = useState(targetRef);
+
+            const changeRef = () => {
+                let ind = currRefIndex + 1;
+
+                if (ind > refs.length - 1) {
+                    setCurrentRefIndex(0);
+                    ind = 0;
+                }
+
+                setCurrentRefIndex(ind);
+                setCurrentRef(refs[ind]);
+            };
+            
+            const StyledContent = styled.div`
+                background: ${surfaceSolid03};
+                padding: 1rem;
+
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <>
+                    <Button ref={targetRef}>Target 0</Button>
+                    <Button style={{ margin: '0 5rem' }} onClick={changeRef}>
+                        Change target to Target {currRefIndex + 1 > refs.length - 1 ? 0 : currRefIndex + 1}
+                    </Button>
+                    <Button ref={targetRef2}>Target 1</Button>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={currentRef}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>Close</Button>
+                        </StyledContent>
+                    </Popover>
+
+                    <div style={{ padding: '5rem' }}>Current Target: {currRefIndex}</div>
+                    <Button ref={targetRef3}>Target 2</Button>
+                </>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+

--- a/website/plasma-web-docs/docs/components/Popover.mdx
+++ b/website/plasma-web-docs/docs/components/Popover.mdx
@@ -3,53 +3,137 @@ id: popover
 title: Popover
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Popover
 <Description name="Popover" />
 <PropsTable name="Popover" />
-<StorybookLink name="Popover" />
 
-```tsx live
-import React from 'react';
-import styled from "styled-components";
-import { surfaceSolid03 } from "@salutejs/plasma-tokens-web";
-import { Popover, Button } from '@salutejs/plasma-web';
+:::info
+`target` может быть как ReactNode, так и RefObject:
+:::
 
-export function App() {
-    const [isOpen, setIsOpen] = React.useState(false);
+<Tabs>
+    <TabItem value="reactNode" label="React Node" default>
+        ```tsx live
+        import React from 'react';
+        import styled from "styled-components";
+        import { surfaceSolid03 } from "@salutejs/plasma-tokens-web";
+        import { Popover, Button } from '@salutejs/plasma-web';
 
-    const StyledContent = styled.div`
-        background: ${surfaceSolid03};
-        padding: 1rem;
+        export function App() {
+            const [isOpen, setIsOpen] = React.useState(false);
 
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    `;
+            const StyledContent = styled.div`
+                background: ${surfaceSolid03};
+                padding: 1rem;
 
-    return (
-        <section style={{width: '20rem', height: '15rem'}}>
-            <Popover
-                opened={isOpen}
-                onToggle={(is) => setIsOpen(is)}
-                role="presentation"
-                id="popover"
-                target={<Button>Target</Button>}
-                offset={[0, 6]}
-                hasArrow
-                placement='bottom'
-                trigger='click'
-                closeOnOverlayClick
-                closeOnEsc
-                isFocusTrapped
-            >
-                <StyledContent>
-                    <>Content</>
-                    <Button onClick={() => setIsOpen(false)}>close</Button>
-                </StyledContent>
-            </Popover>
-        </section>
-    );
-}
-```
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <section style={{width: '20rem', height: '15rem'}}>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={<Button>Target</Button>}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>close</Button>
+                        </StyledContent>
+                    </Popover>
+                </section>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="refObject" label="RefObject">
+        ```tsx live
+        import React, { useRef, useState } from 'react';
+        import styled from "styled-components";
+        import { surfaceSolid03 } from "@salutejs/plasma-tokens-web";
+        import { Popover, Button } from '@salutejs/plasma-web';
+
+        export function App() {
+            const [isOpen, setIsOpen] = useState(false);
+
+            const targetRef = useRef<HTMLButtonElement | null>(null);
+            const targetRef2 = useRef<HTMLButtonElement | null>(null);
+            const targetRef3 = useRef<HTMLButtonElement | null>(null);
+
+            const refs = [targetRef, targetRef2, targetRef3];
+
+            const [currRefIndex, setCurrentRefIndex] = useState(0);
+            const [currentRef, setCurrentRef] = useState(targetRef);
+
+            const changeRef = () => {
+                let ind = currRefIndex + 1;
+
+                if (ind > refs.length - 1) {
+                    setCurrentRefIndex(0);
+                    ind = 0;
+                }
+
+                setCurrentRefIndex(ind);
+                setCurrentRef(refs[ind]);
+            };
+            
+            const StyledContent = styled.div`
+                background: ${surfaceSolid03};
+                padding: 1rem;
+
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <>
+                    <Button ref={targetRef}>Target 0</Button>
+                    <Button style={{ margin: '0 5rem' }} onClick={changeRef}>
+                        Change targetAsRef to Target {currRefIndex + 1 > refs.length - 1 ? 0 : currRefIndex + 1}
+                    </Button>
+                    <Button ref={targetRef2}>Target 1</Button>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={currentRef}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>Close</Button>
+                        </StyledContent>
+                    </Popover>
+
+                    <div style={{ padding: '5rem' }}>Current Target: {currRefIndex}</div>
+                    <Button ref={targetRef3}>Target 2</Button>
+                </>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+

--- a/website/sdds-cs-docs/docs/components/Popover.mdx
+++ b/website/sdds-cs-docs/docs/components/Popover.mdx
@@ -4,51 +4,136 @@ title: Popover
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Popover
 <Description name="Popover" />
 <PropsTable name="Popover" />
 
-```tsx live
-import React from 'react';
-import styled from "styled-components";
-import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
-import { Popover, Button } from '@salutejs/sdds-cs';
+:::info
+`target` может быть как ReactNode, так и RefObject:
+:::
 
-export function App() {
-    const [isOpen, setIsOpen] = React.useState(false);
+<Tabs>
+    <TabItem value="reactNode" label="React Node" default>
+        ```tsx live
+        import React from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
+        import { Popover, Button } from '@salutejs/sdds-cs';
 
-    const StyledContent = styled.div`
-        background: ${surfaceSolidTertiary};
-        padding: 1rem;
+        export function App() {
+            const [isOpen, setIsOpen] = React.useState(false);
 
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    `;
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
 
-    return (
-        <section style={{width: '20rem', height: '15rem'}}>
-            <Popover
-                opened={isOpen}
-                onToggle={(is) => setIsOpen(is)}
-                role="presentation"
-                id="popover"
-                target={<Button>Target</Button>}
-                offset={[0, 6]}
-                hasArrow
-                placement='bottom'
-                trigger='click'
-                closeOnOverlayClick
-                closeOnEsc
-                isFocusTrapped
-            >
-                <StyledContent>
-                    <>Content</>
-                    <Button onClick={() => setIsOpen(false)}>close</Button>
-                </StyledContent>
-            </Popover>
-        </section>
-    );
-}
-```
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <section style={{width: '20rem', height: '15rem'}}>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={<Button>Target</Button>}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>close</Button>
+                        </StyledContent>
+                    </Popover>
+                </section>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="refObject" label="RefObject">
+        ```tsx live
+        import React, { useRef, useState } from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
+        import { Popover, Button } from '@salutejs/sdds-cs';
+
+        export function App() {
+            const [isOpen, setIsOpen] = useState(false);
+
+            const targetRef = useRef<HTMLButtonElement | null>(null);
+            const targetRef2 = useRef<HTMLButtonElement | null>(null);
+            const targetRef3 = useRef<HTMLButtonElement | null>(null);
+
+            const refs = [targetRef, targetRef2, targetRef3];
+
+            const [currRefIndex, setCurrentRefIndex] = useState(0);
+            const [currentRef, setCurrentRef] = useState(targetRef);
+
+            const changeRef = () => {
+                let ind = currRefIndex + 1;
+
+                if (ind > refs.length - 1) {
+                    setCurrentRefIndex(0);
+                    ind = 0;
+                }
+
+                setCurrentRefIndex(ind);
+                setCurrentRef(refs[ind]);
+            };
+            
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
+
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <>
+                    <Button ref={targetRef}>Target 0</Button>
+                    <Button style={{ margin: '0 5rem' }} onClick={changeRef}>
+                        Change targetAsRef to Target {currRefIndex + 1 > refs.length - 1 ? 0 : currRefIndex + 1}
+                    </Button>
+                    <Button ref={targetRef2}>Target 1</Button>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={currentRef}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>Close</Button>
+                        </StyledContent>
+                    </Popover>
+
+                    <div style={{ padding: '5rem' }}>Current Target: {currRefIndex}</div>
+                    <Button ref={targetRef3}>Target 2</Button>
+                </>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+

--- a/website/sdds-dfa-docs/docs/components/Popover.mdx
+++ b/website/sdds-dfa-docs/docs/components/Popover.mdx
@@ -4,51 +4,136 @@ title: Popover
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Popover
 <Description name="Popover" />
 <PropsTable name="Popover" />
 
-```tsx live
-import React from 'react';
-import styled from "styled-components";
-import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
-import { Popover, Button } from '@salutejs/sdds-dfa';
+:::info
+`target` может быть как ReactNode, так и RefObject:
+:::
 
-export function App() {
-    const [isOpen, setIsOpen] = React.useState(false);
+<Tabs>
+    <TabItem value="reactNode" label="React Node" default>
+        ```tsx live
+        import React from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
+        import { Popover, Button } from '@salutejs/sdds-dfa';
 
-    const StyledContent = styled.div`
-        background: ${surfaceSolidTertiary};
-        padding: 1rem;
+        export function App() {
+            const [isOpen, setIsOpen] = React.useState(false);
 
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    `;
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
 
-    return (
-        <section style={{width: '20rem', height: '15rem'}}>
-            <Popover
-                opened={isOpen}
-                onToggle={(is) => setIsOpen(is)}
-                role="presentation"
-                id="popover"
-                target={<Button>Target</Button>}
-                offset={[0, 6]}
-                hasArrow
-                placement='bottom'
-                trigger='click'
-                closeOnOverlayClick
-                closeOnEsc
-                isFocusTrapped
-            >
-                <StyledContent>
-                    <>Content</>
-                    <Button onClick={() => setIsOpen(false)}>close</Button>
-                </StyledContent>
-            </Popover>
-        </section>
-    );
-}
-```
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <section style={{width: '20rem', height: '15rem'}}>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={<Button>Target</Button>}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>close</Button>
+                        </StyledContent>
+                    </Popover>
+                </section>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="refObject" label="RefObject">
+        ```tsx live
+        import React, { useRef, useState } from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
+        import { Popover, Button } from '@salutejs/sdds-dfa';
+
+        export function App() {
+            const [isOpen, setIsOpen] = useState(false);
+
+            const targetRef = useRef<HTMLButtonElement | null>(null);
+            const targetRef2 = useRef<HTMLButtonElement | null>(null);
+            const targetRef3 = useRef<HTMLButtonElement | null>(null);
+
+            const refs = [targetRef, targetRef2, targetRef3];
+
+            const [currRefIndex, setCurrentRefIndex] = useState(0);
+            const [currentRef, setCurrentRef] = useState(targetRef);
+
+            const changeRef = () => {
+                let ind = currRefIndex + 1;
+
+                if (ind > refs.length - 1) {
+                    setCurrentRefIndex(0);
+                    ind = 0;
+                }
+
+                setCurrentRefIndex(ind);
+                setCurrentRef(refs[ind]);
+            };
+            
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
+
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <>
+                    <Button ref={targetRef}>Target 0</Button>
+                    <Button style={{ margin: '0 5rem' }} onClick={changeRef}>
+                        Change targetAsRef to Target {currRefIndex + 1 > refs.length - 1 ? 0 : currRefIndex + 1}
+                    </Button>
+                    <Button ref={targetRef2}>Target 1</Button>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={currentRef}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>Close</Button>
+                        </StyledContent>
+                    </Popover>
+
+                    <div style={{ padding: '5rem' }}>Current Target: {currRefIndex}</div>
+                    <Button ref={targetRef3}>Target 2</Button>
+                </>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+

--- a/website/sdds-insol-docs/docs/components/Popover.mdx
+++ b/website/sdds-insol-docs/docs/components/Popover.mdx
@@ -4,51 +4,136 @@ title: Popover
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Popover
 <Description name="Popover" />
 <PropsTable name="Popover" />
 
-```tsx live
-import React from 'react';
-import styled from "styled-components";
-import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
-import { Popover, Button } from '@salutejs/sdds-insol';
+:::info
+`target` может быть как ReactNode, так и RefObject:
+:::
 
-export function App() {
-    const [isOpen, setIsOpen] = React.useState(false);
+<Tabs>
+    <TabItem value="reactNode" label="React Node" default>
+        ```tsx live
+        import React from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
+        import { Popover, Button } from '@salutejs/sdds-insol';
 
-    const StyledContent = styled.div`
-        background: ${surfaceSolidTertiary};
-        padding: 1rem;
+        export function App() {
+            const [isOpen, setIsOpen] = React.useState(false);
 
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    `;
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
 
-    return (
-        <section style={{width: '20rem', height: '15rem'}}>
-            <Popover
-                opened={isOpen}
-                onToggle={(is) => setIsOpen(is)}
-                role="presentation"
-                id="popover"
-                target={<Button>Target</Button>}
-                offset={[0, 6]}
-                hasArrow
-                placement='bottom'
-                trigger='click'
-                closeOnOverlayClick
-                closeOnEsc
-                isFocusTrapped
-            >
-                <StyledContent>
-                    <>Content</>
-                    <Button onClick={() => setIsOpen(false)}>close</Button>
-                </StyledContent>
-            </Popover>
-        </section>
-    );
-}
-```
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <section style={{width: '20rem', height: '15rem'}}>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={<Button>Target</Button>}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>close</Button>
+                        </StyledContent>
+                    </Popover>
+                </section>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="refObject" label="RefObject">
+        ```tsx live
+        import React, { useRef, useState } from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
+        import { Popover, Button } from '@salutejs/sdds-insol';
+
+        export function App() {
+            const [isOpen, setIsOpen] = useState(false);
+
+            const targetRef = useRef<HTMLButtonElement | null>(null);
+            const targetRef2 = useRef<HTMLButtonElement | null>(null);
+            const targetRef3 = useRef<HTMLButtonElement | null>(null);
+
+            const refs = [targetRef, targetRef2, targetRef3];
+
+            const [currRefIndex, setCurrentRefIndex] = useState(0);
+            const [currentRef, setCurrentRef] = useState(targetRef);
+
+            const changeRef = () => {
+                let ind = currRefIndex + 1;
+
+                if (ind > refs.length - 1) {
+                    setCurrentRefIndex(0);
+                    ind = 0;
+                }
+
+                setCurrentRefIndex(ind);
+                setCurrentRef(refs[ind]);
+            };
+            
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
+
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <>
+                    <Button ref={targetRef}>Target 0</Button>
+                    <Button style={{ margin: '0 5rem' }} onClick={changeRef}>
+                        Change targetAsRef to Target {currRefIndex + 1 > refs.length - 1 ? 0 : currRefIndex + 1}
+                    </Button>
+                    <Button ref={targetRef2}>Target 1</Button>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={currentRef}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>Close</Button>
+                        </StyledContent>
+                    </Popover>
+
+                    <div style={{ padding: '5rem' }}>Current Target: {currRefIndex}</div>
+                    <Button ref={targetRef3}>Target 2</Button>
+                </>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+

--- a/website/sdds-serv-docs/docs/components/Popover.mdx
+++ b/website/sdds-serv-docs/docs/components/Popover.mdx
@@ -4,51 +4,136 @@ title: Popover
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # Popover
 <Description name="Popover" />
 <PropsTable name="Popover" />
 
-```tsx live
-import React from 'react';
-import styled from "styled-components";
-import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
-import { Popover, Button } from '@salutejs/sdds-serv';
+:::info
+`target` может быть как ReactNode, так и RefObject:
+:::
 
-export function App() {
-    const [isOpen, setIsOpen] = React.useState(false);
+<Tabs>
+    <TabItem value="reactNode" label="React Node" default>
+        ```tsx live
+        import React from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
+        import { Popover, Button } from '@salutejs/sdds-serv';
 
-    const StyledContent = styled.div`
-        background: ${surfaceSolidTertiary};
-        padding: 1rem;
+        export function App() {
+            const [isOpen, setIsOpen] = React.useState(false);
 
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    `;
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
 
-    return (
-        <section style={{width: '20rem', height: '15rem'}}>
-            <Popover
-                opened={isOpen}
-                onToggle={(is) => setIsOpen(is)}
-                role="presentation"
-                id="popover"
-                target={<Button>Target</Button>}
-                offset={[0, 6]}
-                hasArrow
-                placement='bottom'
-                trigger='click'
-                closeOnOverlayClick
-                closeOnEsc
-                isFocusTrapped
-            >
-                <StyledContent>
-                    <>Content</>
-                    <Button onClick={() => setIsOpen(false)}>close</Button>
-                </StyledContent>
-            </Popover>
-        </section>
-    );
-}
-```
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <section style={{width: '20rem', height: '15rem'}}>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={<Button>Target</Button>}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>close</Button>
+                        </StyledContent>
+                    </Popover>
+                </section>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="refObject" label="RefObject">
+        ```tsx live
+        import React, { useRef, useState } from 'react';
+        import styled from "styled-components";
+        import { surfaceSolidTertiary } from "@salutejs/sdds-themes/tokens";
+        import { Popover, Button } from '@salutejs/sdds-serv';
+
+        export function App() {
+            const [isOpen, setIsOpen] = useState(false);
+
+            const targetRef = useRef<HTMLButtonElement | null>(null);
+            const targetRef2 = useRef<HTMLButtonElement | null>(null);
+            const targetRef3 = useRef<HTMLButtonElement | null>(null);
+
+            const refs = [targetRef, targetRef2, targetRef3];
+
+            const [currRefIndex, setCurrentRefIndex] = useState(0);
+            const [currentRef, setCurrentRef] = useState(targetRef);
+
+            const changeRef = () => {
+                let ind = currRefIndex + 1;
+
+                if (ind > refs.length - 1) {
+                    setCurrentRefIndex(0);
+                    ind = 0;
+                }
+
+                setCurrentRefIndex(ind);
+                setCurrentRef(refs[ind]);
+            };
+            
+            const StyledContent = styled.div`
+                background: ${surfaceSolidTertiary};
+                padding: 1rem;
+
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            `;
+
+            return (
+                <>
+                    <Button ref={targetRef}>Target 0</Button>
+                    <Button style={{ margin: '0 5rem' }} onClick={changeRef}>
+                        Change targetAsRef to Target {currRefIndex + 1 > refs.length - 1 ? 0 : currRefIndex + 1}
+                    </Button>
+                    <Button ref={targetRef2}>Target 1</Button>
+                    <Popover
+                        opened={isOpen}
+                        onToggle={(is) => setIsOpen(is)}
+                        role="presentation"
+                        id="popover"
+                        target={currentRef}
+                        offset={[0, 6]}
+                        placement='bottom'
+                        trigger='click'
+                        hasArrow
+                        closeOnOverlayClick
+                        closeOnEsc
+                        isFocusTrapped
+                    >
+                        <StyledContent>
+                            <>Content</>
+                            <Button onClick={() => setIsOpen(false)}>Close</Button>
+                        </StyledContent>
+                    </Popover>
+
+                    <div style={{ padding: '5rem' }}>Current Target: {currRefIndex}</div>
+                    <Button ref={targetRef3}>Target 2</Button>
+                </>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+


### PR DESCRIPTION
## Core

### Popover

- в target можно передать ref на элемент, рядом с которым произойдет открытие

### What/why changed

Появилась необходимость задавать ref в target, для динамического изменения элемента, рядом с которым произойдет открытие

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.242.0-canary.1647.12467637991.0
  npm install @salutejs/plasma-b2c@1.484.0-canary.1647.12467637991.0
  npm install @salutejs/plasma-giga@0.211.0-canary.1647.12467637991.0
  npm install @salutejs/plasma-new-hope@0.231.0-canary.1647.12467637991.0
  npm install @salutejs/plasma-web@1.486.0-canary.1647.12467637991.0
  npm install @salutejs/sdds-cs@0.219.0-canary.1647.12467637991.0
  npm install @salutejs/sdds-dfa@0.213.0-canary.1647.12467637991.0
  npm install @salutejs/sdds-finportal@0.207.0-canary.1647.12467637991.0
  npm install @salutejs/sdds-insol@0.208.0-canary.1647.12467637991.0
  npm install @salutejs/sdds-serv@0.215.0-canary.1647.12467637991.0
  # or 
  yarn add @salutejs/plasma-asdk@0.242.0-canary.1647.12467637991.0
  yarn add @salutejs/plasma-b2c@1.484.0-canary.1647.12467637991.0
  yarn add @salutejs/plasma-giga@0.211.0-canary.1647.12467637991.0
  yarn add @salutejs/plasma-new-hope@0.231.0-canary.1647.12467637991.0
  yarn add @salutejs/plasma-web@1.486.0-canary.1647.12467637991.0
  yarn add @salutejs/sdds-cs@0.219.0-canary.1647.12467637991.0
  yarn add @salutejs/sdds-dfa@0.213.0-canary.1647.12467637991.0
  yarn add @salutejs/sdds-finportal@0.207.0-canary.1647.12467637991.0
  yarn add @salutejs/sdds-insol@0.208.0-canary.1647.12467637991.0
  yarn add @salutejs/sdds-serv@0.215.0-canary.1647.12467637991.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
