### PR TITLE
PLASMA-4145: edit storybook textarea

### DIFF
--- a/packages/plasma-b2c/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextArea/TextArea.stories.tsx
@@ -7,12 +7,14 @@ import type { PopoverPlacement } from '@salutejs/plasma-new-hope';
 import { TextArea } from '.';
 import type { TextAreaProps } from '.';
 
+const labelPlacements = ['inner', 'outer'];
+
 const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
-const statuses = ['', 'success', 'warning', 'error'];
 const sizes = ['xs', 's', 'm', 'l'];
+const views = ['default', 'positive', 'warning', 'negative'];
 const hintViews = ['default'];
 const hintSizes = ['m', 's'];
 const hintTriggers = ['hover', 'click'];
@@ -59,10 +61,9 @@ const meta: Meta<TextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        status: {
-            options: statuses,
+        clear: {
             control: {
-                type: 'select',
+                type: 'boolean',
             },
         },
         size: {
@@ -72,8 +73,14 @@ const meta: Meta<TextAreaProps> = {
                 type: 'select',
             },
         },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
         labelPlacement: {
-            options: ['inner', 'outer'],
+            options: labelPlacements,
             control: {
                 type: 'select',
             },
@@ -95,6 +102,11 @@ const meta: Meta<TextAreaProps> = {
                 type: 'number',
             },
             if: { arg: 'clear', truthy: false },
+        },
+        hasHint: {
+            control: {
+                type: 'boolean',
+            },
         },
         hintText: {
             control: { type: 'text' },
@@ -139,27 +151,21 @@ const meta: Meta<TextAreaProps> = {
         },
         helperText: {
             control: { type: 'text' },
-            if: { arg: 'hasHint', truthy: true },
-        },
-        helperText: {
-            control: { type: 'text' },
-            if: { arg: 'helperText', truthy: true },
         },
         width: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
         height: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
-        rows: {
+        leftHelper: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
         },
-        cols: {
+        titleCaption: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
+        },
+        rightHelper: {
+            control: { type: 'text' },
         },
         ...disableProps([
             'helperBlock',
@@ -185,6 +191,7 @@ const meta: Meta<TextAreaProps> = {
             'hintTargetIcon',
             'hintOffset',
             'hintContentLeft',
+            'hintView',
         ]),
     },
     args: {

--- a/packages/plasma-b2c/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextArea/TextArea.stories.tsx
@@ -137,6 +137,30 @@ const meta: Meta<TextAreaProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'hasHint', truthy: true },
+        },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'helperText', truthy: true },
+        },
+        width: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        height: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        rows: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
+        cols: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
         ...disableProps([
             'helperBlock',
             '$isFocused',
@@ -157,6 +181,10 @@ const meta: Meta<TextAreaProps> = {
             'onFocus',
             'onBlur',
             'leftHelperPlacement',
+            'status',
+            'hintTargetIcon',
+            'hintOffset',
+            'hintContentLeft',
         ]),
     },
     args: {

--- a/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
@@ -92,12 +92,6 @@ const meta: Meta<TextFieldProps> = {
             },
             if: { arg: 'clear', truthy: true },
         },
-        status: {
-            options: statuses,
-            control: {
-                type: 'select',
-            },
-        },
         size: {
             options: sizes,
             control: {

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState, createRef, useCallback, useRef, MouseEventHandler } from 'react';
+import React, { forwardRef, useState, createRef, useCallback, useRef, MouseEventHandler, useLayoutEffect } from 'react';
 import { css } from '@linaria/core';
 import { useForkRef, useResizeObserver } from '@salutejs/plasma-core';
 
@@ -198,6 +198,12 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaRootPr
                 setIsHintVisible(true);
             }
         };
+
+        useLayoutEffect(() => {
+            if (outerRef.current) {
+                setUncontrolledValue(outerRef.current.value);
+            }
+        }, [outerRef]);
 
         useResizeObserver(outerRef, (currentElement) => {
             const { width: inlineWidth } = currentElement.style;

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/TextArea/TextArea.stories.tsx
@@ -13,6 +13,8 @@ import { config } from './TextArea.config';
 import { TextArea } from './TextArea';
 
 const labelPlacements = ['inner', 'outer'];
+const sizes = ['xs', 's', 'm', 'l'];
+const views = ['default', 'positive', 'warning', 'negative'];
 const hintViews = ['default'];
 const hintSizes = ['m', 's'];
 const hintTriggers = ['hover', 'click'];
@@ -67,22 +69,23 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        rows: {
+        size: {
+            options: sizes,
+            defaultValue: 'm',
             control: {
-                type: 'number',
+                type: 'select',
             },
-            if: { arg: 'clear', truthy: false },
         },
-        cols: {
+        view: {
+            options: views,
             control: {
-                type: 'number',
+                type: 'select',
             },
-            if: { arg: 'clear', truthy: false },
         },
         labelPlacement: {
             options: labelPlacements,
             control: {
-                type: 'inline-radio',
+                type: 'select',
             },
         },
         hasDivider: {
@@ -90,6 +93,23 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'boolean',
             },
             if: { arg: 'clear', truthy: true },
+        },
+        cols: {
+            control: {
+                type: 'number',
+            },
+            if: { arg: 'clear', truthy: false },
+        },
+        rows: {
+            control: {
+                type: 'number',
+            },
+            if: { arg: 'clear', truthy: false },
+        },
+        hasHint: {
+            control: {
+                type: 'boolean',
+            },
         },
         hintText: {
             control: { type: 'text' },
@@ -132,7 +152,50 @@ const meta: Meta<StoryTextAreaProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
-        ...disableProps(['leftHelperPlacement']),
+        helperText: {
+            control: { type: 'text' },
+        },
+        width: {
+            control: { type: 'text' },
+        },
+        height: {
+            control: { type: 'text' },
+        },
+        leftHelper: {
+            control: { type: 'text' },
+        },
+        titleCaption: {
+            control: { type: 'text' },
+        },
+        rightHelper: {
+            control: { type: 'text' },
+        },
+        ...disableProps([
+            'helperBlock',
+            '$isFocused',
+            'contentRight',
+            'autoComplete',
+            'autoFocus',
+            'dirName',
+            'form',
+            'minLength',
+            'maxLength',
+            'name',
+            'value',
+            'wrap',
+            'theme',
+            'as',
+            'forwardedAs',
+            'onChange',
+            'onFocus',
+            'onBlur',
+            'leftHelperPlacement',
+            'status',
+            'hintTargetIcon',
+            'hintOffset',
+            'hintContentLeft',
+            'hintView',
+        ]),
     },
     args: {
         id: 'example-textarea',

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/TextArea/TextArea.stories.tsx
@@ -13,6 +13,7 @@ import { config } from './TextArea.config';
 import { TextArea } from './TextArea';
 
 const labelPlacements = ['inner', 'outer'];
+const sizes = ['xs', 's', 'm', 'l'];
 const hintViews = ['default'];
 const hintSizes = ['m', 's'];
 const hintTriggers = ['hover', 'click'];
@@ -67,17 +68,18 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        rows: {
+        size: {
+            options: sizes,
+            defaultValue: 'm',
             control: {
-                type: 'number',
+                type: 'select',
             },
-            if: { arg: 'clear', truthy: false },
         },
-        cols: {
+        view: {
+            options: views,
             control: {
-                type: 'number',
+                type: 'select',
             },
-            if: { arg: 'clear', truthy: false },
         },
         labelPlacement: {
             options: labelPlacements,
@@ -90,6 +92,23 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'boolean',
             },
             if: { arg: 'clear', truthy: true },
+        },
+        cols: {
+            control: {
+                type: 'number',
+            },
+            if: { arg: 'clear', truthy: false },
+        },
+        rows: {
+            control: {
+                type: 'number',
+            },
+            if: { arg: 'clear', truthy: false },
+        },
+        hasHint: {
+            control: {
+                type: 'boolean',
+            },
         },
         hintText: {
             control: { type: 'text' },
@@ -132,7 +151,50 @@ const meta: Meta<StoryTextAreaProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
-        ...disableProps(['leftHelperPlacement']),
+        helperText: {
+            control: { type: 'text' },
+        },
+        width: {
+            control: { type: 'text' },
+        },
+        height: {
+            control: { type: 'text' },
+        },
+        leftHelper: {
+            control: { type: 'text' },
+        },
+        titleCaption: {
+            control: { type: 'text' },
+        },
+        rightHelper: {
+            control: { type: 'text' },
+        },
+        ...disableProps([
+            'helperBlock',
+            '$isFocused',
+            'contentRight',
+            'autoComplete',
+            'autoFocus',
+            'dirName',
+            'form',
+            'minLength',
+            'maxLength',
+            'name',
+            'value',
+            'wrap',
+            'theme',
+            'as',
+            'forwardedAs',
+            'onChange',
+            'onFocus',
+            'onBlur',
+            'leftHelperPlacement',
+            'status',
+            'hintTargetIcon',
+            'hintOffset',
+            'hintContentLeft',
+            'hintView',
+        ]),
     },
     args: {
         id: 'example-textarea',

--- a/packages/plasma-web/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-web/src/components/TextArea/TextArea.stories.tsx
@@ -8,12 +8,14 @@ import { IconPlaceholder, InSpacingDecorator, disableProps } from '../../helpers
 import { TextArea } from '.';
 import type { TextAreaProps } from '.';
 
+const labelPlacements = ['inner', 'outer'];
+
 const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
-const statuses = ['', 'success', 'warning', 'error'];
 const sizes = ['xs', 's', 'm', 'l'];
+const views = ['default', 'positive', 'warning', 'negative'];
 const hintViews = ['default'];
 const hintSizes = ['m', 's'];
 const hintTriggers = ['hover', 'click'];
@@ -60,10 +62,9 @@ const meta: Meta<TextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        status: {
-            options: statuses,
+        clear: {
             control: {
-                type: 'select',
+                type: 'boolean',
             },
         },
         size: {
@@ -73,8 +74,14 @@ const meta: Meta<TextAreaProps> = {
                 type: 'select',
             },
         },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
         labelPlacement: {
-            options: ['inner', 'outer'],
+            options: labelPlacements,
             control: {
                 type: 'select',
             },
@@ -96,6 +103,11 @@ const meta: Meta<TextAreaProps> = {
                 type: 'number',
             },
             if: { arg: 'clear', truthy: false },
+        },
+        hasHint: {
+            control: {
+                type: 'boolean',
+            },
         },
         hintText: {
             control: { type: 'text' },
@@ -140,27 +152,21 @@ const meta: Meta<TextAreaProps> = {
         },
         helperText: {
             control: { type: 'text' },
-            if: { arg: 'hasHint', truthy: true },
-        },
-        helperText: {
-            control: { type: 'text' },
-            if: { arg: 'helperText', truthy: true },
         },
         width: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
         height: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
-        rows: {
+        leftHelper: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
         },
-        cols: {
+        titleCaption: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
+        },
+        rightHelper: {
+            control: { type: 'text' },
         },
         ...disableProps([
             'helperBlock',
@@ -186,6 +192,7 @@ const meta: Meta<TextAreaProps> = {
             'hintTargetIcon',
             'hintOffset',
             'hintContentLeft',
+            'hintView',
         ]),
     },
     args: {

--- a/packages/plasma-web/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/plasma-web/src/components/TextArea/TextArea.stories.tsx
@@ -138,7 +138,32 @@ const meta: Meta<TextAreaProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'hasHint', truthy: true },
+        },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'helperText', truthy: true },
+        },
+        width: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        height: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        rows: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
+        cols: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
         ...disableProps([
+            'helperBlock',
             '$isFocused',
             'contentRight',
             'autoComplete',
@@ -156,9 +181,11 @@ const meta: Meta<TextAreaProps> = {
             'onChange',
             'onFocus',
             'onBlur',
-            'helperText',
-            'helperBlock',
             'leftHelperPlacement',
+            'status',
+            'hintTargetIcon',
+            'hintOffset',
+            'hintContentLeft',
         ]),
     },
     args: {

--- a/packages/plasma-web/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.stories.tsx
@@ -98,12 +98,6 @@ const meta: Meta<TextFieldProps> = {
             },
             if: { arg: 'clear', truthy: true },
         },
-        status: {
-            options: statuses,
-            control: {
-                type: 'select',
-            },
-        },
         size: {
             options: sizes,
             control: {

--- a/packages/sdds-cs/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-cs/src/components/TextArea/TextArea.stories.tsx
@@ -4,7 +4,6 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 import { IconPlasma } from '@salutejs/plasma-icons';
-import type { PopoverPlacement } from '@salutejs/plasma-new-hope';
 
 import { TextArea } from './TextArea';
 
@@ -17,29 +16,9 @@ type StoryTextAreaPropsCustom = {
 
 type StoryTextAreaProps = ComponentProps<typeof TextArea> & StoryTextAreaPropsCustom;
 
-const sizes = ['s'];
-const views = ['default', 'negative'];
+const hintViews = ['default'];
 const hintSizes = ['m', 's'];
 const hintTriggers = ['hover', 'click'];
-const hintPlacements: Array<PopoverPlacement> = [
-    'top',
-    'top-start',
-    'top-end',
-
-    'bottom',
-    'bottom-start',
-    'bottom-end',
-
-    'left',
-    'left-start',
-    'left-end',
-
-    'right',
-    'right-start',
-    'right-end',
-
-    'auto',
-];
 
 const meta: Meta<StoryTextAreaProps> = {
     title: 'Data Entry/TextArea',
@@ -64,34 +43,15 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        labelPlacement: {
-            options: placements,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        leftHelperPlacement: {
-            options: placements,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        size: {
-            options: sizes,
-            defaultValue: 'm',
-            control: {
-                type: 'select',
-            },
-        },
-        view: {
-            options: views,
-            control: {
-                type: 'select',
-            },
-        },
         clear: {
             control: {
                 type: 'boolean',
+            },
+        },
+        labelPlacement: {
+            options: ['inner', 'outer'],
+            control: {
+                type: 'select',
             },
         },
         hasDivider: {
@@ -112,8 +72,20 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'clear', truthy: false },
         },
+        hasHint: {
+            control: {
+                type: 'boolean',
+            },
+        },
         hintText: {
             control: { type: 'text' },
+            if: { arg: 'hasHint', truthy: true },
+        },
+        hintView: {
+            options: hintViews,
+            control: {
+                type: 'select',
+            },
             if: { arg: 'hasHint', truthy: true },
         },
         hintSize: {
@@ -131,12 +103,12 @@ const meta: Meta<StoryTextAreaProps> = {
             if: { arg: 'hasHint', truthy: true },
         },
         hintPlacement: {
-            options: hintPlacements,
+            options: placements,
             control: {
                 type: 'select',
             },
             if: { arg: 'hasHint', truthy: true },
-            mappers: hintPlacements,
+            mappers: placements,
         },
         hintHasArrow: {
             control: { type: 'boolean' },
@@ -145,6 +117,24 @@ const meta: Meta<StoryTextAreaProps> = {
         hintWidth: {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
+        },
+        helperText: {
+            control: { type: 'text' },
+        },
+        width: {
+            control: { type: 'text' },
+        },
+        height: {
+            control: { type: 'text' },
+        },
+        leftHelper: {
+            control: { type: 'text' },
+        },
+        titleCaption: {
+            control: { type: 'text' },
+        },
+        rightHelper: {
+            control: { type: 'text' },
         },
         ...disableProps([
             'helperBlock',

--- a/packages/sdds-dfa/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-dfa/src/components/TextArea/TextArea.stories.tsx
@@ -65,8 +65,8 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        labelPlacement: {
-            options: labelPlacements,
+        status: {
+            options: statuses,
             control: {
                 type: 'select',
             },
@@ -78,8 +78,8 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'select',
             },
         },
-        view: {
-            options: views,
+        labelPlacement: {
+            options: ['inner', 'outer'],
             control: {
                 type: 'select',
             },
@@ -143,6 +143,30 @@ const meta: Meta<StoryTextAreaProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'hasHint', truthy: true },
+        },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'helperText', truthy: true },
+        },
+        width: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        height: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        rows: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
+        cols: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
         ...disableProps([
             'helperBlock',
             '$isFocused',
@@ -162,12 +186,11 @@ const meta: Meta<StoryTextAreaProps> = {
             'onChange',
             'onFocus',
             'onBlur',
-            'status',
-            'resize',
-            'height',
-            'width',
-            'helperText',
             'leftHelperPlacement',
+            'status',
+            'hintTargetIcon',
+            'hintOffset',
+            'hintContentLeft',
         ]),
     },
     args: {

--- a/packages/sdds-dfa/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-dfa/src/components/TextArea/TextArea.stories.tsx
@@ -65,10 +65,9 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        status: {
-            options: statuses,
+        clear: {
             control: {
-                type: 'select',
+                type: 'boolean',
             },
         },
         size: {
@@ -78,8 +77,14 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'select',
             },
         },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
         labelPlacement: {
-            options: ['inner', 'outer'],
+            options: labelPlacements,
             control: {
                 type: 'select',
             },
@@ -101,6 +106,11 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'number',
             },
             if: { arg: 'clear', truthy: false },
+        },
+        hasHint: {
+            control: {
+                type: 'boolean',
+            },
         },
         hintText: {
             control: { type: 'text' },
@@ -145,27 +155,21 @@ const meta: Meta<StoryTextAreaProps> = {
         },
         helperText: {
             control: { type: 'text' },
-            if: { arg: 'hasHint', truthy: true },
-        },
-        helperText: {
-            control: { type: 'text' },
-            if: { arg: 'helperText', truthy: true },
         },
         width: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
         height: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
-        rows: {
+        leftHelper: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
         },
-        cols: {
+        titleCaption: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
+        },
+        rightHelper: {
+            control: { type: 'text' },
         },
         ...disableProps([
             'helperBlock',
@@ -191,6 +195,7 @@ const meta: Meta<StoryTextAreaProps> = {
             'hintTargetIcon',
             'hintOffset',
             'hintContentLeft',
+            'hintView',
         ]),
     },
     args: {

--- a/packages/sdds-finportal/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-finportal/src/components/TextArea/TextArea.stories.tsx
@@ -65,8 +65,8 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        labelPlacement: {
-            options: labelPlacements,
+        status: {
+            options: statuses,
             control: {
                 type: 'select',
             },
@@ -78,8 +78,8 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'select',
             },
         },
-        view: {
-            options: views,
+        labelPlacement: {
+            options: ['inner', 'outer'],
             control: {
                 type: 'select',
             },
@@ -143,6 +143,30 @@ const meta: Meta<StoryTextAreaProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'hasHint', truthy: true },
+        },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'helperText', truthy: true },
+        },
+        width: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        height: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        rows: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
+        cols: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
         ...disableProps([
             'helperBlock',
             '$isFocused',
@@ -162,12 +186,11 @@ const meta: Meta<StoryTextAreaProps> = {
             'onChange',
             'onFocus',
             'onBlur',
-            'status',
-            'resize',
-            'height',
-            'width',
-            'helperText',
             'leftHelperPlacement',
+            'status',
+            'hintTargetIcon',
+            'hintOffset',
+            'hintContentLeft',
         ]),
     },
     args: {

--- a/packages/sdds-finportal/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-finportal/src/components/TextArea/TextArea.stories.tsx
@@ -65,10 +65,9 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        status: {
-            options: statuses,
+        clear: {
             control: {
-                type: 'select',
+                type: 'boolean',
             },
         },
         size: {
@@ -78,8 +77,14 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'select',
             },
         },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
         labelPlacement: {
-            options: ['inner', 'outer'],
+            options: labelPlacements,
             control: {
                 type: 'select',
             },
@@ -101,6 +106,11 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'number',
             },
             if: { arg: 'clear', truthy: false },
+        },
+        hasHint: {
+            control: {
+                type: 'boolean',
+            },
         },
         hintText: {
             control: { type: 'text' },
@@ -145,27 +155,21 @@ const meta: Meta<StoryTextAreaProps> = {
         },
         helperText: {
             control: { type: 'text' },
-            if: { arg: 'hasHint', truthy: true },
-        },
-        helperText: {
-            control: { type: 'text' },
-            if: { arg: 'helperText', truthy: true },
         },
         width: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
         height: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
-        rows: {
+        leftHelper: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
         },
-        cols: {
+        titleCaption: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
+        },
+        rightHelper: {
+            control: { type: 'text' },
         },
         ...disableProps([
             'helperBlock',
@@ -191,6 +195,7 @@ const meta: Meta<StoryTextAreaProps> = {
             'hintTargetIcon',
             'hintOffset',
             'hintContentLeft',
+            'hintView',
         ]),
     },
     args: {

--- a/packages/sdds-insol/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-insol/src/components/TextArea/TextArea.stories.tsx
@@ -66,8 +66,8 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        labelPlacement: {
-            options: labelPlacements,
+        status: {
+            options: statuses,
             control: {
                 type: 'select',
             },
@@ -79,8 +79,8 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'select',
             },
         },
-        view: {
-            options: views,
+        labelPlacement: {
+            options: ['inner', 'outer'],
             control: {
                 type: 'select',
             },
@@ -144,6 +144,30 @@ const meta: Meta<StoryTextAreaProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'hasHint', truthy: true },
+        },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'helperText', truthy: true },
+        },
+        width: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        height: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        rows: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
+        cols: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
         ...disableProps([
             'helperBlock',
             '$isFocused',
@@ -163,12 +187,11 @@ const meta: Meta<StoryTextAreaProps> = {
             'onChange',
             'onFocus',
             'onBlur',
-            'status',
-            'resize',
-            'height',
-            'width',
-            'helperText',
             'leftHelperPlacement',
+            'status',
+            'hintTargetIcon',
+            'hintOffset',
+            'hintContentLeft',
         ]),
     },
     args: {

--- a/packages/sdds-insol/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-insol/src/components/TextArea/TextArea.stories.tsx
@@ -66,12 +66,6 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        status: {
-            options: statuses,
-            control: {
-                type: 'select',
-            },
-        },
         size: {
             options: sizes,
             defaultValue: 'm',
@@ -79,8 +73,14 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'select',
             },
         },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
         labelPlacement: {
-            options: ['inner', 'outer'],
+            options: labelPlacements,
             control: {
                 type: 'select',
             },
@@ -146,10 +146,6 @@ const meta: Meta<StoryTextAreaProps> = {
         },
         helperText: {
             control: { type: 'text' },
-            if: { arg: 'hasHint', truthy: true },
-        },
-        helperText: {
-            control: { type: 'text' },
             if: { arg: 'helperText', truthy: true },
         },
         width: {
@@ -159,14 +155,6 @@ const meta: Meta<StoryTextAreaProps> = {
         height: {
             control: { type: 'text' },
             if: { arg: 'width', truthy: true },
-        },
-        rows: {
-            control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
-        },
-        cols: {
-            control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
         },
         ...disableProps([
             'helperBlock',

--- a/packages/sdds-serv/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-serv/src/components/TextArea/TextArea.stories.tsx
@@ -65,8 +65,8 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        labelPlacement: {
-            options: labelPlacements,
+        status: {
+            options: statuses,
             control: {
                 type: 'select',
             },
@@ -78,8 +78,8 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'select',
             },
         },
-        view: {
-            options: views,
+        labelPlacement: {
+            options: ['inner', 'outer'],
             control: {
                 type: 'select',
             },
@@ -143,6 +143,30 @@ const meta: Meta<StoryTextAreaProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'hasHint', truthy: true },
+        },
+        helperText: {
+            control: { type: 'text' },
+            if: { arg: 'helperText', truthy: true },
+        },
+        width: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        height: {
+            control: { type: 'text' },
+            if: { arg: 'width', truthy: true },
+        },
+        rows: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
+        cols: {
+            control: { type: 'text' },
+            if: { arg: 'number', truthy: true },
+        },
         ...disableProps([
             'helperBlock',
             '$isFocused',
@@ -162,12 +186,11 @@ const meta: Meta<StoryTextAreaProps> = {
             'onChange',
             'onFocus',
             'onBlur',
-            'status',
-            'resize',
-            'height',
-            'width',
-            'helperText',
             'leftHelperPlacement',
+            'status',
+            'hintTargetIcon',
+            'hintOffset',
+            'hintContentLeft',
         ]),
     },
     args: {

--- a/packages/sdds-serv/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/sdds-serv/src/components/TextArea/TextArea.stories.tsx
@@ -65,10 +65,9 @@ const meta: Meta<StoryTextAreaProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
-        status: {
-            options: statuses,
+        clear: {
             control: {
-                type: 'select',
+                type: 'boolean',
             },
         },
         size: {
@@ -78,8 +77,14 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'select',
             },
         },
+        view: {
+            options: views,
+            control: {
+                type: 'select',
+            },
+        },
         labelPlacement: {
-            options: ['inner', 'outer'],
+            options: labelPlacements,
             control: {
                 type: 'select',
             },
@@ -101,6 +106,11 @@ const meta: Meta<StoryTextAreaProps> = {
                 type: 'number',
             },
             if: { arg: 'clear', truthy: false },
+        },
+        hasHint: {
+            control: {
+                type: 'boolean',
+            },
         },
         hintText: {
             control: { type: 'text' },
@@ -145,27 +155,21 @@ const meta: Meta<StoryTextAreaProps> = {
         },
         helperText: {
             control: { type: 'text' },
-            if: { arg: 'hasHint', truthy: true },
-        },
-        helperText: {
-            control: { type: 'text' },
-            if: { arg: 'helperText', truthy: true },
         },
         width: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
         height: {
             control: { type: 'text' },
-            if: { arg: 'width', truthy: true },
         },
-        rows: {
+        leftHelper: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
         },
-        cols: {
+        titleCaption: {
             control: { type: 'text' },
-            if: { arg: 'number', truthy: true },
+        },
+        rightHelper: {
+            control: { type: 'text' },
         },
         ...disableProps([
             'helperBlock',
@@ -191,6 +195,7 @@ const meta: Meta<StoryTextAreaProps> = {
             'hintTargetIcon',
             'hintOffset',
             'hintContentLeft',
+            'hintView',
         ]),
     },
     args: {


### PR DESCRIPTION
## Core

### Textarea

- актуализированы примеры в storybook в соответствии с дизайном 
- исправлена работа `placeholder` при работе `react-hook-form` с defaultValues

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.240.0-canary.1649.12458108927.0
  npm install @salutejs/plasma-b2c@1.482.0-canary.1649.12458108927.0
  npm install @salutejs/plasma-giga@0.209.0-canary.1649.12458108927.0
  npm install @salutejs/plasma-new-hope@0.229.0-canary.1649.12458108927.0
  npm install @salutejs/plasma-web@1.484.0-canary.1649.12458108927.0
  npm install @salutejs/sdds-cs@0.217.0-canary.1649.12458108927.0
  npm install @salutejs/sdds-dfa@0.211.0-canary.1649.12458108927.0
  npm install @salutejs/sdds-finportal@0.205.0-canary.1649.12458108927.0
  npm install @salutejs/sdds-insol@0.206.0-canary.1649.12458108927.0
  npm install @salutejs/sdds-serv@0.213.0-canary.1649.12458108927.0
  # or 
  yarn add @salutejs/plasma-asdk@0.240.0-canary.1649.12458108927.0
  yarn add @salutejs/plasma-b2c@1.482.0-canary.1649.12458108927.0
  yarn add @salutejs/plasma-giga@0.209.0-canary.1649.12458108927.0
  yarn add @salutejs/plasma-new-hope@0.229.0-canary.1649.12458108927.0
  yarn add @salutejs/plasma-web@1.484.0-canary.1649.12458108927.0
  yarn add @salutejs/sdds-cs@0.217.0-canary.1649.12458108927.0
  yarn add @salutejs/sdds-dfa@0.211.0-canary.1649.12458108927.0
  yarn add @salutejs/sdds-finportal@0.205.0-canary.1649.12458108927.0
  yarn add @salutejs/sdds-insol@0.206.0-canary.1649.12458108927.0
  yarn add @salutejs/sdds-serv@0.213.0-canary.1649.12458108927.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
