### PR TITLE
PLASMA-4169: cast types for notification

### DIFF
--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -125,6 +125,8 @@ import { h4Bold } from '@salutejs/sdds-themes/tokens';
 import { h5 } from '@salutejs/sdds-themes/tokens';
 import { h5Bold } from '@salutejs/sdds-themes/tokens';
 import { HTMLAttributes } from 'react';
+import { HTMLAttributesWithoutOnChange } from '@salutejs/plasma-new-hope/types/engines/types';
+import { HTMLAttributesWithoutOnChangeAndDefaultValue } from '@salutejs/plasma-new-hope/types/engines/types';
 import { ImageProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -2361,7 +2363,22 @@ export { modalClasses }
 export { ModalProps }
 
 // @public (undocumented)
-const Notification_2: React_2.ForwardRefExoticComponent<NotificationProps & React_2.RefAttributes<HTMLDivElement>>;
+const Notification_2: React_2.FunctionComponent<PropsType<    {
+view: {
+default: PolymorphicClassName;
+};
+layout: {
+horizontal: PolymorphicClassName;
+vertical: PolymorphicClassName;
+};
+size: {
+xs: PolymorphicClassName;
+xxs: PolymorphicClassName;
+};
+closeIconType: {
+thin: PolymorphicClassName;
+};
+}> & (React_2.HTMLAttributes<HTMLElement> | HTMLAttributesWithoutOnChange<HTMLElement> | HTMLAttributesWithoutOnChangeAndDefaultValue<HTMLElement>)>;
 export { Notification_2 as Notification }
 
 export { NotificationIconPlacement }

--- a/packages/sdds-cs/src/components/Notification/Notification.tsx
+++ b/packages/sdds-cs/src/components/Notification/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefExoticComponent, ReactNode, RefAttributes } from 'react';
+import React, { ReactNode } from 'react';
 import {
     component,
     mergeConfig,
@@ -18,9 +18,7 @@ export { modalClasses } from '../Modal';
 
 const mergedConfig = mergeConfig(notificationConfig, config);
 
-export const Notification = component(mergedConfig) as ForwardRefExoticComponent<
-    NotificationProps & RefAttributes<HTMLDivElement>
->;
+export const Notification = component(mergedConfig);
 
 export const NotificationsProvider: React.FC<{
     children: ReactNode;

--- a/packages/sdds-dfa/src/components/Notification/Notification.tsx
+++ b/packages/sdds-dfa/src/components/Notification/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefExoticComponent, ReactNode, RefAttributes } from 'react';
+import React, { ReactNode } from 'react';
 import {
     component,
     mergeConfig,
@@ -18,9 +18,7 @@ export { modalClasses } from '../Modal';
 
 const mergedConfig = mergeConfig(notificationConfig, config);
 
-export const Notification = component(mergedConfig) as ForwardRefExoticComponent<
-    NotificationProps & RefAttributes<HTMLDivElement>
->;
+export const Notification = component(mergedConfig);
 
 export const NotificationsProvider: React.FC<{
     children: ReactNode;

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -125,6 +125,8 @@ import { h4Bold } from '@salutejs/sdds-themes/tokens';
 import { h5 } from '@salutejs/sdds-themes/tokens';
 import { h5Bold } from '@salutejs/sdds-themes/tokens';
 import { HTMLAttributes } from 'react';
+import { HTMLAttributesWithoutOnChange } from '@salutejs/plasma-new-hope/types/engines/types';
+import { HTMLAttributesWithoutOnChangeAndDefaultValue } from '@salutejs/plasma-new-hope/types/engines/types';
 import { ImageProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -2580,7 +2582,22 @@ export { modalClasses }
 export { ModalProps }
 
 // @public (undocumented)
-const Notification_2: React_2.ForwardRefExoticComponent<NotificationProps & React_2.RefAttributes<HTMLDivElement>>;
+const Notification_2: React_2.FunctionComponent<PropsType<    {
+view: {
+default: PolymorphicClassName;
+};
+layout: {
+horizontal: PolymorphicClassName;
+vertical: PolymorphicClassName;
+};
+closeIconType: {
+default: PolymorphicClassName;
+};
+size: {
+xs: PolymorphicClassName;
+xxs: PolymorphicClassName;
+};
+}> & (React_2.HTMLAttributes<HTMLElement> | HTMLAttributesWithoutOnChange<HTMLElement> | HTMLAttributesWithoutOnChangeAndDefaultValue<HTMLElement>)>;
 export { Notification_2 as Notification }
 
 export { NotificationIconPlacement }

--- a/packages/sdds-finportal/src/components/Notification/Notification.tsx
+++ b/packages/sdds-finportal/src/components/Notification/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefExoticComponent, ReactNode, RefAttributes } from 'react';
+import React, { ReactNode } from 'react';
 import {
     component,
     mergeConfig,
@@ -18,9 +18,7 @@ export { modalClasses } from '../Modal';
 
 const mergedConfig = mergeConfig(notificationConfig, config);
 
-export const Notification = component(mergedConfig) as ForwardRefExoticComponent<
-    NotificationProps & RefAttributes<HTMLDivElement>
->;
+export const Notification = component(mergedConfig);
 
 export const NotificationsProvider: React.FC<{
     children: ReactNode;

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -125,6 +125,8 @@ import { h4Bold } from '@salutejs/sdds-themes/tokens';
 import { h5 } from '@salutejs/sdds-themes/tokens';
 import { h5Bold } from '@salutejs/sdds-themes/tokens';
 import { HTMLAttributes } from 'react';
+import { HTMLAttributesWithoutOnChange } from '@salutejs/plasma-new-hope/types/engines/types';
+import { HTMLAttributesWithoutOnChangeAndDefaultValue } from '@salutejs/plasma-new-hope/types/engines/types';
 import { ImageProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -2594,7 +2596,22 @@ export { modalClasses }
 export { ModalProps }
 
 // @public (undocumented)
-const Notification_2: React_2.ForwardRefExoticComponent<NotificationProps & React_2.RefAttributes<HTMLDivElement>>;
+const Notification_2: React_2.FunctionComponent<PropsType<    {
+view: {
+default: PolymorphicClassName;
+};
+layout: {
+horizontal: PolymorphicClassName;
+vertical: PolymorphicClassName;
+};
+closeIconType: {
+default: PolymorphicClassName;
+};
+size: {
+xs: PolymorphicClassName;
+xxs: PolymorphicClassName;
+};
+}> & (React_2.HTMLAttributes<HTMLElement> | HTMLAttributesWithoutOnChange<HTMLElement> | HTMLAttributesWithoutOnChangeAndDefaultValue<HTMLElement>)>;
 export { Notification_2 as Notification }
 
 export { NotificationIconPlacement }

--- a/packages/sdds-insol/src/components/Notification/Notification.tsx
+++ b/packages/sdds-insol/src/components/Notification/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefExoticComponent, ReactNode, RefAttributes } from 'react';
+import React, { ReactNode } from 'react';
 import {
     component,
     mergeConfig,
@@ -18,9 +18,7 @@ export { modalClasses } from '../Modal';
 
 const mergedConfig = mergeConfig(notificationConfig, config);
 
-export const Notification = component(mergedConfig) as ForwardRefExoticComponent<
-    NotificationProps & RefAttributes<HTMLDivElement>
->;
+export const Notification = component(mergedConfig);
 
 export const NotificationsProvider: React.FC<{
     children: ReactNode;

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -125,6 +125,8 @@ import { h4Bold } from '@salutejs/sdds-themes/tokens';
 import { h5 } from '@salutejs/sdds-themes/tokens';
 import { h5Bold } from '@salutejs/sdds-themes/tokens';
 import { HTMLAttributes } from 'react';
+import { HTMLAttributesWithoutOnChange } from '@salutejs/plasma-new-hope/types/engines/types';
+import { HTMLAttributesWithoutOnChangeAndDefaultValue } from '@salutejs/plasma-new-hope/types/engines/types';
 import { ImageProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -2582,7 +2584,22 @@ export { modalClasses }
 export { ModalProps }
 
 // @public (undocumented)
-const Notification_2: React_2.ForwardRefExoticComponent<NotificationProps & React_2.RefAttributes<HTMLDivElement>>;
+const Notification_2: React_2.FunctionComponent<PropsType<    {
+view: {
+default: PolymorphicClassName;
+};
+layout: {
+horizontal: PolymorphicClassName;
+vertical: PolymorphicClassName;
+};
+closeIconType: {
+default: PolymorphicClassName;
+};
+size: {
+xs: PolymorphicClassName;
+xxs: PolymorphicClassName;
+};
+}> & (React_2.HTMLAttributes<HTMLElement> | HTMLAttributesWithoutOnChange<HTMLElement> | HTMLAttributesWithoutOnChangeAndDefaultValue<HTMLElement>)>;
 export { Notification_2 as Notification }
 
 export { NotificationIconPlacement }

--- a/packages/sdds-serv/src/components/Notification/Notification.tsx
+++ b/packages/sdds-serv/src/components/Notification/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { ForwardRefExoticComponent, ReactNode, RefAttributes } from 'react';
+import React, { ReactNode } from 'react';
 import {
     component,
     mergeConfig,
@@ -18,9 +18,7 @@ export { modalClasses } from '../Modal';
 
 const mergedConfig = mergeConfig(notificationConfig, config);
 
-export const Notification = component(mergedConfig) as ForwardRefExoticComponent<
-    NotificationProps & RefAttributes<HTMLDivElement>
->;
+export const Notification = component(mergedConfig);
 
 export const NotificationsProvider: React.FC<{
     children: ReactNode;


### PR DESCRIPTION
## Core

### Notification

- Исправлен тип выходного компонента `notification`

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-cs@0.214.1-canary.1664.12429823449.0
  npm install @salutejs/sdds-dfa@0.208.1-canary.1664.12429823449.0
  npm install @salutejs/sdds-finportal@0.202.1-canary.1664.12429823449.0
  npm install @salutejs/sdds-insol@0.203.1-canary.1664.12429823449.0
  npm install @salutejs/sdds-serv@0.210.1-canary.1664.12429823449.0
  # or 
  yarn add @salutejs/sdds-cs@0.214.1-canary.1664.12429823449.0
  yarn add @salutejs/sdds-dfa@0.208.1-canary.1664.12429823449.0
  yarn add @salutejs/sdds-finportal@0.202.1-canary.1664.12429823449.0
  yarn add @salutejs/sdds-insol@0.203.1-canary.1664.12429823449.0
  yarn add @salutejs/sdds-serv@0.210.1-canary.1664.12429823449.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
