### PR TITLE
infra(sdds-serv): fix typings path

### DIFF
--- a/packages/plasma-new-hope/package.json
+++ b/packages/plasma-new-hope/package.json
@@ -15,6 +15,11 @@
       "require": "./styled-components/cjs/index.js",
       "import": "./styled-components/es/index.js",
       "types": "./types/index.d.ts"
+    },
+    "./emotion": {
+      "require": "./emotion/cjs/index.js",
+      "import": "./emotion/es/index.js",
+      "types": "./types/index.d.ts"
     }
   },
   "files": [

--- a/packages/plasma-new-hope/package.json
+++ b/packages/plasma-new-hope/package.json
@@ -2,9 +2,21 @@
   "name": "@salutejs/plasma-new-hope",
   "version": "0.229.0-dev.0",
   "description": "Salute Design System blueprint",
-  "main": "cjs/index.js",
-  "module": "es/index.js",
-  "types": "types/index.d.ts",
+  "main": "./cjs/index.js",
+  "module": "./es/index.js",
+  "types": "./types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./cjs/index.js",
+      "import": "./es/index.js",
+      "types": "./types/index.d.ts"
+    },
+    "./styled-components": {
+      "require": "./styled-components/cjs/index.js",
+      "import": "./styled-components/es/index.js",
+      "types": "./types/index.d.ts"
+    }
+  },
   "files": [
     "cjs",
     "es",

--- a/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,7 +7,8 @@ import type { BreadcrumbsProps } from './Breadcrumbs.types';
 import { base as sizeCSS } from './variations/_size/base';
 import { base as viewCSS } from './variations/_view/base';
 import { base, Separator } from './Breadcrumbs.styles';
-import { addSeparator, convertIconSize, getRenderItems } from './utils';
+import { addSeparator, convertIconSize } from './utils';
+import { getRenderItems } from './utils/getShortItems';
 
 export const breadcrumbsRoot = (Root: RootProps<HTMLDivElement, BreadcrumbsProps>) =>
     forwardRef<HTMLDivElement, BreadcrumbsProps>(

--- a/packages/plasma-new-hope/src/components/Breadcrumbs/utils/getShortItems.tsx
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/utils/getShortItems.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
+import type { ReactNode } from 'react';
 
 import { BreadcrumbShorter } from '../ui/BreadcrumbShorter/BreadcrumbShorter';
 import { StyledLink } from '../Breadcrumbs.styles';
@@ -16,16 +17,6 @@ export const shortItems = (items: ReactNode[], renderSeparator: ReactNode, showI
     const shorter = <BreadcrumbShorter separator={renderSeparator}>{renderItems}</BreadcrumbShorter>;
     items.splice(leftSlice, rightSlice - leftSlice, shorter);
     return items;
-};
-
-export const convertIconSize = (size?: string) => {
-    switch (size) {
-        case 's':
-        case 'xs':
-            return 'xs';
-        default:
-            return 's';
-    }
 };
 
 export const getRenderItems = (items: BreadcrumbsItem[], renderSeparator: ReactNode, showItems?: number) => {
@@ -54,8 +45,4 @@ export const getRenderItems = (items: BreadcrumbsItem[], renderSeparator: ReactN
     );
 
     return renderItems;
-};
-
-export const addSeparator = (items: ReactNode[], renderSeparator: ReactNode) => {
-    return items.flatMap((item, idx) => (idx < items.length - 1 ? [item, renderSeparator] : [item]));
 };

--- a/packages/plasma-new-hope/src/components/Breadcrumbs/utils/index.ts
+++ b/packages/plasma-new-hope/src/components/Breadcrumbs/utils/index.ts
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+export const convertIconSize = (size?: string) => {
+    switch (size) {
+        case 's':
+        case 'xs':
+            return 'xs';
+        default:
+            return 's';
+    }
+};
+
+export const addSeparator = (items: ReactNode[], renderSeparator: ReactNode) => {
+    return items.flatMap((item, idx) => (idx < items.length - 1 ? [item, renderSeparator] : [item]));
+};

--- a/packages/plasma-new-hope/src/components/Calendar/utils/getDateWithModification.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/utils/getDateWithModification.ts
@@ -1,8 +1,7 @@
 import type { DateItem, DateObject, DisabledDay, EventDay } from '../Calendar.types';
-import type { CalendarStateType } from '..';
-import { CalendarState } from '../store/types';
+import { CalendarState, CalendarStateType } from '../store/types';
 
-import { getPropsMap } from '.';
+import { getPropsMap } from './calendarGridHelper';
 
 type GetDatesWithModificationsArgs = {
     dates: DateItem[];

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.context.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.context.tsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import type { ItemContext } from './Combobox.types';
+
+export const Context = createContext<ItemContext>({} as ItemContext);

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState, useReducer, useMemo, createContext, useLayoutEffect, useRef } from 'react';
+import React, { forwardRef, useState, useReducer, useMemo, useLayoutEffect, useRef } from 'react';
 import type { ChangeEvent, ForwardedRef } from 'react';
 import { safeUseId, useForkRef } from '@salutejs/plasma-core';
 
@@ -23,13 +23,12 @@ import { Inner, StyledTextField } from './ui';
 import { pathReducer, focusedPathReducer } from './reducers';
 import { getPathMap, getTreeMaps } from './hooks/getPathMaps';
 import { Ul, base, StyledArrow, IconArrowWrapper, StyledEmptyState } from './Combobox.styles';
-import type { ItemContext, ComboboxProps } from './Combobox.types';
+import type { ComboboxProps } from './Combobox.types';
 import { base as viewCSS } from './variations/_view/base';
 import { base as sizeCSS } from './variations/_size/base';
 import type { ItemOptionTransformed } from './ui/Inner/ui/Item/Item.types';
 import { SelectNative } from './ui/SelectNative/SelectNative';
-
-export const Context = createContext<ItemContext>({} as ItemContext);
+import { Context } from './Combobox.context';
 
 /**
  * Поле ввода с выпадающим списком и возможностью фильтрации и выбора элементов.

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/Inner/ui/Item/Item.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/Inner/ui/Item/Item.tsx
@@ -4,7 +4,7 @@ import { sizeToIconSize, getItemId } from '../../../../utils';
 import { classes } from '../../../../Combobox.tokens';
 import { cx, isEmpty } from '../../../../../../../utils';
 import { IconDisclosureRightCentered, IconDone } from '../../../../../../_Icon';
-import { Context } from '../../../../Combobox';
+import { Context } from '../../../../Combobox.context';
 import { useDidMountEffect } from '../../../../../../../hooks';
 
 import { ItemProps } from './Item.types';

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.context.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.context.tsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import type { ItemContext } from './Dropdown.types';
+
+export const Context = createContext<ItemContext>({} as ItemContext);

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, forwardRef, useReducer, useRef } from 'react';
+import React, { forwardRef, useReducer, useRef } from 'react';
 import { safeUseId } from '@salutejs/plasma-core';
 
 import { RootProps } from '../../engines';
@@ -12,13 +12,12 @@ import { base as viewCSS } from './variations/_view/base';
 import { base as sizeCSS } from './variations/_size/base';
 import { Ul, base } from './Dropdown.styles';
 import { childrenWithProps, getItemByFocused, getItemId, getPlacement } from './utils';
-import type { DropdownProps, HandleGlobalToggleType, ItemContext } from './Dropdown.types';
+import type { DropdownProps, HandleGlobalToggleType } from './Dropdown.types';
 import { classes } from './Dropdown.tokens';
 import { useKeyNavigation } from './hooks/useKeyboardNavigation';
 import { useHashMaps } from './hooks/useHashMaps';
 import { FloatingPopover } from './FloatingPopover';
-
-export const Context = createContext<ItemContext>({} as ItemContext);
+import { Context } from './Dropdown.context';
 
 /**
  * Выпадающий список.

--- a/packages/plasma-new-hope/src/components/Dropdown/ui/DropdownInner/DropdownInner.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/ui/DropdownInner/DropdownInner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { FC } from 'react';
 import { safeUseId } from '@salutejs/plasma-core';
 
-import { DropdownItem } from '..';
+import { DropdownItem } from '../DropdownItem/DropdownItem';
 import { Ul } from '../../Dropdown.styles';
 import { FloatingPopover } from '../../FloatingPopover';
 

--- a/packages/plasma-new-hope/src/components/Dropdown/ui/DropdownItem/DropdownItem.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/ui/DropdownItem/DropdownItem.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, FC, useContext } from 'react';
 import { classes } from '../../Dropdown.tokens';
 import { cx } from '../../../../utils';
 import { IconDisclosureRight } from '../../../_Icon';
-import { Context } from '../../Dropdown';
+import { Context } from '../../Dropdown.context';
 import { getItemId } from '../../utils';
 
 import {

--- a/packages/plasma-new-hope/src/components/Select/Select.context.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.context.tsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import type { ItemContext } from './Select.types';
+
+export const Context = createContext<ItemContext>({} as ItemContext);

--- a/packages/plasma-new-hope/src/components/Select/Select.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.tsx
@@ -3,7 +3,6 @@ import React, {
     useState,
     useReducer,
     useMemo,
-    createContext,
     useLayoutEffect,
     useRef,
     ChangeEvent,
@@ -28,12 +27,11 @@ import { Inner, Target } from './ui';
 import { pathReducer, focusedPathReducer } from './reducers';
 import { usePathMaps } from './hooks/usePathMaps';
 import { Ul, base } from './Select.styles';
-import type { ItemContext, MergedSelectProps, RequiredProps } from './Select.types';
+import type { MergedSelectProps, RequiredProps } from './Select.types';
 import type { MergedDropdownNodeTransformed } from './ui/Inner/ui/Item/Item.types';
 import { FloatingPopover } from './FloatingPopover';
 import { SelectNative } from './ui/SelectNative/SelectNative';
-
-export const Context = createContext<ItemContext>({} as ItemContext);
+import { Context } from './Select.context';
 
 /**
  * Выпадающий список. Поддерживает выбор одного или нескольких значений.

--- a/packages/plasma-new-hope/src/components/Select/ui/Inner/Inner.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Inner/Inner.tsx
@@ -7,7 +7,7 @@ import { Ul } from '../../Select.styles';
 import { FloatingPopover } from '../../FloatingPopover';
 
 import type { MergedDropdownNodeTransformed } from './ui/Item/Item.types';
-import { Item } from './ui';
+import { Item } from './ui/Item/Item';
 import { InnerProps } from './Inner.type';
 
 export const Inner: FC<InnerProps> = ({ item, currentLevel, path, dispatchPath, index, listWidth }) => {

--- a/packages/plasma-new-hope/src/components/Select/ui/Inner/ui/Item/Item.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Inner/ui/Item/Item.tsx
@@ -4,7 +4,7 @@ import { sizeToIconSize, getItemId } from '../../../../utils';
 import { classes } from '../../../../Select.tokens';
 import { cx, isEmpty } from '../../../../../../utils';
 import { IconDisclosureRightCentered, IconDone } from '../../../../../_Icon';
-import { Context } from '../../../../Select';
+import { Context } from '../../../../Select.context';
 import { useDidMountEffect } from '../../../../../../hooks';
 
 import { ItemProps } from './Item.types';

--- a/packages/plasma-new-hope/src/components/Slider/components/DoubleUncontrolled/DoubleUncontrolled.tsx
+++ b/packages/plasma-new-hope/src/components/Slider/components/DoubleUncontrolled/DoubleUncontrolled.tsx
@@ -1,6 +1,6 @@
 import React, { KeyboardEvent, FC, useState, useCallback } from 'react';
 
-import { DoubleSlider } from '../index';
+import { DoubleSlider } from '../Double/Double';
 import { FormTypeString } from '../../../../types/FormType';
 
 import { DoubleUncontrolledProps } from './DoubleUncontrolled.types';

--- a/packages/plasma-new-hope/src/engines/common.tsx
+++ b/packages/plasma-new-hope/src/engines/common.tsx
@@ -3,52 +3,12 @@ import React from 'react';
 import { _component } from './linaria';
 import type {
     ComponentConfig,
-    HTMLAnyAttributes,
     HTMLTagList,
     PropsType,
     Variants,
     HTMLAttributesWithoutOnChange,
     HTMLAttributesWithoutOnChangeAndDefaultValue,
 } from './types';
-
-//
-// Тип HTMLAttributesOmitOnChange требуется чтобы использовать компонент с кастомным пропсом onChange
-//
-
-export const getStaticVariants = (config: ComponentConfig) => {
-    if (!config.variations) {
-        return [];
-    }
-    const res = [];
-    const { variations } = config;
-
-    // eslint-disable-next-line guard-for-in
-    for (const key in variations) {
-        const { css } = variations[key];
-        css && res.push(css);
-    }
-
-    return res;
-};
-
-export const getDynamicVariants = (config: ComponentConfig) => {
-    return (props: HTMLAnyAttributes) => {
-        const res = [];
-
-        // eslint-disable-next-line guard-for-in
-        for (const key in config.variations) {
-            if (key in props) {
-                const variant = config.variations[key];
-
-                const css = variant[props[key]];
-                // no css for { modifier: true }
-                css && Array.isArray(css) ? res.push(...css) : res.push(css);
-            }
-        }
-
-        return res;
-    };
-};
 
 export const mergeConfig = <
     Tag extends HTMLTagList,

--- a/packages/plasma-new-hope/src/engines/emotion.tsx
+++ b/packages/plasma-new-hope/src/engines/emotion.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { getStaticVariants, getDynamicVariants } from './common';
+import { getStaticVariants, getDynamicVariants } from './utils';
 import type { ComponentConfig, HTMLAnyAttributes } from './types';
 
 export { css };

--- a/packages/plasma-new-hope/src/engines/linaria.tsx
+++ b/packages/plasma-new-hope/src/engines/linaria.tsx
@@ -3,7 +3,7 @@ import { cx } from '@linaria/core';
 
 // TODO: #1008 Избавиться от импортов и переделать addFocus
 import 'focus-visible';
-import { getStaticVariants, getDynamicVariants } from './common';
+import { getStaticVariants, getDynamicVariants } from './utils';
 import type { ComponentConfig, HTMLAnyAttributes } from './types';
 
 /* eslint-disable no-underscore-dangle */

--- a/packages/plasma-new-hope/src/engines/styled-components.tsx
+++ b/packages/plasma-new-hope/src/engines/styled-components.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 
-import { getStaticVariants, getDynamicVariants } from './common';
+import { getStaticVariants, getDynamicVariants } from './utils';
 import type { ComponentConfig, HTMLAnyAttributes } from './types';
 
 export { styled, css };

--- a/packages/plasma-new-hope/src/engines/utils.ts
+++ b/packages/plasma-new-hope/src/engines/utils.ts
@@ -1,0 +1,36 @@
+import type { ComponentConfig, HTMLAnyAttributes } from './types';
+
+export const getStaticVariants = (config: ComponentConfig) => {
+    if (!config.variations) {
+        return [];
+    }
+    const res = [];
+    const { variations } = config;
+
+    // eslint-disable-next-line guard-for-in
+    for (const key in variations) {
+        const { css } = variations[key];
+        css && res.push(css);
+    }
+
+    return res;
+};
+
+export const getDynamicVariants = (config: ComponentConfig) => {
+    return (props: HTMLAnyAttributes) => {
+        const res = [];
+
+        // eslint-disable-next-line guard-for-in
+        for (const key in config.variations) {
+            if (key in props) {
+                const variant = config.variations[key];
+
+                const css = variant[props[key]];
+                // no css for { modifier: true }
+                css && Array.isArray(css) ? res.push(...css) : res.push(css);
+            }
+        }
+
+        return res;
+    };
+};

--- a/packages/sdds-cs/emotion/package.json
+++ b/packages/sdds-cs/emotion/package.json
@@ -1,5 +1,5 @@
 {
     "module": "es/index.js",
     "main": "cjs/index.js",
-    "types": "../types/index.d.ts"
+    "types": "../index.d.ts"
 }

--- a/packages/sdds-cs/package.json
+++ b/packages/sdds-cs/package.json
@@ -21,9 +21,36 @@
     "api-extractor.json",
     "CHANGELOG.md"
   ],
-  "main": "index.js",
-  "module": "es/index.js",
-  "types": "index.d.ts",
+  "main": "./index.js",
+  "module": "./es/index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./components/index.js",
+      "import": "./es/index.js",
+      "types": "./index.d.ts"
+    },
+    "./styled-components": {
+      "require": "./styled-components/cjs/index.js",
+      "import": "./styled-components/es/index.js",
+      "types": "./index.d.ts"
+    },
+    "./emotion": {
+      "require": "./emotion/cjs/index.js",
+      "import": "./emotion/es/index.js",
+      "types": "./index.d.ts"
+    },
+    "./tokens": {
+      "require": "./tokens/index.js",
+      "import": "./es/tokens/index.js",
+      "types": "./tokens/index.d.ts"
+    },
+    "./mixins": {
+      "require": "./mixins/index.js",
+      "import": "./es/mixins/index.js",
+      "types": "./mixins/index.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:salute-developers/plasma.git",

--- a/packages/sdds-cs/package.json
+++ b/packages/sdds-cs/package.json
@@ -30,11 +30,6 @@
       "import": "./es/index.js",
       "types": "./index.d.ts"
     },
-    "./styled-components": {
-      "require": "./styled-components/cjs/index.js",
-      "import": "./styled-components/es/index.js",
-      "types": "./index.d.ts"
-    },
     "./emotion": {
       "require": "./emotion/cjs/index.js",
       "import": "./emotion/es/index.js",
@@ -124,9 +119,10 @@
     "build:styled-components": "npm run build:styled-components:esm && npm run build:styled-components:cjs",
     "build:styled-components:cjs": "BABEL_ENV=cjs SC_NAMESPACE=sdds-srvc babel ./src --out-dir . --extensions .ts,.tsx",
     "build:styled-components:esm": "BABEL_ENV=esm SC_NAMESPACE=sdds-srvc babel ./src --out-dir ./es --extensions .ts,.tsx",
-    "postbuild:styled-components": "npm run generate:typings",
-    "postbuild:emotion": "rm -rf src-emotion && npm run generate:typings",
-    "generate:typings": "tsc --outDir . --emitDeclarationOnly",
+    "postbuild:styled-components": "rm -rf src-sc",
+    "postbuild:emotion": "rm -rf src-emotion",
+    "remove:typings": "rm -rf components/**/*.d.ts && rm -f index.d.ts && rm -f mixins/index.d.ts && rm -f tokens/index.d.ts",
+    "generate:typings": "npm run remove:typings && tsc --outDir . --emitDeclarationOnly",
     "storybook": "storybook dev -p ${PORT:-7007} -c .storybook",
     "prestorybook:emotion": "npm run prebuild:emotion",
     "storybook:emotion": "USE_EMOTION_COMPONENTS=true storybook dev -p ${PORT:-7002} -c .storybook",
@@ -141,7 +137,7 @@
       "src/**/*stories.tsx",
       "src/**/*perftest.tsx"
     ],
-    "atLeast": 99.96
+    "atLeast": 99.94
   },
   "contributors": [
     "Vasiliy Loginevskiy",

--- a/packages/sdds-serv/emotion/package.json
+++ b/packages/sdds-serv/emotion/package.json
@@ -1,5 +1,5 @@
 {
     "module": "es/index.js",
     "main": "cjs/index.js",
-    "types": "../types/index.d.ts"
+    "types": "../index.d.ts"
 }

--- a/packages/sdds-serv/package.json
+++ b/packages/sdds-serv/package.json
@@ -24,7 +24,7 @@
   ],
   "main": "./index.js",
   "module": "./es/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
       "require": "./components/index.js",

--- a/packages/sdds-serv/package.json
+++ b/packages/sdds-serv/package.json
@@ -126,9 +126,10 @@
     "build:styled-components:esm": "BABEL_ENV=esm SC_NAMESPACE=sdds-srvc babel ./src --out-dir ./styled-components/es --extensions .ts,.tsx",
     "build:css": "BABEL_ENV=esm SC_NAMESPACE=sdds-srvc rollup -c",
     "postbuild:css": "rm -rf src-css",
-    "postbuild:styled-components": "npm run generate:typings",
-    "postbuild:emotion": "rm -rf src-emotion && npm run generate:typings",
-    "generate:typings": "tsc --outDir . --emitDeclarationOnly",
+    "postbuild:styled-components": "rm -rf src-sc",
+    "postbuild:emotion": "rm -rf src-emotion",
+    "remove:typings": "rm -rf components/**/*.d.ts && rm -f index.d.ts && rm -f mixins/index.d.ts && rm -f tokens/index.d.ts",
+    "generate:typings": "npm run remove:typings && tsc --outDir . --emitDeclarationOnly",
     "storybook": "npm run storybook:sc",
     "prestorybook:emotion": "npm run prebuild:emotion",
     "storybook:emotion": "USE_EMOTION_COMPONENTS=true storybook dev -p ${PORT:-7002} -c .storybook",
@@ -143,7 +144,7 @@
       "src/**/*stories.tsx",
       "src/**/*perftest.tsx"
     ],
-    "atLeast": 99.96
+    "atLeast": 99.94
   },
   "contributors": [
     "Vasiliy Loginevskiy",

--- a/packages/sdds-serv/package.json
+++ b/packages/sdds-serv/package.json
@@ -22,9 +22,26 @@
     "api-extractor.json",
     "CHANGELOG.md"
   ],
-  "main": "index.js",
-  "module": "es/index.js",
-  "types": "index.d.ts",
+  "main": "./index.js",
+  "module": "./es/index.js",
+  "types": "./types/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./components/index.js",
+      "import": "./es/index.js",
+      "types": "./index.d.ts"
+    },
+    "./styled-components": {
+      "require": "./styled-components/cjs/index.js",
+      "import": "./styled-components/es/index.js",
+      "types": "./index.d.ts"
+    },
+    "./emotion": {
+      "require": "./emotion/cjs/index.js",
+      "import": "./emotion/es/index.js",
+      "types": "./index.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:salute-developers/plasma.git",

--- a/packages/sdds-serv/scripts/copy-linaria-components.sh
+++ b/packages/sdds-serv/scripts/copy-linaria-components.sh
@@ -9,7 +9,7 @@ touch src-css/index.d.ts
 for component in $components; do
     cp -R src/components/$component src-css/components/;
     grep -E "\<$component\>" src/index.ts >> src-css/index.ts
-    echo "export * from '../components/$component';" >> css/index.d.ts;
+    echo "export * from '../components/$component';" >> src-css/index.d.ts;
     
 done;
 

--- a/packages/sdds-serv/styled-components/package.json
+++ b/packages/sdds-serv/styled-components/package.json
@@ -1,5 +1,5 @@
 {
     "module": "es/index.js",
     "main": "cjs/index.js",
-    "types": "../types/index.d.ts"
+    "types": "../index.d.ts"
 }

--- a/packages/sdds-serv/tsconfig.json
+++ b/packages/sdds-serv/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "allowJs": false,
         "target": "ES5",
         "module": "CommonJS",
         "lib": ["dom", "dom.iterable", "esnext"],
@@ -40,5 +41,14 @@
         }
     },
     "include": ["./src"],
-    "exclude": ["./src/helpers", "./src/**/*.stories.tsx", "./src/**/*.component-test.tsx", "./src/**/*.perftest.tsx"]
+    "exclude": [
+        "./src/helpers",
+        "./src/**/*.stories.tsx",
+        "./src/**/*.component-test.tsx",
+        "./src/**/*.perftest.tsx",
+        "./components",
+        "./es",
+        "./styled-components",
+        "./emotion"
+    ]
 }

--- a/packages/sdds-serv/tsconfig.json
+++ b/packages/sdds-serv/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "allowJs": false,
         "target": "ES5",
         "module": "CommonJS",
         "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
## Core

### Breadcrumbs, Calendar, Combobox, Dropdown, Select, Slider

- исправлены циклические зависимости

## SDDS-CS

### Chore

- добавлен объект `exports` в `package.json` для исправления ошибки vitest ([vitest issue](https://github.com/vitest-dev/vitest/discussions/4233))

## SDDS-SERV

### Chore

- fix error in path of  d.ts file generation in `copy-linaria.sh` script;
- add `exports` object in package json for vitest ([vitest issue](https://github.com/vitest-dev/vitest/discussions/4233))

### What/why changed

By default components are exported built with linaria. So they use plain css. In order to fix build, there is need to use two more rollup plugins:
- for css import (example: [rollup-plugin-import-css](https://www.npmjs.com/package/rollup-plugin-import-css))
- for json files resolve (example: [@rollup/plugin-json](https://www.npmjs.com/package/@rollup/plugin-json))

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.241.0-canary.1666.12465577572.0
  npm install @salutejs/plasma-b2c@1.483.0-canary.1666.12465577572.0
  npm install @salutejs/plasma-giga@0.210.0-canary.1666.12465577572.0
  npm install @salutejs/plasma-new-hope@0.230.0-canary.1666.12465577572.0
  npm install @salutejs/plasma-web@1.485.0-canary.1666.12465577572.0
  npm install @salutejs/sdds-cs@0.218.0-canary.1666.12465577572.0
  npm install @salutejs/sdds-dfa@0.212.0-canary.1666.12465577572.0
  npm install @salutejs/sdds-finportal@0.206.0-canary.1666.12465577572.0
  npm install @salutejs/sdds-insol@0.207.0-canary.1666.12465577572.0
  npm install @salutejs/sdds-serv@0.214.0-canary.1666.12465577572.0
  # or 
  yarn add @salutejs/plasma-asdk@0.241.0-canary.1666.12465577572.0
  yarn add @salutejs/plasma-b2c@1.483.0-canary.1666.12465577572.0
  yarn add @salutejs/plasma-giga@0.210.0-canary.1666.12465577572.0
  yarn add @salutejs/plasma-new-hope@0.230.0-canary.1666.12465577572.0
  yarn add @salutejs/plasma-web@1.485.0-canary.1666.12465577572.0
  yarn add @salutejs/sdds-cs@0.218.0-canary.1666.12465577572.0
  yarn add @salutejs/sdds-dfa@0.212.0-canary.1666.12465577572.0
  yarn add @salutejs/sdds-finportal@0.206.0-canary.1666.12465577572.0
  yarn add @salutejs/sdds-insol@0.207.0-canary.1666.12465577572.0
  yarn add @salutejs/sdds-serv@0.214.0-canary.1666.12465577572.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
