### PR TITLE
PLASMA-4191: set required prop to dom attribute in TextArea & TextField

### DIFF
--- a/packages/plasma-b2c/src/components/TextArea/TextArea.component-test.tsx
+++ b/packages/plasma-b2c/src/components/TextArea/TextArea.component-test.tsx
@@ -362,6 +362,26 @@ describe('plasma-b2c: TextArea', () => {
                 cy.matchImageSnapshot();
             });
         });
+
+        it('required attribute', () => {
+            mount(
+                <CypressTestDecorator>
+                    <TextArea id="required" value="Value" placeholder="Placeholder" label="Title" required />
+                    <TextArea
+                        id="falseRequired"
+                        value="Value"
+                        placeholder="Placeholder"
+                        label="Title"
+                        required={false}
+                    />
+                    <TextArea id="notRequired" value="Value" placeholder="Placeholder" label="Title" />
+                </CypressTestDecorator>,
+            );
+
+            cy.get('#required').should('have.attr', 'required');
+            cy.get('#falseRequired').should('not.have.attr', 'required');
+            cy.get('#notRequired').should('not.have.attr', 'required');
+        });
     });
 
     describe('with hint', () => {

--- a/packages/plasma-b2c/src/components/TextField/TextField.component-test.tsx
+++ b/packages/plasma-b2c/src/components/TextField/TextField.component-test.tsx
@@ -552,6 +552,26 @@ describe('plasma-b2c: TextField', () => {
                 cy.matchImageSnapshot();
             });
         });
+
+        it('required attribute', () => {
+            mount(
+                <CypressTestDecoratorWithTypo>
+                    <TextField id="required" value="Value" placeholder="Placeholder" label="Title" required />
+                    <TextField
+                        id="falseRequired"
+                        value="Value"
+                        placeholder="Placeholder"
+                        label="Title"
+                        required={false}
+                    />
+                    <TextField id="notRequired" value="Value" placeholder="Placeholder" label="Title" />
+                </CypressTestDecoratorWithTypo>,
+            );
+
+            cy.get('#required').should('have.attr', 'required');
+            cy.get('#falseRequired').should('not.have.attr', 'required');
+            cy.get('#notRequired').should('not.have.attr', 'required');
+        });
     });
 
     it('chipType', () => {

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -351,6 +351,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaRootPr
                             applyCustomWidth={applyCustomWidth}
                             ref={mergeRefs(outerRef, innerRef)}
                             disabled={disabled}
+                            required={required}
                             height={applyAutoResize ? minAuto : height}
                             width={width}
                             placeholder={placeholderLabel}

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -475,6 +475,7 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldRootProps
                                     ref={inputForkRef}
                                     id={innerId}
                                     value={outerValue}
+                                    required={required}
                                     aria-labelledby={labelId}
                                     aria-describedby={helperTextId}
                                     placeholder={innerPlaceholderValue}

--- a/packages/plasma-web/src/components/TextArea/TextArea.component-test.tsx
+++ b/packages/plasma-web/src/components/TextArea/TextArea.component-test.tsx
@@ -281,6 +281,26 @@ describe('plasma-web: TextArea', () => {
                 cy.matchImageSnapshot();
             });
         });
+
+        it('required attribute', () => {
+            mount(
+                <CypressTestDecoratorWithTypo>
+                    <TextArea id="required" value="Value" placeholder="Placeholder" label="Title" required />
+                    <TextArea
+                        id="falseRequired"
+                        value="Value"
+                        placeholder="Placeholder"
+                        label="Title"
+                        required={false}
+                    />
+                    <TextArea id="notRequired" value="Value" placeholder="Placeholder" label="Title" />
+                </CypressTestDecoratorWithTypo>,
+            );
+
+            cy.get('#required').should('have.attr', 'required');
+            cy.get('#falseRequired').should('not.have.attr', 'required');
+            cy.get('#notRequired').should('not.have.attr', 'required');
+        });
     });
 
     it('_size :empty', () => {

--- a/packages/plasma-web/src/components/TextField/TextField.component-test.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.component-test.tsx
@@ -582,6 +582,26 @@ describe('plasma-web: TextField', () => {
                 cy.matchImageSnapshot();
             });
         });
+
+        it('required attribute', () => {
+            mount(
+                <CypressTestDecoratorWithTypo>
+                    <TextField id="required" value="Value" placeholder="Placeholder" label="Title" required />
+                    <TextField
+                        id="falseRequired"
+                        value="Value"
+                        placeholder="Placeholder"
+                        label="Title"
+                        required={false}
+                    />
+                    <TextField id="notRequired" value="Value" placeholder="Placeholder" label="Title" />
+                </CypressTestDecoratorWithTypo>,
+            );
+
+            cy.get('#required').should('have.attr', 'required');
+            cy.get('#falseRequired').should('not.have.attr', 'required');
+            cy.get('#notRequired').should('not.have.attr', 'required');
+        });
     });
 
     describe('with hint', () => {


### PR DESCRIPTION
## Core

### TextArea, TextField

- свойства required попадает в `DOM` на соотвествующие элементы

### What/why changed



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.241.0-canary.1670.12462995068.0
  npm install @salutejs/plasma-b2c@1.483.0-canary.1670.12462995068.0
  npm install @salutejs/plasma-giga@0.210.0-canary.1670.12462995068.0
  npm install @salutejs/plasma-new-hope@0.230.0-canary.1670.12462995068.0
  npm install @salutejs/plasma-web@1.485.0-canary.1670.12462995068.0
  npm install @salutejs/sdds-cs@0.218.0-canary.1670.12462995068.0
  npm install @salutejs/sdds-dfa@0.212.0-canary.1670.12462995068.0
  npm install @salutejs/sdds-finportal@0.206.0-canary.1670.12462995068.0
  npm install @salutejs/sdds-insol@0.207.0-canary.1670.12462995068.0
  npm install @salutejs/sdds-serv@0.214.0-canary.1670.12462995068.0
  # or 
  yarn add @salutejs/plasma-asdk@0.241.0-canary.1670.12462995068.0
  yarn add @salutejs/plasma-b2c@1.483.0-canary.1670.12462995068.0
  yarn add @salutejs/plasma-giga@0.210.0-canary.1670.12462995068.0
  yarn add @salutejs/plasma-new-hope@0.230.0-canary.1670.12462995068.0
  yarn add @salutejs/plasma-web@1.485.0-canary.1670.12462995068.0
  yarn add @salutejs/sdds-cs@0.218.0-canary.1670.12462995068.0
  yarn add @salutejs/sdds-dfa@0.212.0-canary.1670.12462995068.0
  yarn add @salutejs/sdds-finportal@0.206.0-canary.1670.12462995068.0
  yarn add @salutejs/sdds-insol@0.207.0-canary.1670.12462995068.0
  yarn add @salutejs/sdds-serv@0.214.0-canary.1670.12462995068.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
