### PR TITLE
PLASMA-4175: Select behaviour improvement

### DIFF
--- a/packages/plasma-b2c/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Select/Select.component-test.tsx
@@ -1134,4 +1134,95 @@ describe('plasma-b2c: Select', () => {
         cy.get('[id$="tree_level_1"]').should('not.exist');
         cy.get('button').should('not.have.focus');
     });
+
+    it('flow: opening', () => {
+        cy.viewport(1300, 500);
+
+        const Component = () => {
+            const [valueSingle, setValueSingle] = React.useState('paris');
+            const [valueMultiple, setValueMultiple] = React.useState(['paris', 'lyon']);
+
+            return (
+                <CypressTestDecoratorWithTypo>
+                    <div style={{ display: 'flex' }}>
+                        <div style={{ width: '300px' }}>
+                            <Select
+                                id="button-single"
+                                target="button-like"
+                                label="Список стран single"
+                                items={items}
+                                value={valueSingle}
+                                onChange={setValueSingle}
+                            />
+                        </div>
+
+                        <div style={{ width: '300px' }}>
+                            <Select
+                                id="button-multiple"
+                                multiselect
+                                target="button-like"
+                                label="Список стран single"
+                                items={items}
+                                value={valueMultiple}
+                                onChange={setValueMultiple}
+                            />
+                        </div>
+
+                        <div style={{ width: '300px' }}>
+                            <Select
+                                id="textfield-single"
+                                target="textfield-like"
+                                items={items}
+                                value={valueSingle}
+                                onChange={setValueSingle}
+                            />
+                        </div>
+
+                        <div style={{ width: '300px' }}>
+                            <Select
+                                id="textfield-multiple"
+                                multiselect
+                                target="textfield-like"
+                                items={items}
+                                value={valueMultiple}
+                                onChange={setValueMultiple}
+                            />
+                        </div>
+                    </div>
+                </CypressTestDecoratorWithTypo>
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#button-single').click();
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#button-single').click();
+        cy.get('ul[role="tree"]').should('not.exist');
+        cy.get('#button-single .select-target-arrow').click({ force: true });
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#button-single .select-target-arrow').click({ force: true });
+        cy.get('ul[role="tree"]').should('not.exist');
+
+        cy.get('#button-multiple').click();
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#button-multiple').click();
+        cy.get('ul[role="tree"]').should('not.exist');
+        cy.get('#button-multiple .select-target-arrow').click({ force: true });
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#button-multiple .select-target-arrow').click({ force: true });
+        cy.get('ul[role="tree"]').should('not.exist');
+
+        cy.get('#textfield-single').click();
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#textfield-single').click();
+        cy.get('ul[role="tree"]').should('not.exist');
+
+        cy.get('#textfield-multiple').realClick({ position: 'topLeft' });
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#textfield-multiple').realClick({ position: 'topLeft' });
+        cy.get('ul[role="tree"]').should('not.exist');
+        cy.get('#textfield-multiple').realClick({ position: 'center' });
+        cy.get('ul[role="tree"]').should('not.exist');
+    });
 });

--- a/packages/plasma-new-hope/src/components/Select/Select.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.tsx
@@ -39,6 +39,7 @@ import { Context } from './Select.context';
 export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectProps, 'items'>>) =>
     forwardRef<HTMLButtonElement, MergedSelectProps>((props, ref) => {
         const {
+            id,
             value: outerValue,
             onChange: outerOnChange,
             target = 'textfield-like',
@@ -125,12 +126,12 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
             newValue?: string | number | Array<string | number> | ChangeEvent<HTMLSelectElement> | null,
         ) => {
             if (outerOnChange) {
-                // Условие для отправки если комбобокс используется без формы.
+                // Условие для отправки если компонент используется без формы.
                 if (!name && (typeof newValue === 'string' || Array.isArray(newValue))) {
                     outerOnChange(newValue as any);
                 }
 
-                // Условие для отправки если комбобокс используется с формой.
+                // Условие для отправки если компонент используется с формой.
                 if (name && typeof newValue === 'object' && !Array.isArray(newValue)) {
                     outerOnChange(newValue as any);
                 }
@@ -140,20 +141,6 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
             if (typeof newValue === 'string' || Array.isArray(newValue)) {
                 setInternalValue(newValue);
             }
-        };
-
-        const handleClickArrow = () => {
-            if (disabled) {
-                return;
-            }
-
-            if (isCurrentListOpen) {
-                dispatchPath({ type: 'reset' });
-            } else {
-                dispatchPath({ type: 'opened_first_level' });
-            }
-
-            dispatchFocusedPath({ type: 'reset' });
         };
 
         const handleListToggle = (opened: boolean) => {
@@ -308,6 +295,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
                 labelPlacement={labelPlacement}
                 chipView={chipView}
                 disabled={disabled}
+                id={id}
                 {...(rest as any)}
             >
                 {name && (
@@ -337,7 +325,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
                     <FloatingPopover
                         ref={floatingPopoverRef}
                         opened={isCurrentListOpen}
-                        onToggle={(opened: boolean) => opened && handleListToggle(true)}
+                        onToggle={handleListToggle}
                         placement={placement}
                         portal={portal}
                         listWidth={listWidth}
@@ -359,7 +347,6 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
                                 inputWrapperRef={referenceRef as React.MutableRefObject<HTMLDivElement>}
                                 multiselect={props.multiselect}
                                 view={view}
-                                handleClickArrow={handleClickArrow}
                                 helperText={helperText}
                                 treeId={treeId}
                                 activeDescendantItemValue={activeDescendantItemValue}

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/Target.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/Target.tsx
@@ -23,7 +23,6 @@ export const Target = forwardRef<HTMLButtonElement, TargetProps>(
             inputWrapperRef,
             multiselect,
             view,
-            handleClickArrow,
             helperText,
             treeId,
             activeDescendantItemValue,
@@ -79,7 +78,6 @@ export const Target = forwardRef<HTMLButtonElement, TargetProps>(
                 labelPlacement={labelPlacement}
                 size={size}
                 view={view}
-                handleClickArrow={handleClickArrow}
                 contentLeft={contentLeft}
                 helperText={helperText}
                 treeId={treeId}

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/Target.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/Target.types.ts
@@ -26,7 +26,6 @@ export type TargetProps = Pick<
     onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
     selectProps: MergedSelectProps;
     inputWrapperRef: MutableRefObject<HTMLDivElement>;
-    handleClickArrow: () => void;
     treeId: string;
     activeDescendantItemValue: string;
     onChange: (newValue: string | number | Array<string | number>) => void;

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.tsx
@@ -20,7 +20,6 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
             onKeyDown,
             size,
             view,
-            handleClickArrow,
             contentLeft,
             helperText,
             treeId,
@@ -109,7 +108,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
                 placeholder={value instanceof Array && value.length ? '' : placeholder}
                 contentLeft={contentLeft as React.ReactElement}
                 contentRight={
-                    <IconArrowWrapper disabled={Boolean(disabled)} onClick={handleClickArrow}>
+                    <IconArrowWrapper disabled={Boolean(disabled)}>
                         <StyledArrow color="inherit" size={sizeToIconSize(size)} className={withArrowInverse} />
                     </IconArrowWrapper>
                 }

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.types.ts
@@ -13,7 +13,6 @@ export type TextfieldProps = Pick<
     | 'onKeyDown'
     | 'size'
     | 'view'
-    | 'handleClickArrow'
     | 'contentLeft'
     | 'helperText'
     | 'treeId'

--- a/packages/plasma-web/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-web/src/components/Select/Select.component-test.tsx
@@ -1134,4 +1134,95 @@ describe('plasma-web: Select', () => {
         cy.get('[id$="tree_level_1"]').should('not.exist');
         cy.get('button').should('not.have.focus');
     });
+
+    it('flow: opening', () => {
+        cy.viewport(1300, 500);
+
+        const Component = () => {
+            const [valueSingle, setValueSingle] = React.useState('paris');
+            const [valueMultiple, setValueMultiple] = React.useState(['paris', 'lyon']);
+
+            return (
+                <CypressTestDecoratorWithTypo>
+                    <div style={{ display: 'flex' }}>
+                        <div style={{ width: '300px' }}>
+                            <Select
+                                id="button-single"
+                                target="button-like"
+                                label="Список стран single"
+                                items={items}
+                                value={valueSingle}
+                                onChange={setValueSingle}
+                            />
+                        </div>
+
+                        <div style={{ width: '300px' }}>
+                            <Select
+                                id="button-multiple"
+                                multiselect
+                                target="button-like"
+                                label="Список стран single"
+                                items={items}
+                                value={valueMultiple}
+                                onChange={setValueMultiple}
+                            />
+                        </div>
+
+                        <div style={{ width: '300px' }}>
+                            <Select
+                                id="textfield-single"
+                                target="textfield-like"
+                                items={items}
+                                value={valueSingle}
+                                onChange={setValueSingle}
+                            />
+                        </div>
+
+                        <div style={{ width: '300px' }}>
+                            <Select
+                                id="textfield-multiple"
+                                multiselect
+                                target="textfield-like"
+                                items={items}
+                                value={valueMultiple}
+                                onChange={setValueMultiple}
+                            />
+                        </div>
+                    </div>
+                </CypressTestDecoratorWithTypo>
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#button-single').click();
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#button-single').click();
+        cy.get('ul[role="tree"]').should('not.exist');
+        cy.get('#button-single .select-target-arrow').click({ force: true });
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#button-single .select-target-arrow').click({ force: true });
+        cy.get('ul[role="tree"]').should('not.exist');
+
+        cy.get('#button-multiple').click();
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#button-multiple').click();
+        cy.get('ul[role="tree"]').should('not.exist');
+        cy.get('#button-multiple .select-target-arrow').click({ force: true });
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#button-multiple .select-target-arrow').click({ force: true });
+        cy.get('ul[role="tree"]').should('not.exist');
+
+        cy.get('#textfield-single').click();
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#textfield-single').click();
+        cy.get('ul[role="tree"]').should('not.exist');
+
+        cy.get('#textfield-multiple').realClick({ position: 'topLeft' });
+        cy.get('ul[role="tree"]').should('be.visible');
+        cy.get('#textfield-multiple').realClick({ position: 'topLeft' });
+        cy.get('ul[role="tree"]').should('not.exist');
+        cy.get('#textfield-multiple').realClick({ position: 'center' });
+        cy.get('ul[role="tree"]').should('not.exist');
+    });
 });


### PR DESCRIPTION
## Core
### Select

- закрытие выпадающего списка теперь возможно по повторному нажатию на таргет;

### What/why changed
Привели поведение открытия/закрытия к надлежащему виду.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.246.0-canary.1676.12492303809.0
  npm install @salutejs/plasma-b2c@1.488.0-canary.1676.12492303809.0
  npm install @salutejs/plasma-giga@0.215.0-canary.1676.12492303809.0
  npm install @salutejs/plasma-new-hope@0.235.0-canary.1676.12492303809.0
  npm install @salutejs/plasma-web@1.490.0-canary.1676.12492303809.0
  npm install @salutejs/sdds-cs@0.223.0-canary.1676.12492303809.0
  npm install @salutejs/sdds-dfa@0.217.0-canary.1676.12492303809.0
  npm install @salutejs/sdds-finportal@0.211.0-canary.1676.12492303809.0
  npm install @salutejs/sdds-insol@0.212.0-canary.1676.12492303809.0
  npm install @salutejs/sdds-serv@0.219.0-canary.1676.12492303809.0
  # or 
  yarn add @salutejs/plasma-asdk@0.246.0-canary.1676.12492303809.0
  yarn add @salutejs/plasma-b2c@1.488.0-canary.1676.12492303809.0
  yarn add @salutejs/plasma-giga@0.215.0-canary.1676.12492303809.0
  yarn add @salutejs/plasma-new-hope@0.235.0-canary.1676.12492303809.0
  yarn add @salutejs/plasma-web@1.490.0-canary.1676.12492303809.0
  yarn add @salutejs/sdds-cs@0.223.0-canary.1676.12492303809.0
  yarn add @salutejs/sdds-dfa@0.217.0-canary.1676.12492303809.0
  yarn add @salutejs/sdds-finportal@0.211.0-canary.1676.12492303809.0
  yarn add @salutejs/sdds-insol@0.212.0-canary.1676.12492303809.0
  yarn add @salutejs/sdds-serv@0.219.0-canary.1676.12492303809.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
