### PR TITLE
PLASMA-3959: add badge for only sc components ( copy )

### DIFF
--- a/website/plasma-b2c-docs/docs/components/AudioPlayer.mdx
+++ b/website/plasma-b2c-docs/docs/components/AudioPlayer.mdx
@@ -3,9 +3,11 @@ id: AudioPlayer
 title: AudioPlayer
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # AudioPlayer
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="AudioPlayer" />
 <PropsTable name="AudioPlayer" />

--- a/website/plasma-b2c-docs/docs/components/Card.mdx
+++ b/website/plasma-b2c-docs/docs/components/Card.mdx
@@ -3,9 +3,12 @@ id: card
 title: Card
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Card
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 Набор компонентов для создания карточек.
 
 <StorybookLink name="Card" />

--- a/website/plasma-b2c-docs/docs/components/Carousel.mdx
+++ b/website/plasma-b2c-docs/docs/components/Carousel.mdx
@@ -3,9 +3,12 @@ id: carousel
 title: Carousel
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Carousel
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 Набор компонентов для создания списков с прокруткой (галерей).
 
 <StorybookLink name="Carousel" />

--- a/website/plasma-b2c-docs/docs/components/ElasticGrid.mdx
+++ b/website/plasma-b2c-docs/docs/components/ElasticGrid.mdx
@@ -3,9 +3,11 @@ id: ElasticGrid
 title: ElasticGrid
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # ElasticGrid
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="ElasticGrid" />
 <PropsTable name="ElasticGrid" />

--- a/website/plasma-b2c-docs/docs/components/Modal.mdx
+++ b/website/plasma-b2c-docs/docs/components/Modal.mdx
@@ -3,9 +3,12 @@ id: modal
 title: Modal
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Modal
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 <Description name="Modal" />
 <PropsTable name="Modal" />
 <StorybookLink name="Modal" />

--- a/website/plasma-b2c-docs/docs/components/Overlay.mdx
+++ b/website/plasma-b2c-docs/docs/components/Overlay.mdx
@@ -3,9 +3,12 @@ id: overlay
 title: Overlay
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Overlay
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 <Description name="Overlay" />
 <PropsTable name="Overlay" exclude={['css']} />
 <StorybookLink name="Overlay" />

--- a/website/plasma-b2c-docs/docs/components/Portal.mdx
+++ b/website/plasma-b2c-docs/docs/components/Portal.mdx
@@ -3,9 +3,12 @@ id: portal
 title: Portal
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Portal
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 <Description name="Portal" />
 <PropsTable name="Portal" exclude={['css']} />
 <StorybookLink name="Portal" />

--- a/website/plasma-b2c-docs/docs/components/PreviewGallery.mdx
+++ b/website/plasma-b2c-docs/docs/components/PreviewGallery.mdx
@@ -3,9 +3,11 @@ id: PreviewGallery
 title: PreviewGallery
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # PreviewGallery
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="PreviewGallery" />
 <PropsTable name="PreviewGallery" />

--- a/website/plasma-b2c-docs/docs/components/Upload.mdx
+++ b/website/plasma-b2c-docs/docs/components/Upload.mdx
@@ -3,9 +3,11 @@ id: Upload
 title: Upload
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Upload
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="Upload" />
 <PropsTable name="Upload" />

--- a/website/plasma-b2c-docs/docs/components/UploadAudio.mdx
+++ b/website/plasma-b2c-docs/docs/components/UploadAudio.mdx
@@ -3,9 +3,12 @@ id: UploadAudio
 title: UploadAudio
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
-## UploadAudio
+# UploadAudio
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 <Description name="UploadAudio" />
 <PropsTable name="UploadAudio" />
 <StorybookLink name="UploadAudio" />

--- a/website/plasma-b2c-docs/docs/components/UploadVisual.mdx
+++ b/website/plasma-b2c-docs/docs/components/UploadVisual.mdx
@@ -3,9 +3,11 @@ id: UploadVisual
 title: UploadVisual
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # UploadVisual
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="UploadVisual" />
 <PropsTable name="UploadVisual" />

--- a/website/plasma-b2c-docs/src/components/Badge.tsx
+++ b/website/plasma-b2c-docs/src/components/Badge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { FC } from 'react';
+import { Badge, Tooltip, BodyXS } from '@salutejs/plasma-b2c';
+
+export const DocsBadge: FC<{ title: string; desctiption: string }> = ({ title, desctiption }) => (
+    <div
+        style={{
+            marginTop: '-22px',
+            marginBottom: '16px',
+        }}
+    >
+        <Tooltip
+            target={
+                <Badge size="m" view="accent">
+                    <BodyXS bold>{title}</BodyXS>
+                </Badge>
+            }
+            text={desctiption}
+            placement="right-start"
+            trigger="hover"
+            hoverTimeout={500}
+            maxWidth="400px"
+            hasArrow={false}
+            style={{
+                verticalAlign: 'middle',
+            }}
+        />
+    </div>
+);

--- a/website/plasma-b2c-docs/src/components/index.ts
+++ b/website/plasma-b2c-docs/src/components/index.ts
@@ -2,3 +2,4 @@ export { CodeSandbox } from './CodeSandbox';
 export { Description } from './Description';
 export { PropsTable } from './PropsTable';
 export { StorybookLink } from './Storybook';
+export { DocsBadge as Badge } from './Badge';

--- a/website/plasma-giga-docs/docs/components/Overlay.mdx
+++ b/website/plasma-giga-docs/docs/components/Overlay.mdx
@@ -3,8 +3,10 @@ id: overlay
 title: Overlay
 ---
 
-import { PropsTable, Description } from '@site/src/components';
+import { PropsTable, Description, Badge } from '@site/src/components';
 
 # Overlay
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 <Description name="Overlay" />
 <PropsTable name="Overlay" exclude={['css']} />

--- a/website/plasma-giga-docs/docs/components/Portal.mdx
+++ b/website/plasma-giga-docs/docs/components/Portal.mdx
@@ -3,9 +3,12 @@ id: portal
 title: Portal
 ---
 
-import { PropsTable, Description } from '@site/src/components';
+import { PropsTable, Description, Badge } from '@site/src/components';
 
 # Portal
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 <Description name="Portal" />
 <PropsTable name="Portal" exclude={['css']} />
 

--- a/website/plasma-giga-docs/src/components/Badge.tsx
+++ b/website/plasma-giga-docs/src/components/Badge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { FC } from 'react';
+import { Badge, Tooltip, BodyXS } from '@salutejs/plasma-giga';
+
+export const DocsBadge: FC<{ title: string; desctiption: string }> = ({ title, desctiption }) => (
+    <div
+        style={{
+            marginTop: '-22px',
+            marginBottom: '16px',
+        }}
+    >
+        <Tooltip
+            target={
+                <Badge size="m" view="accent">
+                    <BodyXS bold>{title}</BodyXS>
+                </Badge>
+            }
+            text={desctiption}
+            placement="right-start"
+            trigger="hover"
+            hoverTimeout={500}
+            maxWidth="400px"
+            hasArrow={false}
+            style={{
+                verticalAlign: 'middle',
+            }}
+        />
+    </div>
+);

--- a/website/plasma-giga-docs/src/components/index.ts
+++ b/website/plasma-giga-docs/src/components/index.ts
@@ -1,3 +1,4 @@
 export { CodeSandbox } from './CodeSandbox';
 export { Description } from './Description';
 export { PropsTable } from './PropsTable';
+export { DocsBadge as Badge } from './Badge';

--- a/website/plasma-web-docs/docs/components/AudioPlayer.mdx
+++ b/website/plasma-web-docs/docs/components/AudioPlayer.mdx
@@ -3,9 +3,11 @@ id: AudioPlayer
 title: AudioPlayer
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # AudioPlayer
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="AudioPlayer" />
 <PropsTable name="AudioPlayer" />

--- a/website/plasma-web-docs/docs/components/Card.mdx
+++ b/website/plasma-web-docs/docs/components/Card.mdx
@@ -3,9 +3,12 @@ id: card
 title: Card
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Card
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 Набор компонентов для создания карточек.
 
 <StorybookLink name="Card" />

--- a/website/plasma-web-docs/docs/components/Carousel.mdx
+++ b/website/plasma-web-docs/docs/components/Carousel.mdx
@@ -3,9 +3,12 @@ id: carousel
 title: Carousel
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Carousel
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 Набор компонентов для создания списков с прокруткой (галерей).
 
 <StorybookLink name="Carousel" />

--- a/website/plasma-web-docs/docs/components/ElasticGrid.mdx
+++ b/website/plasma-web-docs/docs/components/ElasticGrid.mdx
@@ -3,9 +3,11 @@ id: ElasticGrid
 title: ElasticGrid
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # ElasticGrid
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="ElasticGrid" />
 <PropsTable name="ElasticGrid" />

--- a/website/plasma-web-docs/docs/components/Modal.mdx
+++ b/website/plasma-web-docs/docs/components/Modal.mdx
@@ -3,9 +3,11 @@ id: modal
 title: Modal
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Modal
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 <Description name="Modal" />
 <PropsTable name="Modal" />
 <StorybookLink name="Modal" />

--- a/website/plasma-web-docs/docs/components/Overlay.mdx
+++ b/website/plasma-web-docs/docs/components/Overlay.mdx
@@ -3,9 +3,11 @@ id: overlay
 title: Overlay
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Overlay
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 <Description name="Overlay" />
 <PropsTable name="Overlay" exclude={['css']} />
 <StorybookLink name="Overlay" />

--- a/website/plasma-web-docs/docs/components/Portal.mdx
+++ b/website/plasma-web-docs/docs/components/Portal.mdx
@@ -3,9 +3,11 @@ id: portal
 title: Portal
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Portal
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 <Description name="Portal" />
 <PropsTable name="Portal" exclude={['css']} />
 <StorybookLink name="Portal" />

--- a/website/plasma-web-docs/docs/components/PreviewGallery.mdx
+++ b/website/plasma-web-docs/docs/components/PreviewGallery.mdx
@@ -3,9 +3,11 @@ id: PreviewGallery
 title: PreviewGallery
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # PreviewGallery
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="PreviewGallery" />
 <PropsTable name="PreviewGallery" />

--- a/website/plasma-web-docs/docs/components/Upload.mdx
+++ b/website/plasma-web-docs/docs/components/Upload.mdx
@@ -3,9 +3,11 @@ id: Upload
 title: Upload
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # Upload
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="Upload" />
 <PropsTable name="Upload" />

--- a/website/plasma-web-docs/docs/components/UploadAudio.mdx
+++ b/website/plasma-web-docs/docs/components/UploadAudio.mdx
@@ -3,9 +3,11 @@ id: UploadAudio
 title: UploadAudio
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
-## UploadAudio
+# UploadAudio
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 <Description name="UploadAudio" />
 <PropsTable name="UploadAudio" />
 <StorybookLink name="UploadAudio" />

--- a/website/plasma-web-docs/docs/components/UploadVisual.mdx
+++ b/website/plasma-web-docs/docs/components/UploadVisual.mdx
@@ -3,9 +3,11 @@ id: UploadVisual
 title: UploadVisual
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description, StorybookLink, Badge } from '@site/src/components';
 
 # UploadVisual
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 
 <Description name="UploadVisual" />
 <PropsTable name="UploadVisual" />

--- a/website/plasma-web-docs/src/components/Badge.tsx
+++ b/website/plasma-web-docs/src/components/Badge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { FC } from 'react';
+import { Badge, Tooltip, BodyXS } from '@salutejs/plasma-web';
+
+export const DocsBadge: FC<{ title: string; desctiption: string }> = ({ title, desctiption }) => (
+    <div
+        style={{
+            marginTop: '-22px',
+            marginBottom: '16px',
+        }}
+    >
+        <Tooltip
+            target={
+                <Badge size="m" view="accent">
+                    <BodyXS bold>{title}</BodyXS>
+                </Badge>
+            }
+            text={desctiption}
+            placement="right-start"
+            trigger="hover"
+            hoverTimeout={500}
+            maxWidth="400px"
+            hasArrow={false}
+            style={{
+                verticalAlign: 'middle',
+            }}
+        />
+    </div>
+);

--- a/website/plasma-web-docs/src/components/index.ts
+++ b/website/plasma-web-docs/src/components/index.ts
@@ -2,3 +2,4 @@ export { CodeSandbox } from './CodeSandbox';
 export { Description } from './Description';
 export { PropsTable } from './PropsTable';
 export { StorybookLink } from './Storybook';
+export { DocsBadge as Badge } from './Badge';

--- a/website/sdds-cs-docs/src/components/Badge.tsx
+++ b/website/sdds-cs-docs/src/components/Badge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { FC } from 'react';
+import { Badge, Tooltip, BodyXS } from '@salutejs/sdds-cs';
+
+export const DocsBadge: FC<{ title: string; desctiption: string }> = ({ title, desctiption }) => (
+    <div
+        style={{
+            marginTop: '-22px',
+            marginBottom: '16px',
+        }}
+    >
+        <Tooltip
+            target={
+                <Badge size="m" view="accent">
+                    <BodyXS bold>{title}</BodyXS>
+                </Badge>
+            }
+            text={desctiption}
+            placement="right-start"
+            trigger="hover"
+            hoverTimeout={500}
+            maxWidth="400px"
+            hasArrow={false}
+            style={{
+                verticalAlign: 'middle',
+            }}
+        />
+    </div>
+);

--- a/website/sdds-cs-docs/src/components/index.ts
+++ b/website/sdds-cs-docs/src/components/index.ts
@@ -1,3 +1,4 @@
 export { CodeSandbox } from './CodeSandbox';
 export { Description } from './Description';
 export { PropsTable } from './PropsTable';
+export { DocsBadge as Badge } from './Badge';

--- a/website/sdds-dfa-docs/src/components/Badge.tsx
+++ b/website/sdds-dfa-docs/src/components/Badge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { FC } from 'react';
+import { Badge, Tooltip, BodyXS } from '@salutejs/sdds-dfa';
+
+export const DocsBadge: FC<{ title: string; desctiption: string }> = ({ title, desctiption }) => (
+    <div
+        style={{
+            marginTop: '-22px',
+            marginBottom: '16px',
+        }}
+    >
+        <Tooltip
+            target={
+                <Badge size="m" view="accent">
+                    <BodyXS bold>{title}</BodyXS>
+                </Badge>
+            }
+            text={desctiption}
+            placement="right-start"
+            trigger="hover"
+            hoverTimeout={500}
+            maxWidth="400px"
+            hasArrow={false}
+            style={{
+                verticalAlign: 'middle',
+            }}
+        />
+    </div>
+);

--- a/website/sdds-dfa-docs/src/components/index.ts
+++ b/website/sdds-dfa-docs/src/components/index.ts
@@ -1,3 +1,4 @@
 export { CodeSandbox } from './CodeSandbox';
 export { Description } from './Description';
 export { PropsTable } from './PropsTable';
+export { DocsBadge as Badge } from './Badge';

--- a/website/sdds-insol-docs/docs/components/Overlay.mdx
+++ b/website/sdds-insol-docs/docs/components/Overlay.mdx
@@ -3,8 +3,10 @@ id: overlay
 title: Overlay
 ---
 
-import { PropsTable, Description } from '@site/src/components';
+import { PropsTable, Description, Badge } from '@site/src/components';
 
 # Overlay
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
 <Description name="Overlay" />
 <PropsTable name="Overlay" exclude={['css']} />

--- a/website/sdds-insol-docs/docs/components/Portal.mdx
+++ b/website/sdds-insol-docs/docs/components/Portal.mdx
@@ -3,9 +3,12 @@ id: portal
 title: Portal
 ---
 
-import { PropsTable, Description } from '@site/src/components';
+import { PropsTable, Description, Badge } from '@site/src/components';
 
 # Portal
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 <Description name="Portal" />
 <PropsTable name="Portal" exclude={['css']} />
 

--- a/website/sdds-insol-docs/src/components/Badge.tsx
+++ b/website/sdds-insol-docs/src/components/Badge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { FC } from 'react';
+import { Badge, Tooltip, BodyXS } from '@salutejs/sdds-insol';
+
+export const DocsBadge: FC<{ title: string; desctiption: string }> = ({ title, desctiption }) => (
+    <div
+        style={{
+            marginTop: '-22px',
+            marginBottom: '16px',
+        }}
+    >
+        <Tooltip
+            target={
+                <Badge size="m" view="accent">
+                    <BodyXS bold>{title}</BodyXS>
+                </Badge>
+            }
+            text={desctiption}
+            placement="right-start"
+            trigger="hover"
+            hoverTimeout={500}
+            maxWidth="400px"
+            hasArrow={false}
+            style={{
+                verticalAlign: 'middle',
+            }}
+        />
+    </div>
+);

--- a/website/sdds-insol-docs/src/components/index.ts
+++ b/website/sdds-insol-docs/src/components/index.ts
@@ -1,3 +1,4 @@
 export { CodeSandbox } from './CodeSandbox';
 export { Description } from './Description';
 export { PropsTable } from './PropsTable';
+export { DocsBadge as Badge } from './Badge';

--- a/website/sdds-serv-docs/docs/components/Overlay.mdx
+++ b/website/sdds-serv-docs/docs/components/Overlay.mdx
@@ -3,8 +3,11 @@ id: overlay
 title: Overlay
 ---
 
-import { PropsTable, Description } from '@site/src/components';
+import { PropsTable, Description, Badge } from '@site/src/components';
 
 # Overlay
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 <Description name="Overlay" />
 <PropsTable name="Overlay" exclude={['css']} />

--- a/website/sdds-serv-docs/docs/components/Portal.mdx
+++ b/website/sdds-serv-docs/docs/components/Portal.mdx
@@ -3,9 +3,12 @@ id: portal
 title: Portal
 ---
 
-import { PropsTable, Description } from '@site/src/components';
+import { PropsTable, Description, Badge } from '@site/src/components';
 
 # Portal
+
+<Badge title="styled-components" desctiption="Доступен только в сборке `styled-components`" />
+
 <Description name="Portal" />
 <PropsTable name="Portal" exclude={['css']} />
 

--- a/website/sdds-serv-docs/src/components/Badge.tsx
+++ b/website/sdds-serv-docs/src/components/Badge.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { FC } from 'react';
+import { Badge, Tooltip, BodyXS } from '@salutejs/sdds-serv';
+
+export const DocsBadge: FC<{ title: string; desctiption: string }> = ({ title, desctiption }) => (
+    <div
+        style={{
+            marginTop: '-22px',
+            marginBottom: '16px',
+        }}
+    >
+        <Tooltip
+            target={
+                <Badge size="m" view="accent">
+                    <BodyXS bold>{title}</BodyXS>
+                </Badge>
+            }
+            text={desctiption}
+            placement="right-start"
+            trigger="hover"
+            hoverTimeout={500}
+            maxWidth="400px"
+            hasArrow={false}
+            style={{
+                verticalAlign: 'middle',
+            }}
+        />
+    </div>
+);

--- a/website/sdds-serv-docs/src/components/index.ts
+++ b/website/sdds-serv-docs/src/components/index.ts
@@ -1,3 +1,4 @@
 export { CodeSandbox } from './CodeSandbox';
 export { Description } from './Description';
 export { PropsTable } from './PropsTable';
+export { DocsBadge as Badge } from './Badge';


### PR DESCRIPTION
## Core

### Docs

- Добавлен компонент `badge` для документации ( импорт из наших библиотек )
- К компонентам  `Audioplayer`, `ButtonBase`, `Card`, `Carousel`, `ElasticGrid`, `List`, `Modal`, `Overlay`, `PaginationDots`, `Popup`, `Portal`, `PreviewGallery`, `Upload`, `UploadAudio`, `UploadVisual` добавлена метка о том что они используются только в сборке `styled-components`

### What/why changed

