### PR TITLE
hotfix: reverting exports prop from package.json due to ts overcomplexity

### DIFF
--- a/packages/plasma-new-hope/package.json
+++ b/packages/plasma-new-hope/package.json
@@ -2,26 +2,9 @@
   "name": "@salutejs/plasma-new-hope",
   "version": "0.235.0",
   "description": "Salute Design System blueprint",
-  "main": "./cjs/index.js",
-  "module": "./es/index.js",
-  "types": "./types/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./cjs/index.js",
-      "import": "./es/index.js",
-      "types": "./types/index.d.ts"
-    },
-    "./styled-components": {
-      "require": "./styled-components/cjs/index.js",
-      "import": "./styled-components/es/index.js",
-      "types": "./types/index.d.ts"
-    },
-    "./emotion": {
-      "require": "./emotion/cjs/index.js",
-      "import": "./emotion/es/index.js",
-      "types": "./types/index.d.ts"
-    }
-  },
+  "main": "cjs/index.js",
+  "module": "es/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "cjs",
     "es",

--- a/packages/sdds-cs/package.json
+++ b/packages/sdds-cs/package.json
@@ -21,31 +21,9 @@
     "api-extractor.json",
     "CHANGELOG.md"
   ],
-  "main": "./index.js",
-  "module": "./es/index.js",
-  "types": "./index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./components/index.js",
-      "import": "./es/index.js",
-      "types": "./index.d.ts"
-    },
-    "./emotion": {
-      "require": "./emotion/cjs/index.js",
-      "import": "./emotion/es/index.js",
-      "types": "./index.d.ts"
-    },
-    "./tokens": {
-      "require": "./tokens/index.js",
-      "import": "./es/tokens/index.js",
-      "types": "./tokens/index.d.ts"
-    },
-    "./mixins": {
-      "require": "./mixins/index.js",
-      "import": "./es/mixins/index.js",
-      "types": "./mixins/index.d.ts"
-    }
-  },
+  "main": "index.js",
+  "module": "es/index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:salute-developers/plasma.git",

--- a/packages/sdds-serv/package.json
+++ b/packages/sdds-serv/package.json
@@ -20,28 +20,12 @@
     "tokens",
     "index.d.ts",
     "api-extractor.json",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "_virtual"
   ],
   "main": "./index.js",
   "module": "./es/index.js",
   "types": "./index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./components/index.js",
-      "import": "./es/index.js",
-      "types": "./index.d.ts"
-    },
-    "./styled-components": {
-      "require": "./styled-components/cjs/index.js",
-      "import": "./styled-components/es/index.js",
-      "types": "./index.d.ts"
-    },
-    "./emotion": {
-      "require": "./emotion/cjs/index.js",
-      "import": "./emotion/es/index.js",
-      "types": "./index.d.ts"
-    }
-  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:salute-developers/plasma.git",


### PR DESCRIPTION
### What/why changed

Отказались от указания путей через свойство exports    
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.249.1-canary.1689.12525929253.0
  npm install @salutejs/plasma-b2c@1.491.1-canary.1689.12525929253.0
  npm install @salutejs/plasma-giga@0.218.1-canary.1689.12525929253.0
  npm install @salutejs/plasma-hope@1.328.1-canary.1689.12525929253.0
  npm install @salutejs/plasma-new-hope@0.237.1-canary.1689.12525929253.0
  npm install @salutejs/plasma-web@1.493.1-canary.1689.12525929253.0
  npm install @salutejs/sdds-cs@0.226.1-canary.1689.12525929253.0
  npm install @salutejs/sdds-dfa@0.221.1-canary.1689.12525929253.0
  npm install @salutejs/sdds-finportal@0.214.1-canary.1689.12525929253.0
  npm install @salutejs/sdds-insol@0.215.1-canary.1689.12525929253.0
  npm install @salutejs/sdds-serv@0.222.1-canary.1689.12525929253.0
  # or 
  yarn add @salutejs/plasma-asdk@0.249.1-canary.1689.12525929253.0
  yarn add @salutejs/plasma-b2c@1.491.1-canary.1689.12525929253.0
  yarn add @salutejs/plasma-giga@0.218.1-canary.1689.12525929253.0
  yarn add @salutejs/plasma-hope@1.328.1-canary.1689.12525929253.0
  yarn add @salutejs/plasma-new-hope@0.237.1-canary.1689.12525929253.0
  yarn add @salutejs/plasma-web@1.493.1-canary.1689.12525929253.0
  yarn add @salutejs/sdds-cs@0.226.1-canary.1689.12525929253.0
  yarn add @salutejs/sdds-dfa@0.221.1-canary.1689.12525929253.0
  yarn add @salutejs/sdds-finportal@0.214.1-canary.1689.12525929253.0
  yarn add @salutejs/sdds-insol@0.215.1-canary.1689.12525929253.0
  yarn add @salutejs/sdds-serv@0.222.1-canary.1689.12525929253.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
