### PR TITLE
PLASMA-4257: fix `Dropdown` tokens and sizes in `sdds-cs`

### DIFF
--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tokens.ts
@@ -56,6 +56,7 @@ export const tokens = {
     itemFontWeightBold: '--plasma-dropdown-item-letter-spacing',
     itemFontLetterSpacing: '--plasma-dropdown-item-line-height',
     itemFontLineHeight: '--plasma-dropdown-item-font-weight',
+    itemMargin: '--plasma-dropdown-item-margin',
     itemPadding: '--plasma-dropdown-item-padding',
     itemPaddingTight: '--plasma-dropdown-item-padding-tight',
     itemGap: '--plasma-dropdown-item-gap',

--- a/packages/plasma-new-hope/src/components/Dropdown/ui/DropdownItem/DropdownItem.styles.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/ui/DropdownItem/DropdownItem.styles.ts
@@ -32,7 +32,7 @@ export const StyledCell = styled(Cell)``;
 
 export const DisclosureIconWrapper = styled.div`
     line-height: 0;
-    color: var(${constants.disclosureIconColor});
+    color: var(${tokens.disclosureIconColor}, var(${constants.disclosureIconColor}));
 `;
 
 // TODO: Удалить после поддержки JS переменных в конфиге компонент
@@ -63,7 +63,7 @@ export const Wrapper = styled.li<{ variant: DropdownProps['variant'] }>`
     align-items: center;
     gap: ${({ variant }) => `var(${variant === 'tight' ? tokens.itemGapTight : tokens.itemGap})`};
     min-height: var(${tokens.itemHeight});
-    margin: 0 calc(0.125rem + var(${tokens.borderWidth}, 0rem));
+    margin: var(${tokens.itemMargin}, 0 calc(0.125rem + var(${tokens.borderWidth}, 0rem)));
     box-sizing: content-box;
     padding: ${({ variant }) => `var(${variant === 'tight' ? tokens.itemPaddingTight : tokens.itemPadding})`};
     font-family: var(${tokens.itemFontFamily});
@@ -73,7 +73,10 @@ export const Wrapper = styled.li<{ variant: DropdownProps['variant'] }>`
     letter-spacing: var(${tokens.itemFontLetterSpacing});
     line-height: var(${tokens.itemFontLineHeight});
     background-color: var(${constants.itemBackground});
-    border-radius: calc(var(${tokens.borderRadius}) - 0.125rem - var(${tokens.borderWidth}, 0rem));
+    border-radius: var(
+        ${tokens.itemBorderRadius},
+        calc(var(${tokens.borderRadius}) - 0.125rem - var(${tokens.borderWidth}, 0rem))
+    );
     user-select: none;
     background-clip: padding-box;
 

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -1486,10 +1486,7 @@ export { DrawerProps }
 // @public (undocumented)
 export const Dropdown: <T extends DropdownItemOption>(props: Omit<DropdownNewProps<T>, "size" | "view"> & Pick<PropsType<    {
 size: {
-l: PolymorphicClassName;
-m: PolymorphicClassName;
 s: PolymorphicClassName;
-xs: PolymorphicClassName;
 };
 view: {
 default: PolymorphicClassName;

--- a/packages/sdds-cs/src/components/Dropdown/Dropdown.config.ts
+++ b/packages/sdds-cs/src/components/Dropdown/Dropdown.config.ts
@@ -3,63 +3,29 @@ import { css, dropdownTokens as tokens } from '@salutejs/plasma-new-hope/styled-
 export const config = {
     defaults: {
         view: 'default',
-        size: 'm',
+        size: 's',
     },
     variations: {
         size: {
-            l: css`
-                ${tokens.padding}: 0.125rem;
-                ${tokens.width}: 17.5rem;
-                ${tokens.borderRadius}: 0.875rem;
+            s: css`
+                ${tokens.padding}: 0rem;
+                ${tokens.width}: 12.5rem;
+                ${tokens.borderRadius}: 0.625rem;
                 ${tokens.borderWidth}: 0.125rem;
 
                 ${tokens.itemHeight}: 1.5rem;
-                ${tokens.itemPadding}: 1rem 1.125rem;
-                ${tokens.itemPaddingTight}: 0.75rem 1.125rem;
+                ${tokens.itemMargin}: 0rem;
+                ${tokens.itemPadding}: 0.5rem 0.75rem;
+                ${tokens.itemPaddingTight}: 0.25rem 0.75rem;
 
-                ${tokens.dividerMarginTop}: 0.5rem;
-                ${tokens.dividerMarginRight}: 1.125rem;
-                ${tokens.dividerMarginBottom}: 0.5rem;
-                ${tokens.dividerMarginLeft}: 1.125rem;
-                ${tokens.dividerMarginTopTight}: 0.375rem;
-                ${tokens.dividerMarginBottomTight}: 0.375rem;
-
-                ${tokens.itemFontFamily}: var(--plasma-typo-body-l-font-family);
-                ${tokens.itemFontSize}: var(--plasma-typo-body-l-font-size);
-                ${tokens.itemFontStyle}: var(--plasma-typo-body-l-font-style);
-                ${tokens.itemFontWeightBold}: var(--plasma-typo-body-l-font-weight);
-                ${tokens.itemFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
-                ${tokens.itemFontLineHeight}: var(--plasma-typo-body-l-line-height);
-
-                ${tokens.cellPadding}: 0rem;
-                ${tokens.cellPaddingLeftContent}: 0rem;
-                ${tokens.cellPaddingContent}: 0rem;
-                ${tokens.cellPaddingRightContent}: 0rem;
-                ${tokens.cellTextboxGap}: 0.125rem;
-                ${tokens.cellGap}: 0.375rem;
-                ${tokens.cellTitleFontFamily}: var(--plasma-typo-body-l-font-family);
-                ${tokens.cellTitleFontSize}: var(--plasma-typo-body-l-font-size);
-                ${tokens.cellTitleFontStyle}: var(--plasma-typo-body-l-font-style);
-                ${tokens.cellTitleFontWeight}: var(--plasma-typo-body-l-font-weight);
-                ${tokens.cellTitleLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
-                ${tokens.cellTitleLineHeight}: var(--plasma-typo-body-l-line-height);
-            `,
-            m: css`
-                ${tokens.padding}: 0.125rem;
-                ${tokens.width}: 15rem;
-                ${tokens.borderRadius}: 0.75rem;
-                ${tokens.borderWidth}: 0.125rem;
-
-                ${tokens.itemHeight}: 1.5rem;
-                ${tokens.itemPadding}: 0.75rem 0.875rem;
-                ${tokens.itemPaddingTight}: 0.5rem 0.875rem;
+                ${tokens.itemBorderRadius}: 0.5rem;
 
                 ${tokens.dividerMarginTop}: 0.375rem;
-                ${tokens.dividerMarginRight}: 0.875rem;
+                ${tokens.dividerMarginRight}: 0.75rem;
                 ${tokens.dividerMarginBottom}: 0.375rem;
-                ${tokens.dividerMarginLeft}: 0.875rem;
-                ${tokens.dividerMarginTopTight}: 0.375rem;
-                ${tokens.dividerMarginBottomTight}: 0.375rem;
+                ${tokens.dividerMarginLeft}: 0.75rem;
+                ${tokens.dividerMarginTopTight}: 0.25rem;
+                ${tokens.dividerMarginBottomTight}: 0.25rem;
 
                 ${tokens.itemFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${tokens.itemFontSize}: var(--plasma-typo-body-m-font-size);
@@ -81,80 +47,6 @@ export const config = {
                 ${tokens.cellTitleLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${tokens.cellTitleLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
-            s: css`
-                ${tokens.padding}: 0.125rem;
-                ${tokens.width}: 12.5rem;
-                ${tokens.borderRadius}: 0.625rem;
-                ${tokens.borderWidth}: 0.125rem;
-
-                ${tokens.itemHeight}: 1.5rem;
-                ${tokens.itemPadding}: 0.5rem 0.75rem;
-                ${tokens.itemPaddingTight}: 0.25rem 0.75rem;
-
-                ${tokens.dividerMarginTop}: 0.375rem;
-                ${tokens.dividerMarginRight}: 0.75rem;
-                ${tokens.dividerMarginBottom}: 0.375rem;
-                ${tokens.dividerMarginLeft}: 0.75rem;
-                ${tokens.dividerMarginTopTight}: 0.25rem;
-                ${tokens.dividerMarginBottomTight}: 0.25rem;
-
-                ${tokens.itemFontFamily}: var(--plasma-typo-body-s-font-family);
-                ${tokens.itemFontSize}: var(--plasma-typo-body-s-font-size);
-                ${tokens.itemFontStyle}: var(--plasma-typo-body-s-font-style);
-                ${tokens.itemFontWeightBold}: var(--plasma-typo-body-s-font-weight);
-                ${tokens.itemFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
-                ${tokens.itemFontLineHeight}: var(--plasma-typo-body-s-line-height);
-
-                ${tokens.cellPadding}: 0rem;
-                ${tokens.cellPaddingLeftContent}: 0rem;
-                ${tokens.cellPaddingContent}: 0rem;
-                ${tokens.cellPaddingRightContent}: 0rem;
-                ${tokens.cellTextboxGap}: 0.125rem;
-                ${tokens.cellGap}: 0.375rem;
-                ${tokens.cellTitleFontFamily}: var(--plasma-typo-body-s-font-family);
-                ${tokens.cellTitleFontSize}: var(--plasma-typo-body-s-font-size);
-                ${tokens.cellTitleFontStyle}: var(--plasma-typo-body-s-font-style);
-                ${tokens.cellTitleFontWeight}: var(--plasma-typo-body-s-font-weight);
-                ${tokens.cellTitleLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
-                ${tokens.cellTitleLineHeight}: var(--plasma-typo-body-s-line-height);
-            `,
-            xs: css`
-                ${tokens.padding}: 0.125rem;
-                ${tokens.width}: 10rem;
-                ${tokens.borderRadius}: 0.5rem;
-                ${tokens.borderWidth}: 0.125rem;
-
-                ${tokens.itemHeight}: 1rem;
-                ${tokens.itemPadding}: 0.5rem;
-                ${tokens.itemPaddingTight}: 0.25rem 0.5rem;
-
-                ${tokens.dividerMarginTop}: 0.25rem;
-                ${tokens.dividerMarginRight}: 0.5rem;
-                ${tokens.dividerMarginBottom}: 0.25rem;
-                ${tokens.dividerMarginLeft}: 0.5rem;
-                ${tokens.dividerMarginTopTight}: 0.125rem;
-                ${tokens.dividerMarginBottomTight}: 0.125rem;
-
-                ${tokens.itemFontFamily}: var(--plasma-typo-body-xs-font-family);
-                ${tokens.itemFontSize}: var(--plasma-typo-body-xs-font-size);
-                ${tokens.itemFontStyle}: var(--plasma-typo-body-xs-font-style);
-                ${tokens.itemFontWeightBold}: var(--plasma-typo-body-xs-font-weight);
-                ${tokens.itemFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
-                ${tokens.itemFontLineHeight}: var(--plasma-typo-body-xs-line-height);
-
-                ${tokens.cellPadding}: 0rem;
-                ${tokens.cellPaddingLeftContent}: 0rem;
-                ${tokens.cellPaddingContent}: 0rem;
-                ${tokens.cellPaddingRightContent}: 0rem;
-                ${tokens.cellTextboxGap}: 0.125rem;
-                ${tokens.cellGap}: 0.25rem;
-                ${tokens.cellTitleFontFamily}: var(--plasma-typo-body-xs-font-family);
-                ${tokens.cellTitleFontSize}: var(--plasma-typo-body-xs-font-size);
-                ${tokens.cellTitleFontStyle}: var(--plasma-typo-body-xs-font-style);
-                ${tokens.cellTitleFontWeight}: var(--plasma-typo-body-xs-font-weight);
-                ${tokens.cellTitleLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
-                ${tokens.cellTitleLineHeight}: var(--plasma-typo-body-xs-line-height);
-            `,
         },
         view: {
             default: css`
@@ -170,6 +62,7 @@ export const config = {
                 ${tokens.itemColor}: var(--text-primary);
                 ${tokens.disclosureIconColor}: var(--text-accent);
                 ${tokens.dividerColor}: var(--surface-solid-primary);
+                ${tokens.disclosureIconColor}: var(--text-accent);
             `,
         },
     },

--- a/packages/sdds-cs/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-cs/src/components/Dropdown/Dropdown.stories.tsx
@@ -12,7 +12,7 @@ type DropdownProps = ComponentProps<typeof Dropdown>;
 
 const placements: DropdownProps['placement'][] = ['auto', 'top', 'right', 'bottom', 'left'];
 const triggers: DropdownProps['trigger'][] = ['click', 'hover'];
-const size = ['xs', 's', 'm', 'l'];
+const size = ['s'];
 const variant = ['normal', 'tight'];
 
 const meta: Meta<DropdownProps> = {
@@ -58,7 +58,7 @@ const meta: Meta<DropdownProps> = {
         },
     },
     args: {
-        size: 'm',
+        size: 's',
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
@@ -72,7 +72,6 @@ const meta: Meta<DropdownProps> = {
     parameters: {
         controls: {
             include: [
-                'size',
                 'variant',
                 'placement',
                 'trigger',


### PR DESCRIPTION
## CORE

### Dropdown

- добавлен токен `itemMargin`
- добавлен токен `disclosureIconColor`

## SDDS-CS

### Dropdown

- в конфигурационных файлах и `storybook` оставлен только размер `s`
- значения токенов приведены к макету

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.255.1-canary.1705.12885562854.0
  npm install @salutejs/plasma-b2c@1.497.1-canary.1705.12885562854.0
  npm install @salutejs/plasma-giga@0.224.1-canary.1705.12885562854.0
  npm install @salutejs/plasma-new-hope@0.243.1-canary.1705.12885562854.0
  npm install @salutejs/plasma-web@1.499.1-canary.1705.12885562854.0
  npm install @salutejs/sdds-cs@0.232.1-canary.1705.12885562854.0
  npm install @salutejs/sdds-dfa@0.227.1-canary.1705.12885562854.0
  npm install @salutejs/sdds-finportal@0.220.1-canary.1705.12885562854.0
  npm install @salutejs/sdds-insol@0.221.1-canary.1705.12885562854.0
  npm install @salutejs/sdds-serv@0.228.1-canary.1705.12885562854.0
  # or 
  yarn add @salutejs/plasma-asdk@0.255.1-canary.1705.12885562854.0
  yarn add @salutejs/plasma-b2c@1.497.1-canary.1705.12885562854.0
  yarn add @salutejs/plasma-giga@0.224.1-canary.1705.12885562854.0
  yarn add @salutejs/plasma-new-hope@0.243.1-canary.1705.12885562854.0
  yarn add @salutejs/plasma-web@1.499.1-canary.1705.12885562854.0
  yarn add @salutejs/sdds-cs@0.232.1-canary.1705.12885562854.0
  yarn add @salutejs/sdds-dfa@0.227.1-canary.1705.12885562854.0
  yarn add @salutejs/sdds-finportal@0.220.1-canary.1705.12885562854.0
  yarn add @salutejs/sdds-insol@0.221.1-canary.1705.12885562854.0
  yarn add @salutejs/sdds-serv@0.228.1-canary.1705.12885562854.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
