### PR TITLE
fix: Replace template placeholder to package name 

### DIFF
--- a/website/plasma-b2c-docs/docs/components/Notification.mdx
+++ b/website/plasma-b2c-docs/docs/components/Notification.mdx
@@ -42,7 +42,7 @@ ReactDOM.render(
 
 ```tsx live
 import React from 'react';
-import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/{{ package }}';
+import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/plasma-b2c';
 
 export function App() {
     const handleShow = React.useCallback(() => {

--- a/website/plasma-giga-docs/docs/components/Segment.mdx
+++ b/website/plasma-giga-docs/docs/components/Segment.mdx
@@ -31,7 +31,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 ```tsx live
 import React from 'react';
-import { SegmentGroup, SegmentItem, SegmentProvider, useSegment } from '@salutejs/{{ package }}';
+import { SegmentGroup, SegmentItem, SegmentProvider, useSegment } from '@salutejs/plasma-giga';
 
 export function App() {
     const items = Array(8).fill(0);
@@ -74,7 +74,7 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { SegmentGroup, SegmentItem, SegmentProvider, useSegment } from '@salutejs/{{ package }}';
+import { SegmentGroup, SegmentItem, SegmentProvider, useSegment } from '@salutejs/plasma-giga';
 
 export function App() {
     const items = Array(8).fill(0);

--- a/website/plasma-giga-docs/docs/components/Slider.mdx
+++ b/website/plasma-giga-docs/docs/components/Slider.mdx
@@ -14,7 +14,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 ```tsx live
 import React from 'react';
-import { Slider  } from '@salutejs/{{ package }}';
+import { Slider  } from '@salutejs/plasma-giga';
 
 export function App() {
     return (
@@ -29,7 +29,7 @@ export function App() {
 
 ```tsx live
 import React, { useState } from 'react';
-import { Slider  } from '@salutejs/{{ package }}';
+import { Slider  } from '@salutejs/plasma-giga';
 
 export function App() {
     const [value, setValue] = useState([10, 80]);
@@ -81,7 +81,7 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { Slider  } from '@salutejs/{{ package }}';
+import { Slider  } from '@salutejs/plasma-giga';
 import { IconMic } from '@salutejs/plasma-icons';
 
 export function App() {


### PR DESCRIPTION
### What/why changed

Заглушки от scafolld заменены на названия пакетов.  
