### PR TITLE
fix(*): Fix ToastController timeout clearing

### DIFF
--- a/packages/plasma-new-hope/src/components/Toast/ToastController.tsx
+++ b/packages/plasma-new-hope/src/components/Toast/ToastController.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import type { FC } from 'react';
 
 import { classes } from './Toast.tokens';
@@ -11,7 +11,7 @@ export const ToastControllerHoc = <T extends ToastProps>(ToastComponent: FC<T>) 
     function ToastController(props: ToastControllerProps) {
         const { position = 'bottom', offset, fade, text, ...rest } = props;
 
-        const { hideToast, isVisible, hideTimeout, animationRunTimeout } = useToastInner();
+        const { hideToast, isVisible } = useToastInner();
         const toastKey = `${text}${position}`;
 
         const showedClass = isVisible ? classes.toastShowed : classes.toastHidden;
@@ -22,17 +22,6 @@ export const ToastControllerHoc = <T extends ToastProps>(ToastComponent: FC<T>) 
             onCloseButtonClick: hideToast,
             ...rest,
         } as T;
-
-        useEffect(() => {
-            return () => {
-                if (hideTimeout?.current) {
-                    clearTimeout(hideTimeout.current);
-                }
-                if (animationRunTimeout?.current) {
-                    clearTimeout(animationRunTimeout.current);
-                }
-            };
-        }, []);
 
         if (!text) {
             return null;

--- a/packages/plasma-new-hope/src/components/Toast/ToastProvider/ToastProvider.tsx
+++ b/packages/plasma-new-hope/src/components/Toast/ToastProvider/ToastProvider.tsx
@@ -108,13 +108,13 @@ export const ToastProviderHoc = <T extends ToastProps>(ToastComponent: FC<T>) =>
         const { onHide, timeout } = toastInfo;
 
         const hideToast = useCallback(() => {
-            if (!isVisible) {
-                return;
-            }
-
             if (hideTimeout?.current) {
                 clearTimeout(hideTimeout.current);
                 hideTimeout.current = null;
+            }
+
+            if (!isVisible) {
+                return;
             }
 
             onHide?.();
@@ -131,14 +131,28 @@ export const ToastProviderHoc = <T extends ToastProps>(ToastComponent: FC<T>) =>
                 clearTimeout(animationRunTimeout.current);
                 animationRunTimeout.current = null;
             }
+
+            return () => {
+                if (animationRunTimeout?.current) {
+                    clearTimeout(animationRunTimeout.current);
+                }
+            };
         }, [timeout]);
 
+        // очистка таймаутов перенесена из ToastController, т. к. в StrictМоde react делает дополнительный unmount
         useEffect(() => {
             if (timeout && isVisible) {
                 hideTimeout.current = setTimeout(() => {
                     hideToast();
                 }, timeout);
             }
+
+            return () => {
+                if (hideTimeout?.current) {
+                    clearTimeout(hideTimeout.current);
+                    hideTimeout.current = null;
+                }
+            };
         }, [isVisible, timeout]);
 
         return (


### PR DESCRIPTION
## Core
### Toast

Убрана очистка таймаута в ToastContorller 

### What/why changed

Не работал таймайут при монтировании приложения через React.createRoot

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.263.1-canary.1712.13062616456.0
  npm install @salutejs/plasma-b2c@1.505.1-canary.1712.13062616456.0
  npm install @salutejs/plasma-giga@0.232.1-canary.1712.13062616456.0
  npm install @salutejs/plasma-new-hope@0.251.1-canary.1712.13062616456.0
  npm install @salutejs/plasma-web@1.507.1-canary.1712.13062616456.0
  npm install @salutejs/sdds-cs@0.240.1-canary.1712.13062616456.0
  npm install @salutejs/sdds-dfa@0.235.1-canary.1712.13062616456.0
  npm install @salutejs/sdds-finportal@0.228.1-canary.1712.13062616456.0
  npm install @salutejs/sdds-insol@0.229.1-canary.1712.13062616456.0
  npm install @salutejs/sdds-serv@0.236.1-canary.1712.13062616456.0
  # or 
  yarn add @salutejs/plasma-asdk@0.263.1-canary.1712.13062616456.0
  yarn add @salutejs/plasma-b2c@1.505.1-canary.1712.13062616456.0
  yarn add @salutejs/plasma-giga@0.232.1-canary.1712.13062616456.0
  yarn add @salutejs/plasma-new-hope@0.251.1-canary.1712.13062616456.0
  yarn add @salutejs/plasma-web@1.507.1-canary.1712.13062616456.0
  yarn add @salutejs/sdds-cs@0.240.1-canary.1712.13062616456.0
  yarn add @salutejs/sdds-dfa@0.235.1-canary.1712.13062616456.0
  yarn add @salutejs/sdds-finportal@0.228.1-canary.1712.13062616456.0
  yarn add @salutejs/sdds-insol@0.229.1-canary.1712.13062616456.0
  yarn add @salutejs/sdds-serv@0.236.1-canary.1712.13062616456.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
