### PR TITLE
PLASMA-4288: add xs size for Chip

### DIFF
--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -1236,6 +1236,7 @@ accent: PolymorphicClassName;
 };
 size: {
 s: PolymorphicClassName;
+xs: PolymorphicClassName;
 };
 disabled: {
 true: PolymorphicClassName;

--- a/packages/sdds-cs/src/components/Chip/Chip.config.tsx
+++ b/packages/sdds-cs/src/components/Chip/Chip.config.tsx
@@ -71,6 +71,30 @@ export const config = {
 
                 ${chipTokens.closeIconSize}: 1.5rem;
             `,
+            xs: css`
+                ${chipTokens.borderRadius}: 0.38rem;
+                ${chipTokens.pilledBorderRadius}: 0.75rem;
+                ${chipTokens.width}: auto;
+                ${chipTokens.height}: 1.5rem;
+                ${chipTokens.padding}: 0.125rem 0.5rem;
+
+                ${chipTokens.fontFamily}: var(--plasma-typo-body-s-font-family);
+                ${chipTokens.fontSize}: var(--plasma-typo-body-s-font-size);
+                ${chipTokens.fontStyle}: var(--plasma-typo-body-s-font-style);
+                ${chipTokens.fontWeight}: var(--plasma-typo-body-s-font-weight);
+                ${chipTokens.letterSpacing}: var(--plasma-typo-body-s-letter-spacing);
+                ${chipTokens.lineHeight}: var(--plasma-typo-body-s-line-height);
+
+                ${chipTokens.leftContentMarginLeft}: 0;
+                ${chipTokens.leftContentMarginRight}: 0.25rem;
+                ${chipTokens.clearContentMarginLeft}: 0.25rem;
+                ${chipTokens.clearContentMarginRight}: -0.25rem;
+
+                ${chipTokens.scaleHover}: 1.02;
+                ${chipTokens.scaleActive}: 0.98;
+
+                ${chipTokens.closeIconSize}: 1rem;
+            `,
         },
         disabled: {
             true: css`

--- a/packages/sdds-cs/src/components/Chip/Chip.stories.tsx
+++ b/packages/sdds-cs/src/components/Chip/Chip.stories.tsx
@@ -6,7 +6,7 @@ import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 import { Chip } from '.';
 
 const views = ['default', 'secondary', 'accent'];
-const sizes = ['s'];
+const sizes = ['s', 'xs'];
 
 const onClear = action('onClear');
 
@@ -27,7 +27,7 @@ const meta: Meta<typeof Chip> = {
                 type: 'select',
             },
         },
-        ...disableProps(['readOnly', 'onClear', 'contentLeft', 'contentRight', 'contentClearButton', 'text', 'size']),
+        ...disableProps(['readOnly', 'onClear', 'contentLeft', 'contentRight', 'contentClearButton', 'text']),
     },
 };
 
@@ -64,8 +64,9 @@ export const WithIcon: Story = {
     render: (args) => {
         const iconSizeMapper = {
             s: '1.5rem',
+            xs: '1rem',
         };
-        const iconSize = args.size || 'm';
+        const iconSize = args.size || 's';
 
         return (
             <Chip

--- a/website/sdds-cs-docs/docs/components/Chip.mdx
+++ b/website/sdds-cs-docs/docs/components/Chip.mdx
@@ -87,3 +87,20 @@ export function App() {
     );
 }
 ```
+
+### Размер Chip
+Размер Chip задается с помощью свойства `size`:
+
+```tsx live
+import React from 'react';
+import { Chip } from '@salutejs/sdds-cs';
+
+export function App() {
+    return (
+        <div>
+            <Chip text="Chip" size="s" view="default" />
+            <Chip text="Chip" size="xs" view="default" />
+        </div>
+    );
+}
+```


### PR DESCRIPTION
## SDDS-CS

### Chip

- добавлен размер `xs`

<img width="144" alt="image" src="https://github.com/user-attachments/assets/901f0824-9d8b-49fa-8a15-df05162e8565" />

### What/why changed

Добавлен размер xs для Chip

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-cs@0.236.0-canary.1713.12904792306.0
  # or 
  yarn add @salutejs/sdds-cs@0.236.0-canary.1713.12904792306.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
