### PR TITLE
PLASMA-4350: add UNSAFE_SSR_ENABLED to Notification

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -3087,6 +3087,7 @@ export const NotificationsProvider: React_2.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
+    UNSAFE_SSR_ENABLED?: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/plasma-b2c/src/components/Notification/Notification.tsx
+++ b/packages/plasma-b2c/src/components/Notification/Notification.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode } from 'react';
 import {
+    NotificationPlacement,
     notificationConfig,
     NotificationsProvider as Provider,
-    NotificationPlacement,
     component,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
@@ -19,9 +19,10 @@ export const NotificationsProvider: React.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, frame = 'document', placement }) => {
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, frame = 'document', placement, UNSAFE_SSR_ENABLED }) => {
     return (
-        <Provider config={mergedConfig} frame={frame} placement={placement}>
+        <Provider config={mergedConfig} frame={frame} placement={placement} UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {children}
         </Provider>
     );

--- a/packages/plasma-giga/api/plasma-giga.api.md
+++ b/packages/plasma-giga/api/plasma-giga.api.md
@@ -2694,6 +2694,7 @@ export const NotificationsProvider: React_2.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
+    UNSAFE_SSR_ENABLED?: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/plasma-giga/src/components/Notification/Notification.tsx
+++ b/packages/plasma-giga/src/components/Notification/Notification.tsx
@@ -24,9 +24,10 @@ export const NotificationsProvider: React.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, frame = 'document', placement }) => {
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, frame = 'document', placement, UNSAFE_SSR_ENABLED }) => {
     return (
-        <Provider config={mergedConfig} frame={frame} placement={placement}>
+        <Provider config={mergedConfig} frame={frame} placement={placement} UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {children}
         </Provider>
     );

--- a/packages/plasma-new-hope/src/components/Notification/Notification.types.ts
+++ b/packages/plasma-new-hope/src/components/Notification/Notification.types.ts
@@ -84,6 +84,10 @@ export interface NotificationProps extends AsProps, Omit<HTMLAttributes<HTMLDivE
      * Вид закрывающей иконки в Notification.
      */
     closeIconType?: 'default' | 'thin';
+    /**
+     * @description Только для применения в рамках SSR.
+     */
+    UNSAFE_SSR_ENABLED?: boolean;
 }
 
 export interface NotificationPortalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {

--- a/packages/plasma-new-hope/src/components/Notification/Notification.types.ts
+++ b/packages/plasma-new-hope/src/components/Notification/Notification.types.ts
@@ -100,4 +100,8 @@ export interface NotificationPortalProps extends Omit<HTMLAttributes<HTMLDivElem
      * @default bottom-right
      */
     placement?: NotificationPlacement;
+    /**
+     * @description Только для применения в рамках SSR.
+     */
+    UNSAFE_SSR_ENABLED?: boolean;
 }

--- a/packages/plasma-new-hope/src/components/Notification/NotificationsPortal.tsx
+++ b/packages/plasma-new-hope/src/components/Notification/NotificationsPortal.tsx
@@ -24,7 +24,12 @@ const StyledPopup = styled(Popup)`
 /**
  * Обертка для визуального представления уведомлений.
  */
-export const NotificationsPortal: FC<NotificationPortalProps> = ({ config, frame, placement = 'bottom-right' }) => {
+export const NotificationsPortal: FC<NotificationPortalProps> = ({
+    config,
+    frame,
+    placement = 'bottom-right',
+    UNSAFE_SSR_ENABLED,
+}) => {
     const { notifications } = useStoreon<NotificationsState, NotificationsEvents>('notifications');
 
     const Notification = useMemo(
@@ -33,7 +38,7 @@ export const NotificationsPortal: FC<NotificationPortalProps> = ({ config, frame
     );
 
     return (
-        <PopupProvider>
+        <PopupProvider UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {notifications.length > 0 && (
                 <StyledPopup opened frame={frame} placement={placement} zIndex="9100">
                     <StyledRoot placement={placement}>

--- a/packages/plasma-new-hope/src/components/Notification/NotificationsProvider.tsx
+++ b/packages/plasma-new-hope/src/components/Notification/NotificationsProvider.tsx
@@ -13,11 +13,20 @@ export const NotificationsProvider: FC<{
     config: ComponentConfig<string, Variants, PropsType<Variants>, NotificationProps & HTMLAttributes<HTMLDivElement>>;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, config, frame, placement }) => {
+    /**
+     * @description Только для применения в рамках SSR.
+     */
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, config, frame, placement, UNSAFE_SSR_ENABLED }) => {
     return (
         <StoreContext.Provider value={NotificationsStore}>
             {children}
-            <NotificationsPortal frame={frame} placement={placement} config={config} />
+            <NotificationsPortal
+                frame={frame}
+                placement={placement}
+                config={config}
+                UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}
+            />
         </StoreContext.Provider>
     );
 };

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -3089,6 +3089,7 @@ export const NotificationsProvider: React_2.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
+    UNSAFE_SSR_ENABLED?: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/plasma-web/src/components/Notification/Notification.tsx
+++ b/packages/plasma-web/src/components/Notification/Notification.tsx
@@ -19,9 +19,10 @@ export const NotificationsProvider: React.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, frame = 'document', placement }) => {
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, frame = 'document', placement, UNSAFE_SSR_ENABLED }) => {
     return (
-        <Provider config={mergedConfig} frame={frame} placement={placement}>
+        <Provider config={mergedConfig} frame={frame} placement={placement} UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {children}
         </Provider>
     );

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -2413,6 +2413,7 @@ export const NotificationsProvider: React_2.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
+    UNSAFE_SSR_ENABLED?: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/sdds-cs/src/components/Notification/Notification.tsx
+++ b/packages/sdds-cs/src/components/Notification/Notification.tsx
@@ -24,9 +24,10 @@ export const NotificationsProvider: React.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, frame = 'document', placement }) => {
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, frame = 'document', placement, UNSAFE_SSR_ENABLED }) => {
     return (
-        <Provider config={mergedConfig} frame={frame} placement={placement}>
+        <Provider config={mergedConfig} frame={frame} placement={placement} UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {children}
         </Provider>
     );

--- a/packages/sdds-dfa/src/components/Notification/Notification.tsx
+++ b/packages/sdds-dfa/src/components/Notification/Notification.tsx
@@ -24,9 +24,10 @@ export const NotificationsProvider: React.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, frame = 'document', placement }) => {
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, frame = 'document', placement, UNSAFE_SSR_ENABLED }) => {
     return (
-        <Provider config={mergedConfig} frame={frame} placement={placement}>
+        <Provider config={mergedConfig} frame={frame} placement={placement} UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {children}
         </Provider>
     );

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -2702,6 +2702,7 @@ export const NotificationsProvider: React_2.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
+    UNSAFE_SSR_ENABLED?: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/sdds-finportal/src/components/Notification/Notification.tsx
+++ b/packages/sdds-finportal/src/components/Notification/Notification.tsx
@@ -24,9 +24,10 @@ export const NotificationsProvider: React.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, frame = 'document', placement }) => {
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, frame = 'document', placement, UNSAFE_SSR_ENABLED }) => {
     return (
-        <Provider config={mergedConfig} frame={frame} placement={placement}>
+        <Provider config={mergedConfig} frame={frame} placement={placement} UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {children}
         </Provider>
     );

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -2430,6 +2430,7 @@ export const NotificationsProvider: React_2.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
+    UNSAFE_SSR_ENABLED?: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/sdds-insol/src/components/Notification/Notification.tsx
+++ b/packages/sdds-insol/src/components/Notification/Notification.tsx
@@ -24,9 +24,10 @@ export const NotificationsProvider: React.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, frame = 'document', placement }) => {
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, frame = 'document', placement, UNSAFE_SSR_ENABLED }) => {
     return (
-        <Provider config={mergedConfig} frame={frame} placement={placement}>
+        <Provider config={mergedConfig} frame={frame} placement={placement} UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {children}
         </Provider>
     );

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -2704,6 +2704,7 @@ export const NotificationsProvider: React_2.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
+    UNSAFE_SSR_ENABLED?: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/sdds-serv/src/components/Notification/Notification.tsx
+++ b/packages/sdds-serv/src/components/Notification/Notification.tsx
@@ -24,9 +24,10 @@ export const NotificationsProvider: React.FC<{
     children: ReactNode;
     frame?: string;
     placement?: NotificationPlacement;
-}> = ({ children, frame = 'document', placement }) => {
+    UNSAFE_SSR_ENABLED?: boolean;
+}> = ({ children, frame = 'document', placement, UNSAFE_SSR_ENABLED }) => {
     return (
-        <Provider config={mergedConfig} frame={frame} placement={placement}>
+        <Provider config={mergedConfig} frame={frame} placement={placement} UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {children}
         </Provider>
     );


### PR DESCRIPTION
## Core

### Notification

- добавлен UNSAFE_SSR_ENABLED по аналогии с PopupProvider

### What/why changed

Добавлен UNSAFE_SSR_ENABLED по аналогии с PopupProvider, для решения проблемы с гидрацией.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.263.0-canary.1718.13051742234.0
  npm install @salutejs/plasma-b2c@1.505.0-canary.1718.13051742234.0
  npm install @salutejs/plasma-giga@0.232.0-canary.1718.13051742234.0
  npm install @salutejs/plasma-new-hope@0.251.0-canary.1718.13051742234.0
  npm install @salutejs/plasma-web@1.507.0-canary.1718.13051742234.0
  npm install @salutejs/sdds-cs@0.240.0-canary.1718.13051742234.0
  npm install @salutejs/sdds-dfa@0.235.0-canary.1718.13051742234.0
  npm install @salutejs/sdds-finportal@0.228.0-canary.1718.13051742234.0
  npm install @salutejs/sdds-insol@0.229.0-canary.1718.13051742234.0
  npm install @salutejs/sdds-serv@0.236.0-canary.1718.13051742234.0
  # or 
  yarn add @salutejs/plasma-asdk@0.263.0-canary.1718.13051742234.0
  yarn add @salutejs/plasma-b2c@1.505.0-canary.1718.13051742234.0
  yarn add @salutejs/plasma-giga@0.232.0-canary.1718.13051742234.0
  yarn add @salutejs/plasma-new-hope@0.251.0-canary.1718.13051742234.0
  yarn add @salutejs/plasma-web@1.507.0-canary.1718.13051742234.0
  yarn add @salutejs/sdds-cs@0.240.0-canary.1718.13051742234.0
  yarn add @salutejs/sdds-dfa@0.235.0-canary.1718.13051742234.0
  yarn add @salutejs/sdds-finportal@0.228.0-canary.1718.13051742234.0
  yarn add @salutejs/sdds-insol@0.229.0-canary.1718.13051742234.0
  yarn add @salutejs/sdds-serv@0.236.0-canary.1718.13051742234.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
