### PR TITLE
PLASMA-4294: Fix TabItem divider color in `sdds-insol`

### DIFF
--- a/packages/sdds-insol/src/components/Tabs/horizontal/HorizontalTabItem.config.ts
+++ b/packages/sdds-insol/src/components/Tabs/horizontal/HorizontalTabItem.config.ts
@@ -81,8 +81,8 @@ export const config = {
                 ${tabsTokens.outlineFocusColor}: var(--surface-accent);
 
                 ${tabsTokens.itemSelectedDividerHeight}: 0.125rem;
-                ${tabsTokens.itemSelectedDividerColor}: var(--text-primary);
-                ${tabsTokens.itemSelectedDividerColorHover}: var(--text-primary);
+                ${tabsTokens.itemSelectedDividerColor}: var(--text-accent);
+                ${tabsTokens.itemSelectedDividerColorHover}: var(--text-accent);
             `,
             default: css`
                 ${tabsTokens.itemColor}: var(--text-primary);

--- a/packages/sdds-insol/src/components/Tabs/vertical/VerticalTabItem.config.ts
+++ b/packages/sdds-insol/src/components/Tabs/vertical/VerticalTabItem.config.ts
@@ -31,8 +31,8 @@ export const config = {
 
                 ${tabsTokens.itemSelectedDividerWidth}: 0.125rem;
                 ${tabsTokens.itemSelectedDividerHeight}: 0.125rem;
-                ${tabsTokens.itemSelectedDividerColor}: var(--text-primary);
-                ${tabsTokens.itemSelectedDividerColorHover}: var(--text-primary);
+                ${tabsTokens.itemSelectedDividerColor}: var(--text-accent);
+                ${tabsTokens.itemSelectedDividerColorHover}: var(--text-accent);
             `,
         },
         size: {


### PR DESCRIPTION
## SDDS-INSOL

### Tabs
- исправлен цвет `divider` у `TabItem`

### What/why changed

#### Before:

<img width="1300" alt="tabsHorizBefore" src="https://github.com/user-attachments/assets/b3bb4d7b-d9dc-4753-a846-8edfc3c6d45c" />

<img width="340" alt="tabsVertBefore" src="https://github.com/user-attachments/assets/c5bd8312-78ed-4fe4-bded-8230ab50bf99" />

#### After:

<img width="1257" alt="tabsHorizAfter" src="https://github.com/user-attachments/assets/a7c53b70-a3a5-40a5-91d6-4ba747ead58a" />

<img width="369" alt="tabsVertAfter" src="https://github.com/user-attachments/assets/43a7e18f-6411-49d3-a184-6c96ce0eb9f0" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-insol@0.226.2-canary.1721.12949402068.0
  # or 
  yarn add @salutejs/sdds-insol@0.226.2-canary.1721.12949402068.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
