### PR TITLE
PLASMA-4356: make placement optional for DropdownItem

### DIFF
--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.template-doc.mdx
@@ -32,7 +32,7 @@ type Items = Array<{
         /**
         * Сторона открытия вложенного дропдауна относительно текущего элемента;
         */
-        placement: DropdownPlacement;
+        placement?: DropdownPlacement;
         /**
          * Список дочерних items.
          */

--- a/packages/plasma-new-hope/src/components/Dropdown/ui/DropdownItem/DropdownItem.type.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/ui/DropdownItem/DropdownItem.type.ts
@@ -15,7 +15,7 @@ export type DropdownItemOption = {
     /**
      * Сторона открытия вложенного дропдауна относительно текущего элемента
      */
-    placement: DropdownPlacement;
+    placement?: DropdownPlacement;
     /**
      * Список дочерних items
      */

--- a/website/plasma-b2c-docs/docs/components/Dropdown.mdx
+++ b/website/plasma-b2c-docs/docs/components/Dropdown.mdx
@@ -32,7 +32,7 @@ type Items = Array<{
         /**
         * Сторона открытия вложенного дропдауна относительно текущего элемента;
         */
-        placement: DropdownPlacement;
+        placement?: DropdownPlacement;
         /**
          * Список дочерних items.
          */

--- a/website/plasma-giga-docs/docs/components/Dropdown.mdx
+++ b/website/plasma-giga-docs/docs/components/Dropdown.mdx
@@ -32,7 +32,7 @@ type Items = Array<{
         /**
         * Сторона открытия вложенного дропдауна относительно текущего элемента;
         */
-        placement: DropdownPlacement;
+        placement?: DropdownPlacement;
         /**
          * Список дочерних items.
          */

--- a/website/plasma-web-docs/docs/components/Dropdown.mdx
+++ b/website/plasma-web-docs/docs/components/Dropdown.mdx
@@ -32,7 +32,7 @@ type Items = Array<{
         /**
         * Сторона открытия вложенного дропдауна относительно текущего элемента;
         */
-        placement: DropdownPlacement;
+        placement?: DropdownPlacement;
         /**
          * Список дочерних items.
          */

--- a/website/sdds-cs-docs/docs/components/Dropdown.mdx
+++ b/website/sdds-cs-docs/docs/components/Dropdown.mdx
@@ -33,7 +33,7 @@ type Items = Array<{
         /**
         * Сторона открытия вложенного дропдауна относительно текущего элемента;
         */
-        placement: DropdownPlacement;
+        placement?: DropdownPlacement;
         /**
          * Список дочерних items.
          */

--- a/website/sdds-dfa-docs/docs/components/Dropdown.mdx
+++ b/website/sdds-dfa-docs/docs/components/Dropdown.mdx
@@ -32,7 +32,7 @@ type Items = Array<{
         /**
         * Сторона открытия вложенного дропдауна относительно текущего элемента;
         */
-        placement: DropdownPlacement;
+        placement?: DropdownPlacement;
         /**
          * Список дочерних items.
          */

--- a/website/sdds-insol-docs/docs/components/Dropdown.mdx
+++ b/website/sdds-insol-docs/docs/components/Dropdown.mdx
@@ -32,7 +32,7 @@ type Items = Array<{
         /**
         * Сторона открытия вложенного дропдауна относительно текущего элемента;
         */
-        placement: DropdownPlacement;
+        placement?: DropdownPlacement;
         /**
          * Список дочерних items.
          */

--- a/website/sdds-serv-docs/docs/components/Dropdown.mdx
+++ b/website/sdds-serv-docs/docs/components/Dropdown.mdx
@@ -32,7 +32,7 @@ type Items = Array<{
         /**
         * Сторона открытия вложенного дропдауна относительно текущего элемента;
         */
-        placement: DropdownPlacement;
+        placement?: DropdownPlacement;
         /**
          * Список дочерних items.
          */


### PR DESCRIPTION
## Core

### Dropdown

- свойство `placement` для вложенных дропдаунов сделано опциональным

### What/why changed

Свойство `placement` для вложенных дропдаунов сделано опциональным.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.260.0-canary.1723.12945644036.0
  npm install @salutejs/plasma-b2c@1.502.0-canary.1723.12945644036.0
  npm install @salutejs/plasma-giga@0.229.0-canary.1723.12945644036.0
  npm install @salutejs/plasma-new-hope@0.248.0-canary.1723.12945644036.0
  npm install @salutejs/plasma-web@1.504.0-canary.1723.12945644036.0
  npm install @salutejs/sdds-cs@0.237.0-canary.1723.12945644036.0
  npm install @salutejs/sdds-dfa@0.232.0-canary.1723.12945644036.0
  npm install @salutejs/sdds-finportal@0.225.0-canary.1723.12945644036.0
  npm install @salutejs/sdds-insol@0.226.0-canary.1723.12945644036.0
  npm install @salutejs/sdds-serv@0.233.0-canary.1723.12945644036.0
  # or 
  yarn add @salutejs/plasma-asdk@0.260.0-canary.1723.12945644036.0
  yarn add @salutejs/plasma-b2c@1.502.0-canary.1723.12945644036.0
  yarn add @salutejs/plasma-giga@0.229.0-canary.1723.12945644036.0
  yarn add @salutejs/plasma-new-hope@0.248.0-canary.1723.12945644036.0
  yarn add @salutejs/plasma-web@1.504.0-canary.1723.12945644036.0
  yarn add @salutejs/sdds-cs@0.237.0-canary.1723.12945644036.0
  yarn add @salutejs/sdds-dfa@0.232.0-canary.1723.12945644036.0
  yarn add @salutejs/sdds-finportal@0.225.0-canary.1723.12945644036.0
  yarn add @salutejs/sdds-insol@0.226.0-canary.1723.12945644036.0
  yarn add @salutejs/sdds-serv@0.233.0-canary.1723.12945644036.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
