### PR TITLE
PLASMA-3841: fix Divider `view` tokens in `sdds-finportal`

### DIFF
--- a/packages/sdds-finportal/src/components/Divider/Divider.config.draft.ts
+++ b/packages/sdds-finportal/src/components/Divider/Divider.config.draft.ts
@@ -1,0 +1,38 @@
+import { css, dividerTokens } from '@salutejs/plasma-new-hope/styled-components';
+
+export const config = {
+    defaults: {
+        view: 'default',
+        size: 'm',
+        orientation: 'horizontal',
+    },
+    variations: {
+        view: {
+            default: css`
+                ${dividerTokens.background}: var(--outline-solid-primary);
+            `,
+            dark: css`
+                ${dividerTokens.background}: var(--on-dark-outline-solid-primary);
+            `,
+            light: css`
+                ${dividerTokens.background}: var(--on-light-outline-solid-primary);
+            `,
+            inverse: css`
+                ${dividerTokens.background}: var(--inverse-outline-solid-primary);
+            `,
+        },
+        size: {
+            m: css`
+                ${dividerTokens.borderRadius}: 0.0625rem;
+            `,
+        },
+        orientation: {
+            horizontal: css`
+                ${dividerTokens.baseSideSize}: 0.0625rem;
+            `,
+            vertical: css`
+                ${dividerTokens.baseSideSize}: 0.0625rem;
+            `,
+        },
+    },
+};

--- a/packages/sdds-finportal/src/components/Divider/Divider.stories.tsx
+++ b/packages/sdds-finportal/src/components/Divider/Divider.stories.tsx
@@ -3,10 +3,18 @@ import type { ComponentProps } from 'react';
 import styled from 'styled-components';
 import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 import type { StoryObj, Meta } from '@storybook/react';
+import { dividerConfig } from '@salutejs/plasma-new-hope/styled-components';
 
 import { BodyS } from '../Typography';
+import { hasComponentDraftConfig } from '../../helpers/hasComponentDraftConfig';
+import { createComponentByConfig } from '../../helpers/createComponentByConfig';
 
-import { Divider } from './Divider';
+import { config as defaultConfig } from './Divider.config';
+import { config as draftConfig } from './Divider.config.draft';
+
+const config = hasComponentDraftConfig() ? draftConfig : defaultConfig;
+
+const Divider = createComponentByConfig(dividerConfig, config);
 
 const meta: Meta<typeof Divider> = {
     title: 'Data Display/Divider',


### PR DESCRIPTION
## SDDS-FINPORTAL

### Divider
- добавлен черновик для `Divider` с новыми токенами для `view`

### What/why changed
Токены заменены на `--outline-solid-primary`. Изменения добавлены в draft config для draft storybook.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-finportal@0.225.2-canary.1725.12985545035.0
  # or 
  yarn add @salutejs/sdds-finportal@0.225.2-canary.1725.12985545035.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
