### PR TITLE
PLASMA-4295: update Segment config

### DIFF
--- a/packages/plasma-new-hope/src/components/Segment/tokens.ts
+++ b/packages/plasma-new-hope/src/components/Segment/tokens.ts
@@ -15,6 +15,7 @@ export const tokens = {
     fontSize: '--plasma-segment-item-font-size',
     fontStyle: '--plasma-segment-item-font-style',
     fontWeight: '--plasma-segment-item-font-weight',
+    fontWeightSelectedItem: '--plasma-segment-item-font-weight-selected-item',
     letterSpacing: '--plasma-segment-item-letter-spacing',
     lineHeight: '--plasma-segment-item-lineheight',
 

--- a/packages/plasma-new-hope/src/components/Segment/ui/SegmentItem/variations/_size/base.ts
+++ b/packages/plasma-new-hope/src/components/Segment/ui/SegmentItem/variations/_size/base.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 
-import { tokens } from '../../../../tokens';
+import { classes, tokens } from '../../../../tokens';
 
 export const base = css`
     font-family: var(${tokens.fontFamily});
@@ -17,4 +17,8 @@ export const base = css`
     height: var(${tokens.itemHeight});
 
     padding: var(${tokens.itemPadding});
+
+    &.${classes.selectedSegmentItem} {
+        font-weight: var(${tokens.fontWeightSelectedItem}, var(${tokens.fontWeight}));
+    }
 `;

--- a/packages/plasma-new-hope/src/components/Segment/ui/SegmentItem/variations/_view/base.ts
+++ b/packages/plasma-new-hope/src/components/Segment/ui/SegmentItem/variations/_view/base.ts
@@ -37,6 +37,10 @@ export const base = css`
             background-color: var(${tokens.itemSelectedBackgroundColorHover});
 
             ${RightContent} {
+                color: var(${tokens.itemSelectedColorHover});
+            }
+
+            ${RightContent}.${classes.segmentAdditionalText} {
                 color: var(${tokens.itemSelectedAdditionalColorHover});
             }
         }

--- a/packages/plasma-new-hope/src/components/Segment/ui/SegmentItem/variations/_view/base.ts
+++ b/packages/plasma-new-hope/src/components/Segment/ui/SegmentItem/variations/_view/base.ts
@@ -20,7 +20,7 @@ export const base = css`
         }
     }
 
-    &.${String(classes.selectedSegmentItem)} {
+    &.${classes.selectedSegmentItem} {
         color: var(${tokens.itemSelectedColor});
         background-color: var(${tokens.itemSelectedBackgroundColor});
 

--- a/packages/sdds-insol/src/components/Segment/Segment.stories.tsx
+++ b/packages/sdds-insol/src/components/Segment/Segment.stories.tsx
@@ -3,6 +3,8 @@ import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 import { IconMic } from '@salutejs/plasma-icons';
+import styled from 'styled-components';
+import { segmentTokens } from '@salutejs/plasma-new-hope/styled-components';
 
 import { Counter } from '../Counter/Counter';
 
@@ -27,18 +29,40 @@ type StorySegmentProps = ComponentProps<typeof SegmentGroup> & CustomStoryProps;
 
 const sizes = ['xs', 's', 'm', 'l'] as const;
 
+const getIconSizeProps = (size: string) => {
+    switch (size) {
+        case 'xs':
+        case 's':
+            return '1rem';
+        case 'm':
+            return '1.25rem';
+        default:
+            return '1.5rem';
+    }
+};
+
+const StyledIconMic = styled(IconMic)<{ customSize?: string }>`
+    ${({ customSize }) =>
+        customSize &&
+        `
+            width: ${customSize};
+            height: ${customSize};
+            flex: 0 0 ${customSize};
+        `}
+`;
+
 const getContentLeft = (contentLeftOption: string, size: Size) => {
-    const iconSize = size === 'xs' ? 'xs' : 's';
-    return contentLeftOption === 'icon' ? <IconMic size={iconSize} color="inherit" /> : undefined;
+    return contentLeftOption === 'icon' ? (
+        <StyledIconMic customSize={getIconSizeProps(size)} color="inherit" />
+    ) : undefined;
 };
 
 const getContentRight = (contentRightOption: string, size: Size) => {
-    const iconSize = size === 'xs' ? 'xs' : 's';
     const counterSize = size === 'xs' ? 'xxs' : 'xs';
 
     switch (contentRightOption) {
         case 'icon':
-            return <IconMic size={iconSize} color="inherit" />;
+            return <StyledIconMic customSize={getIconSizeProps(size)} color="inherit" />;
         case 'counter':
             return <Counter size={counterSize} count={1} view="positive" />;
         case 'text':

--- a/packages/sdds-insol/src/components/Segment/SegmentGroup.config.ts
+++ b/packages/sdds-insol/src/components/Segment/SegmentGroup.config.ts
@@ -65,7 +65,7 @@ export const config = {
         },
         filledBackground: {
             true: css`
-                ${segmentTokens.groupFilledBackgroundColor}: var(--surface-transparent-secondary);
+                ${segmentTokens.groupFilledBackgroundColor}: var(--surface-solid-secondary);
             `,
         },
         orientation: {

--- a/packages/sdds-insol/src/components/Segment/SegmentItem.config.ts
+++ b/packages/sdds-insol/src/components/Segment/SegmentItem.config.ts
@@ -30,10 +30,10 @@ export const config = {
                 ${segmentTokens.itemBackgroundColorHover}: transparent;
                 ${segmentTokens.itemAdditionalColor}: var(--text-secondary);
                 ${segmentTokens.itemAdditionalColorHover}: var(--text-secondary);
-                ${segmentTokens.itemSelectedColor}: var(--text-primary);
-                ${segmentTokens.itemSelectedBackgroundColor}: var(--surface-transparent-card);
-                ${segmentTokens.itemSelectedColorHover}: var(--text-primary-hover);
-                ${segmentTokens.itemSelectedBackgroundColorHover}: var(--surface-transparent-card);
+                ${segmentTokens.itemSelectedColor}: var(--text-accent);
+                ${segmentTokens.itemSelectedBackgroundColor}: var(--surface-solid-card);
+                ${segmentTokens.itemSelectedColorHover}: var(--text-accent-hover);
+                ${segmentTokens.itemSelectedBackgroundColorHover}: var(--surface-solid-card);
                 ${segmentTokens.itemSelectedAdditionalColor}: var(--text-secondary);
                 ${segmentTokens.itemSelectedAdditionalColorHover}: var(--text-secondary);
 
@@ -70,7 +70,8 @@ export const config = {
                 ${segmentTokens.fontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${segmentTokens.fontSize}: var(--plasma-typo-body-xs-font-size);
                 ${segmentTokens.fontStyle}: var(--plasma-typo-body-xs-font-style);
-                ${segmentTokens.fontWeight}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${segmentTokens.fontWeight}: var(--plasma-typo-body-xs-font-weight);
+                ${segmentTokens.fontWeightSelectedItem}: var(--plasma-typo-body-xs-bold-font-weight);
                 ${segmentTokens.letterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${segmentTokens.lineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -84,12 +85,13 @@ export const config = {
                 ${segmentTokens.itemIconMargin}: 0.125rem;
                 ${segmentTokens.itemMarginLeft}: 0rem;
 
-                ${segmentTokens.fontFamily}: var(--plasma-typo-body-s-font-family);
-                ${segmentTokens.fontSize}: var(--plasma-typo-body-s-font-size);
-                ${segmentTokens.fontStyle}: var(--plasma-typo-body-s-font-style);
-                ${segmentTokens.fontWeight}: var(--plasma-typo-body-s-bold-font-weight);
-                ${segmentTokens.letterSpacing}: var(--plasma-typo-body-s-letter-spacing);
-                ${segmentTokens.lineHeight}: var(--plasma-typo-body-s-line-height);
+                ${segmentTokens.fontFamily}: var(--plasma-typo-body-xs-font-family);
+                ${segmentTokens.fontSize}: var(--plasma-typo-body-xs-font-size);
+                ${segmentTokens.fontStyle}: var(--plasma-typo-body-xs-font-style);
+                ${segmentTokens.fontWeight}: var(--plasma-typo-body-xs-font-weight);
+                ${segmentTokens.fontWeightSelectedItem}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${segmentTokens.letterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
+                ${segmentTokens.lineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
             m: css`
                 ${segmentTokens.itemBorderRadius}: 0.75rem;
@@ -101,12 +103,13 @@ export const config = {
                 ${segmentTokens.itemIconMargin}: 0.25rem;
                 ${segmentTokens.itemMarginLeft}: 0rem;
 
-                ${segmentTokens.fontFamily}: var(--plasma-typo-body-m-font-family);
-                ${segmentTokens.fontSize}: var(--plasma-typo-body-m-font-size);
-                ${segmentTokens.fontStyle}: var(--plasma-typo-body-m-font-style);
-                ${segmentTokens.fontWeight}: var(--plasma-typo-body-m-bold-font-weight);
-                ${segmentTokens.letterSpacing}: var(--plasma-typo-body-m-letter-spacing);
-                ${segmentTokens.lineHeight}: var(--plasma-typo-body-m-line-height);
+                ${segmentTokens.fontFamily}: var(--plasma-typo-body-xs-font-family);
+                ${segmentTokens.fontSize}: var(--plasma-typo-body-xs-font-size);
+                ${segmentTokens.fontStyle}: var(--plasma-typo-body-xs-font-style);
+                ${segmentTokens.fontWeight}: var(--plasma-typo-body-xs-font-weight);
+                ${segmentTokens.fontWeightSelectedItem}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${segmentTokens.letterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
+                ${segmentTokens.lineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
             l: css`
                 ${segmentTokens.itemBorderRadius}: 0.875rem;
@@ -118,12 +121,13 @@ export const config = {
                 ${segmentTokens.itemIconMargin}: 0.375rem;
                 ${segmentTokens.itemMarginLeft}: 0;
 
-                ${segmentTokens.fontFamily}: var(--plasma-typo-body-l-font-family);
-                ${segmentTokens.fontSize}: var(--plasma-typo-body-l-font-size);
-                ${segmentTokens.fontStyle}: var(--plasma-typo-body-l-font-style);
-                ${segmentTokens.fontWeight}: var(--plasma-typo-body-l-bold-font-weight);
-                ${segmentTokens.letterSpacing}: var(--plasma-typo-body-l-letter-spacing);
-                ${segmentTokens.lineHeight}: var(--plasma-typo-body-l-line-height);
+                ${segmentTokens.fontFamily}: var(--plasma-typo-body-s-font-family);
+                ${segmentTokens.fontSize}: var(--plasma-typo-body-s-font-size);
+                ${segmentTokens.fontStyle}: var(--plasma-typo-body-s-font-style);
+                ${segmentTokens.fontWeight}: var(--plasma-typo-body-s-font-weight);
+                ${segmentTokens.fontWeightSelectedItem}: var(--plasma-typo-body-s-bold-font-weight);
+                ${segmentTokens.letterSpacing}: var(--plasma-typo-body-s-letter-spacing);
+                ${segmentTokens.lineHeight}: var(--plasma-typo-body-s-line-height);
             `,
         },
         disabled: {


### PR DESCRIPTION
## SDDS-INSOL

### Segment

- актуализированы размеры шрифта в компоненте
- исправлен цвет иконки при наведении на выбранный сегмент

<img width="373" alt="image" src="https://github.com/user-attachments/assets/7702d0d6-524b-4426-a18e-f2edbea92753" />

### What/why changed

Актуализация компонента, согласно макетам

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.261.0-canary.1726.13029058317.0
  npm install @salutejs/plasma-b2c@1.503.0-canary.1726.13029058317.0
  npm install @salutejs/plasma-giga@0.230.0-canary.1726.13029058317.0
  npm install @salutejs/plasma-new-hope@0.249.0-canary.1726.13029058317.0
  npm install @salutejs/plasma-web@1.505.0-canary.1726.13029058317.0
  npm install @salutejs/sdds-cs@0.238.0-canary.1726.13029058317.0
  npm install @salutejs/sdds-dfa@0.233.0-canary.1726.13029058317.0
  npm install @salutejs/sdds-finportal@0.226.0-canary.1726.13029058317.0
  npm install @salutejs/sdds-insol@0.227.0-canary.1726.13029058317.0
  npm install @salutejs/sdds-serv@0.234.0-canary.1726.13029058317.0
  # or 
  yarn add @salutejs/plasma-asdk@0.261.0-canary.1726.13029058317.0
  yarn add @salutejs/plasma-b2c@1.503.0-canary.1726.13029058317.0
  yarn add @salutejs/plasma-giga@0.230.0-canary.1726.13029058317.0
  yarn add @salutejs/plasma-new-hope@0.249.0-canary.1726.13029058317.0
  yarn add @salutejs/plasma-web@1.505.0-canary.1726.13029058317.0
  yarn add @salutejs/sdds-cs@0.238.0-canary.1726.13029058317.0
  yarn add @salutejs/sdds-dfa@0.233.0-canary.1726.13029058317.0
  yarn add @salutejs/sdds-finportal@0.226.0-canary.1726.13029058317.0
  yarn add @salutejs/sdds-insol@0.227.0-canary.1726.13029058317.0
  yarn add @salutejs/sdds-serv@0.234.0-canary.1726.13029058317.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
