### PR TITLE
PLASMA-4392: fix Portal hydration error

### DIFF
--- a/packages/plasma-b2c/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/plasma-b2c/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -230,12 +230,14 @@ const DefaultStory = (args: StoryProps) => {
     const iconSize = args.size === 'xs' ? 'xs' : 's';
 
     return (
-        <Autocomplete
-            {...args}
-            suggestions={suggestions}
-            contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
-            contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
-        />
+        <div style={{ width: '70%', margin: '0 auto' }}>
+            <Autocomplete
+                {...args}
+                suggestions={suggestions}
+                contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
+            />
+        </div>
     );
 };
 

--- a/packages/plasma-giga/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/plasma-giga/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -230,12 +230,14 @@ const DefaultStory = (args: StoryProps) => {
     const iconSize = args.size === 'xs' ? 'xs' : 's';
 
     return (
-        <Autocomplete
-            {...args}
-            suggestions={suggestions}
-            contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
-            contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
-        />
+        <div style={{ width: '70%', margin: '0 auto' }}>
+            <Autocomplete
+                {...args}
+                suggestions={suggestions}
+                contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
+            />
+        </div>
     );
 };
 

--- a/packages/plasma-new-hope/src/components/Portal/Portal.tsx
+++ b/packages/plasma-new-hope/src/components/Portal/Portal.tsx
@@ -1,8 +1,6 @@
 import React, { FC } from 'react';
 import ReactDOM from 'react-dom';
 
-import { canUseDOM } from '../../utils';
-
 import { PortalProps } from './Portal.types';
 
 /**
@@ -10,16 +8,7 @@ import { PortalProps } from './Portal.types';
  * Представляет собой ReactDOM.createPortal() в форме компонента.
  */
 export const Portal: FC<PortalProps> = ({ children, container, disabled = false }) => {
-    if (!canUseDOM) {
-        return null;
-    }
-
     const portalContainer = typeof container === 'function' ? container() : container;
 
-    return (
-        <>
-            {(disabled || !portalContainer) && children}
-            {!disabled && portalContainer && ReactDOM.createPortal(children, portalContainer)}
-        </>
-    );
+    return <>{disabled || !portalContainer ? children : ReactDOM.createPortal(children, portalContainer)}</>;
 };

--- a/packages/plasma-new-hope/src/components/TextField/TextField.styles.ts
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.styles.ts
@@ -2,13 +2,12 @@ import { styled } from '@linaria/react';
 
 import { component, mergeConfig } from '../../engines';
 import { tooltipConfig } from '../Tooltip';
+import { popoverClasses } from '../Popover';
 
 import { classes, tokens } from './TextField.tokens';
 
 const mergedConfig = mergeConfig(tooltipConfig);
 const Tooltip = component(mergedConfig);
-
-export const Hint = styled(Tooltip)``;
 
 export const InputWrapper = styled.div`
     position: relative;
@@ -173,6 +172,12 @@ export const HintTargetWrapper = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
+`;
+
+export const Hint = styled(Tooltip)`
+    ${HintTargetWrapper} .${popoverClasses.root} {
+        width: fit-content;
+    }
 `;
 
 export const HintIconWrapper = styled.div`

--- a/packages/plasma-web/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/plasma-web/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -230,12 +230,14 @@ const DefaultStory = (args: StoryProps) => {
     const iconSize = args.size === 'xs' ? 'xs' : 's';
 
     return (
-        <Autocomplete
-            {...args}
-            suggestions={suggestions}
-            contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
-            contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
-        />
+        <div style={{ width: '70%', margin: '0 auto' }}>
+            <Autocomplete
+                {...args}
+                suggestions={suggestions}
+                contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
+            />
+        </div>
     );
 };
 

--- a/packages/sdds-dfa/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/sdds-dfa/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -230,12 +230,14 @@ const DefaultStory = (args: StoryProps) => {
     const iconSize = args.size === 'xs' ? 'xs' : 's';
 
     return (
-        <Autocomplete
-            {...args}
-            suggestions={suggestions}
-            contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
-            contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
-        />
+        <div style={{ width: '70%', margin: '0 auto' }}>
+            <Autocomplete
+                {...args}
+                suggestions={suggestions}
+                contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
+            />
+        </div>
     );
 };
 

--- a/packages/sdds-finportal/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/sdds-finportal/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -230,12 +230,14 @@ const DefaultStory = (args: StoryProps) => {
     const iconSize = args.size === 'xs' ? 'xs' : 's';
 
     return (
-        <Autocomplete
-            {...args}
-            suggestions={suggestions}
-            contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
-            contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
-        />
+        <div style={{ width: '70%', margin: '0 auto' }}>
+            <Autocomplete
+                {...args}
+                suggestions={suggestions}
+                contentLeft={enableContentLeft ? <IconPlasma size={iconSize} /> : undefined}
+                contentRight={enableContentRight ? <IconPlasma size={iconSize} /> : undefined}
+            />
+        </div>
     );
 };
 


### PR DESCRIPTION
## Core

### Portal

- исправлена ошибка гидрации в Next

### Autocomplete

- исправлена ширина компонента в storybook

### What/why changed

Из-за проверки canUseDOM на сервере возвращался null, а в клиенте была разметка. Из-за этого возникала ошибка гидрации

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.266.0-canary.1730.13072913854.0
  npm install @salutejs/plasma-b2c@1.508.0-canary.1730.13072913854.0
  npm install @salutejs/plasma-giga@0.235.0-canary.1730.13072913854.0
  npm install @salutejs/plasma-new-hope@0.254.0-canary.1730.13072913854.0
  npm install @salutejs/plasma-web@1.510.0-canary.1730.13072913854.0
  npm install @salutejs/sdds-cs@0.243.0-canary.1730.13072913854.0
  npm install @salutejs/sdds-dfa@0.238.0-canary.1730.13072913854.0
  npm install @salutejs/sdds-finportal@0.231.0-canary.1730.13072913854.0
  npm install @salutejs/sdds-insol@0.232.0-canary.1730.13072913854.0
  npm install @salutejs/sdds-serv@0.239.0-canary.1730.13072913854.0
  # or 
  yarn add @salutejs/plasma-asdk@0.266.0-canary.1730.13072913854.0
  yarn add @salutejs/plasma-b2c@1.508.0-canary.1730.13072913854.0
  yarn add @salutejs/plasma-giga@0.235.0-canary.1730.13072913854.0
  yarn add @salutejs/plasma-new-hope@0.254.0-canary.1730.13072913854.0
  yarn add @salutejs/plasma-web@1.510.0-canary.1730.13072913854.0
  yarn add @salutejs/sdds-cs@0.243.0-canary.1730.13072913854.0
  yarn add @salutejs/sdds-dfa@0.238.0-canary.1730.13072913854.0
  yarn add @salutejs/sdds-finportal@0.231.0-canary.1730.13072913854.0
  yarn add @salutejs/sdds-insol@0.232.0-canary.1730.13072913854.0
  yarn add @salutejs/sdds-serv@0.239.0-canary.1730.13072913854.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
