### PR TITLE
PLASMA-4371: explicit props type export in Dropdown, Select, Combobox

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -135,7 +135,6 @@ import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import { DropdownItemProps } from '@salutejs/plasma-hope';
 import { DropdownItem as DropdownItemType } from '@salutejs/plasma-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
-import type { DropdownNodeSelect } from '@salutejs/plasma-new-hope';
 import { DropdownNodeType } from '@salutejs/plasma-hope';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
 import { DropdownPopupProps } from '@salutejs/plasma-hope';
@@ -270,9 +269,9 @@ import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProviderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SelectGroup } from '@salutejs/plasma-hope';
+import { DropdownNodeSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 import { SelectPlacement } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import { SelectPlacementBasic } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
-import { MergedSelectProps as SelectProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SelectProps as SelectPropsHope } from '@salutejs/plasma-hope';
 import { selectText } from '@salutejs/plasma-hope';
 import { setRef } from '@salutejs/plasma-core';
@@ -3627,14 +3626,17 @@ export { SegmentProvider }
 
 export { SegmentProviderProps }
 
-// Warning: (ae-forgotten-export) The symbol "SelectProps_2" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export const Select: <T, K extends DropdownNodeSelect>(props: SelectProps_2<T, K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export const Select: <T, K extends SelectItemOption>(props: SelectProps<T, K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 export { SelectGroup }
 
-export { SelectProps }
+export { SelectItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "SelectNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type SelectProps<T, K extends SelectItemOption> = DistributiveOmit<MergedSelectProps<T, K>, 'size' | 'view' | 'chipView' | 'disabled'> & DistributivePick<ComponentProps<typeof SelectNewHope>, 'size' | 'view' | 'chipView' | 'disabled'>;
 
 export { SelectPropsHope }
 

--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -131,7 +131,7 @@ import { DrawerContentProps } from '@salutejs/plasma-new-hope/styled-components'
 import { DrawerFooterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerHeaderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { DropdownItemOption } from '@salutejs/plasma-new-hope';
+import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import { DropdownItemProps } from '@salutejs/plasma-hope';
 import { DropdownItem as DropdownItemType } from '@salutejs/plasma-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
@@ -139,7 +139,6 @@ import type { DropdownNodeSelect } from '@salutejs/plasma-new-hope';
 import { DropdownNodeType } from '@salutejs/plasma-hope';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
 import { DropdownPopupProps } from '@salutejs/plasma-hope';
-import { DropdownProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DropdownTrigger } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
 import { dropzoneClasses } from '@salutejs/plasma-new-hope/styled-components';
 import { dropzoneTokens } from '@salutejs/plasma-new-hope/styled-components';
@@ -1961,6 +1960,8 @@ default: PolymorphicClassName;
 // @public (undocumented)
 export const DropdownItem: React_2.ForwardRefExoticComponent<DropdownItemProps & React_2.RefAttributes<HTMLDivElement>>;
 
+export { DropdownItemOption }
+
 export { DropdownItemProps }
 
 export { DropdownItemType }
@@ -1975,7 +1976,10 @@ export const DropdownPopup: React_2.ForwardRefExoticComponent<DropdownPopupProps
 
 export { DropdownPopupProps }
 
-export { DropdownProps }
+// Warning: (ae-forgotten-export) The symbol "DropdownNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> & Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 // @public (undocumented)
 export const Dropzone: FunctionComponent<PropsType<    {

--- a/packages/plasma-b2c/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plasma-b2c/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { config } from './Dropdown.config';
 const mergedConfig = mergeConfig(dropdownConfig, config);
 const DropdownNewHope = component(mergedConfig);
 
-type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
     Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 const DropdownComponent = <T extends DropdownItemOption>(

--- a/packages/plasma-b2c/src/components/Dropdown/index.ts
+++ b/packages/plasma-b2c/src/components/Dropdown/index.ts
@@ -1,7 +1,8 @@
 export { withAssistiveDropdown } from '@salutejs/plasma-hope';
-export type { DropdownProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Dropdown } from './Dropdown';
+export type { DropdownProps } from './Dropdown';
+export type { DropdownItemOption } from '@salutejs/plasma-new-hope';
 
 // TODO: #1271
 export { DropdownItem } from './components/DropdownItem';

--- a/packages/plasma-b2c/src/components/Select/Select.tsx
+++ b/packages/plasma-b2c/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ import { config } from './Select.config';
 const mergedConfig = mergeConfig(selectConfig, config);
 const SelectNewHope = component(mergedConfig);
 
-type SelectProps<T, K extends DropdownNodeSelect> = DistributiveOmit<
+export type SelectProps<T, K extends DropdownNodeSelect> = DistributiveOmit<
     MergedSelectPropsNewHope<T, K>,
     'size' | 'view' | 'chipView' | 'disabled'
 > &

--- a/packages/plasma-b2c/src/components/Select/index.ts
+++ b/packages/plasma-b2c/src/components/Select/index.ts
@@ -1,6 +1,7 @@
 export { Select } from './Select';
 
 export type { SelectProps as SelectPropsHope } from '@salutejs/plasma-hope';
-export type { MergedSelectProps as SelectProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { SelectProps } from './Select';
+export type { DropdownNodeSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 
 export { SelectGroup } from '@salutejs/plasma-hope';

--- a/packages/plasma-giga/api/plasma-giga.api.md
+++ b/packages/plasma-giga/api/plasma-giga.api.md
@@ -94,7 +94,7 @@ import { DrawerContentProps } from '@salutejs/plasma-new-hope/styled-components'
 import { DrawerFooterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerHeaderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { DropdownItemOption } from '@salutejs/plasma-new-hope';
+import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
 import { DropdownNodeSelect } from '@salutejs/plasma-new-hope/styled-components';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
@@ -1661,6 +1661,13 @@ default: PolymorphicClassName;
     listHeight?: Property.Height<string | number> | undefined;
     hoverIndex?: number | undefined;
 } & React_2.HTMLAttributes<HTMLDivElement> & React_2.RefAttributes<HTMLDivElement>, "size" | "view"> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { DropdownItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "DropdownNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> & Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 // @public (undocumented)
 export const Dropzone: FunctionComponent<PropsType<    {

--- a/packages/plasma-giga/api/plasma-giga.api.md
+++ b/packages/plasma-giga/api/plasma-giga.api.md
@@ -136,7 +136,6 @@ import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import type { ItemOption } from '@salutejs/plasma-new-hope';
-import type { ItemOptionSelect } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -200,6 +199,7 @@ import { SegmentGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProviderProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 import { SelectPlacement } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import { SelectPlacementBasic } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import type { SelectProps as SelectProps_2 } from '@salutejs/plasma-new-hope';
@@ -3172,10 +3172,15 @@ export { SegmentProvider }
 
 export { SegmentProviderProps }
 
-// Warning: (ae-forgotten-export) The symbol "SelectProps" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Select: <K extends SelectItemOption>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { SelectItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "SelectNewHope" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Select: <K extends ItemOptionSelect>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type SelectProps<K extends SelectItemOption> = DistributiveOmit<SelectProps_2<K>, 'size' | 'view' | 'chipView' | 'disabled'> & DistributivePick<ComponentProps<typeof SelectNewHope>, 'size' | 'view' | 'chipView' | 'disabled'>;
 
 // @public
 export const Sheet: FunctionComponent<PropsType<    {

--- a/packages/plasma-giga/api/plasma-giga.api.md
+++ b/packages/plasma-giga/api/plasma-giga.api.md
@@ -61,7 +61,8 @@ import { ColCount } from '@salutejs/plasma-new-hope/styled-components';
 import { ColOffsetProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { ComboboxProps } from '@salutejs/plasma-new-hope';
+import { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';
+import type { ComboboxProps as ComboboxProps_2 } from '@salutejs/plasma-new-hope';
 import { CommitInstanceCallback } from '@salutejs/plasma-new-hope/types/components/DatePicker/RangeDate/RangeDate.types';
 import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -135,7 +136,6 @@ import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
-import type { ItemOption } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -175,7 +175,7 @@ import { priceClasses } from '@salutejs/plasma-new-hope/styled-components';
 import { PriceProps } from '@salutejs/plasma-new-hope/types/components/Price/Price.types';
 import { ProgressProps } from '@salutejs/plasma-new-hope/styled-components';
 import { Property } from 'csstype';
-import { Props as Props_2 } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
+import { Props } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
 import { RangeInputRefs } from '@salutejs/plasma-new-hope/styled-components';
@@ -1393,10 +1393,16 @@ export { ColProps }
 
 export { ColSizeProps }
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Combobox: <T extends ComboboxItemOption>(props: ComboboxProps<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { ComboboxItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "PropsFromConfig" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ComboboxNew" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Combobox: <T extends ItemOption>(props: Props<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type ComboboxProps<T extends ComboboxItemOption> = DistributiveOmit<ComboboxProps_2<T>, PropsFromConfig> & DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 // @public
 export const Counter: FunctionComponent<PropsType<    {
@@ -1755,7 +1761,7 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & Props_2 & RefAttributes<HTMLDivElement>>;
+}> & Props & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
 export const Flow: FunctionComponent<PropsType<    {}> & FlowProps & {

--- a/packages/plasma-giga/src/components/Combobox/Combobox.tsx
+++ b/packages/plasma-giga/src/components/Combobox/Combobox.tsx
@@ -14,7 +14,7 @@ const ComboboxNew = component(mergedConfig);
 
 type PropsFromConfig = keyof typeof config['variations'];
 
-type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
+export type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
     DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 const ComboboxComponent = <T extends ItemOption>(props: Props<T>, ref: React.ForwardedRef<HTMLInputElement>) => {

--- a/packages/plasma-giga/src/components/Combobox/index.ts
+++ b/packages/plasma-giga/src/components/Combobox/index.ts
@@ -1,1 +1,4 @@
 export { Combobox } from './Combobox';
+
+export type { Props as ComboboxProps } from './Combobox';
+export type { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/plasma-giga/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plasma-giga/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { config } from './Dropdown.config';
 const mergedConfig = mergeConfig(dropdownConfig, config);
 const DropdownNewHope = component(mergedConfig);
 
-type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
     Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 const DropdownComponent = <T extends DropdownItemOption>(

--- a/packages/plasma-giga/src/components/Dropdown/index.ts
+++ b/packages/plasma-giga/src/components/Dropdown/index.ts
@@ -1,1 +1,3 @@
 export { Dropdown } from './Dropdown';
+export type { DropdownProps } from './Dropdown';
+export type { DropdownItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/plasma-giga/src/components/Select/Select.tsx
+++ b/packages/plasma-giga/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ import { config } from './Select.config';
 const mergedConfig = mergeConfig(selectConfig, config);
 const SelectNewHope = component(mergedConfig);
 
-type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
+export type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
     SelectPropsNewHope<K>,
     'size' | 'view' | 'chipView' | 'disabled'
 > &

--- a/packages/plasma-giga/src/components/Select/index.ts
+++ b/packages/plasma-giga/src/components/Select/index.ts
@@ -1,1 +1,3 @@
 export { Select } from './Select';
+export type { SelectProps } from './Select';
+export type { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -131,7 +131,7 @@ import { DrawerContentProps } from '@salutejs/plasma-new-hope/styled-components'
 import { DrawerFooterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerHeaderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { DropdownItemOption } from '@salutejs/plasma-new-hope';
+import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import { DropdownItemProps } from '@salutejs/plasma-hope';
 import { DropdownItem as DropdownItemType } from '@salutejs/plasma-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
@@ -139,7 +139,6 @@ import type { DropdownNodeSelect } from '@salutejs/plasma-new-hope';
 import { DropdownNodeType } from '@salutejs/plasma-hope';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
 import { DropdownPopupProps } from '@salutejs/plasma-hope';
-import { DropdownProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DropdownTrigger } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
 import { dropzoneClasses } from '@salutejs/plasma-new-hope/styled-components';
 import { dropzoneTokens } from '@salutejs/plasma-new-hope/styled-components';
@@ -1963,6 +1962,8 @@ default: PolymorphicClassName;
 // @public (undocumented)
 export const DropdownItem: React_2.ForwardRefExoticComponent<DropdownItemProps & React_2.RefAttributes<HTMLDivElement>>;
 
+export { DropdownItemOption }
+
 export { DropdownItemProps }
 
 export { DropdownItemType }
@@ -1977,7 +1978,10 @@ export const DropdownPopup: React_2.ForwardRefExoticComponent<DropdownPopupProps
 
 export { DropdownPopupProps }
 
-export { DropdownProps }
+// Warning: (ae-forgotten-export) The symbol "DropdownNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> & Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 // @public (undocumented)
 export const Dropzone: FunctionComponent<PropsType<    {

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -135,7 +135,6 @@ import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import { DropdownItemProps } from '@salutejs/plasma-hope';
 import { DropdownItem as DropdownItemType } from '@salutejs/plasma-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
-import type { DropdownNodeSelect } from '@salutejs/plasma-new-hope';
 import { DropdownNodeType } from '@salutejs/plasma-hope';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
 import { DropdownPopupProps } from '@salutejs/plasma-hope';
@@ -270,9 +269,9 @@ import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProviderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SelectGroup } from '@salutejs/plasma-hope';
+import { DropdownNodeSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 import { SelectPlacement } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import { SelectPlacementBasic } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
-import { MergedSelectProps as SelectProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SelectProps as SelectPropsHope } from '@salutejs/plasma-hope';
 import { selectText } from '@salutejs/plasma-hope';
 import { setRef } from '@salutejs/plasma-core';
@@ -3629,14 +3628,17 @@ export { SegmentProvider }
 
 export { SegmentProviderProps }
 
-// Warning: (ae-forgotten-export) The symbol "SelectProps_2" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export const Select: <T, K extends DropdownNodeSelect>(props: SelectProps_2<T, K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export const Select: <T, K extends SelectItemOption>(props: SelectProps<T, K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
 
 export { SelectGroup }
 
-export { SelectProps }
+export { SelectItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "SelectNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type SelectProps<T, K extends SelectItemOption> = DistributiveOmit<MergedSelectProps<T, K>, 'size' | 'view' | 'chipView' | 'disabled'> & DistributivePick<ComponentProps<typeof SelectNewHope>, 'size' | 'view' | 'chipView' | 'disabled'>;
 
 export { SelectPropsHope }
 

--- a/packages/plasma-web/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { config } from './Dropdown.config';
 const mergedConfig = mergeConfig(dropdownConfig, config);
 const DropdownNewHope = component(mergedConfig);
 
-type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
     Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 const DropdownComponent = <T extends DropdownItemOption>(

--- a/packages/plasma-web/src/components/Dropdown/index.ts
+++ b/packages/plasma-web/src/components/Dropdown/index.ts
@@ -1,7 +1,8 @@
 export { withAssistiveDropdown } from '@salutejs/plasma-hope';
-export type { DropdownProps } from '@salutejs/plasma-new-hope/styled-components';
 
 export { Dropdown } from './Dropdown';
+export type { DropdownProps } from './Dropdown';
+export type { DropdownItemOption } from '@salutejs/plasma-new-hope';
 
 // TODO: #1271
 export { DropdownItem } from './components/DropdownItem';

--- a/packages/plasma-web/src/components/Select/Select.tsx
+++ b/packages/plasma-web/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ import { config } from './Select.config';
 const mergedConfig = mergeConfig(selectConfig, config);
 const SelectNewHope = component(mergedConfig);
 
-type SelectProps<T, K extends DropdownNodeSelect> = DistributiveOmit<
+export type SelectProps<T, K extends DropdownNodeSelect> = DistributiveOmit<
     MergedSelectPropsNewHope<T, K>,
     'size' | 'view' | 'chipView' | 'disabled'
 > &

--- a/packages/plasma-web/src/components/Select/index.ts
+++ b/packages/plasma-web/src/components/Select/index.ts
@@ -1,6 +1,7 @@
 export { Select } from './Select';
 
 export type { SelectProps as SelectPropsHope } from '@salutejs/plasma-hope';
-export type { MergedSelectProps as SelectProps } from '@salutejs/plasma-new-hope/styled-components';
+export type { SelectProps } from './Select';
+export type { DropdownNodeSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 
 export { SelectGroup } from '@salutejs/plasma-hope';

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -94,7 +94,7 @@ import { DrawerContentProps } from '@salutejs/plasma-new-hope/styled-components'
 import { DrawerFooterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerHeaderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { DropdownItemOption } from '@salutejs/plasma-new-hope';
+import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
 import { DropdownNodeSelect } from '@salutejs/plasma-new-hope/styled-components';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
@@ -1533,6 +1533,13 @@ default: PolymorphicClassName;
     listHeight?: Property.Height<string | number> | undefined;
     hoverIndex?: number | undefined;
 } & React_2.HTMLAttributes<HTMLDivElement> & React_2.RefAttributes<HTMLDivElement>, "size" | "view"> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { DropdownItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "DropdownNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> & Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 // @public (undocumented)
 export const Dropzone: FunctionComponent<PropsType<    {

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -61,7 +61,8 @@ import { ColCount } from '@salutejs/plasma-new-hope/styled-components';
 import { ColOffsetProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { ComboboxProps } from '@salutejs/plasma-new-hope';
+import { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';
+import type { ComboboxProps as ComboboxProps_2 } from '@salutejs/plasma-new-hope';
 import { CommitInstanceCallback } from '@salutejs/plasma-new-hope/types/components/DatePicker/RangeDate/RangeDate.types';
 import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -135,7 +136,6 @@ import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
-import type { ItemOption } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -172,7 +172,7 @@ import { priceClasses } from '@salutejs/plasma-new-hope/styled-components';
 import { PriceProps } from '@salutejs/plasma-new-hope/types/components/Price/Price.types';
 import { ProgressProps } from '@salutejs/plasma-new-hope/styled-components';
 import { Property } from 'csstype';
-import { Props as Props_2 } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
+import { Props } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
 import { RangeInputRefs } from '@salutejs/plasma-new-hope/styled-components';
@@ -1281,10 +1281,16 @@ export { ColProps }
 
 export { ColSizeProps }
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Combobox: <T extends ComboboxItemOption>(props: ComboboxProps<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { ComboboxItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "PropsFromConfig" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ComboboxNew" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Combobox: <T extends ItemOption>(props: Props<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type ComboboxProps<T extends ComboboxItemOption> = DistributiveOmit<ComboboxProps_2<T>, PropsFromConfig> & DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 // @public
 export const Counter: FunctionComponent<PropsType<    {
@@ -1627,7 +1633,7 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & Props_2 & RefAttributes<HTMLDivElement>>;
+}> & Props & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
 export const Flow: FunctionComponent<PropsType<    {}> & FlowProps & {

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -136,7 +136,6 @@ import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import type { ItemOption } from '@salutejs/plasma-new-hope';
-import type { ItemOptionSelect } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -195,6 +194,7 @@ import { SegmentGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProviderProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 import { SelectPlacement } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import { SelectPlacementBasic } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import type { SelectProps as SelectProps_2 } from '@salutejs/plasma-new-hope';
@@ -2813,10 +2813,15 @@ export { SegmentProvider }
 
 export { SegmentProviderProps }
 
-// Warning: (ae-forgotten-export) The symbol "SelectProps" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Select: <K extends SelectItemOption>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { SelectItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "SelectNewHope" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Select: <K extends ItemOptionSelect>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type SelectProps<K extends SelectItemOption> = DistributiveOmit<SelectProps_2<K>, 'size' | 'view' | 'chipView' | 'disabled'> & DistributivePick<ComponentProps<typeof SelectNewHope>, 'size' | 'view' | 'chipView' | 'disabled'>;
 
 // @public
 export const Sheet: FunctionComponent<PropsType<    {

--- a/packages/sdds-cs/src/components/Combobox/Combobox.tsx
+++ b/packages/sdds-cs/src/components/Combobox/Combobox.tsx
@@ -14,7 +14,7 @@ const ComboboxNew = component(mergedConfig);
 
 type PropsFromConfig = keyof typeof config['variations'];
 
-type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
+export type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
     DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 const ComboboxComponent = <T extends ItemOption>(props: Props<T>, ref: React.ForwardedRef<HTMLInputElement>) => {

--- a/packages/sdds-cs/src/components/Combobox/index.ts
+++ b/packages/sdds-cs/src/components/Combobox/index.ts
@@ -1,1 +1,4 @@
 export { Combobox } from './Combobox';
+
+export type { Props as ComboboxProps } from './Combobox';
+export type { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-cs/src/components/Dropdown/Dropdown.tsx
+++ b/packages/sdds-cs/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { config } from './Dropdown.config';
 const mergedConfig = mergeConfig(dropdownConfig, config);
 const DropdownNewHope = component(mergedConfig);
 
-type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
     Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 const DropdownComponent = <T extends DropdownItemOption>(

--- a/packages/sdds-cs/src/components/Dropdown/index.ts
+++ b/packages/sdds-cs/src/components/Dropdown/index.ts
@@ -1,1 +1,3 @@
 export { Dropdown } from './Dropdown';
+export type { DropdownProps } from './Dropdown';
+export type { DropdownItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-cs/src/components/Select/Select.tsx
+++ b/packages/sdds-cs/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ import { config } from './Select.config';
 const mergedConfig = mergeConfig(selectConfig, config);
 const SelectNewHope = component(mergedConfig);
 
-type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
+export type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
     SelectPropsNewHope<K>,
     'size' | 'view' | 'chipView' | 'disabled'
 > &

--- a/packages/sdds-cs/src/components/Select/index.ts
+++ b/packages/sdds-cs/src/components/Select/index.ts
@@ -1,1 +1,3 @@
 export { Select } from './Select';
+export type { SelectProps } from './Select';
+export type { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -57,7 +57,8 @@ import { ColCount } from '@salutejs/plasma-new-hope/styled-components';
 import { ColOffsetProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { ComboboxProps } from '@salutejs/plasma-new-hope';
+import { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';
+import type { ComboboxProps as ComboboxProps_2 } from '@salutejs/plasma-new-hope';
 import { CommitInstanceCallback } from '@salutejs/plasma-new-hope/types/components/DatePicker/RangeDate/RangeDate.types';
 import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -129,7 +130,6 @@ import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
-import type { ItemOption } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -165,7 +165,7 @@ import { priceClasses } from '@salutejs/plasma-new-hope/styled-components';
 import { PriceProps } from '@salutejs/plasma-new-hope/types/components/Price/Price.types';
 import { ProgressProps } from '@salutejs/plasma-new-hope/styled-components';
 import { Property } from 'csstype';
-import { Props as Props_2 } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
+import { Props } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
 import { RangeInputRefs } from '@salutejs/plasma-new-hope/styled-components';
@@ -1349,10 +1349,16 @@ export { ColProps }
 
 export { ColSizeProps }
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Combobox: <T extends ComboboxItemOption>(props: ComboboxProps<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { ComboboxItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "PropsFromConfig" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ComboboxNew" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Combobox: <T extends ItemOption>(props: Props<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type ComboboxProps<T extends ComboboxItemOption> = DistributiveOmit<ComboboxProps_2<T>, PropsFromConfig> & DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 // @public
 export const Counter: FunctionComponent<PropsType<    {
@@ -1711,7 +1717,7 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & Props_2 & RefAttributes<HTMLDivElement>>;
+}> & Props & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
 export const Flow: FunctionComponent<PropsType<    {}> & FlowProps & {

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -90,7 +90,7 @@ import { DrawerContentProps } from '@salutejs/plasma-new-hope/styled-components'
 import { DrawerFooterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerHeaderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { DropdownItemOption } from '@salutejs/plasma-new-hope';
+import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
 import { DropdownNodeSelect } from '@salutejs/plasma-new-hope/styled-components';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
@@ -1617,6 +1617,13 @@ default: PolymorphicClassName;
     listHeight?: Property.Height<string | number> | undefined;
     hoverIndex?: number | undefined;
 } & React_2.HTMLAttributes<HTMLDivElement> & React_2.RefAttributes<HTMLDivElement>, "size" | "view"> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { DropdownItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "DropdownNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> & Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 // @public (undocumented)
 export const Dropzone: FunctionComponent<PropsType<    {

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -130,7 +130,6 @@ import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import type { ItemOption } from '@salutejs/plasma-new-hope';
-import type { ItemOptionSelect } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -190,6 +189,7 @@ import { SegmentGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProviderProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 import { SelectPlacement } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import { SelectPlacementBasic } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import type { SelectProps as SelectProps_2 } from '@salutejs/plasma-new-hope';
@@ -3097,10 +3097,15 @@ export { SegmentProvider }
 
 export { SegmentProviderProps }
 
-// Warning: (ae-forgotten-export) The symbol "SelectProps" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Select: <K extends SelectItemOption>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { SelectItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "SelectNewHope" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Select: <K extends ItemOptionSelect>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type SelectProps<K extends SelectItemOption> = DistributiveOmit<SelectProps_2<K>, 'size' | 'view' | 'chipView' | 'disabled'> & DistributivePick<ComponentProps<typeof SelectNewHope>, 'size' | 'view' | 'chipView' | 'disabled'>;
 
 // @public
 export const Sheet: FunctionComponent<PropsType<    {

--- a/packages/sdds-dfa/src/components/Combobox/Combobox.tsx
+++ b/packages/sdds-dfa/src/components/Combobox/Combobox.tsx
@@ -14,7 +14,7 @@ const ComboboxNew = component(mergedConfig);
 
 type PropsFromConfig = keyof typeof config['variations'];
 
-type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
+export type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
     DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 const ComboboxComponent = <T extends ItemOption>(props: Props<T>, ref: React.ForwardedRef<HTMLInputElement>) => {

--- a/packages/sdds-dfa/src/components/Combobox/index.ts
+++ b/packages/sdds-dfa/src/components/Combobox/index.ts
@@ -1,1 +1,4 @@
 export { Combobox } from './Combobox';
+
+export type { Props as ComboboxProps } from './Combobox';
+export type { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-dfa/src/components/Dropdown/Dropdown.tsx
+++ b/packages/sdds-dfa/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { config } from './Dropdown.config';
 const mergedConfig = mergeConfig(dropdownConfig, config);
 const DropdownNewHope = component(mergedConfig);
 
-type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
     Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 const DropdownComponent = <T extends DropdownItemOption>(

--- a/packages/sdds-dfa/src/components/Dropdown/index.ts
+++ b/packages/sdds-dfa/src/components/Dropdown/index.ts
@@ -1,1 +1,3 @@
 export { Dropdown } from './Dropdown';
+export type { DropdownProps } from './Dropdown';
+export type { DropdownItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-dfa/src/components/Select/Select.tsx
+++ b/packages/sdds-dfa/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ import { config } from './Select.config';
 const mergedConfig = mergeConfig(selectConfig, config);
 const SelectNewHope = component(mergedConfig);
 
-type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
+export type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
     SelectPropsNewHope<K>,
     'size' | 'view' | 'chipView' | 'disabled'
 > &

--- a/packages/sdds-dfa/src/components/Select/index.ts
+++ b/packages/sdds-dfa/src/components/Select/index.ts
@@ -1,1 +1,3 @@
 export { Select } from './Select';
+export type { SelectProps } from './Select';
+export type { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -61,7 +61,8 @@ import { ColCount } from '@salutejs/plasma-new-hope/styled-components';
 import { ColOffsetProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { ComboboxProps } from '@salutejs/plasma-new-hope';
+import { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';
+import type { ComboboxProps as ComboboxProps_2 } from '@salutejs/plasma-new-hope';
 import { CommitInstanceCallback } from '@salutejs/plasma-new-hope/types/components/DatePicker/RangeDate/RangeDate.types';
 import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -135,7 +136,6 @@ import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
-import type { ItemOption } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -175,7 +175,7 @@ import { priceClasses } from '@salutejs/plasma-new-hope/styled-components';
 import { PriceProps } from '@salutejs/plasma-new-hope/types/components/Price/Price.types';
 import { ProgressProps } from '@salutejs/plasma-new-hope/styled-components';
 import { Property } from 'csstype';
-import { Props as Props_2 } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
+import { Props } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
 import { RangeInputRefs } from '@salutejs/plasma-new-hope/styled-components';
@@ -1399,10 +1399,16 @@ export { ColProps }
 
 export { ColSizeProps }
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Combobox: <T extends ComboboxItemOption>(props: ComboboxProps<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { ComboboxItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "PropsFromConfig" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ComboboxNew" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Combobox: <T extends ItemOption>(props: Props<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type ComboboxProps<T extends ComboboxItemOption> = DistributiveOmit<ComboboxProps_2<T>, PropsFromConfig> & DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 // @public
 export const Counter: FunctionComponent<PropsType<    {
@@ -1761,7 +1767,7 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & Props_2 & RefAttributes<HTMLDivElement>>;
+}> & Props & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
 export const Flow: FunctionComponent<PropsType<    {}> & FlowProps & {

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -136,7 +136,6 @@ import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import type { ItemOption } from '@salutejs/plasma-new-hope';
-import type { ItemOptionSelect } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -198,6 +197,7 @@ import { SegmentGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProviderProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 import { SelectPlacement } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import { SelectPlacementBasic } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import type { SelectProps as SelectProps_2 } from '@salutejs/plasma-new-hope';
@@ -3139,10 +3139,15 @@ export { SegmentProvider }
 
 export { SegmentProviderProps }
 
-// Warning: (ae-forgotten-export) The symbol "SelectProps" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Select: <K extends SelectItemOption>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { SelectItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "SelectNewHope" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Select: <K extends ItemOptionSelect>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type SelectProps<K extends SelectItemOption> = DistributiveOmit<SelectProps_2<K>, 'size' | 'view' | 'chipView' | 'disabled'> & DistributivePick<ComponentProps<typeof SelectNewHope>, 'size' | 'view' | 'chipView' | 'disabled'>;
 
 // @public
 export const Sheet: FunctionComponent<PropsType<    {

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -94,7 +94,7 @@ import { DrawerContentProps } from '@salutejs/plasma-new-hope/styled-components'
 import { DrawerFooterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerHeaderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { DropdownItemOption } from '@salutejs/plasma-new-hope';
+import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
 import { DropdownNodeSelect } from '@salutejs/plasma-new-hope/styled-components';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
@@ -1667,6 +1667,13 @@ default: PolymorphicClassName;
     listHeight?: Property.Height<string | number> | undefined;
     hoverIndex?: number | undefined;
 } & React_2.HTMLAttributes<HTMLDivElement> & React_2.RefAttributes<HTMLDivElement>, "size" | "view"> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { DropdownItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "DropdownNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> & Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 // @public (undocumented)
 export const Dropzone: FunctionComponent<PropsType<    {

--- a/packages/sdds-finportal/src/components/Combobox/Combobox.tsx
+++ b/packages/sdds-finportal/src/components/Combobox/Combobox.tsx
@@ -14,7 +14,7 @@ const ComboboxNew = component(mergedConfig);
 
 type PropsFromConfig = keyof typeof config['variations'];
 
-type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
+export type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
     DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 const ComboboxComponent = <T extends ItemOption>(props: Props<T>, ref: React.ForwardedRef<HTMLInputElement>) => {

--- a/packages/sdds-finportal/src/components/Combobox/index.ts
+++ b/packages/sdds-finportal/src/components/Combobox/index.ts
@@ -1,1 +1,4 @@
 export { Combobox } from './Combobox';
+
+export type { Props as ComboboxProps } from './Combobox';
+export type { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-finportal/src/components/Dropdown/Dropdown.tsx
+++ b/packages/sdds-finportal/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { config } from './Dropdown.config';
 const mergedConfig = mergeConfig(dropdownConfig, config);
 const DropdownNewHope = component(mergedConfig);
 
-type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
     Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 const DropdownComponent = <T extends DropdownItemOption>(

--- a/packages/sdds-finportal/src/components/Dropdown/index.ts
+++ b/packages/sdds-finportal/src/components/Dropdown/index.ts
@@ -1,1 +1,3 @@
 export { Dropdown } from './Dropdown';
+export type { DropdownProps } from './Dropdown';
+export type { DropdownItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-finportal/src/components/Select/Select.tsx
+++ b/packages/sdds-finportal/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ import { config } from './Select.config';
 const mergedConfig = mergeConfig(selectConfig, config);
 const SelectNewHope = component(mergedConfig);
 
-type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
+export type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
     SelectPropsNewHope<K>,
     'size' | 'view' | 'chipView' | 'disabled'
 > &

--- a/packages/sdds-finportal/src/components/Select/index.ts
+++ b/packages/sdds-finportal/src/components/Select/index.ts
@@ -1,1 +1,3 @@
 export { Select } from './Select';
+export type { SelectProps } from './Select';
+export type { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -95,7 +95,7 @@ import { DrawerContentProps } from '@salutejs/plasma-new-hope/styled-components'
 import { DrawerFooterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerHeaderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { DropdownItemOption } from '@salutejs/plasma-new-hope';
+import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
 import { DropdownNodeSelect } from '@salutejs/plasma-new-hope/styled-components';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
@@ -1387,6 +1387,13 @@ default: PolymorphicClassName;
     listHeight?: Property.Height<string | number> | undefined;
     hoverIndex?: number | undefined;
 } & React_2.HTMLAttributes<HTMLDivElement> & React_2.RefAttributes<HTMLDivElement>, "size" | "view"> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { DropdownItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "DropdownNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> & Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 // @public (undocumented)
 export const Dropzone: FunctionComponent<PropsType<    {

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -61,7 +61,8 @@ import { ColCount } from '@salutejs/plasma-new-hope/styled-components';
 import { ColOffsetProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { ComboboxProps } from '@salutejs/plasma-new-hope';
+import { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';
+import type { ComboboxProps as ComboboxProps_2 } from '@salutejs/plasma-new-hope';
 import { CommitInstanceCallback } from '@salutejs/plasma-new-hope/types/components/DatePicker/RangeDate/RangeDate.types';
 import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -136,7 +137,6 @@ import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
-import type { ItemOption } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -176,7 +176,7 @@ import { priceClasses } from '@salutejs/plasma-new-hope/styled-components';
 import { PriceProps } from '@salutejs/plasma-new-hope/types/components/Price/Price.types';
 import { ProgressProps } from '@salutejs/plasma-new-hope/styled-components';
 import { Property } from 'csstype';
-import { Props as Props_2 } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
+import { Props } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
 import { RangeInputRefs } from '@salutejs/plasma-new-hope/styled-components';
@@ -1118,10 +1118,16 @@ export { ColProps }
 
 export { ColSizeProps }
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Combobox: <T extends ComboboxItemOption>(props: ComboboxProps<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { ComboboxItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "PropsFromConfig" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ComboboxNew" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Combobox: <T extends ItemOption>(props: Props<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type ComboboxProps<T extends ComboboxItemOption> = DistributiveOmit<ComboboxProps_2<T>, PropsFromConfig | 'hintTargetPlacement'> & DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 // @public
 export const Counter: FunctionComponent<PropsType<    {
@@ -1481,7 +1487,7 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & Props_2 & RefAttributes<HTMLDivElement>>;
+}> & Props & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
 export const Flow: FunctionComponent<PropsType<    {}> & FlowProps & {

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -137,7 +137,6 @@ import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import type { ItemOption } from '@salutejs/plasma-new-hope';
-import type { ItemOptionSelect } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -201,6 +200,7 @@ import { SegmentGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProviderProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 import { SelectPlacement } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import { SelectPlacementBasic } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import type { SelectProps as SelectProps_2 } from '@salutejs/plasma-new-hope';
@@ -2908,10 +2908,15 @@ export { SegmentProvider }
 
 export { SegmentProviderProps }
 
-// Warning: (ae-forgotten-export) The symbol "SelectProps" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Select: <K extends SelectItemOption>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { SelectItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "SelectNewHope" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Select: <K extends ItemOptionSelect>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type SelectProps<K extends SelectItemOption> = DistributiveOmit<SelectProps_2<K>, 'size' | 'view' | 'chipView' | 'disabled' | 'hintTargetPlacement'> & DistributivePick<ComponentProps<typeof SelectNewHope>, 'size' | 'view' | 'chipView' | 'disabled'>;
 
 // @public
 export const Sheet: FunctionComponent<PropsType<    {

--- a/packages/sdds-insol/src/components/Combobox/Combobox.tsx
+++ b/packages/sdds-insol/src/components/Combobox/Combobox.tsx
@@ -14,7 +14,7 @@ const ComboboxNew = component(mergedConfig);
 
 type PropsFromConfig = keyof typeof config['variations'];
 
-type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig | 'hintTargetPlacement'> &
+export type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig | 'hintTargetPlacement'> &
     DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 const ComboboxComponent = <T extends ItemOption>(props: Props<T>, ref: React.ForwardedRef<HTMLInputElement>) => {

--- a/packages/sdds-insol/src/components/Combobox/index.ts
+++ b/packages/sdds-insol/src/components/Combobox/index.ts
@@ -1,1 +1,4 @@
 export { Combobox } from './Combobox';
+
+export type { Props as ComboboxProps } from './Combobox';
+export type { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-insol/src/components/Dropdown/Dropdown.tsx
+++ b/packages/sdds-insol/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { config } from './Dropdown.config';
 const mergedConfig = mergeConfig(dropdownConfig, config);
 const DropdownNewHope = component(mergedConfig);
 
-type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
     Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 const DropdownComponent = <T extends DropdownItemOption>(

--- a/packages/sdds-insol/src/components/Dropdown/index.ts
+++ b/packages/sdds-insol/src/components/Dropdown/index.ts
@@ -1,1 +1,3 @@
 export { Dropdown } from './Dropdown';
+export type { DropdownProps } from './Dropdown';
+export type { DropdownItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-insol/src/components/Select/Select.tsx
+++ b/packages/sdds-insol/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ import { config } from './Select.config';
 const mergedConfig = mergeConfig(selectConfig, config);
 const SelectNewHope = component(mergedConfig);
 
-type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
+export type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
     SelectPropsNewHope<K>,
     'size' | 'view' | 'chipView' | 'disabled' | 'hintTargetPlacement'
 > &

--- a/packages/sdds-insol/src/components/Select/index.ts
+++ b/packages/sdds-insol/src/components/Select/index.ts
@@ -1,1 +1,3 @@
 export { Select } from './Select';
+export type { SelectProps } from './Select';
+export type { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -61,7 +61,8 @@ import { ColCount } from '@salutejs/plasma-new-hope/styled-components';
 import { ColOffsetProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColProps } from '@salutejs/plasma-new-hope/styled-components';
 import { ColSizeProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { ComboboxProps } from '@salutejs/plasma-new-hope';
+import { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';
+import type { ComboboxProps as ComboboxProps_2 } from '@salutejs/plasma-new-hope';
 import { CommitInstanceCallback } from '@salutejs/plasma-new-hope/types/components/DatePicker/RangeDate/RangeDate.types';
 import { ComponentProps } from 'react';
 import { CounterProps } from '@salutejs/plasma-new-hope/styled-components';
@@ -135,7 +136,6 @@ import { ImgHTMLAttributes } from 'react';
 import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
-import type { ItemOption } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -175,7 +175,7 @@ import { priceClasses } from '@salutejs/plasma-new-hope/styled-components';
 import { PriceProps } from '@salutejs/plasma-new-hope/types/components/Price/Price.types';
 import { ProgressProps } from '@salutejs/plasma-new-hope/styled-components';
 import { Property } from 'csstype';
-import { Props as Props_2 } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
+import { Props } from '@salutejs/plasma-new-hope/types/components/EmptyState/EmptyState.types';
 import { PropsType } from '@salutejs/plasma-new-hope/types/engines/types';
 import { RadioGroup } from '@salutejs/plasma-new-hope/styled-components';
 import { RangeInputRefs } from '@salutejs/plasma-new-hope/styled-components';
@@ -1401,10 +1401,16 @@ export { ColProps }
 
 export { ColSizeProps }
 
-// Warning: (ae-forgotten-export) The symbol "Props" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Combobox: <T extends ComboboxItemOption>(props: ComboboxProps<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { ComboboxItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "PropsFromConfig" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "ComboboxNew" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Combobox: <T extends ItemOption>(props: Props<T> & React_2.RefAttributes<HTMLInputElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type ComboboxProps<T extends ComboboxItemOption> = DistributiveOmit<ComboboxProps_2<T>, PropsFromConfig> & DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 // @public
 export const Counter: FunctionComponent<PropsType<    {
@@ -1763,7 +1769,7 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & Props_2 & RefAttributes<HTMLDivElement>>;
+}> & Props & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
 export const Flow: FunctionComponent<PropsType<    {}> & FlowProps & {

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -136,7 +136,6 @@ import { IndicatorProps } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes } from '@salutejs/plasma-new-hope/styled-components';
 import { InputHTMLAttributes as InputHTMLAttributes_2 } from 'react';
 import type { ItemOption } from '@salutejs/plasma-new-hope';
-import type { ItemOptionSelect } from '@salutejs/plasma-new-hope';
 import { JSXElementConstructor } from 'react';
 import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { LabelProps } from '@salutejs/plasma-new-hope/types/components/TextField/TextField.types';
@@ -200,6 +199,7 @@ import { SegmentGroupProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentItemProps } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProvider } from '@salutejs/plasma-new-hope/styled-components';
 import { SegmentProviderProps } from '@salutejs/plasma-new-hope/styled-components';
+import { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';
 import { SelectPlacement } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import { SelectPlacementBasic } from '@salutejs/plasma-new-hope/types/components/Select/Select.types';
 import type { SelectProps as SelectProps_2 } from '@salutejs/plasma-new-hope';
@@ -3182,10 +3182,15 @@ export { SegmentProvider }
 
 export { SegmentProviderProps }
 
-// Warning: (ae-forgotten-export) The symbol "SelectProps" needs to be exported by the entry point index.d.ts
+// @public (undocumented)
+export const Select: <K extends SelectItemOption>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { SelectItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "SelectNewHope" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const Select: <K extends ItemOptionSelect>(props: SelectProps<K> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+export type SelectProps<K extends SelectItemOption> = DistributiveOmit<SelectProps_2<K>, 'size' | 'view' | 'chipView' | 'disabled'> & DistributivePick<ComponentProps<typeof SelectNewHope>, 'size' | 'view' | 'chipView' | 'disabled'>;
 
 // @public
 export const Sheet: FunctionComponent<PropsType<    {

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -94,7 +94,7 @@ import { DrawerContentProps } from '@salutejs/plasma-new-hope/styled-components'
 import { DrawerFooterProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerHeaderProps } from '@salutejs/plasma-new-hope/styled-components';
 import { DrawerProps } from '@salutejs/plasma-new-hope/styled-components';
-import type { DropdownItemOption } from '@salutejs/plasma-new-hope';
+import { DropdownItemOption } from '@salutejs/plasma-new-hope';
 import type { DropdownNewProps } from '@salutejs/plasma-new-hope';
 import { DropdownNodeSelect } from '@salutejs/plasma-new-hope/styled-components';
 import { DropdownPlacement } from '@salutejs/plasma-new-hope/types/components/Dropdown/Dropdown.types';
@@ -1669,6 +1669,13 @@ default: PolymorphicClassName;
     listHeight?: Property.Height<string | number> | undefined;
     hoverIndex?: number | undefined;
 } & React_2.HTMLAttributes<HTMLDivElement> & React_2.RefAttributes<HTMLDivElement>, "size" | "view"> & React_2.RefAttributes<HTMLButtonElement>) => React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | null;
+
+export { DropdownItemOption }
+
+// Warning: (ae-forgotten-export) The symbol "DropdownNewHope" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> & Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 // @public (undocumented)
 export const Dropzone: FunctionComponent<PropsType<    {

--- a/packages/sdds-serv/src/components/Combobox/Combobox.tsx
+++ b/packages/sdds-serv/src/components/Combobox/Combobox.tsx
@@ -14,7 +14,7 @@ const ComboboxNew = component(mergedConfig);
 
 type PropsFromConfig = keyof typeof config['variations'];
 
-type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
+export type Props<T extends ItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
     DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
 
 const ComboboxComponent = <T extends ItemOption>(props: Props<T>, ref: React.ForwardedRef<HTMLInputElement>) => {

--- a/packages/sdds-serv/src/components/Combobox/index.ts
+++ b/packages/sdds-serv/src/components/Combobox/index.ts
@@ -1,1 +1,4 @@
 export { Combobox } from './Combobox';
+
+export type { Props as ComboboxProps } from './Combobox';
+export type { ItemOption as ComboboxItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-serv/src/components/Dropdown/Dropdown.tsx
+++ b/packages/sdds-serv/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { config } from './Dropdown.config';
 const mergedConfig = mergeConfig(dropdownConfig, config);
 const DropdownNewHope = component(mergedConfig);
 
-type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
+export type DropdownProps<T extends DropdownItemOption> = Omit<DropdownNewProps<T>, 'size' | 'view'> &
     Pick<ComponentProps<typeof DropdownNewHope>, 'size' | 'view'>;
 
 const DropdownComponent = <T extends DropdownItemOption>(

--- a/packages/sdds-serv/src/components/Dropdown/index.ts
+++ b/packages/sdds-serv/src/components/Dropdown/index.ts
@@ -1,1 +1,3 @@
 export { Dropdown } from './Dropdown';
+export type { DropdownProps } from './Dropdown';
+export type { DropdownItemOption } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-serv/src/components/Select/Select.tsx
+++ b/packages/sdds-serv/src/components/Select/Select.tsx
@@ -12,7 +12,7 @@ import { config } from './Select.config';
 const mergedConfig = mergeConfig(selectConfig, config);
 const SelectNewHope = component(mergedConfig);
 
-type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
+export type SelectProps<K extends ItemOptionSelect> = DistributiveOmit<
     SelectPropsNewHope<K>,
     'size' | 'view' | 'chipView' | 'disabled'
 > &

--- a/packages/sdds-serv/src/components/Select/index.ts
+++ b/packages/sdds-serv/src/components/Select/index.ts
@@ -1,1 +1,3 @@
 export { Select } from './Select';
+export type { SelectProps } from './Select';
+export type { ItemOptionSelect as SelectItemOption } from '@salutejs/plasma-new-hope';


### PR DESCRIPTION
## Core

### Dropdown

- добавлен явный экспорт типов;

### Select

- добавлен явный экспорт типов;

### What/why changed

По просьбам консумеров добавляем явный экспорт типов компонентов.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.511.2-canary.1732.13151168550.0
  npm install @salutejs/plasma-giga@0.238.2-canary.1732.13151168550.0
  npm install @salutejs/plasma-web@1.513.2-canary.1732.13151168550.0
  npm install @salutejs/sdds-cs@0.246.2-canary.1732.13151168550.0
  npm install @salutejs/sdds-dfa@0.241.2-canary.1732.13151168550.0
  npm install @salutejs/sdds-finportal@0.234.2-canary.1732.13151168550.0
  npm install @salutejs/sdds-insol@0.235.2-canary.1732.13151168550.0
  npm install @salutejs/sdds-serv@0.242.2-canary.1732.13151168550.0
  # or 
  yarn add @salutejs/plasma-b2c@1.511.2-canary.1732.13151168550.0
  yarn add @salutejs/plasma-giga@0.238.2-canary.1732.13151168550.0
  yarn add @salutejs/plasma-web@1.513.2-canary.1732.13151168550.0
  yarn add @salutejs/sdds-cs@0.246.2-canary.1732.13151168550.0
  yarn add @salutejs/sdds-dfa@0.241.2-canary.1732.13151168550.0
  yarn add @salutejs/sdds-finportal@0.234.2-canary.1732.13151168550.0
  yarn add @salutejs/sdds-insol@0.235.2-canary.1732.13151168550.0
  yarn add @salutejs/sdds-serv@0.242.2-canary.1732.13151168550.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
