### PR TITLE
PLASMA-3710: fix `Accordion` tokens in `sdds-finportal`

### DIFF
--- a/packages/plasma-new-hope/src/components/Accordion/Accordion.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/Accordion.tokens.ts
@@ -26,7 +26,11 @@ export const tokens = {
     accordionItemBorder: '--plasma-accordion-item-border',
     accordionItemBorderBottom: '--plasma-accordion-item-border-bottom',
     accordionItemIconColor: '--plasma-accordion-item-color-icon',
-    accordionItemIconSize: '--plasma-accordion-item-icon-szie',
+    accordionItemIconSize: '--plasma-accordion-item-icon-size',
+
+    accordionItemHeaderLeftGap: '--plasma-accordion-item-header-left-gap',
+    accordionItemHeaderLeftGapDefault: '--plasma-accordion-item-header-left-gap-default',
+    accordionItemHeaderLeftGapClear: '--plasma-accordion-item-header-left-gap-clear',
 
     accordionItemTitleColor: '--plasma-accordion-item-title-color',
     accordionItemTitleFontFamily: '--plasma-accordion-item-title-font-family',

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
@@ -45,7 +45,7 @@ export const StyledAccordionHeader = styled.button`
 
 export const StyledAccordionHeaderLeft = styled.div`
     display: flex;
-    gap: var(${tokens.accordionItemGap});
+    gap: var(${tokens.accordionItemHeaderLeftGap}, var(${tokens.accordionItemGap}));
     justify-content: space-between;
     align-items: center;
 `;

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
@@ -76,7 +76,7 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
                 <StyledMinus size="xs" color="inherit" sizeCustomProperty={tokens.accordionItemIconSize} />
                 <StyledMinus
                     size="xs"
-                    color="inhert"
+                    color="inherit"
                     className={openedBodyClass ?? classes.accordionPlusAnimationElement}
                     sizeCustomProperty={tokens.accordionItemIconSize}
                 />
@@ -120,11 +120,12 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
                         <StyledAccordionTitle>{title}</StyledAccordionTitle>
                     </StyledAccordionHeaderLeft>
 
-                    {contentRight || (
-                        <StyledAccordionContentRight className={rightContentRotate}>
-                            {rightContent && rightContent}
-                        </StyledAccordionContentRight>
-                    )}
+                    {contentRight ||
+                        (rightContent && (
+                            <StyledAccordionContentRight className={rightContentRotate}>
+                                {rightContent && rightContent}
+                            </StyledAccordionContentRight>
+                        ))}
                 </StyledAccordionHeader>
                 <StyledAccordionBodyAnimate
                     aria-labelledby={`accordion-item-${key}`}

--- a/packages/sdds-finportal/src/components/Accordion/Accordion.config.draft.ts
+++ b/packages/sdds-finportal/src/components/Accordion/Accordion.config.draft.ts
@@ -1,0 +1,234 @@
+import { css, accordionTokens } from '@salutejs/plasma-new-hope/styled-components';
+
+export const config = {
+    defaults: {
+        view: 'default',
+        size: 'm',
+    },
+    variations: {
+        view: {
+            default: css`
+                ${accordionTokens.accordionGap}: 0.125rem;
+                ${accordionTokens.accordionWidth}: 20rem;
+                ${accordionTokens.accordionItemPadding}: var(${accordionTokens.accordionItemPaddingVertical}) var(${accordionTokens.accordionItemPaddingHorizontal});
+                ${accordionTokens.accordionItemBackground}: var(--surface-solid-card);
+                ${accordionTokens.accordionItemTitleColor}: var(--text-primary);
+                ${accordionTokens.accordionItemTextColor}: var(--text-primary);
+                ${accordionTokens.accordionItemIconColor}: var(--text-primary);
+                ${accordionTokens.accordionItemFocus}: var(--surface-accent);
+                ${accordionTokens.accordionBackground}: var(--surface-clear);
+                ${accordionTokens.accordionItemBorderBottom}: 0;
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: var(${accordionTokens.accordionItemPaddingHorizontal});
+
+                ${accordionTokens.accordionItemHeaderLeftGap}: var(${accordionTokens.accordionItemHeaderLeftGapDefault});
+            `,
+            clear: css`
+                ${accordionTokens.accordionGap}: 0;
+                ${accordionTokens.accordionWidth}: 20rem;
+                ${accordionTokens.accordionItemPadding}: var(${accordionTokens.accordionItemPaddingVertical}) 0rem;
+                ${accordionTokens.accordionItemBackground}: var(--surface-clear);
+                ${accordionTokens.accordionItemTitleColor}: var(--text-primary);
+                ${accordionTokens.accordionItemTextColor}: var(--text-primary);
+                ${accordionTokens.accordionItemIconColor}: var(--text-primary);
+                ${accordionTokens.accordionItemFocus}: var(--surface-accent);
+                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionBackground}: var(--surface-clear);
+                ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
+                ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;
+
+                ${accordionTokens.accordionItemHeaderLeftGap}: var(${accordionTokens.accordionItemHeaderLeftGapClear});
+            `,
+        },
+        size: {
+            l: css`
+                ${accordionTokens.accordionItemPaddingVertical}: 0.9375rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1.25rem;
+                ${accordionTokens.accordionItemGap}: 1rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.875rem;
+
+                ${accordionTokens.accordionItemHeaderLeftGapDefault}: 0.375rem;
+                ${accordionTokens.accordionItemHeaderLeftGapClear}: 0.5rem;
+
+                ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-body-l-font-family);
+                ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-body-l-font-size);
+                ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-body-l-font-style);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-l-bold-font-weight);
+                ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
+                ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-body-l-line-height);
+
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-l-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-l-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-l-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-l-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-l-line-height);
+            `,
+            m: css`
+                ${accordionTokens.accordionItemPaddingVertical}: 0.75rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1rem;
+
+                ${accordionTokens.accordionItemGap}: 0.75rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.75rem;
+
+                ${accordionTokens.accordionItemHeaderLeftGapDefault}: 0.375rem;
+                ${accordionTokens.accordionItemHeaderLeftGapClear}: 0.5rem;
+
+                ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-body-m-font-family);
+                ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-body-m-font-size);
+                ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-body-m-font-style);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-m-bold-font-weight);
+                ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
+                ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-body-m-line-height);
+
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-m-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-m-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-m-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-m-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-m-line-height);
+            `,
+            s: css`
+                ${accordionTokens.accordionItemPaddingVertical}: 0.625rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 0.75rem;
+
+                ${accordionTokens.accordionItemGap}: 0.75rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.625rem;
+
+                ${accordionTokens.accordionItemHeaderLeftGapDefault}: 0.5rem;
+                ${accordionTokens.accordionItemHeaderLeftGapClear}: 0.25rem;
+
+                ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-body-s-font-family);
+                ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-body-s-font-size);
+                ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-body-s-font-style);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-s-bold-font-weight);
+                ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
+                ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-body-s-line-height);
+
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-s-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-s-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-s-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-s-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-s-line-height);
+            `,
+            xs: css`
+                ${accordionTokens.accordionItemPaddingVertical}: 0.5rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 0.75rem;
+
+                ${accordionTokens.accordionItemGap}: 0.75rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.5rem;
+
+                ${accordionTokens.accordionItemHeaderLeftGapDefault}: 0.25rem;
+                ${accordionTokens.accordionItemHeaderLeftGapClear}: 0.25rem;
+
+                ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-body-xs-font-family);
+                ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-body-xs-font-size);
+                ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-body-xs-font-style);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
+                ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-body-xs-line-height);
+
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-xs-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-xs-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-xs-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-xs-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-xs-line-height);
+            `,
+            h2: css`
+                ${accordionTokens.accordionItemPaddingVertical}: 0.9375rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1.25rem;
+                ${accordionTokens.accordionItemGap}: 1rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.75rem;
+                ${accordionTokens.accordionItemIconSize}: 1.5rem;
+
+                ${accordionTokens.accordionItemHeaderLeftGapDefault}: 0.375rem;
+                ${accordionTokens.accordionItemHeaderLeftGapClear}: 0.5rem;
+
+                ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-h2-font-family);
+                ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-h2-font-size);
+                ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-h2-font-style);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h2-bold-font-weight);
+                ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
+                ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-h2-line-height);
+
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-l-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-l-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-l-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-l-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-l-line-height);
+            `,
+            h3: css`
+                ${accordionTokens.accordionItemPaddingVertical}: 0.6875rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1rem;
+                ${accordionTokens.accordionItemGap}: 0.75rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.75rem;
+                ${accordionTokens.accordionItemIconSize}: 1.5rem;
+
+                ${accordionTokens.accordionItemHeaderLeftGapDefault}: 0.375rem;
+                ${accordionTokens.accordionItemHeaderLeftGapClear}: 0.5rem;
+
+                ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-h3-font-family);
+                ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-h3-font-size);
+                ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-h3-font-style);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h3-bold-font-weight);
+                ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
+                ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-h3-line-height);
+
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-l-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-l-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-l-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-l-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-l-line-height);
+            `,
+            h4: css`
+                ${accordionTokens.accordionItemPaddingVertical}: 0.5625rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 0.75rem;
+                ${accordionTokens.accordionItemGap}: 0.75rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.625rem;
+
+                ${accordionTokens.accordionItemHeaderLeftGapDefault}: 0.5rem;
+                ${accordionTokens.accordionItemHeaderLeftGapClear}: 0.5rem;
+
+                ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-h4-font-family);
+                ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-h4-font-size);
+                ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-h4-font-style);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h4-bold-font-weight);
+                ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
+                ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-h4-line-height);
+
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-m-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-m-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-m-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-m-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-m-line-height);
+            `,
+            h5: css`
+                ${accordionTokens.accordionItemPaddingVertical}: 0.375rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 0.75rem;
+                ${accordionTokens.accordionItemGap}: 0.75rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.5rem;
+
+                ${accordionTokens.accordionItemHeaderLeftGapDefault}: 0.25rem;
+                ${accordionTokens.accordionItemHeaderLeftGapClear}: 0.25rem;
+
+                ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-h5-font-family);
+                ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-h5-font-size);
+                ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-h5-font-style);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h5-bold-font-weight);
+                ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
+                ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-h5-line-height);
+
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-m-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-m-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-m-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-m-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-m-line-height);
+            `,
+        },
+    },
+};

--- a/packages/sdds-finportal/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/sdds-finportal/src/components/Accordion/Accordion.stories.tsx
@@ -2,10 +2,19 @@ import React, { useState, ComponentProps, ReactNode } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 import { IconPlus } from '@salutejs/plasma-icons';
+import { accordionConfig } from '@salutejs/plasma-new-hope/styled-components';
 
 import { IconButton } from '../IconButton/IconButton';
+import { hasComponentDraftConfig } from '../../helpers/hasComponentDraftConfig';
+import { createComponentByConfig } from '../../helpers/createComponentByConfig';
 
-import { Accordion, AccordionItem } from './Accordion';
+import { AccordionItem } from './Accordion';
+import { config as defaultConfig } from './Accordion.config';
+import { config as draftConfig } from './Accordion.config.draft';
+
+const config = hasComponentDraftConfig() ? draftConfig : defaultConfig;
+
+const Accordion = createComponentByConfig(accordionConfig, config);
 
 type AccordionItemCustomProps = {
     type: 'arrow' | 'sign' | 'clear';


### PR DESCRIPTION
## SDDS-FINPORTAL

### Accordion
- добавлен `draft config`
- токены приведены в соответствие с макетом

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.267.2-canary.1733.13113759730.0
  npm install @salutejs/plasma-b2c@1.509.2-canary.1733.13113759730.0
  npm install @salutejs/plasma-giga@0.236.2-canary.1733.13113759730.0
  npm install @salutejs/plasma-new-hope@0.255.2-canary.1733.13113759730.0
  npm install @salutejs/plasma-web@1.511.2-canary.1733.13113759730.0
  npm install @salutejs/sdds-cs@0.244.2-canary.1733.13113759730.0
  npm install @salutejs/sdds-dfa@0.239.2-canary.1733.13113759730.0
  npm install @salutejs/sdds-finportal@0.232.2-canary.1733.13113759730.0
  npm install @salutejs/sdds-insol@0.233.2-canary.1733.13113759730.0
  npm install @salutejs/sdds-serv@0.240.2-canary.1733.13113759730.0
  # or 
  yarn add @salutejs/plasma-asdk@0.267.2-canary.1733.13113759730.0
  yarn add @salutejs/plasma-b2c@1.509.2-canary.1733.13113759730.0
  yarn add @salutejs/plasma-giga@0.236.2-canary.1733.13113759730.0
  yarn add @salutejs/plasma-new-hope@0.255.2-canary.1733.13113759730.0
  yarn add @salutejs/plasma-web@1.511.2-canary.1733.13113759730.0
  yarn add @salutejs/sdds-cs@0.244.2-canary.1733.13113759730.0
  yarn add @salutejs/sdds-dfa@0.239.2-canary.1733.13113759730.0
  yarn add @salutejs/sdds-finportal@0.232.2-canary.1733.13113759730.0
  yarn add @salutejs/sdds-insol@0.233.2-canary.1733.13113759730.0
  yarn add @salutejs/sdds-serv@0.240.2-canary.1733.13113759730.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
