### PR TITLE
PLASMA-4305: update Accordion config

### DIFF
--- a/packages/plasma-new-hope/src/components/Accordion/Accordion.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/Accordion.tokens.ts
@@ -3,6 +3,7 @@ export const classes = {
     fixedStretching: 'accordion-stretching-fixed',
     accordionRoot: 'accordion-root',
     accordionItem: 'accordion-item',
+    accordionItemOpened: 'accordion-item-opened',
     clearAccordionItem: 'clear-accordion-item',
     accordionItemShowBody: 'accordion-item-show-body',
     accordionPlusAnimationElement: 'accordion-plus-animation-element',
@@ -16,6 +17,7 @@ export const tokens = {
     accordionBackground: '--plasma-accordion-background',
 
     accordionItemBackground: '--plasma-accordion-item-background',
+    accordionItemShadow: '--plasma-accordion-item-shadow',
     accordionItemBorderRadius: '--plasma-accordion-item-border-radius',
     accordionItemPadding: '--plasma-accordion-item-padding',
     accordionItemPaddingVertical: '--plasma-accordion-item-padding-vertical',
@@ -33,6 +35,7 @@ export const tokens = {
     accordionItemHeaderLeftGapClear: '--plasma-accordion-item-header-left-gap-clear',
 
     accordionItemTitleColor: '--plasma-accordion-item-title-color',
+    accordionItemOpenedTitleColor: '--plasma-accordion-item-title-opened-color',
     accordionItemTitleFontFamily: '--plasma-accordion-item-title-font-family',
     accordionItemTitleFontSize: '--plasma-accordion-item-title-font-size',
     accordionItemTitleFontStyle: '--plasma-accordion-item-title-font-style',

--- a/packages/plasma-new-hope/src/components/Accordion/Accordion.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/Accordion.tokens.ts
@@ -23,6 +23,7 @@ export const tokens = {
     accordionItemPaddingVertical: '--plasma-accordion-item-padding-vertical',
     accordionItemPaddingHorizontal: '--plasma-accordion-item-padding-horizontal',
     accordionItemPaddingHorizontalLeft: '--plasma-accordion-item-padding-horizontal-left',
+    accordionItemBodyPaddingBottom: '--plasma-accordion-item-body-padding-bottom',
     accordionItemGap: '--plasma-accordion-item-gap',
     accordionItemFocus: '--plasma-accordion-item-focus',
     accordionItemBorder: '--plasma-accordion-item-border',

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
@@ -4,21 +4,6 @@ import { IconChevronDownFill, IconMinus } from '../../../_Icon';
 import { classes, tokens } from '../../Accordion.tokens';
 import { addFocus } from '../../../../mixins';
 
-export const StyledAccordionItem = styled.div`
-    background: var(${tokens.accordionItemBackground});
-    border: var(${tokens.accordionItemBorder});
-    border-bottom: var(${tokens.accordionItemBorderBottom});
-
-    &:last-child {
-        border-bottom: var(${tokens.accordionItemBorder});
-    }
-
-    &.${classes.accordionDisabled} {
-        opacity: 0.4;
-        cursor: not-allowed;
-    }
-`;
-
 export const StyledAccordionHeader = styled.button`
     width: 100%;
     border: none;
@@ -137,6 +122,7 @@ export const StyledMinus = styled(IconMinus)`
     &.${classes.accordionItemShowBody} {
         transition: 0.2s;
         transform: rotate(0deg);
+        color: var(${tokens.accordionItemOpenedTitleColor}, var(${tokens.accordionItemIconColor}));
     }
 `;
 
@@ -147,4 +133,30 @@ export const StyledPlus = styled.div`
     justify-content: center;
     width: var(${tokens.accordionItemIconSize}, 1rem);
     height: var(${tokens.accordionItemIconSize}, 1rem);
+`;
+
+export const StyledAccordionItem = styled.div`
+    background: var(${tokens.accordionItemBackground});
+    border: var(${tokens.accordionItemBorder});
+    border-bottom: var(${tokens.accordionItemBorderBottom});
+    box-shadow: var(${tokens.accordionItemShadow});
+
+    &:last-child {
+        border-bottom: var(${tokens.accordionItemBorder});
+    }
+
+    &.${classes.accordionDisabled} {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    &.${classes.accordionItemOpened} {
+        ${StyledArrow} {
+            color: var(${tokens.accordionItemOpenedTitleColor}, var(${tokens.accordionItemIconColor}));
+        }
+
+        ${StyledAccordionTitle} {
+            color: var(${tokens.accordionItemOpenedTitleColor}, var(${tokens.accordionItemTitleColor}));
+        }
+    }
 `;

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
@@ -75,7 +75,7 @@ export const StyledAccordionBodyAnimate = styled.div`
 
     &.${classes.accordionItemShowBody} {
         grid-template-rows: 1fr;
-        padding-bottom: var(${tokens.accordionItemPaddingVertical});
+        padding-bottom: var(${tokens.accordionItemBodyPaddingBottom}, var(${tokens.accordionItemPaddingVertical}));
 
         &.${classes.accordionPlusAnimationElement} {
             transition: 0.2s;

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
@@ -84,6 +84,7 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
         );
 
         const accordionBorderRadius = convertRoundnessMatrix(pin, `var(${tokens.accordionItemBorderRadius})`, '1.5rem');
+        const openedClass = opened ?? value ? classes.accordionItemOpened : '';
         const disabledClass = disabled ? classes.accordionDisabled : '';
 
         const leftContent =
@@ -98,7 +99,7 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
 
         return (
             <StyledAccordionItem
-                className={cx(classes.accordionItem, className, disabledClass)}
+                className={cx(classes.accordionItem, className, openedClass, disabledClass)}
                 key={key}
                 ref={outerRef}
                 style={{ borderRadius: accordionBorderRadius, ...style }}

--- a/packages/sdds-insol/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-insol/src/components/Accordion/Accordion.config.ts
@@ -8,11 +8,12 @@ export const config = {
     variations: {
         view: {
             default: css`
-                ${accordionTokens.accordionGap}: 0.125rem;
                 ${accordionTokens.accordionWidth}: 20rem;
                 ${accordionTokens.accordionItemPadding}: var(${accordionTokens.accordionItemPaddingVertical}) var(${accordionTokens.accordionItemPaddingHorizontal});
                 ${accordionTokens.accordionItemBackground}: var(--surface-solid-card);
+                ${accordionTokens.accordionItemShadow}: var(--shadow-down-soft-s);
                 ${accordionTokens.accordionItemTitleColor}: var(--text-primary);
+                ${accordionTokens.accordionItemOpenedTitleColor}: var(--text-accent);
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
@@ -26,6 +27,7 @@ export const config = {
                 ${accordionTokens.accordionItemPadding}: var(${accordionTokens.accordionItemPaddingVertical}) 0rem;
                 ${accordionTokens.accordionItemBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemTitleColor}: var(--text-primary);
+                ${accordionTokens.accordionItemOpenedTitleColor}: var(--text-accent);
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
@@ -39,13 +41,14 @@ export const config = {
             l: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 1.0625rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 1.25rem;
-                ${accordionTokens.accordionItemGap}: 0.5rem;
+                ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.875rem;
+                ${accordionTokens.accordionGap}: 1rem;
 
                 ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-body-l-font-family);
                 ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-body-l-font-size);
                 ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-body-l-font-style);
-                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-l-bold-font-weight);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-body-l-line-height);
 
@@ -58,15 +61,16 @@ export const config = {
             `,
             m: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 0.875rem;
-                ${accordionTokens.accordionItemPaddingHorizontal}: 1.125rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1rem;
 
-                ${accordionTokens.accordionItemGap}: 0.375rem;
+                ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.75rem;
+                ${accordionTokens.accordionGap}: 0.875rem;
 
                 ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-body-m-font-family);
                 ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-body-m-font-size);
                 ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-body-m-font-style);
-                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-m-bold-font-weight);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-body-m-line-height);
 
@@ -81,13 +85,14 @@ export const config = {
                 ${accordionTokens.accordionItemPaddingVertical}: 0.6875rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 0.875rem;
 
-                ${accordionTokens.accordionItemGap}: 0.375rem;
+                ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.625rem;
+                ${accordionTokens.accordionGap}: 0.75rem;
 
                 ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-body-s-font-size);
                 ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-body-s-font-style);
-                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-s-bold-font-weight);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-body-s-line-height);
 
@@ -99,16 +104,17 @@ export const config = {
                 ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
             xs: css`
-                ${accordionTokens.accordionItemPaddingVertical}: 0.5rem;
-                ${accordionTokens.accordionItemPaddingHorizontal}: 0.75rem;
+                ${accordionTokens.accordionItemPaddingVertical}: 0.563rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 0.625rem;
 
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.5rem;
+                ${accordionTokens.accordionGap}: 0.75rem;
 
                 ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-body-xs-font-style);
-                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-body-xs-line-height);
 
@@ -120,16 +126,17 @@ export const config = {
                 ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
             h2: css`
-                ${accordionTokens.accordionItemPaddingVertical}: 1rem;
-                ${accordionTokens.accordionItemPaddingHorizontal}: 1.25rem;
+                ${accordionTokens.accordionItemPaddingVertical}: 1.625rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1.75rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
-                ${accordionTokens.accordionItemBorderRadius}: 0.75rem;
                 ${accordionTokens.accordionItemIconSize}: 1.5rem;
+                ${accordionTokens.accordionItemBorderRadius}: 1.25rem;
+                ${accordionTokens.accordionGap}: 1.5rem;
 
                 ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-h2-font-family);
                 ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-h2-font-size);
                 ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-h2-font-style);
-                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h2-bold-font-weight);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-h2-line-height);
 
@@ -141,16 +148,17 @@ export const config = {
                 ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
             h3: css`
-                ${accordionTokens.accordionItemPaddingVertical}: 0.875rem;
-                ${accordionTokens.accordionItemPaddingHorizontal}: 1.125rem;
+                ${accordionTokens.accordionItemPaddingVertical}: 1.5rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1.625rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
-                ${accordionTokens.accordionItemBorderRadius}: 0.75rem;
                 ${accordionTokens.accordionItemIconSize}: 1.5rem;
+                ${accordionTokens.accordionItemBorderRadius}: 1.125rem;
+                ${accordionTokens.accordionGap}: 1.5rem;
 
                 ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-h3-font-family);
                 ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-h3-font-size);
                 ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-h3-font-style);
-                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h3-bold-font-weight);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-h3-line-height);
 
@@ -162,35 +170,37 @@ export const config = {
                 ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
             h4: css`
-                ${accordionTokens.accordionItemPaddingVertical}: 0.688rem;
-                ${accordionTokens.accordionItemPaddingHorizontal}: 0.875rem;
+                ${accordionTokens.accordionItemPaddingVertical}: 1.438rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1.5rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
-                ${accordionTokens.accordionItemBorderRadius}: 0.625rem;
+                ${accordionTokens.accordionItemBorderRadius}: 1rem;
+                ${accordionTokens.accordionGap}: 1.5rem;
 
                 ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-h4-font-family);
                 ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-h4-font-size);
                 ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-h4-font-style);
-                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h4-bold-font-weight);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-h4-line-height);
 
-                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-m-font-family);
-                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-m-font-size);
-                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-m-font-style);
-                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-m-font-weight);
-                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
-                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-m-line-height);
+                ${accordionTokens.accordionItemTextFontFamily}: var(--plasma-typo-body-l-font-family);
+                ${accordionTokens.accordionItemTextFontSize}: var(--plasma-typo-body-l-font-size);
+                ${accordionTokens.accordionItemTextFontStyle}: var(--plasma-typo-body-l-font-style);
+                ${accordionTokens.accordionItemTextFontWeight}: var(--plasma-typo-body-l-font-weight);
+                ${accordionTokens.accordionItemTextLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
+                ${accordionTokens.accordionItemTextLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
             h5: css`
-                ${accordionTokens.accordionItemPaddingVertical}: 0.5rem;
-                ${accordionTokens.accordionItemPaddingHorizontal}: 0.75rem;
+                ${accordionTokens.accordionItemPaddingVertical}: 1.25rem;
+                ${accordionTokens.accordionItemPaddingHorizontal}: 1.375rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
-                ${accordionTokens.accordionItemBorderRadius}: 0.5rem;
+                ${accordionTokens.accordionItemBorderRadius}: 0.875rem;
+                ${accordionTokens.accordionGap}: 1.25rem;
 
                 ${accordionTokens.accordionItemTitleFontFamily}: var(--plasma-typo-h5-font-family);
                 ${accordionTokens.accordionItemTitleFontSize}: var(--plasma-typo-h5-font-size);
                 ${accordionTokens.accordionItemTitleFontStyle}: var(--plasma-typo-h5-font-style);
-                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h5-bold-font-weight);
+                ${accordionTokens.accordionItemTitleFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${accordionTokens.accordionItemTitleLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${accordionTokens.accordionItemTitleLineHeight}: var(--plasma-typo-h5-line-height);
 

--- a/packages/sdds-insol/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-insol/src/components/Accordion/Accordion.config.ts
@@ -10,7 +10,7 @@ export const config = {
             default: css`
                 ${accordionTokens.accordionWidth}: 20rem;
                 ${accordionTokens.accordionItemPadding}: var(${accordionTokens.accordionItemPaddingVertical}) var(${accordionTokens.accordionItemPaddingHorizontal});
-                ${accordionTokens.accordionItemBackground}: var(--surface-solid-card);
+                ${accordionTokens.accordionItemBackground}: var(--surface-transparent-card);
                 ${accordionTokens.accordionItemShadow}: var(--shadow-down-soft-s);
                 ${accordionTokens.accordionItemTitleColor}: var(--text-primary);
                 ${accordionTokens.accordionItemOpenedTitleColor}: var(--text-accent);
@@ -41,6 +41,7 @@ export const config = {
             l: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 1.0625rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 1.25rem;
+                ${accordionTokens.accordionItemBodyPaddingBottom}: 1.125rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.875rem;
                 ${accordionTokens.accordionGap}: 1rem;
@@ -62,6 +63,7 @@ export const config = {
             m: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 0.875rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 1rem;
+                ${accordionTokens.accordionItemBodyPaddingBottom}: 1rem;
 
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.75rem;
@@ -84,6 +86,7 @@ export const config = {
             s: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 0.6875rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 0.875rem;
+                ${accordionTokens.accordionItemBodyPaddingBottom}: 0.75rem;
 
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.625rem;
@@ -106,6 +109,7 @@ export const config = {
             xs: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 0.563rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 0.625rem;
+                ${accordionTokens.accordionItemBodyPaddingBottom}: 0.625rem;
 
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.5rem;
@@ -128,6 +132,7 @@ export const config = {
             h2: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 1.625rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 1.75rem;
+                ${accordionTokens.accordionItemBodyPaddingBottom}: 1.625rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemIconSize}: 1.5rem;
                 ${accordionTokens.accordionItemBorderRadius}: 1.25rem;
@@ -150,6 +155,7 @@ export const config = {
             h3: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 1.5rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 1.625rem;
+                ${accordionTokens.accordionItemBodyPaddingBottom}: 1.5rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemIconSize}: 1.5rem;
                 ${accordionTokens.accordionItemBorderRadius}: 1.125rem;
@@ -172,6 +178,7 @@ export const config = {
             h4: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 1.438rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 1.5rem;
+                ${accordionTokens.accordionItemBodyPaddingBottom}: 1.5rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 1rem;
                 ${accordionTokens.accordionGap}: 1.5rem;
@@ -193,6 +200,7 @@ export const config = {
             h5: css`
                 ${accordionTokens.accordionItemPaddingVertical}: 1.25rem;
                 ${accordionTokens.accordionItemPaddingHorizontal}: 1.375rem;
+                ${accordionTokens.accordionItemBodyPaddingBottom}: 1.375rem;
                 ${accordionTokens.accordionItemGap}: 0.25rem;
                 ${accordionTokens.accordionItemBorderRadius}: 0.875rem;
                 ${accordionTokens.accordionGap}: 1.25rem;

--- a/packages/sdds-insol/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/sdds-insol/src/components/Accordion/Accordion.stories.tsx
@@ -1,14 +1,16 @@
 import React, { useState, ComponentProps, ReactNode } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
-import { IconPlus } from '@salutejs/plasma-icons';
+import { IconPlus, IconChevronDown } from '@salutejs/plasma-icons';
+import styled from 'styled-components';
 
 import { IconButton } from '../IconButton/IconButton';
 
 import { Accordion, AccordionItem } from './Accordion';
 
 type AccordionItemCustomProps = {
-    type: 'arrow' | 'sign' | 'clear';
+    type: 'arrow' | 'clear';
+    enableRightArrow: boolean;
     title: string;
     body: ReactNode;
     pin?:
@@ -26,7 +28,7 @@ type AccordionProps = ComponentProps<typeof Accordion> & AccordionItemCustomProp
 const views = ['default', 'clear'] as const;
 const sizes = ['l', 'm', 's', 'xs', 'h2', 'h3', 'h4', 'h5'] as const;
 const stretching = ['filled', 'fixed'] as const;
-const types = ['arrow', 'sign', 'clear'] as const;
+const types = ['arrow', 'clear'] as const;
 const pins = [
     'square-square',
     'square-clear',
@@ -47,6 +49,7 @@ const meta: Meta<AccordionProps> = {
         size: 'm',
         stretching: 'filled',
         disabled: false,
+        enableRightArrow: false,
         type: 'arrow',
         pin: undefined,
         title: 'Как оплатить заправку бонусами СберСпасибо?',
@@ -78,6 +81,7 @@ const meta: Meta<AccordionProps> = {
             control: {
                 type: 'select',
             },
+            if: { arg: 'enableRightArrow', truthy: false },
         },
         pin: {
             options: pins,
@@ -89,26 +93,6 @@ const meta: Meta<AccordionProps> = {
 };
 
 export default meta;
-
-export const Default: StoryObj<AccordionProps> = {
-    render: (props: AccordionProps) => {
-        const args = { ...props, text: undefined };
-
-        return (
-            <Accordion {...args}>
-                <AccordionItem type={args.type} pin={args.pin} title={args.title}>
-                    {args.body}
-                </AccordionItem>
-                <AccordionItem type={args.type} pin={args.pin} title={args.title}>
-                    {args.body}
-                </AccordionItem>
-                <AccordionItem type={args.type} pin={args.pin} title={args.title}>
-                    {args.body}
-                </AccordionItem>
-            </Accordion>
-        );
-    },
-};
 
 const getSizeForIcon = (size) => (size === 'xs' ? 'xs' : 's');
 const getSizeForIconButton = (size) => {
@@ -128,6 +112,71 @@ const getSizeForIconButton = (size) => {
         default:
             return 'm';
     }
+};
+
+const getSizeForArrow = (size) => {
+    switch (size) {
+        case 'h2':
+        case 'h3':
+            return 's';
+        case 'l':
+        case 'm':
+        case 's':
+        case 'xs':
+        case 'h5':
+        case 'h4':
+            return 'xs';
+        default:
+            return 'xs';
+    }
+};
+
+const StyledArrow = styled(IconChevronDown)`
+    transition: transform 0.2s;
+`;
+
+const Wrapper = styled.div`
+    .accordion-item-opened ${StyledArrow} {
+        transform: rotate(180deg);
+        color: var(--text-accent);
+    }
+`;
+
+export const Default: StoryObj<AccordionProps> = {
+    render: ({ enableRightArrow, ...props }: AccordionProps) => {
+        const args = { ...props, text: undefined };
+
+        return (
+            <Wrapper>
+                <Accordion {...args}>
+                    <AccordionItem
+                        type={args.type}
+                        pin={args.pin}
+                        title={args.title}
+                        contentRight={enableRightArrow ? <StyledArrow size={getSizeForArrow(args.size)} /> : undefined}
+                    >
+                        {args.body}
+                    </AccordionItem>
+                    <AccordionItem
+                        type={args.type}
+                        pin={args.pin}
+                        title={args.title}
+                        contentRight={enableRightArrow ? <StyledArrow size={getSizeForArrow(args.size)} /> : undefined}
+                    >
+                        {args.body}
+                    </AccordionItem>
+                    <AccordionItem
+                        type={args.type}
+                        pin={args.pin}
+                        title={args.title}
+                        contentRight={enableRightArrow ? <StyledArrow size={getSizeForArrow(args.size)} /> : undefined}
+                    >
+                        {args.body}
+                    </AccordionItem>
+                </Accordion>
+            </Wrapper>
+        );
+    },
 };
 
 const ControlledAccordion = (props: ComponentProps<typeof Accordion>) => {


### PR DESCRIPTION
## SDDS-INSOL

### Accordion

- исправлены отступы для Header размеров
- заголовок окрашивается в акцентный цвет у открытых элементов

<img width="683" alt="image" src="https://github.com/user-attachments/assets/f44e9b4b-0ffb-41d4-a886-34e08788745d" />

### What/why changed

Приведение конфига Accordion в соответствие с макетом

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.270.0-canary.1736.13152101875.0
  npm install @salutejs/plasma-b2c@1.512.0-canary.1736.13152101875.0
  npm install @salutejs/plasma-giga@0.239.0-canary.1736.13152101875.0
  npm install @salutejs/plasma-new-hope@0.258.0-canary.1736.13152101875.0
  npm install @salutejs/plasma-web@1.514.0-canary.1736.13152101875.0
  npm install @salutejs/sdds-cs@0.247.0-canary.1736.13152101875.0
  npm install @salutejs/sdds-dfa@0.242.0-canary.1736.13152101875.0
  npm install @salutejs/sdds-finportal@0.235.0-canary.1736.13152101875.0
  npm install @salutejs/sdds-insol@0.236.0-canary.1736.13152101875.0
  npm install @salutejs/sdds-serv@0.243.0-canary.1736.13152101875.0
  # or 
  yarn add @salutejs/plasma-asdk@0.270.0-canary.1736.13152101875.0
  yarn add @salutejs/plasma-b2c@1.512.0-canary.1736.13152101875.0
  yarn add @salutejs/plasma-giga@0.239.0-canary.1736.13152101875.0
  yarn add @salutejs/plasma-new-hope@0.258.0-canary.1736.13152101875.0
  yarn add @salutejs/plasma-web@1.514.0-canary.1736.13152101875.0
  yarn add @salutejs/sdds-cs@0.247.0-canary.1736.13152101875.0
  yarn add @salutejs/sdds-dfa@0.242.0-canary.1736.13152101875.0
  yarn add @salutejs/sdds-finportal@0.235.0-canary.1736.13152101875.0
  yarn add @salutejs/sdds-insol@0.236.0-canary.1736.13152101875.0
  yarn add @salutejs/sdds-serv@0.243.0-canary.1736.13152101875.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
