### PR TITLE
PLASMA-4355: Remove required prop in chip mode in Textfield

### DIFF
--- a/packages/plasma-b2c/src/components/TextField/TextField.component-test.tsx
+++ b/packages/plasma-b2c/src/components/TextField/TextField.component-test.tsx
@@ -572,6 +572,20 @@ describe('plasma-b2c: TextField', () => {
             cy.get('#falseRequired').should('not.have.attr', 'required');
             cy.get('#notRequired').should('not.have.attr', 'required');
         });
+
+        it('required with chips', () => {
+            mount(
+                <CypressTestDecoratorWithTypo>
+                    <TextField enumerationType="chip" id="textfield" placeholder="Placeholder" label="Title" required />
+                </CypressTestDecoratorWithTypo>,
+            );
+
+            cy.get('#textfield').should('have.attr', 'required');
+            cy.get('#textfield').type('some value{enter}');
+            cy.get('#textfield').should('not.have.attr', 'required');
+            cy.get('#textfield').type('{backspace}');
+            cy.get('#textfield').should('have.attr', 'required');
+        });
     });
 
     it('chipType', () => {

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -485,7 +485,7 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldRootProps
                                     ref={inputForkRef}
                                     id={innerId}
                                     value={outerValue}
-                                    required={required}
+                                    required={enumerationType === 'chip' ? chips.length === 0 && required : required}
                                     aria-labelledby={labelId}
                                     aria-describedby={helperTextId}
                                     placeholder={innerPlaceholderValue}

--- a/packages/plasma-web/src/components/TextField/TextField.component-test.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.component-test.tsx
@@ -602,6 +602,20 @@ describe('plasma-web: TextField', () => {
             cy.get('#falseRequired').should('not.have.attr', 'required');
             cy.get('#notRequired').should('not.have.attr', 'required');
         });
+
+        it('required with chips', () => {
+            mount(
+                <CypressTestDecoratorWithTypo>
+                    <TextField enumerationType="chip" id="textfield" placeholder="Placeholder" label="Title" required />
+                </CypressTestDecoratorWithTypo>,
+            );
+
+            cy.get('#textfield').should('have.attr', 'required');
+            cy.get('#textfield').type('some value{enter}');
+            cy.get('#textfield').should('not.have.attr', 'required');
+            cy.get('#textfield').type('{backspace}');
+            cy.get('#textfield').should('have.attr', 'required');
+        });
     });
 
     describe('with hint', () => {


### PR DESCRIPTION
## Core

### Textfield

- исправлен баг, связанный с пропсом required в режиме с чипами;

### What/why changed
Оригинально проблема пришла из комопнента комбобокс, но т.к. комбобокс наследуется от текстфилда - то фикс сделан именно в нем. Суть в следующем: если включен режим с чипами (мультипл мод), и также если прокидывается пропс `required`, то форма не отправляется, т.к. инпут остается пустым (что понятно, чип выбран и инпут очищается). Мой фикс прост и лаконичен: мы просто убираем required из html-инпута, если выбран 1 и более чип. Для сингл режима все осталось по-прежнему.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.271.0-canary.1738.13153391749.0
  npm install @salutejs/plasma-b2c@1.513.0-canary.1738.13153391749.0
  npm install @salutejs/plasma-giga@0.240.0-canary.1738.13153391749.0
  npm install @salutejs/plasma-new-hope@0.259.0-canary.1738.13153391749.0
  npm install @salutejs/plasma-web@1.515.0-canary.1738.13153391749.0
  npm install @salutejs/sdds-cs@0.248.0-canary.1738.13153391749.0
  npm install @salutejs/sdds-dfa@0.243.0-canary.1738.13153391749.0
  npm install @salutejs/sdds-finportal@0.236.0-canary.1738.13153391749.0
  npm install @salutejs/sdds-insol@0.237.0-canary.1738.13153391749.0
  npm install @salutejs/sdds-serv@0.244.0-canary.1738.13153391749.0
  # or 
  yarn add @salutejs/plasma-asdk@0.271.0-canary.1738.13153391749.0
  yarn add @salutejs/plasma-b2c@1.513.0-canary.1738.13153391749.0
  yarn add @salutejs/plasma-giga@0.240.0-canary.1738.13153391749.0
  yarn add @salutejs/plasma-new-hope@0.259.0-canary.1738.13153391749.0
  yarn add @salutejs/plasma-web@1.515.0-canary.1738.13153391749.0
  yarn add @salutejs/sdds-cs@0.248.0-canary.1738.13153391749.0
  yarn add @salutejs/sdds-dfa@0.243.0-canary.1738.13153391749.0
  yarn add @salutejs/sdds-finportal@0.236.0-canary.1738.13153391749.0
  yarn add @salutejs/sdds-insol@0.237.0-canary.1738.13153391749.0
  yarn add @salutejs/sdds-serv@0.244.0-canary.1738.13153391749.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
