### PR TITLE
PLASMA-4293: add page guide for next.js

### DIFF
--- a/website/plasma-b2c-docs/docs/next.mdx
+++ b/website/plasma-b2c-docs/docs/next.mdx
@@ -1,0 +1,101 @@
+---
+id: next
+title: Работа с Next
+sidebar_position: 1
+---
+
+Подключение библиотеки и ее компонентов не отличается от стандартного варианта, за исключением некоторых нюансов, о которых ниже.
+
+:::caution
+    <span>Библиотека не поддерживает работу с <strong>React Server Components (App router)</strong>. За исключением тех мест в вашем проекте, где явно задана директива <strong>'use client'</strong>.</span>
+:::
+
+<br />
+
+<blockquote>
+    В дальнейшем речь пойдет исключительно для <u><b>pages</b> router'a</u>, вне зависимости от версии Next.
+</blockquote>
+
+## Подключение тем
+
+Ниже представлены различные способы подключения темы в проект:
+
+### Styled Components
+
+<blockquote>
+    Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components. Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
+</blockquote>
+
+```jsx
+import type { AppProps } from "next/app";
+import { plasma_b2c__light } from '@salutejs/plasma-themes';
+import { createGlobalStyle } from "styled-components";
+
+const PlasmaTheme = createGlobalStyle(plasma_b2c__light);
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+      <>
+        <PlasmaTheme />
+
+        <Component {...pageProps} />
+      </>
+  );
+}
+```
+
+### Импорт CSS
+
+```jsx
+import type { AppProps } from "next/app";
+import '@salutejs/plasma-themes/css/plasma_b2c__dark.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+```
+
+## Работа с компонентами
+
+Библиотека поставляет компоненты в формате `Styled Components` и на обычном `CSS`.
+
+### Пример со Styled Components
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/plasma-b2c'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с CSS
+
+:::caution
+Next не разрешает импорт CSS из сторонних модулей, поэтому важно не забыть добавить наши библиотеки в `next.config.js` следующим образом:
+:::
+
+```js
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['@salutejs/plasma-b2c', '@salutejs/plasma-new-hope']
+};
+````
+И далее уже можно подключать наши компоненты:
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/plasma-b2c/css'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```

--- a/website/plasma-giga-docs/docs/next.mdx
+++ b/website/plasma-giga-docs/docs/next.mdx
@@ -1,0 +1,116 @@
+---
+id: next
+title: Работа с Next
+sidebar_position: 1
+---
+
+Подключение библиотеки и ее компонентов не отличается от стандартного варианта, за исключением некоторых нюансов, о которых ниже.
+
+:::caution
+    <span>Библиотека не поддерживает работу с <strong>React Server Components (App router)</strong>. За исключением тех мест в вашем проекте, где явно задана директива <strong>'use client'</strong>.</span>
+:::
+
+<br />
+
+<blockquote>
+    В дальнейшем речь пойдет исключительно для <u><b>pages</b> router'a</u>, вне зависимости от версии Next.
+</blockquote>
+
+## Подключение тем
+
+Ниже представлены различные способы подключения темы в проект:
+
+### Styled Components
+
+<blockquote>
+    Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components. Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
+</blockquote>
+
+```jsx
+import type { AppProps } from "next/app";
+import { plasma_giga__light } from '@salutejs/plasma-themes';
+import { createGlobalStyle } from "styled-components";
+
+const PlasmaTheme = createGlobalStyle(plasma_giga__light);
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+      <>
+        <PlasmaTheme />
+
+        <Component {...pageProps} />
+      </>
+  );
+}
+```
+
+### Импорт CSS
+
+```jsx
+import type { AppProps } from "next/app";
+import '@salutejs/plasma-themes/css/plasma_giga__dark.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+```
+
+## Работа с компонентами
+
+Библиотека поставляет компоненты в формате `Styled Components`, `Emotion` и на обычном `CSS`.
+
+### Пример со Styled Components
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/plasma-giga/styled-components'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с Emotion
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/plasma-giga/emotion'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с CSS
+
+:::caution
+Next не разрешает импорт CSS из сторонних модулей, поэтому важно не забыть добавить наши библиотеки в `next.config.js` следующим образом:
+:::
+
+```js
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['@salutejs/plasma-giga', '@salutejs/plasma-new-hope']
+};
+````
+И далее уже можно подключать наши компоненты:
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/plasma-giga'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```

--- a/website/plasma-web-docs/docs/next.mdx
+++ b/website/plasma-web-docs/docs/next.mdx
@@ -1,0 +1,101 @@
+---
+id: next
+title: Работа с Next
+sidebar_position: 1
+---
+
+Подключение библиотеки и ее компонентов не отличается от стандартного варианта, за исключением некоторых нюансов, о которых ниже.
+
+:::caution
+    <span>Библиотека не поддерживает работу с <strong>React Server Components (App router)</strong>. За исключением тех мест в вашем проекте, где явно задана директива <strong>'use client'</strong>.</span>
+:::
+
+<br />
+
+<blockquote>
+    В дальнейшем речь пойдет исключительно для <u><b>pages</b> router'a</u>, вне зависимости от версии Next.
+</blockquote>
+
+## Подключение тем
+
+Ниже представлены различные способы подключения темы в проект:
+
+### Styled Components
+
+<blockquote>
+    Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components. Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
+</blockquote>
+
+```jsx
+import type { AppProps } from "next/app";
+import { plasma_web__light } from '@salutejs/plasma-themes';
+import { createGlobalStyle } from "styled-components";
+
+const PlasmaTheme = createGlobalStyle(plasma_web__light);
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+      <>
+        <PlasmaTheme />
+
+        <Component {...pageProps} />
+      </>
+  );
+}
+```
+
+### Импорт CSS
+
+```jsx
+import type { AppProps } from "next/app";
+import '@salutejs/plasma-themes/css/plasma_web__dark.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+```
+
+## Работа с компонентами
+
+Библиотека поставляет компоненты в формате `Styled Components` и на обычном `CSS`.
+
+### Пример со Styled Components
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/plasma-web'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с CSS
+
+:::caution
+Next не разрешает импорт CSS из сторонних модулей, поэтому важно не забыть добавить наши библиотеки в `next.config.js` следующим образом:
+:::
+
+```js
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['@salutejs/plasma-web', '@salutejs/plasma-new-hope']
+};
+````
+И далее уже можно подключать наши компоненты:
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/plasma-web/css'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```

--- a/website/sdds-cs-docs/docs/next.mdx
+++ b/website/sdds-cs-docs/docs/next.mdx
@@ -1,0 +1,90 @@
+---
+id: next
+title: Работа с Next
+sidebar_position: 1
+---
+
+Подключение библиотеки и ее компонентов не отличается от стандартного варианта, за исключением некоторых нюансов, о которых ниже.
+
+:::caution
+    <span>Библиотека не поддерживает работу с <strong>React Server Components (App router)</strong>. За исключением тех мест в вашем проекте, где явно задана директива <strong>'use client'</strong>.</span>
+:::
+
+<br />
+
+<blockquote>
+    В дальнейшем речь пойдет исключительно для <u><b>pages</b> router'a</u>, вне зависимости от версии Next.
+</blockquote>
+
+## Подключение тем
+
+Ниже представлены различные способы подключения темы в проект:
+
+### Styled Components
+
+<blockquote>
+    Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components. Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
+</blockquote>
+
+```jsx
+import type { AppProps } from "next/app";
+import { sdds_cs__light } from '@salutejs/sdds-themes';
+import { createGlobalStyle } from "styled-components";
+
+const PlasmaTheme = createGlobalStyle(sdds_cs__light);
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+      <>
+        <PlasmaTheme />
+
+        <Component {...pageProps} />
+      </>
+  );
+}
+```
+
+### Импорт CSS
+
+```jsx
+import type { AppProps } from "next/app";
+import '@salutejs/sdds-themes/css/sdds_cs__dark.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+```
+
+## Работа с компонентами
+
+Библиотека поставляет компоненты в формате `Styled Components` и `Emotion`.
+
+### Пример со Styled Components
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-cs'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с Emotion
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-cs/emotion'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```

--- a/website/sdds-dfa-docs/docs/next.mdx
+++ b/website/sdds-dfa-docs/docs/next.mdx
@@ -1,0 +1,75 @@
+---
+id: next
+title: Работа с Next
+sidebar_position: 1
+---
+
+Подключение библиотеки и ее компонентов не отличается от стандартного варианта, за исключением некоторых нюансов, о которых ниже.
+
+:::caution
+    <span>Библиотека не поддерживает работу с <strong>React Server Components (App router)</strong>. За исключением тех мест в вашем проекте, где явно задана директива <strong>'use client'</strong>.</span>
+:::
+
+<br />
+
+<blockquote>
+    В дальнейшем речь пойдет исключительно для <u><b>pages</b> router'a</u>, вне зависимости от версии Next.
+</blockquote>
+
+## Подключение тем
+
+Ниже представлены различные способы подключения темы в проект:
+
+### Styled Components
+
+<blockquote>
+    Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components. Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
+</blockquote>
+
+```jsx
+import type { AppProps } from "next/app";
+import { sdds_dfa__light } from '@salutejs/sdds-themes';
+import { createGlobalStyle } from "styled-components";
+
+const PlasmaTheme = createGlobalStyle(sdds_dfa__light);
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+      <>
+        <PlasmaTheme />
+
+        <Component {...pageProps} />
+      </>
+  );
+}
+```
+
+### Импорт CSS
+
+```jsx
+import type { AppProps } from "next/app";
+import '@salutejs/sdds-themes/css/sdds_dfa__dark.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+```
+
+## Работа с компонентами
+
+Библиотека поставляет компоненты в формате `Styled Components`.
+
+### Пример со Styled Components
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-dfa'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```

--- a/website/sdds-insol-docs/docs/next.mdx
+++ b/website/sdds-insol-docs/docs/next.mdx
@@ -1,0 +1,116 @@
+---
+id: next
+title: Работа с Next
+sidebar_position: 1
+---
+
+Подключение библиотеки и ее компонентов не отличается от стандартного варианта, за исключением некоторых нюансов, о которых ниже.
+
+:::caution
+    <span>Библиотека не поддерживает работу с <strong>React Server Components (App router)</strong>. За исключением тех мест в вашем проекте, где явно задана директива <strong>'use client'</strong>.</span>
+:::
+
+<br />
+
+<blockquote>
+    В дальнейшем речь пойдет исключительно для <u><b>pages</b> router'a</u>, вне зависимости от версии Next.
+</blockquote>
+
+## Подключение тем
+
+Ниже представлены различные способы подключения темы в проект:
+
+### Styled Components
+
+<blockquote>
+    Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components. Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
+</blockquote>
+
+```jsx
+import type { AppProps } from "next/app";
+import { sdds_insol__light } from '@salutejs/sdds-themes';
+import { createGlobalStyle } from "styled-components";
+
+const PlasmaTheme = createGlobalStyle(sdds_insol__light);
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+      <>
+        <PlasmaTheme />
+
+        <Component {...pageProps} />
+      </>
+  );
+}
+```
+
+### Импорт CSS
+
+```jsx
+import type { AppProps } from "next/app";
+import '@salutejs/sdds-themes/css/sdds_insol__light.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+```
+
+## Работа с компонентами
+
+Библиотека поставляет компоненты в формате `Styled Components`, `Emotion` и на обычном `CSS`.
+
+### Пример со Styled Components
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-insol/styled-components'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с Emotion
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-insol/emotion'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с CSS
+
+:::caution
+Next не разрешает импорт CSS из сторонних модулей, поэтому важно не забыть добавить наши библиотеки в `next.config.js` следующим образом:
+:::
+
+```js
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['@salutejs/sdds-insol', '@salutejs/plasma-new-hope']
+};
+````
+И далее уже можно подключать наши компоненты:
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-insol'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```

--- a/website/sdds-serv-docs/docs/next.mdx
+++ b/website/sdds-serv-docs/docs/next.mdx
@@ -1,0 +1,116 @@
+---
+id: next
+title: Работа с Next
+sidebar_position: 1
+---
+
+Подключение библиотеки и ее компонентов не отличается от стандартного варианта, за исключением некоторых нюансов, о которых ниже.
+
+:::caution
+    <span>Библиотека не поддерживает работу с <strong>React Server Components (App router)</strong>. За исключением тех мест в вашем проекте, где явно задана директива <strong>'use client'</strong>.</span>
+:::
+
+<br />
+
+<blockquote>
+    В дальнейшем речь пойдет исключительно для <u><b>pages</b> router'a</u>, вне зависимости от версии Next.
+</blockquote>
+
+## Подключение тем
+
+Ниже представлены различные способы подключения темы в проект:
+
+### Styled Components
+
+<blockquote>
+    Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components. Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
+</blockquote>
+
+```jsx
+import type { AppProps } from "next/app";
+import { sdds_serv__light } from '@salutejs/sdds-themes';
+import { createGlobalStyle } from "styled-components";
+
+const PlasmaTheme = createGlobalStyle(sdds_serv__light);
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+      <>
+        <PlasmaTheme />
+
+        <Component {...pageProps} />
+      </>
+  );
+}
+```
+
+### Импорт CSS
+
+```jsx
+import type { AppProps } from "next/app";
+import '@salutejs/sdds-themes/css/sdds_serv__light.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+```
+
+## Работа с компонентами
+
+Библиотека поставляет компоненты в формате `Styled Components`, `Emotion` и на обычном `CSS`.
+
+### Пример со Styled Components
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-serv/styled-components'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с Emotion
+
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-serv/emotion'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```
+
+### Пример с CSS
+
+:::caution
+Next не разрешает импорт CSS из сторонних модулей, поэтому важно не забыть добавить наши библиотеки в `next.config.js` следующим образом:
+:::
+
+```js
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['@salutejs/sdds-serv', '@salutejs/plasma-new-hope']
+};
+````
+И далее уже можно подключать наши компоненты:
+```jsx
+import React from 'react';
+import { Button } from '@salutejs/sdds-serv'
+
+export default function Home() {
+  return (
+    <div>
+        <Button>Button</Button>
+    </div>
+  );
+}
+```


### PR DESCRIPTION
## Core

- добавлен раздела в документацию по работе с NextJs

### What/why changed
Добавили раздел в доке по работе с некстом.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.271.0-canary.1740.13154795789.0
  npm install @salutejs/plasma-b2c@1.513.0-canary.1740.13154795789.0
  npm install @salutejs/plasma-giga@0.240.0-canary.1740.13154795789.0
  npm install @salutejs/plasma-new-hope@0.259.0-canary.1740.13154795789.0
  npm install @salutejs/plasma-web@1.515.0-canary.1740.13154795789.0
  npm install @salutejs/sdds-cs@0.248.0-canary.1740.13154795789.0
  npm install @salutejs/sdds-dfa@0.243.0-canary.1740.13154795789.0
  npm install @salutejs/sdds-finportal@0.236.0-canary.1740.13154795789.0
  npm install @salutejs/sdds-insol@0.237.0-canary.1740.13154795789.0
  npm install @salutejs/sdds-serv@0.244.0-canary.1740.13154795789.0
  # or 
  yarn add @salutejs/plasma-asdk@0.271.0-canary.1740.13154795789.0
  yarn add @salutejs/plasma-b2c@1.513.0-canary.1740.13154795789.0
  yarn add @salutejs/plasma-giga@0.240.0-canary.1740.13154795789.0
  yarn add @salutejs/plasma-new-hope@0.259.0-canary.1740.13154795789.0
  yarn add @salutejs/plasma-web@1.515.0-canary.1740.13154795789.0
  yarn add @salutejs/sdds-cs@0.248.0-canary.1740.13154795789.0
  yarn add @salutejs/sdds-dfa@0.243.0-canary.1740.13154795789.0
  yarn add @salutejs/sdds-finportal@0.236.0-canary.1740.13154795789.0
  yarn add @salutejs/sdds-insol@0.237.0-canary.1740.13154795789.0
  yarn add @salutejs/sdds-serv@0.244.0-canary.1740.13154795789.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
