### PR TITLE
fix(plasma-new-hope): redundant log removed from `NumberInput`

### DIFF
--- a/packages/plasma-new-hope/src/components/NumberInput/NumberInput.tsx
+++ b/packages/plasma-new-hope/src/components/NumberInput/NumberInput.tsx
@@ -55,8 +55,6 @@ export const numberInputRoot = (Root: RootProps<HTMLDivElement, NumberInputRootP
             const [isInputFocused, setIsInputFocused] = useState(false);
             const [isAnimationRun, setIsAnimationRun] = useState(false);
 
-            console.log('innerValue', innerValue);
-
             const innerWidth = width ? getSizeValueFromProp(width) : '100%';
 
             const actionIconSize = size === 'xs' ? 'xs' : 's';


### PR DESCRIPTION
## CORE

### NumberInput
- удалён лишний `console.log`

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.267.1-canary.1742.13109369002.0
  npm install @salutejs/plasma-b2c@1.509.1-canary.1742.13109369002.0
  npm install @salutejs/plasma-giga@0.236.1-canary.1742.13109369002.0
  npm install @salutejs/plasma-new-hope@0.255.1-canary.1742.13109369002.0
  npm install @salutejs/plasma-web@1.511.1-canary.1742.13109369002.0
  npm install @salutejs/sdds-cs@0.244.1-canary.1742.13109369002.0
  npm install @salutejs/sdds-dfa@0.239.1-canary.1742.13109369002.0
  npm install @salutejs/sdds-finportal@0.232.1-canary.1742.13109369002.0
  npm install @salutejs/sdds-insol@0.233.1-canary.1742.13109369002.0
  npm install @salutejs/sdds-serv@0.240.1-canary.1742.13109369002.0
  # or 
  yarn add @salutejs/plasma-asdk@0.267.1-canary.1742.13109369002.0
  yarn add @salutejs/plasma-b2c@1.509.1-canary.1742.13109369002.0
  yarn add @salutejs/plasma-giga@0.236.1-canary.1742.13109369002.0
  yarn add @salutejs/plasma-new-hope@0.255.1-canary.1742.13109369002.0
  yarn add @salutejs/plasma-web@1.511.1-canary.1742.13109369002.0
  yarn add @salutejs/sdds-cs@0.244.1-canary.1742.13109369002.0
  yarn add @salutejs/sdds-dfa@0.239.1-canary.1742.13109369002.0
  yarn add @salutejs/sdds-finportal@0.232.1-canary.1742.13109369002.0
  yarn add @salutejs/sdds-insol@0.233.1-canary.1742.13109369002.0
  yarn add @salutejs/sdds-serv@0.240.1-canary.1742.13109369002.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
