### PR TITLE
PLASMA-4415: add year forward to Month update

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/hooks/useCalendarDateChange.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/hooks/useCalendarDateChange.ts
@@ -55,6 +55,7 @@ export const useCalendarDateChange = ({
                 payload: {
                     calendarState: CalendarState.Days,
                     monthIndex: newDate.monthIndex,
+                    year: newDate.year,
                     size: sizeMap.Days.double,
                 },
             });

--- a/packages/plasma-new-hope/src/components/Calendar/store/reducer.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/store/reducer.ts
@@ -124,7 +124,7 @@ export const reducer = (state: InitialState, action: Action): InitialState => {
             };
         }
         case ActionType.UPDATE_MONTH: {
-            const { calendarState, monthIndex, size } = action.payload;
+            const { calendarState, monthIndex, year, size } = action.payload;
 
             return {
                 ...state,
@@ -133,7 +133,7 @@ export const reducer = (state: InitialState, action: Action): InitialState => {
                 date: {
                     day: state.date.day,
                     monthIndex,
-                    year: state.date.year,
+                    year,
                 },
             };
         }

--- a/packages/plasma-new-hope/src/components/Calendar/store/types.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/store/types.ts
@@ -52,7 +52,7 @@ export type UpdateDateAction = { type: ActionType.UPDATE_DATE; payload: { value:
 
 export type UpdateMonthAction = {
     type: ActionType.UPDATE_MONTH;
-    payload: { calendarState: CalendarStateType; monthIndex: number; size: [number, number] };
+    payload: { calendarState: CalendarStateType; monthIndex: number; year: number; size: [number, number] };
 };
 
 export type UpdateYearAction = {


### PR DESCRIPTION
## Core

### Calendar

- исправлен выбор месяца на двойном календаре

### What/why changed

Поправлено поведение календарной сетки месяца. Когда происходит выбор месяца из второй половины двойного календаря, брался год из первой части календаря.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.273.0-canary.1756.13182478014.0
  npm install @salutejs/plasma-b2c@1.515.0-canary.1756.13182478014.0
  npm install @salutejs/plasma-giga@0.242.0-canary.1756.13182478014.0
  npm install @salutejs/plasma-new-hope@0.261.0-canary.1756.13182478014.0
  npm install @salutejs/plasma-web@1.517.0-canary.1756.13182478014.0
  npm install @salutejs/sdds-cs@0.250.0-canary.1756.13182478014.0
  npm install @salutejs/sdds-dfa@0.245.0-canary.1756.13182478014.0
  npm install @salutejs/sdds-finportal@0.238.0-canary.1756.13182478014.0
  npm install @salutejs/sdds-insol@0.239.0-canary.1756.13182478014.0
  npm install @salutejs/sdds-serv@0.246.0-canary.1756.13182478014.0
  # or 
  yarn add @salutejs/plasma-asdk@0.273.0-canary.1756.13182478014.0
  yarn add @salutejs/plasma-b2c@1.515.0-canary.1756.13182478014.0
  yarn add @salutejs/plasma-giga@0.242.0-canary.1756.13182478014.0
  yarn add @salutejs/plasma-new-hope@0.261.0-canary.1756.13182478014.0
  yarn add @salutejs/plasma-web@1.517.0-canary.1756.13182478014.0
  yarn add @salutejs/sdds-cs@0.250.0-canary.1756.13182478014.0
  yarn add @salutejs/sdds-dfa@0.245.0-canary.1756.13182478014.0
  yarn add @salutejs/sdds-finportal@0.238.0-canary.1756.13182478014.0
  yarn add @salutejs/sdds-insol@0.239.0-canary.1756.13182478014.0
  yarn add @salutejs/sdds-serv@0.246.0-canary.1756.13182478014.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
