### PR TITLE
PLASMA-4291: fix min/max Calendar logic for month, quarter, year

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
@@ -31,8 +31,8 @@ export const calendarBaseRoot = (Root: RootProps<HTMLDivElement, HTMLAttributes<
         (
             {
                 value: externalValue,
-                min,
-                max,
+                min: minDate,
+                max: maxDate,
                 includeEdgeDates,
                 type = 'Days',
                 eventList,
@@ -59,6 +59,9 @@ export const calendarBaseRoot = (Root: RootProps<HTMLDivElement, HTMLAttributes<
             const [prevType, setPrevType] = useState(type);
             const [prevValue, setPrevValue] = useState(value);
             const [outOfRangeKey, setOutOfRangeKey] = useState<number>(0);
+
+            const min = minDate && new Date(minDate);
+            const max = maxDate && new Date(maxDate);
 
             const [state, dispatch] = useReducer(reducer, getInitialState(value, min, type));
 

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
@@ -31,8 +31,8 @@ export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttribute
         (
             {
                 value: externalValue,
-                min,
-                max,
+                min: minDate,
+                max: maxDate,
                 includeEdgeDates,
                 type = 'Days',
                 eventList,
@@ -59,6 +59,9 @@ export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttribute
             const [prevType, setPrevType] = useState(type);
             const [prevValue, setPrevValue] = useState(value);
             const [outOfRangeKey, setOutOfRangeKey] = useState<number>(0);
+
+            const min = minDate && new Date(minDate);
+            const max = maxDate && new Date(maxDate);
 
             const [state, dispatch] = useReducer(reducer, getInitialState(value, min, type, true));
 

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarMonths/CalendarMonths.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarMonths/CalendarMonths.tsx
@@ -29,7 +29,18 @@ export const CalendarMonths: React.FC<CalendarMonthsProps> = ({
     onKeyDown,
     locale,
 }) => {
-    const [months, selected] = useMonths({ date: currentDate, value, eventList, disabledList, min, max, locale });
+    const minDate = min ? new Date(min.getFullYear(), min.getMonth(), 1) : undefined;
+    const maxDate = max ? new Date(max.getFullYear(), max.getMonth() + 1, 0) : undefined;
+
+    const [months, selected] = useMonths({
+        date: currentDate,
+        value,
+        eventList,
+        disabledList,
+        min: minDate,
+        max: maxDate,
+        locale,
+    });
     const selectedRef = useRef(selected);
     const onSetSelectedRef = useRef(onSetSelected);
 

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarQuarters/CalendarQuarters.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarQuarters/CalendarQuarters.tsx
@@ -28,7 +28,17 @@ export const CalendarQuarters: React.FC<CalendarQuartersProps> = ({
     onSetSelected,
     onKeyDown,
 }) => {
-    const [quarters, selected] = useQuarters({ date: currentDate, value, eventList, disabledList, min, max });
+    const minDate = min ? new Date(min.getFullYear(), min.getMonth(), 1) : undefined;
+    const maxDate = max ? new Date(max.getFullYear(), max.getMonth() + 1, 0) : undefined;
+
+    const [quarters, selected] = useQuarters({
+        date: currentDate,
+        value,
+        eventList,
+        disabledList,
+        min: minDate,
+        max: maxDate,
+    });
     const selectedRef = useRef(selected);
     const onSetSelectedRef = useRef(onSetSelected);
 

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarYears/CalendarYears.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarYears/CalendarYears.tsx
@@ -29,7 +29,18 @@ export const CalendarYears: React.FC<CalendarYearsProps> = ({
     onSetSelected,
     onKeyDown,
 }) => {
-    const [years, selected] = useYears({ date: currentDate, value, startYear, eventList, disabledList, min, max });
+    const minDate = min ? new Date(min.getFullYear(), 0, 1) : undefined;
+    const maxDate = max ? new Date(max.getFullYear(), 11, 31) : undefined;
+
+    const [years, selected] = useYears({
+        date: currentDate,
+        value,
+        startYear,
+        eventList,
+        disabledList,
+        min: minDate,
+        max: maxDate,
+    });
     const selectedRef = useRef(selected);
     const onSetSelectedRef = useRef(onSetSelected);
 

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/Calendar.stories.tsx
@@ -100,11 +100,11 @@ const StoryDefault = (args: CalendarProps) => {
             isDouble={isDouble}
             date={date}
             value={(isRange ? valueRange : value) as Date & [Date, Date?]}
-            min={min}
-            max={max}
             includeEdgeDates={includeEdgeDates}
             locale={locale}
             onChangeValue={(isRange ? handleOnRangeChange : handleOnChange) as (value: Date | [Date, Date?]) => void}
+            min={min}
+            max={max}
         />
     );
 };
@@ -146,24 +146,24 @@ const StoryBase = (args: CalendarBaseProps & { displayDouble: boolean }) => {
             <CalendarDouble
                 size={size}
                 value={value}
-                min={min}
-                max={max}
                 includeEdgeDates={includeEdgeDates}
                 type={type}
                 locale={locale}
                 onChangeValue={handleOnChange}
+                min={min}
+                max={max}
                 {...rest}
             />
         ) : (
             <CalendarBase
                 size={size}
                 value={value}
-                min={min}
-                max={max}
                 includeEdgeDates={includeEdgeDates}
                 type={type}
                 locale={locale}
                 onChangeValue={handleOnChange}
+                min={min}
+                max={max}
                 {...rest}
             />
         );
@@ -233,24 +233,24 @@ const StoryRange = (args: CalendarBaseRangeProps & { displayDouble: boolean }) =
             <CalendarBaseRange
                 size={size}
                 value={values}
-                min={min}
-                max={max}
                 includeEdgeDates={includeEdgeDates}
                 type={type}
                 onChangeValue={handleOnChange}
                 locale={locale}
+                min={min}
+                max={max}
                 {...rest}
             />
         ) : (
             <CalendarDoubleRange
                 size={size}
                 value={values}
-                min={min}
-                max={max}
                 includeEdgeDates={includeEdgeDates}
                 type={type}
                 onChangeValue={handleOnChange}
                 locale={locale}
+                min={min}
+                max={max}
                 {...rest}
             />
         );

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
@@ -80,6 +80,8 @@ const StoryDefault = ({
     size,
     lang,
     format,
+    min,
+    max,
     ...rest
 }: StoryPropsDefault) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -103,6 +105,8 @@ const StoryDefault = ({
             lang={lang}
             format={format}
             onCommitDate={() => setIsOpen(false)}
+            min={min}
+            max={max}
             {...rest}
         />
     );
@@ -188,6 +192,8 @@ const StoryRange = ({
     secondValueSuccess,
     size,
     lang,
+    min,
+    max,
     ...rest
 }: StoryPropsRange) => {
     const rangeRef = useRef<RangeInputRefs>(null);
@@ -240,6 +246,8 @@ const StoryRange = ({
                 onChangeSecondValue(e, currentValue);
             }}
             lang={lang}
+            min={min}
+            max={max}
             {...dividerIconProps}
             {...rest}
         />
@@ -306,6 +314,8 @@ const StoryDeferred = ({
     valueError,
     valueSuccess,
     size,
+    min,
+    max,
     ...rest
 }: StoryPropsDefault) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -338,6 +348,8 @@ const StoryDeferred = ({
                     onChangeValue(e, currentValue);
                 }}
                 onCommitDate={() => setIsOpen(false)}
+                min={min}
+                max={max}
                 {...rest}
             />
         </>

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/Calendar.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/Calendar.stories.tsx
@@ -100,11 +100,11 @@ const StoryDefault = (args: CalendarProps) => {
             isDouble={isDouble}
             date={date}
             value={(isRange ? valueRange : value) as Date & [Date, Date?]}
-            min={min}
-            max={max}
             includeEdgeDates={includeEdgeDates}
             locale={locale}
             onChangeValue={(isRange ? handleOnRangeChange : handleOnChange) as (value: Date | [Date, Date?]) => void}
+            min={min}
+            max={max}
         />
     );
 };
@@ -146,24 +146,24 @@ const StoryBase = (args: CalendarBaseProps & { displayDouble: boolean }) => {
             <CalendarDouble
                 size={size}
                 value={value}
-                min={min}
-                max={max}
                 includeEdgeDates={includeEdgeDates}
                 type={type}
                 locale={locale}
                 onChangeValue={handleOnChange}
+                min={min}
+                max={max}
                 {...rest}
             />
         ) : (
             <CalendarBase
                 size={size}
                 value={value}
-                min={min}
-                max={max}
                 includeEdgeDates={includeEdgeDates}
                 type={type}
                 locale={locale}
                 onChangeValue={handleOnChange}
+                min={min}
+                max={max}
                 {...rest}
             />
         );
@@ -233,24 +233,24 @@ const StoryRange = (args: CalendarBaseRangeProps & { displayDouble: boolean }) =
             <CalendarBaseRange
                 size={size}
                 value={values}
-                min={min}
-                max={max}
                 includeEdgeDates={includeEdgeDates}
                 type={type}
                 onChangeValue={handleOnChange}
                 locale={locale}
+                min={min}
+                max={max}
                 {...rest}
             />
         ) : (
             <CalendarDoubleRange
                 size={size}
                 value={values}
-                min={min}
-                max={max}
                 includeEdgeDates={includeEdgeDates}
                 type={type}
                 onChangeValue={handleOnChange}
                 locale={locale}
+                min={min}
+                max={max}
                 {...rest}
             />
         );

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/DatePicker/DatePicker.stories.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps, useEffect, useRef, useState } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { IconPlaceholder } from '@salutejs/plasma-sb-utils';
+import { disableProps, IconPlaceholder } from '@salutejs/plasma-sb-utils';
 
 import { WithTheme } from '../../../_helpers';
 import { IconButton } from '../IconButton/IconButton';
@@ -80,6 +80,8 @@ const StoryDefault = ({
     size,
     lang,
     format,
+    min,
+    max,
     ...rest
 }: StoryPropsDefault) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -103,6 +105,8 @@ const StoryDefault = ({
             lang={lang}
             format={format}
             onCommitDate={() => setIsOpen(false)}
+            min={min}
+            max={max}
             {...rest}
         />
     );
@@ -188,6 +192,8 @@ const StoryRange = ({
     secondValueSuccess,
     size,
     lang,
+    min,
+    max,
     ...rest
 }: StoryPropsRange) => {
     const rangeRef = useRef<RangeInputRefs>(null);
@@ -240,6 +246,8 @@ const StoryRange = ({
                 onChangeSecondValue(e, currentValue);
             }}
             lang={lang}
+            min={min}
+            max={max}
             {...dividerIconProps}
             {...rest}
         />
@@ -306,6 +314,8 @@ const StoryDeferred = ({
     valueError,
     valueSuccess,
     size,
+    min,
+    max,
     ...rest
 }: StoryPropsDefault) => {
     const [isOpen, setIsOpen] = useState(false);
@@ -338,6 +348,8 @@ const StoryDeferred = ({
                     onChangeValue(e, currentValue);
                 }}
                 onCommitDate={() => setIsOpen(false)}
+                min={min}
+                max={max}
                 {...rest}
             />
         </>


### PR DESCRIPTION
## Core

### Calendar, DatePicker

- исправлена логика отрисовки календарных сеток "месяц", "квартал", "год" для минимальной и максимальной дат

**Before**:

https://github.com/user-attachments/assets/18943dab-5a6d-4e0f-945b-2aef7c815b23

**After**:

https://github.com/user-attachments/assets/1725f4c3-3db7-469a-b0d6-c1f5e275623f

### What/why changed

При отрисовке сеток использовалась точная минимальная и максимальная дата. Месяц имеет значения 01/{номер месяца}/{год}. Минимальная дата у которой день указан больше 01 приводила к тому, что на сетке месяцев, нужный месяц был в состоянии disabled. Аналогично и для сеток квартал/год.
Теперь в минимальной дате учитывается часть, соответствующая структуре даты. Например для минимальной даты 13.04.2024 в сетке месяцев будет учтен месяц и год. День будет установлен как 01, чтобы 04 месяц (апрель) можно было выбрать.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.282.0-canary.1757.13385858717.0
  npm install @salutejs/plasma-b2c@1.524.0-canary.1757.13385858717.0
  npm install @salutejs/plasma-giga@0.251.0-canary.1757.13385858717.0
  npm install @salutejs/plasma-new-hope@0.270.0-canary.1757.13385858717.0
  npm install @salutejs/plasma-web@1.526.0-canary.1757.13385858717.0
  npm install @salutejs/sdds-cs@0.259.0-canary.1757.13385858717.0
  npm install @salutejs/sdds-dfa@0.254.0-canary.1757.13385858717.0
  npm install @salutejs/sdds-finportal@0.247.0-canary.1757.13385858717.0
  npm install @salutejs/sdds-insol@0.249.0-canary.1757.13385858717.0
  npm install @salutejs/sdds-serv@0.255.0-canary.1757.13385858717.0
  # or 
  yarn add @salutejs/plasma-asdk@0.282.0-canary.1757.13385858717.0
  yarn add @salutejs/plasma-b2c@1.524.0-canary.1757.13385858717.0
  yarn add @salutejs/plasma-giga@0.251.0-canary.1757.13385858717.0
  yarn add @salutejs/plasma-new-hope@0.270.0-canary.1757.13385858717.0
  yarn add @salutejs/plasma-web@1.526.0-canary.1757.13385858717.0
  yarn add @salutejs/sdds-cs@0.259.0-canary.1757.13385858717.0
  yarn add @salutejs/sdds-dfa@0.254.0-canary.1757.13385858717.0
  yarn add @salutejs/sdds-finportal@0.247.0-canary.1757.13385858717.0
  yarn add @salutejs/sdds-insol@0.249.0-canary.1757.13385858717.0
  yarn add @salutejs/sdds-serv@0.255.0-canary.1757.13385858717.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
