### PR TITLE
PLASMA-4098: Accordion Header Tag

### DIFF
--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.styles.ts
@@ -4,7 +4,7 @@ import { IconChevronDownFill, IconMinus } from '../../../_Icon';
 import { classes, tokens } from '../../Accordion.tokens';
 import { addFocus } from '../../../../mixins';
 
-export const StyledAccordionHeader = styled.button`
+export const StyledAccordionHeader = styled.div`
     width: 100%;
     border: none;
     padding: var(${tokens.accordionItemPadding});

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
@@ -106,6 +106,11 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
             >
                 <StyledAccordionHeader
                     role="tab"
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                            handleOpen();
+                        }
+                    }}
                     tabIndex={0}
                     onClick={handleOpen}
                     aria-expanded={opened ?? value}


### PR DESCRIPTION
## Core

### Accordion

- Изменен тег в AccrodionItem с `button` на `div`

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.273.1-canary.1758.13229702930.0
  npm install @salutejs/plasma-b2c@1.515.1-canary.1758.13229702930.0
  npm install @salutejs/plasma-giga@0.242.1-canary.1758.13229702930.0
  npm install @salutejs/plasma-new-hope@0.261.1-canary.1758.13229702930.0
  npm install @salutejs/plasma-web@1.517.1-canary.1758.13229702930.0
  npm install @salutejs/sdds-cs@0.250.1-canary.1758.13229702930.0
  npm install @salutejs/sdds-dfa@0.245.1-canary.1758.13229702930.0
  npm install @salutejs/sdds-finportal@0.238.1-canary.1758.13229702930.0
  npm install @salutejs/sdds-insol@0.239.1-canary.1758.13229702930.0
  npm install @salutejs/sdds-serv@0.246.1-canary.1758.13229702930.0
  # or 
  yarn add @salutejs/plasma-asdk@0.273.1-canary.1758.13229702930.0
  yarn add @salutejs/plasma-b2c@1.515.1-canary.1758.13229702930.0
  yarn add @salutejs/plasma-giga@0.242.1-canary.1758.13229702930.0
  yarn add @salutejs/plasma-new-hope@0.261.1-canary.1758.13229702930.0
  yarn add @salutejs/plasma-web@1.517.1-canary.1758.13229702930.0
  yarn add @salutejs/sdds-cs@0.250.1-canary.1758.13229702930.0
  yarn add @salutejs/sdds-dfa@0.245.1-canary.1758.13229702930.0
  yarn add @salutejs/sdds-finportal@0.238.1-canary.1758.13229702930.0
  yarn add @salutejs/sdds-insol@0.239.1-canary.1758.13229702930.0
  yarn add @salutejs/sdds-serv@0.246.1-canary.1758.13229702930.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
