### PR TITLE
PLASMA-4172: virtual prop in Combobox

### DIFF
--- a/packages/plasma-new-hope/package-lock.json
+++ b/packages/plasma-new-hope/package-lock.json
@@ -24,6 +24,7 @@
         "lodash.chunk": "4.2.0",
         "lodash.throttle": "4.1.1",
         "rc-tree": "5.11.0",
+        "rc-virtual-list": "3.18.1",
         "react-draggable": "4.4.3",
         "react-popper": "2.3.0",
         "storeon": "3.1.5"
@@ -12772,9 +12773,9 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.15.0.tgz",
-      "integrity": "sha512-dF2YQztqrU3ijAeWOqscTshCEr7vpimzSqAVjO1AyAmaqcHulaXpnGR0ptK5PXfxTUy48VkJOiglMIxlkYGs0w==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.18.1.tgz",
+      "integrity": "sha512-ARSsD/dey/I4yNQHFYYUaKLUkD1wnD4lRZIvb3rCLMbTMmoFQJRVrWuSfbNt5P5MzMNooEBDvqrUPM4QN7BMNA==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "classnames": "^2.2.6",
@@ -24085,9 +24086,9 @@
       }
     },
     "rc-virtual-list": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.15.0.tgz",
-      "integrity": "sha512-dF2YQztqrU3ijAeWOqscTshCEr7vpimzSqAVjO1AyAmaqcHulaXpnGR0ptK5PXfxTUy48VkJOiglMIxlkYGs0w==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.18.1.tgz",
+      "integrity": "sha512-ARSsD/dey/I4yNQHFYYUaKLUkD1wnD4lRZIvb3rCLMbTMmoFQJRVrWuSfbNt5P5MzMNooEBDvqrUPM4QN7BMNA==",
       "requires": {
         "@babel/runtime": "^7.20.0",
         "classnames": "^2.2.6",

--- a/packages/plasma-new-hope/package.json
+++ b/packages/plasma-new-hope/package.json
@@ -124,6 +124,7 @@
     "lodash.chunk": "4.2.0",
     "lodash.throttle": "4.1.1",
     "rc-tree": "5.11.0",
+    "rc-virtual-list": "3.18.1",
     "react-draggable": "4.4.3",
     "react-popper": "2.3.0",
     "storeon": "3.1.5"

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
@@ -19,7 +19,7 @@ import {
     getItemId,
     getInitialValue,
 } from './utils';
-import { Inner, StyledTextField } from './ui';
+import { Inner, StyledTextField, VirtualList } from './ui';
 import { pathReducer, focusedPathReducer } from './reducers';
 import { getPathMap, getTreeMaps } from './hooks/getPathMaps';
 import { Ul, base, StyledArrow, IconArrowWrapper, StyledEmptyState } from './Combobox.styles';
@@ -71,6 +71,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             zIndex,
             beforeList,
             afterList,
+            virtual = false,
             hintView,
             hintSize,
             ...rest
@@ -478,29 +479,33 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
                                     listWidth={listWidth}
                                     ref={targetRef}
                                 >
-                                    {beforeList}
-
-                                    {isEmpty(filteredItems) ? (
-                                        <StyledEmptyState
-                                            className={classes.emptyStateWrapper}
-                                            size={size}
-                                            description="Ничего не найдено"
-                                        />
+                                    {virtual ? (
+                                        <VirtualList items={filteredItems} listHeight={listHeight} />
                                     ) : (
-                                        filteredItems.map((item, index) => (
-                                            <Inner
-                                                key={`${index}/0`}
-                                                item={item}
-                                                currentLevel={0}
-                                                path={path}
-                                                dispatchPath={dispatchPath}
-                                                index={index}
-                                                listWidth={listWidth}
-                                            />
-                                        ))
+                                        <>
+                                            {beforeList}
+                                            {isEmpty(filteredItems) ? (
+                                                <StyledEmptyState
+                                                    className={classes.emptyStateWrapper}
+                                                    size={size}
+                                                    description="Ничего не найдено"
+                                                />
+                                            ) : (
+                                                filteredItems.map((item, index) => (
+                                                    <Inner
+                                                        key={`${index}/0`}
+                                                        item={item}
+                                                        currentLevel={0}
+                                                        path={path}
+                                                        dispatchPath={dispatchPath}
+                                                        index={index}
+                                                        listWidth={listWidth}
+                                                    />
+                                                ))
+                                            )}
+                                            {afterList}
+                                        </>
                                     )}
-
-                                    {afterList}
                                 </Ul>
                             </Root>
                         </FloatingPopover>

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
@@ -209,6 +209,12 @@ type BasicProps<T extends ItemOption = ItemOption> = {
      */
     afterList?: React.ReactNode;
     /**
+     * Виртуализация в выпадающем списке.
+     * Не поддерживается в многоуровневых списках.
+     * @default false
+     */
+    virtual?: boolean;
+    /**
      * Размер компонента.
      */
     size?: string;

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/VirtualList/VirtualList.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/VirtualList/VirtualList.tsx
@@ -1,0 +1,30 @@
+import React, { CSSProperties } from 'react';
+import List from 'rc-virtual-list';
+
+import type { ItemOptionTransformed } from '../Inner/ui/Item/Item.types';
+import { Item } from '../Inner/ui';
+
+const getHeight = (listHeight?: CSSProperties['height']) => {
+    if (!listHeight) return 300;
+
+    if (typeof listHeight === 'number') return listHeight;
+
+    return parseInt(listHeight, 10);
+};
+
+interface Props {
+    items: ItemOptionTransformed[];
+    listHeight?: CSSProperties['height'];
+}
+
+export const VirtualList: React.FC<Props> = ({ items, listHeight }) => {
+    return (
+        <List data={items} height={getHeight(listHeight)} itemHeight={100} itemKey="id">
+            {(item, index, props) => (
+                <div {...props}>
+                    <Item item={item} path={['root']} currentLevel={0} index={index} ariaLevel={1} />
+                </div>
+            )}
+        </List>
+    );
+};

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/index.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/index.ts
@@ -1,2 +1,3 @@
 export * from './Inner/Inner';
 export * from './Target/Target';
+export * from './VirtualList/VirtualList';

--- a/website/plasma-b2c-docs/docs/components/Combobox.mdx
+++ b/website/plasma-b2c-docs/docs/components/Combobox.mdx
@@ -345,6 +345,34 @@ type Items = Array<{
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listHeight`.
+        Работает только в одноуровневых списках.
+
+       ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/plasma-b2c';
+
+        export function App() {
+            const items = Array(5000).fill(1).map((_, i) => ({ value: i.toString(), label: i.toString() }));
+
+            return (
+                <div style={{ height: "300px" }}>
+                    <div style={{width: "300px" }}>
+                        <Combobox
+                            items={items}
+                            virtual
+                            listHeight="200px"
+                            placeholder="Placeholder"
+                            label="Label"
+                            helperText="Helper text"
+                        />
+                    </div>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/plasma-giga-docs/docs/components/Combobox.mdx
+++ b/website/plasma-giga-docs/docs/components/Combobox.mdx
@@ -345,6 +345,34 @@ type Items = Array<{
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listHeight`.
+        Работает только в одноуровневых списках.
+
+       ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/plasma-giga';
+
+        export function App() {
+            const items = Array(5000).fill(1).map((_, i) => ({ value: i.toString(), label: i.toString() }));
+
+            return (
+                <div style={{ height: "300px" }}>
+                    <div style={{width: "300px" }}>
+                        <Combobox
+                            items={items}
+                            virtual
+                            listHeight="200px"
+                            placeholder="Placeholder"
+                            label="Label"
+                            helperText="Helper text"
+                        />
+                    </div>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/plasma-web-docs/docs/components/Combobox.mdx
+++ b/website/plasma-web-docs/docs/components/Combobox.mdx
@@ -345,6 +345,34 @@ type Items = Array<{
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listHeight`.
+        Работает только в одноуровневых списках.
+
+       ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/plasma-web';
+
+        export function App() {
+            const items = Array(5000).fill(1).map((_, i) => ({ value: i.toString(), label: i.toString() }));
+
+            return (
+                <div style={{ height: "300px" }}>
+                    <div style={{width: "300px" }}>
+                        <Combobox
+                            items={items}
+                            virtual
+                            listHeight="200px"
+                            placeholder="Placeholder"
+                            label="Label"
+                            helperText="Helper text"
+                        />
+                    </div>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/sdds-cs-docs/docs/components/Combobox.mdx
+++ b/website/sdds-cs-docs/docs/components/Combobox.mdx
@@ -345,6 +345,34 @@ type Items = Array<{
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listHeight`.
+        Работает только в одноуровневых списках.
+
+       ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/sdds-cs';
+
+        export function App() {
+            const items = Array(5000).fill(1).map((_, i) => ({ value: i.toString(), label: i.toString() }));
+
+            return (
+                <div style={{ height: "300px" }}>
+                    <div style={{width: "300px" }}>
+                        <Combobox
+                            items={items}
+                            virtual
+                            listHeight="200px"
+                            placeholder="Placeholder"
+                            label="Label"
+                            helperText="Helper text"
+                        />
+                    </div>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/sdds-dfa-docs/docs/components/Combobox.mdx
+++ b/website/sdds-dfa-docs/docs/components/Combobox.mdx
@@ -345,6 +345,34 @@ type Items = Array<{
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listHeight`.
+        Работает только в одноуровневых списках.
+
+       ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/sdds-dfa';
+
+        export function App() {
+            const items = Array(5000).fill(1).map((_, i) => ({ value: i.toString(), label: i.toString() }));
+
+            return (
+                <div style={{ height: "300px" }}>
+                    <div style={{width: "300px" }}>
+                        <Combobox
+                            items={items}
+                            virtual
+                            listHeight="200px"
+                            placeholder="Placeholder"
+                            label="Label"
+                            helperText="Helper text"
+                        />
+                    </div>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/sdds-insol-docs/docs/components/Combobox.mdx
+++ b/website/sdds-insol-docs/docs/components/Combobox.mdx
@@ -345,6 +345,34 @@ type Items = Array<{
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listHeight`.
+        Работает только в одноуровневых списках.
+
+       ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/sdds-insol';
+
+        export function App() {
+            const items = Array(5000).fill(1).map((_, i) => ({ value: i.toString(), label: i.toString() }));
+
+            return (
+                <div style={{ height: "300px" }}>
+                    <div style={{width: "300px" }}>
+                        <Combobox
+                            items={items}
+                            virtual
+                            listHeight="200px"
+                            placeholder="Placeholder"
+                            label="Label"
+                            helperText="Helper text"
+                        />
+                    </div>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/sdds-serv-docs/docs/components/Combobox.mdx
+++ b/website/sdds-serv-docs/docs/components/Combobox.mdx
@@ -345,6 +345,34 @@ type Items = Array<{
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listHeight`.
+        Работает только в одноуровневых списках.
+
+       ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/sdds-serv';
+
+        export function App() {
+            const items = Array(5000).fill(1).map((_, i) => ({ value: i.toString(), label: i.toString() }));
+
+            return (
+                <div style={{ height: "300px" }}>
+                    <div style={{width: "300px" }}>
+                        <Combobox
+                            items={items}
+                            virtual
+                            listHeight="200px"
+                            placeholder="Placeholder"
+                            label="Label"
+                            helperText="Helper text"
+                        />
+                    </div>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация


### PR DESCRIPTION
## Core

### Combobox

- добавлена опциональная виртуализация в выпадащий список;

### What/why changed
Пропс `virtual` для виртуализации выпадающего списка.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.274.0-canary.1761.13279424878.0
  npm install @salutejs/plasma-b2c@1.516.0-canary.1761.13279424878.0
  npm install @salutejs/plasma-giga@0.243.0-canary.1761.13279424878.0
  npm install @salutejs/plasma-new-hope@0.262.0-canary.1761.13279424878.0
  npm install @salutejs/plasma-web@1.518.0-canary.1761.13279424878.0
  npm install @salutejs/sdds-cs@0.251.0-canary.1761.13279424878.0
  npm install @salutejs/sdds-dfa@0.246.0-canary.1761.13279424878.0
  npm install @salutejs/sdds-finportal@0.239.0-canary.1761.13279424878.0
  npm install @salutejs/sdds-insol@0.240.0-canary.1761.13279424878.0
  npm install @salutejs/sdds-serv@0.247.0-canary.1761.13279424878.0
  # or 
  yarn add @salutejs/plasma-asdk@0.274.0-canary.1761.13279424878.0
  yarn add @salutejs/plasma-b2c@1.516.0-canary.1761.13279424878.0
  yarn add @salutejs/plasma-giga@0.243.0-canary.1761.13279424878.0
  yarn add @salutejs/plasma-new-hope@0.262.0-canary.1761.13279424878.0
  yarn add @salutejs/plasma-web@1.518.0-canary.1761.13279424878.0
  yarn add @salutejs/sdds-cs@0.251.0-canary.1761.13279424878.0
  yarn add @salutejs/sdds-dfa@0.246.0-canary.1761.13279424878.0
  yarn add @salutejs/sdds-finportal@0.239.0-canary.1761.13279424878.0
  yarn add @salutejs/sdds-insol@0.240.0-canary.1761.13279424878.0
  yarn add @salutejs/sdds-serv@0.247.0-canary.1761.13279424878.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
