### PR TITLE
PLAMSA-4394: update close-icon in embedded chips

### DIFF
--- a/packages/sdds-insol/src/components/Combobox/Combobox.config.ts
+++ b/packages/sdds-insol/src/components/Combobox/Combobox.config.ts
@@ -275,7 +275,7 @@ export const config = {
                 ${tokens.textFieldChipPadding}: 0 0.75rem 0 1rem;
                 ${tokens.textFieldChipClearContentMarginLeft}: 0.625rem;
                 ${tokens.textFieldChipClearContentMarginRight}: 0rem;
-                ${tokens.textFieldChipCloseIconSize}: 1.5rem;
+                ${tokens.textFieldChipCloseIconSize}: 1.25rem;
                 ${tokens.textFieldChipFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${tokens.textFieldChipFontSize}: var(--plasma-typo-body-s-font-size);
                 ${tokens.textFieldChipFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -398,7 +398,7 @@ export const config = {
                 ${tokens.textFieldChipPadding}: 0 0.625rem 0 0.875rem;
                 ${tokens.textFieldChipClearContentMarginLeft}: 0.5rem;
                 ${tokens.textFieldChipClearContentMarginRight}: 0rem;
-                ${tokens.textFieldChipCloseIconSize}: 1.25rem;
+                ${tokens.textFieldChipCloseIconSize}: 1rem;
                 ${tokens.textFieldChipFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${tokens.textFieldChipFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${tokens.textFieldChipFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/sdds-insol/src/components/Select/Select.config.ts
+++ b/packages/sdds-insol/src/components/Select/Select.config.ts
@@ -342,7 +342,7 @@ export const config = {
                 ${tokens.textFieldChipPadding}: 0 0.75rem 0 1rem;
                 ${tokens.textFieldChipClearContentMarginLeft}: 0.625rem;
                 ${tokens.textFieldChipClearContentMarginRight}: 0rem;
-                ${tokens.textFieldChipCloseIconSize}: 1.5rem;
+                ${tokens.textFieldChipCloseIconSize}: 1.25rem;
                 ${tokens.textFieldChipFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${tokens.textFieldChipFontSize}: var(--plasma-typo-body-s-font-size);
                 ${tokens.textFieldChipFontStyle}: var(--plasma-typo-body-s-font-style);
@@ -468,7 +468,7 @@ export const config = {
                 ${tokens.textFieldChipPadding}: 0 0.625rem 0 0.875rem;
                 ${tokens.textFieldChipClearContentMarginLeft}: 0.5rem;
                 ${tokens.textFieldChipClearContentMarginRight}: 0rem;
-                ${tokens.textFieldChipCloseIconSize}: 1.25rem;
+                ${tokens.textFieldChipCloseIconSize}: 1rem;
                 ${tokens.textFieldChipFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${tokens.textFieldChipFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${tokens.textFieldChipFontStyle}: var(--plasma-typo-body-xs-font-style);

--- a/packages/sdds-insol/src/components/TextField/TextField.config.ts
+++ b/packages/sdds-insol/src/components/TextField/TextField.config.ts
@@ -285,7 +285,7 @@ export const config = {
                 ${tokens.chipPadding}: 0 0.75rem 0 1rem;
                 ${tokens.chipClearContentMarginLeft}: 0.625rem;
                 ${tokens.chipClearContentMarginRight}: 0rem;
-                ${tokens.chipCloseIconSize}: 1.5rem;
+                ${tokens.chipCloseIconSize}: 1.25rem;
                 ${tokens.chipFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${tokens.chipFontSize}: var(--plasma-typo-body-s-font-size);
                 ${tokens.chipFontStyle}: var(--plasma-typo-body-s-font-style);


### PR DESCRIPTION
## SDDS-INSOL

### TextField, Combobox, Select

- исправлен размер иконки закрытия в чипах

### What/why changed

Исправлен размер иконки закрытия в чипах
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-insol@0.247.0-canary.1765.13373688080.0
  # or 
  yarn add @salutejs/sdds-insol@0.247.0-canary.1765.13373688080.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
