### PR TITLE
PLASMA-4312: исправить выбор disabled эл-ов при multiselect

### DIFF
--- a/packages/plasma-b2c/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Combobox/Combobox.component-test.tsx
@@ -1241,6 +1241,50 @@ describe('plasma-b2c: Combobox', () => {
         cy.matchImageSnapshot();
     });
 
+    it('disabled item behavior', () => {
+        const items = [
+            {
+                value: 'brazil',
+                label: 'Бразилия',
+                items: [
+                    {
+                        value: 'rio_de_janeiro',
+                        label: 'Рио-де-Жанейро',
+                        disabled: true,
+                    },
+                    {
+                        value: 'sao_paulo',
+                        label: 'Сан-Паулу',
+                    },
+                ],
+            },
+        ];
+
+        const Component = () => (
+            <CypressTestDecoratorWithTypo>
+                <div style={{ width: '300px' }}>
+                    <Combobox id="multiple" multiple label="Список стран" items={items} />
+                </div>
+            </CypressTestDecoratorWithTypo>
+        );
+
+        mount(<Component />);
+
+        cy.get('#multiple').click();
+        cy.get('[id$="brazil"]').click();
+        cy.get('[id$="brazil"] .checkbox-trigger').click();
+
+        cy.get('[id$="rio_de_janeiro"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="brazil"]').should('have.attr', 'aria-selected', 'true');
+        cy.get('[id$="sao_paulo"]').should('have.attr', 'aria-selected', 'true');
+
+        cy.get('[id$="brazil"] .checkbox-trigger').click();
+
+        cy.get('[id$="rio_de_janeiro"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="brazil"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="sao_paulo"]').should('have.attr', 'aria-selected', 'false');
+    });
+
     it('flow: single uncontrolled', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-b2c/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Select/Select.component-test.tsx
@@ -916,6 +916,50 @@ describe('plasma-b2c: Select', () => {
         cy.matchImageSnapshot();
     });
 
+    it('disabled item behavior', () => {
+        const items = [
+            {
+                value: 'brazil',
+                label: 'Бразилия',
+                items: [
+                    {
+                        value: 'rio_de_janeiro',
+                        label: 'Рио-де-Жанейро',
+                        disabled: true,
+                    },
+                    {
+                        value: 'sao_paulo',
+                        label: 'Сан-Паулу',
+                    },
+                ],
+            },
+        ];
+
+        const Component = () => (
+            <CypressTestDecoratorWithTypo>
+                <div style={{ width: '300px' }}>
+                    <Select id="multiple" multiselect label="Список стран" items={items} />
+                </div>
+            </CypressTestDecoratorWithTypo>
+        );
+
+        mount(<Component />);
+
+        cy.get('#multiple').click();
+        cy.get('[id$="brazil"]').click();
+        cy.get('[id$="brazil"] .checkbox-trigger').click();
+
+        cy.get('[id$="rio_de_janeiro"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="brazil"]').should('have.attr', 'aria-selected', 'true');
+        cy.get('[id$="sao_paulo"]').should('have.attr', 'aria-selected', 'true');
+
+        cy.get('[id$="brazil"] .checkbox-trigger').click();
+
+        cy.get('[id$="rio_de_janeiro"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="brazil"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="sao_paulo"]').should('have.attr', 'aria-selected', 'false');
+    });
+
     it('keyboard interactions', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
@@ -229,7 +229,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
 
             if (!checkedCopy.get(item.value)) {
                 checkedCopy.set(item.value, true);
-                updateDescendants(item, checkedCopy, true);
+                updateDescendants(item, checkedCopy, true, valueToItemMap);
             } else {
                 checkedCopy.set(item.value, false);
                 updateDescendants(item, checkedCopy, false);

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/Inner/ui/Item/Item.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/ui/Inner/ui/Item/Item.tsx
@@ -101,6 +101,7 @@ export const Item: FC<ItemProps> = ({
                 {multiple && (
                     <StyledCheckboxWrapper onClick={(e) => e.stopPropagation()}>
                         <StyledCheckbox
+                            disabled={disabled}
                             checked={Boolean(checked.get(item.value))}
                             indeterminate={checked.get(item.value) === 'indeterminate'}
                             onChange={handleChange}

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/utils/updateDescendants.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/utils/updateDescendants.ts
@@ -1,20 +1,23 @@
 import type { ItemOptionTransformed } from '../ui/Inner/ui/Item/Item.types';
-import type { ValueToCheckedMapType } from '../hooks/getPathMaps';
+import type { ValueToCheckedMapType, ValueToItemMapType } from '../hooks/getPathMaps';
 
 export const updateDescendants = (
     node: ItemOptionTransformed,
     checkedMap: ValueToCheckedMapType,
     isChecked: boolean,
+    valueToItemMap?: ValueToItemMapType,
 ) => {
     if (!node?.items) {
         return;
     }
 
     node.items.forEach((item) => {
-        checkedMap.set(item.value, isChecked);
+        if (!valueToItemMap?.get(item.value)?.disabled) {
+            checkedMap.set(item.value, isChecked);
+        }
 
         if (item.items) {
-            updateDescendants(item, checkedMap, isChecked);
+            updateDescendants(item, checkedMap, isChecked, valueToItemMap);
         }
     });
 };

--- a/packages/plasma-new-hope/src/components/Select/Select.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.tsx
@@ -181,7 +181,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
 
             if (!checkedCopy.get(item.value)) {
                 checkedCopy.set(item.value, true);
-                updateDescendants(item, checkedCopy, true);
+                updateDescendants(item, checkedCopy, true, valueToItemMap);
             } else {
                 checkedCopy.set(item.value, false);
                 updateDescendants(item, checkedCopy, false);

--- a/packages/plasma-new-hope/src/components/Select/ui/Inner/ui/Item/Item.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Inner/ui/Item/Item.tsx
@@ -102,6 +102,7 @@ export const Item: FC<ItemProps> = ({
                 {multiselect && (
                     <StyledCheckboxWrapper onClick={(e) => e.stopPropagation()}>
                         <StyledCheckbox
+                            disabled={itemDisabled}
                             checked={Boolean(checked.get(item.value))}
                             indeterminate={checked.get(item.value) === 'indeterminate'}
                             onChange={handleChange}

--- a/packages/plasma-new-hope/src/components/Select/utils/updateDescendants.ts
+++ b/packages/plasma-new-hope/src/components/Select/utils/updateDescendants.ts
@@ -1,20 +1,23 @@
 import type { MergedDropdownNodeTransformed } from '../ui/Inner/ui/Item/Item.types';
-import type { ValueToCheckedMapType } from '../hooks/usePathMaps';
+import type { ValueToCheckedMapType, ValueToItemMapType } from '../hooks/usePathMaps';
 
 export const updateDescendants = (
     node: MergedDropdownNodeTransformed,
     checkedMap: ValueToCheckedMapType,
     isChecked: boolean,
+    valueToItemMap?: ValueToItemMapType,
 ) => {
     if (!node?.items) {
         return;
     }
 
     node.items.forEach((item) => {
-        checkedMap.set(item.value, isChecked);
+        if (!valueToItemMap?.get(item.value)?.disabled) {
+            checkedMap.set(item.value, isChecked);
+        }
 
         if (item.items) {
-            updateDescendants(item, checkedMap, isChecked);
+            updateDescendants(item, checkedMap, isChecked, valueToItemMap);
         }
     });
 };

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Combobox.stories.tsx
@@ -246,6 +246,7 @@ const items = [
                     {
                         value: 'rio_de_janeiro',
                         label: 'Рио-де-Жанейро',
+                        disabled: true,
                     },
                     {
                         value: 'sao_paulo',

--- a/packages/plasma-web/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-web/src/components/Combobox/Combobox.component-test.tsx
@@ -1241,6 +1241,50 @@ describe('plasma-web: Combobox', () => {
         cy.matchImageSnapshot();
     });
 
+    it('disabled item behavior', () => {
+        const items = [
+            {
+                value: 'brazil',
+                label: 'Бразилия',
+                items: [
+                    {
+                        value: 'rio_de_janeiro',
+                        label: 'Рио-де-Жанейро',
+                        disabled: true,
+                    },
+                    {
+                        value: 'sao_paulo',
+                        label: 'Сан-Паулу',
+                    },
+                ],
+            },
+        ];
+
+        const Component = () => (
+            <CypressTestDecoratorWithTypo>
+                <div style={{ width: '300px' }}>
+                    <Combobox id="multiple" multiple label="Список стран" items={items} />
+                </div>
+            </CypressTestDecoratorWithTypo>
+        );
+
+        mount(<Component />);
+
+        cy.get('#multiple').click();
+        cy.get('[id$="brazil"]').click();
+        cy.get('[id$="brazil"] .checkbox-trigger').click();
+
+        cy.get('[id$="rio_de_janeiro"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="brazil"]').should('have.attr', 'aria-selected', 'true');
+        cy.get('[id$="sao_paulo"]').should('have.attr', 'aria-selected', 'true');
+
+        cy.get('[id$="brazil"] .checkbox-trigger').click();
+
+        cy.get('[id$="rio_de_janeiro"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="brazil"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="sao_paulo"]').should('have.attr', 'aria-selected', 'false');
+    });
+
     it('flow: single uncontrolled', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-web/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-web/src/components/Select/Select.component-test.tsx
@@ -916,6 +916,50 @@ describe('plasma-web: Select', () => {
         cy.matchImageSnapshot();
     });
 
+    it('disabled item behavior', () => {
+        const items = [
+            {
+                value: 'brazil',
+                label: 'Бразилия',
+                items: [
+                    {
+                        value: 'rio_de_janeiro',
+                        label: 'Рио-де-Жанейро',
+                        disabled: true,
+                    },
+                    {
+                        value: 'sao_paulo',
+                        label: 'Сан-Паулу',
+                    },
+                ],
+            },
+        ];
+
+        const Component = () => (
+            <CypressTestDecoratorWithTypo>
+                <div style={{ width: '300px' }}>
+                    <Select id="multiple" multiselect label="Список стран" items={items} />
+                </div>
+            </CypressTestDecoratorWithTypo>
+        );
+
+        mount(<Component />);
+
+        cy.get('#multiple').click();
+        cy.get('[id$="brazil"]').click();
+        cy.get('[id$="brazil"] .checkbox-trigger').click();
+
+        cy.get('[id$="rio_de_janeiro"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="brazil"]').should('have.attr', 'aria-selected', 'true');
+        cy.get('[id$="sao_paulo"]').should('have.attr', 'aria-selected', 'true');
+
+        cy.get('[id$="brazil"] .checkbox-trigger').click();
+
+        cy.get('[id$="rio_de_janeiro"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="brazil"]').should('have.attr', 'aria-selected', 'false');
+        cy.get('[id$="sao_paulo"]').should('have.attr', 'aria-selected', 'false');
+    });
+
     it('keyboard interactions', () => {
         cy.viewport(1000, 500);
 


### PR DESCRIPTION
## Core

### Select, Combobox

- исправлен баг, связанный с возможностью выбирать `disabled` item через его родителя;

### What/why changed
- исправлен баг, связанный с возможностью выбирать `disabled` item через его родителя;
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.281.0-canary.1766.13384359206.0
  npm install @salutejs/plasma-b2c@1.523.0-canary.1766.13384359206.0
  npm install @salutejs/plasma-giga@0.250.0-canary.1766.13384359206.0
  npm install @salutejs/plasma-new-hope@0.269.0-canary.1766.13384359206.0
  npm install @salutejs/plasma-web@1.525.0-canary.1766.13384359206.0
  npm install @salutejs/sdds-cs@0.258.0-canary.1766.13384359206.0
  npm install @salutejs/sdds-dfa@0.253.0-canary.1766.13384359206.0
  npm install @salutejs/sdds-finportal@0.246.0-canary.1766.13384359206.0
  npm install @salutejs/sdds-insol@0.248.0-canary.1766.13384359206.0
  npm install @salutejs/sdds-serv@0.254.0-canary.1766.13384359206.0
  # or 
  yarn add @salutejs/plasma-asdk@0.281.0-canary.1766.13384359206.0
  yarn add @salutejs/plasma-b2c@1.523.0-canary.1766.13384359206.0
  yarn add @salutejs/plasma-giga@0.250.0-canary.1766.13384359206.0
  yarn add @salutejs/plasma-new-hope@0.269.0-canary.1766.13384359206.0
  yarn add @salutejs/plasma-web@1.525.0-canary.1766.13384359206.0
  yarn add @salutejs/sdds-cs@0.258.0-canary.1766.13384359206.0
  yarn add @salutejs/sdds-dfa@0.253.0-canary.1766.13384359206.0
  yarn add @salutejs/sdds-finportal@0.246.0-canary.1766.13384359206.0
  yarn add @salutejs/sdds-insol@0.248.0-canary.1766.13384359206.0
  yarn add @salutejs/sdds-serv@0.254.0-canary.1766.13384359206.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
