### PR TITLE
PLASM-4431: feat(plasma-new-hope): Add support `intersections` in component configs

### DIFF
--- a/packages/plasma-new-hope/src/engines/emotion.tsx
+++ b/packages/plasma-new-hope/src/engines/emotion.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { getStaticVariants, getDynamicVariants } from './utils';
+import { getStaticVariants, getDynamicVariants, getIntersectionStyles } from './utils';
 import type { ComponentConfig, HTMLAnyAttributes } from './types';
 
 export { css };
@@ -11,22 +11,35 @@ const Root = styled.div<{
     base: string | SerializedStyles;
     staticVariants: (string | SerializedStyles)[];
     dynamicVariants: (props: HTMLAnyAttributes) => any[];
+    intersectionStyles: string[];
 }>`
     ${({ base }) => base};
     ${({ staticVariants }) => staticVariants};
     ${({ dynamicVariants }) => dynamicVariants};
+    ${({ intersectionStyles }) => intersectionStyles};
 `;
 
 /* eslint-disable no-underscore-dangle */
 export const _component = (componentConfig: ComponentConfig) => {
-    const { tag, base } = componentConfig;
+    const { tag, base, intersections } = componentConfig;
     const staticVariants = getStaticVariants(componentConfig);
     const dynamicVariants = getDynamicVariants(componentConfig);
 
     // TODO: should we type tag as more then string ?
     const R = Root.withComponent(tag as keyof JSX.IntrinsicElements);
 
-    return forwardRef<HTMLElement, HTMLAnyAttributes>((props, ref) => (
-        <R base={base} staticVariants={staticVariants} dynamicVariants={dynamicVariants} {...props} ref={ref} />
-    ));
+    return forwardRef<HTMLElement, HTMLAnyAttributes>((props, ref) => {
+        const intersectionStyles = getIntersectionStyles(props, intersections);
+
+        return (
+            <R
+                base={base}
+                staticVariants={staticVariants}
+                dynamicVariants={dynamicVariants}
+                intersectionStyles={intersectionStyles}
+                {...props}
+                ref={ref}
+            />
+        );
+    });
 };

--- a/packages/plasma-new-hope/src/engines/linaria.tsx
+++ b/packages/plasma-new-hope/src/engines/linaria.tsx
@@ -3,20 +3,23 @@ import { cx } from '@linaria/core';
 
 // TODO: #1008 Избавиться от импортов и переделать addFocus
 import 'focus-visible';
-import { getStaticVariants, getDynamicVariants } from './utils';
+import { getStaticVariants, getDynamicVariants, getIntersectionStyles } from './utils';
 import type { ComponentConfig, HTMLAnyAttributes } from './types';
 
 /* eslint-disable no-underscore-dangle */
 export const _component = (componentConfig: ComponentConfig) => {
-    const { tag, base, name } = componentConfig;
+    const { tag, base, name, intersections } = componentConfig;
     const staticVariants = getStaticVariants(componentConfig);
     const dynamicVariants = getDynamicVariants(componentConfig);
+
     const Root = tag as React.ElementType;
 
     const component = forwardRef<HTMLElement, HTMLAnyAttributes>((props, ref) => {
         const { className, ...rest } = props;
         const variants = dynamicVariants(rest);
-        const cls = cx(className, base as string, ...(staticVariants as string[]), ...variants);
+        const intersectionStyles = getIntersectionStyles(rest, intersections);
+
+        const cls = cx(className, base as string, ...(staticVariants as string[]), ...variants, ...intersectionStyles);
 
         // styled-components do it inside
         // filter props

--- a/packages/plasma-new-hope/src/engines/styled-components.tsx
+++ b/packages/plasma-new-hope/src/engines/styled-components.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 
-import { getStaticVariants, getDynamicVariants } from './utils';
+import { getStaticVariants, getDynamicVariants, getIntersectionStyles } from './utils';
 import type { ComponentConfig, HTMLAnyAttributes } from './types';
 
 export { styled, css };
@@ -10,26 +10,33 @@ const Root = styled.div<{
     base: string;
     staticVariants: string[];
     dynamicVariants: (props: HTMLAnyAttributes) => any[];
+    intersectionStyles: string[];
 }>`
     ${({ base }) => base};
     ${({ staticVariants }) => staticVariants};
     ${({ dynamicVariants }) => dynamicVariants};
+    ${({ intersectionStyles }) => intersectionStyles};
 `;
 
 /* eslint-disable no-underscore-dangle */
 export const _component = (componentConfig: ComponentConfig) => {
-    const { tag, base } = componentConfig;
+    const { tag, base, intersections } = componentConfig;
     const staticVariants = getStaticVariants(componentConfig);
     const dynamicVariants = getDynamicVariants(componentConfig);
 
-    return forwardRef<HTMLElement, HTMLAnyAttributes>((props, ref) => (
-        <Root
-            as={tag}
-            base={base}
-            staticVariants={staticVariants}
-            dynamicVariants={dynamicVariants}
-            {...props}
-            ref={ref}
-        />
-    ));
+    return forwardRef<HTMLElement, HTMLAnyAttributes>((props, ref) => {
+        const intersectionStyles = getIntersectionStyles(props, intersections);
+
+        return (
+            <Root
+                as={tag}
+                base={base}
+                staticVariants={staticVariants}
+                dynamicVariants={dynamicVariants}
+                intersectionStyles={intersectionStyles}
+                {...props}
+                ref={ref}
+            />
+        );
+    });
 };

--- a/packages/plasma-new-hope/src/engines/types.ts
+++ b/packages/plasma-new-hope/src/engines/types.ts
@@ -58,6 +58,10 @@ export type Filter<T extends {} = {}, U extends string = string> = {
     [k in keyof T]: k extends U ? unknown : T[k];
 };
 
+export interface Intersection {
+    style: string;
+}
+
 export interface ComponentConfig<
     Tag extends HTMLTagList = React.ElementType,
     VariantList extends Variants = Variants,
@@ -70,4 +74,5 @@ export interface ComponentConfig<
     base: PolymorphicClassName;
     variations: VariantList;
     defaults: Partial<Record<string, string>>;
+    intersections?: Intersection[];
 }

--- a/packages/plasma-new-hope/src/engines/utils.ts
+++ b/packages/plasma-new-hope/src/engines/utils.ts
@@ -1,4 +1,4 @@
-import type { ComponentConfig, HTMLAnyAttributes } from './types';
+import type { ComponentConfig, HTMLAnyAttributes, Intersection } from './types';
 
 export const getStaticVariants = (config: ComponentConfig) => {
     if (!config.variations) {
@@ -33,4 +33,22 @@ export const getDynamicVariants = (config: ComponentConfig) => {
 
         return res;
     };
+};
+
+export const getIntersectionStyles = (props: Record<string, any>, intersections?: Intersection[]) => {
+    if (!intersections) {
+        return [];
+    }
+
+    return intersections.reduce((styles: string[], item) => {
+        const hasMatchStyle = Object.entries(item)
+            .filter(([key]) => key !== 'style')
+            .every(([key, value]) => props[key] === value);
+
+        if (hasMatchStyle) {
+            styles.push(item.style);
+        }
+
+        return styles;
+    }, []);
 };


### PR DESCRIPTION
## Core

-   Добавлена поддержка пересечения свойств в конфигах компонента

Например:

```ts
...
intersection: [
        {
            shape: 'pilled',
            size: 'm',
            style: css`
                ${iconButtonTokens.iconButtonRadius}: 0.75rem
            `,
        },
        {
            shape: 'pilled',
            size: 's',
            style: css`
                ${iconButtonTokens.iconButtonRadius}: 0.5rem
            `,
        },
        {
            shape: 'pilled',
            size: 'xs',
            style: css`
                ${iconButtonTokens.iconButtonRadius}: 0.25rem
            `,
        },
    ],
...
```


### What/why changed

