### PR TITLE
PLASMA-4482: add xl size for Segment

### DIFF
--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -2859,6 +2859,7 @@ xs: PolymorphicClassName;
 s: PolymorphicClassName;
 m: PolymorphicClassName;
 l: PolymorphicClassName;
+xl: PolymorphicClassName;
 };
 disabled: {
 true: PolymorphicClassName;
@@ -2892,6 +2893,7 @@ xs: PolymorphicClassName;
 s: PolymorphicClassName;
 m: PolymorphicClassName;
 l: PolymorphicClassName;
+xl: PolymorphicClassName;
 };
 disabled: {
 true: PolymorphicClassName;

--- a/packages/sdds-insol/src/components/Segment/Segment.stories.tsx
+++ b/packages/sdds-insol/src/components/Segment/Segment.stories.tsx
@@ -16,7 +16,7 @@ const contentRightOptions = ['none', 'text', 'counter', 'icon'];
 
 const segmentItemViews = ['default', 'secondary', 'accent'];
 type SegmentItemView = typeof segmentItemViews[number];
-const sizes = ['xs', 's', 'm', 'l'] as const;
+const sizes = ['xs', 's', 'm', 'l', 'xl'] as const;
 type Size = typeof sizes[number];
 
 type CustomStoryProps = {

--- a/packages/sdds-insol/src/components/Segment/SegmentGroup.config.ts
+++ b/packages/sdds-insol/src/components/Segment/SegmentGroup.config.ts
@@ -51,6 +51,14 @@ export const config = {
                 ${segmentTokens.groupArrowPadding}: 1rem 1.375rem;
                 ${segmentTokens.groupVerticalArrowPadding}: 1.375rem 0;
             `,
+            xl: css`
+                ${segmentTokens.groupBorderRadius}: 1.125rem;
+                ${segmentTokens.groupPilledBorderRadius}: 1.875rem;
+                ${segmentTokens.groupWidth}: auto;
+                ${segmentTokens.groupHeight}: auto;
+                ${segmentTokens.groupArrowPadding}: 1rem 1.375rem;
+                ${segmentTokens.groupVerticalArrowPadding}: 1.375rem 0;
+            `,
         },
         disabled: {
             true: css`

--- a/packages/sdds-insol/src/components/Segment/SegmentItem.config.ts
+++ b/packages/sdds-insol/src/components/Segment/SegmentItem.config.ts
@@ -145,6 +145,24 @@ export const config = {
                 ${segmentTokens.letterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${segmentTokens.lineHeight}: var(--plasma-typo-body-s-line-height);
             `,
+            xl: css`
+                ${segmentTokens.itemBorderRadius}: 1rem;
+                ${segmentTokens.itemWidth}: auto;
+                ${segmentTokens.itemHeight}: 4rem;
+                ${segmentTokens.itemPadding}: 1.25rem 1.75rem;
+                ${segmentTokens.itemPilledPadding}: 1.25rem;
+                ${segmentTokens.itemContentPadding}: 0.0625rem 0.125rem;
+                ${segmentTokens.itemIconMargin}: 0.375rem;
+                ${segmentTokens.itemMarginLeft}: 0;
+
+                ${segmentTokens.fontFamily}: var(--plasma-typo-body-m-font-family);
+                ${segmentTokens.fontSize}: var(--plasma-typo-body-m-font-size);
+                ${segmentTokens.fontStyle}: var(--plasma-typo-body-m-font-style);
+                ${segmentTokens.fontWeight}: var(--plasma-typo-body-m-font-weight);
+                ${segmentTokens.fontWeightSelectedItem}: var(--plasma-typo-body-m-bold-font-weight);
+                ${segmentTokens.letterSpacing}: var(--plasma-typo-body-m-letter-spacing);
+                ${segmentTokens.lineHeight}: var(--plasma-typo-body-m-line-height);
+            `,
         },
         disabled: {
             true: css`


### PR DESCRIPTION
## SDDS-INSOL

### Segment

-  добавлен размер `XL`

<img width="745" src="https://github.com/user-attachments/assets/93e1f234-b032-4a11-8de0-73c251f3d835" />

### What/why changed

Добавлен размер xl
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-insol@0.251.0-canary.1773.13388619410.0
  # or 
  yarn add @salutejs/sdds-insol@0.251.0-canary.1773.13388619410.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
