### PR TITLE
PLASMA-4484: add accent view for Segment

### DIFF
--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -2883,6 +2883,7 @@ view: {
 clear: PolymorphicClassName;
 secondary: PolymorphicClassName;
 default: PolymorphicClassName;
+accent: PolymorphicClassName;
 };
 size: {
 xs: PolymorphicClassName;

--- a/packages/sdds-insol/src/components/Segment/Segment.stories.tsx
+++ b/packages/sdds-insol/src/components/Segment/Segment.stories.tsx
@@ -4,18 +4,19 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 import { IconMic } from '@salutejs/plasma-icons';
 import styled from 'styled-components';
-import { segmentTokens } from '@salutejs/plasma-new-hope/styled-components';
 
 import { Counter } from '../Counter/Counter';
 
-import { SegmentItem, SegmentGroup } from './Segment';
+import { SegmentItem, SegmentGroup, useSegment } from './Segment';
 
 import { SegmentProvider } from '.';
 
 const contentLeftOptions = ['none', 'icon'];
 const contentRightOptions = ['none', 'text', 'counter', 'icon'];
 
-const segmentItemViews = ['default', 'secondary'];
+const segmentItemViews = ['default', 'secondary', 'accent'];
+type SegmentItemView = typeof segmentItemViews[number];
+const sizes = ['xs', 's', 'm', 'l'] as const;
 type Size = typeof sizes[number];
 
 type CustomStoryProps = {
@@ -26,8 +27,6 @@ type CustomStoryProps = {
 };
 
 type StorySegmentProps = ComponentProps<typeof SegmentGroup> & CustomStoryProps;
-
-const sizes = ['xs', 's', 'm', 'l'] as const;
 
 const getIconSizeProps = (size: string) => {
     switch (size) {
@@ -57,14 +56,25 @@ const getContentLeft = (contentLeftOption: string, size: Size) => {
     ) : undefined;
 };
 
-const getContentRight = (contentRightOption: string, size: Size) => {
+const getContentRight = (
+    contentRightOption: string,
+    size: Size,
+    segmentItemView?: SegmentItemView,
+    isSelected?: boolean,
+) => {
     const counterSize = size === 'xs' ? 'xxs' : 'xs';
 
     switch (contentRightOption) {
         case 'icon':
             return <StyledIconMic customSize={getIconSizeProps(size)} color="inherit" />;
         case 'counter':
-            return <Counter size={counterSize} count={1} view="positive" />;
+            return (
+                <Counter
+                    size={counterSize}
+                    count={1}
+                    view={segmentItemView === 'accent' && isSelected ? 'light' : 'positive'}
+                />
+            );
         case 'text':
             return 'Text';
         default:
@@ -140,33 +150,37 @@ const StoryDefault = (props: StorySegmentProps) => {
     } = props;
     const items = Array(itemQuantity).fill(0);
     const isVertical = orientation === 'vertical';
+    const { selectedSegmentItems } = useSegment();
 
     return (
-        <SegmentProvider>
-            <SegmentGroup
-                stretch={stretch}
-                disabled={disabled}
-                clip={false}
-                size={size}
-                orientation={orientation}
-                {...args}
-            >
-                {items.map((_, i) => (
-                    <SegmentItem
-                        view={segmentItemView}
-                        label={`Label ${i}`}
-                        value={`label_${i}`}
-                        size={size}
-                        key={`label_${i}`}
-                        contentLeft={getContentLeft(contentLeftOption, size)}
-                        contentRight={getContentRight(contentRightOption, size)}
-                        {...args}
-                    >
-                        {`Label${i + 1}`}
-                    </SegmentItem>
-                ))}
-            </SegmentGroup>
-        </SegmentProvider>
+        <SegmentGroup
+            stretch={stretch}
+            disabled={disabled}
+            clip={false}
+            size={size}
+            orientation={orientation}
+            {...args}
+        >
+            {items.map((_, i) => (
+                <SegmentItem
+                    view={segmentItemView}
+                    label={`Label ${i}`}
+                    value={`label_${i}`}
+                    size={size}
+                    key={`label_${i}`}
+                    contentLeft={getContentLeft(contentLeftOption, size)}
+                    contentRight={getContentRight(
+                        contentRightOption,
+                        size,
+                        segmentItemView,
+                        selectedSegmentItems.includes(`label_${i}`),
+                    )}
+                    {...args}
+                >
+                    {`Label${i + 1}`}
+                </SegmentItem>
+            ))}
+        </SegmentGroup>
     );
 };
 
@@ -188,5 +202,9 @@ export const Default: StoryObj<StorySegmentProps> = {
     argTypes: {
         ...disableProps(['filledBackground', 'view', 'selectionMode', 'clip']),
     },
-    render: (args: StorySegmentProps) => <StoryDefault {...args} />,
+    render: (args: StorySegmentProps) => (
+        <SegmentProvider>
+            <StoryDefault {...args} />
+        </SegmentProvider>
+    ),
 };

--- a/packages/sdds-insol/src/components/Segment/SegmentItem.config.ts
+++ b/packages/sdds-insol/src/components/Segment/SegmentItem.config.ts
@@ -55,6 +55,22 @@ export const config = {
 
                 ${segmentTokens.groupFilledBackgroundColor}: var(--text-accent);
             `,
+            accent: css`
+                ${segmentTokens.itemColor}: var(--text-primary);
+                ${segmentTokens.itemBackgroundColor}: transparent;
+                ${segmentTokens.itemColorHover}: var(--text-primary-hover);
+                ${segmentTokens.itemBackgroundColorHover}: transparent;
+                ${segmentTokens.itemAdditionalColor}: var(--text-secondary);
+                ${segmentTokens.itemAdditionalColorHover}: var(--text-secondary);
+                ${segmentTokens.itemSelectedColor}: var(--inverse-text-primary);
+                ${segmentTokens.itemSelectedBackgroundColor}: var(--surface-accent);
+                ${segmentTokens.itemSelectedColorHover}: var(--inverse-text-primary-hover);
+                ${segmentTokens.itemSelectedBackgroundColorHover}: var(--surface-accent);
+                ${segmentTokens.itemSelectedAdditionalColor}: var(--inverse-text-secondary);
+                ${segmentTokens.itemSelectedAdditionalColorHover}: var(--inverse-text-secondary);
+
+                ${segmentTokens.groupFilledBackgroundColor}: var(--text-accent);
+            `,
         },
         size: {
             xs: css`


### PR DESCRIPTION
## SDDS-INSOL

### Segment

-  добавлен `view='accent'`

<img width="725" alt="image" src="https://github.com/user-attachments/assets/0f32da46-e10f-49ad-860e-0b8db7b52f37" />

### What/why changed

Добавлен `view='accent'`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-insol@0.242.0-canary.1774.13286891394.0
  # or 
  yarn add @salutejs/sdds-insol@0.242.0-canary.1774.13286891394.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
