### PR TITLE
PLASMA-4445: add onChangeValue prop in combobox

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
@@ -74,6 +74,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             virtual = false,
             hintView,
             hintSize,
+            onChangeValue,
             ...rest
         } = props;
 
@@ -178,6 +179,10 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             setTextValue(e.target.value);
             dispatchPath({ type: 'opened_first_level' });
             dispatchFocusedPath({ type: 'reset' });
+
+            if (onChangeValue) {
+                onChangeValue(e.target.value);
+            }
         };
 
         // Обработчик чипов

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
@@ -201,6 +201,10 @@ type BasicProps<T extends ItemOption = ItemOption> = {
      */
     closeAfterSelect?: boolean;
     /**
+     * Обработчик изменения значения в строке поиска.
+     */
+    onChangeValue?: (value: string) => void;
+    /**
      * Ячейка для контента в начале выпадающего списка.
      */
     beforeList?: React.ReactNode;


### PR DESCRIPTION
## Code

### Combobox

- добавлено св-во `onChangeValue` для отслеживания изменений значения в строке поиска.

### What/why changed
По просьбам консумеров добавлено `onChangeValue`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.283.0-canary.1782.13387584790.0
  npm install @salutejs/plasma-b2c@1.525.0-canary.1782.13387584790.0
  npm install @salutejs/plasma-giga@0.252.0-canary.1782.13387584790.0
  npm install @salutejs/plasma-new-hope@0.271.0-canary.1782.13387584790.0
  npm install @salutejs/plasma-web@1.527.0-canary.1782.13387584790.0
  npm install @salutejs/sdds-cs@0.260.0-canary.1782.13387584790.0
  npm install @salutejs/sdds-dfa@0.255.0-canary.1782.13387584790.0
  npm install @salutejs/sdds-finportal@0.248.0-canary.1782.13387584790.0
  npm install @salutejs/sdds-insol@0.250.0-canary.1782.13387584790.0
  npm install @salutejs/sdds-serv@0.256.0-canary.1782.13387584790.0
  # or 
  yarn add @salutejs/plasma-asdk@0.283.0-canary.1782.13387584790.0
  yarn add @salutejs/plasma-b2c@1.525.0-canary.1782.13387584790.0
  yarn add @salutejs/plasma-giga@0.252.0-canary.1782.13387584790.0
  yarn add @salutejs/plasma-new-hope@0.271.0-canary.1782.13387584790.0
  yarn add @salutejs/plasma-web@1.527.0-canary.1782.13387584790.0
  yarn add @salutejs/sdds-cs@0.260.0-canary.1782.13387584790.0
  yarn add @salutejs/sdds-dfa@0.255.0-canary.1782.13387584790.0
  yarn add @salutejs/sdds-finportal@0.248.0-canary.1782.13387584790.0
  yarn add @salutejs/sdds-insol@0.250.0-canary.1782.13387584790.0
  yarn add @salutejs/sdds-serv@0.256.0-canary.1782.13387584790.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
