### PR TITLE
PLASMA-4258: Update disabled-opacity in calendar and date

### DIFF
--- a/packages/plasma-b2c/src/components/Calendar/CalendarBase.config.ts
+++ b/packages/plasma-b2c/src/components/Calendar/CalendarBase.config.ts
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: ${calendarBaseTokens.calendarContentPrimaryColor};
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;

--- a/packages/plasma-b2c/src/components/Calendar/CalendarDouble.config.ts
+++ b/packages/plasma-b2c/src/components/Calendar/CalendarDouble.config.ts
@@ -24,8 +24,10 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: ${calendarDoubleTokens.calendarContentPrimaryColor};
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 0.4;
 
                 ${calendarDoubleTokens.iconButtonColor}: var(--text-primary);

--- a/packages/plasma-b2c/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/plasma-b2c/src/components/DatePicker/DatePicker.config.ts
@@ -61,8 +61,10 @@ export const config = {
                 ${tokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${tokens.calendarHeaderArrowColor}: ${tokens.calendarContentPrimaryColor};
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
 
                 ${tokens.iconButtonColor}: var(--text-primary);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-clear);

--- a/packages/plasma-giga/src/components/Calendar/CalendarBase.config.ts
+++ b/packages/plasma-giga/src/components/Calendar/CalendarBase.config.ts
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: ${calendarBaseTokens.calendarContentPrimaryColor};
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;

--- a/packages/plasma-giga/src/components/Calendar/CalendarDouble.config.ts
+++ b/packages/plasma-giga/src/components/Calendar/CalendarDouble.config.ts
@@ -24,8 +24,10 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: ${calendarDoubleTokens.calendarContentPrimaryColor};
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 0.4;
 
                 ${calendarDoubleTokens.iconButtonColor}: var(--text-primary);

--- a/packages/plasma-giga/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/plasma-giga/src/components/DatePicker/DatePicker.config.ts
@@ -61,8 +61,10 @@ export const config = {
                 ${tokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${tokens.calendarHeaderArrowColor}: ${tokens.calendarContentPrimaryColor};
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
 
                 ${tokens.iconButtonColor}: var(--text-primary);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-clear);

--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.tokens.ts
@@ -143,6 +143,8 @@ export const tokens = {
     calendarRangeBackground: '--plasma-calendar-range-background',
     calendarOutlineFocusColor: '--plasma-calendar-outline-focus-color',
     calendarContentPrimaryColor: '--plasma-calendar-content-primary-color',
+    calendarContentPrimaryDisabledColor: '--plasma-calendar-content-primary-disabled-color',
     calendarContentSecondaryColor: '--plasma-calendar-content-secondary-color',
+    calendarContentSecondaryDisabledColor: '--plasma-calendar-content-secondary-disabled-color',
     calendarDisabledOpacity: '--plasma-calendar-disabled-opacity',
 };

--- a/packages/plasma-new-hope/src/components/Calendar/ui/DateStructureItem/DateStructureItem.styles.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/DateStructureItem/DateStructureItem.styles.ts
@@ -130,10 +130,18 @@ export const StyledItemRoot = styled.div<DateStructureProps & FocusProps>`
     }
 
     &.${classes.disabled} {
+        color: ${({ isDayInCurrentMonth }) =>
+            isDayInCurrentMonth
+                ? `var(${tokens.calendarContentPrimaryDisabledColor})`
+                : `var(${tokens.calendarContentSecondaryDisabledColor})`};
         ${disabledItem()};
     }
 
     &.${classes.disabledCurrent} {
+        color: ${({ isDayInCurrentMonth }) =>
+            isDayInCurrentMonth
+                ? `var(${tokens.calendarContentPrimaryDisabledColor})`
+                : `var(${tokens.calendarContentSecondaryDisabledColor})`};
         ${disabledCurrentItem()};
     }
 

--- a/packages/plasma-new-hope/src/components/Calendar/ui/DateStructureItem/DateStructureItem.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/DateStructureItem/DateStructureItem.tsx
@@ -55,12 +55,12 @@ export const DateStructureItem = memo(
                 <StyledItemRoot
                     ref={outerRef}
                     className={cx(
+                        disabledClass,
+                        disabledCurrentClass,
                         dayOfWeekClass,
                         selectableClass,
                         selectedClass,
                         currentClass,
-                        disabledClass,
-                        disabledCurrentClass,
                         hoveredClass,
                         dayInCurrentMonthClass,
                     )}

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePicker.tokens.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePicker.tokens.ts
@@ -245,4 +245,6 @@ export const tokens = {
     calendarOutlineFocusColor: '--plasma-date-picker-calendar__outline-focus-color',
     calendarContentPrimaryColor: '--plasma-date-picker-calendar__content-primary-color',
     calendarContentSecondaryColor: '--plasma-date-picker-calendar__content-secondary-color',
+    calendarContentPrimaryDisabledColor: '--plasma-date-picker-calendar__content-primary-disabled-color',
+    calendarContentSecondaryDisabledColor: '--plasma-date-picker-calendar__content-secondary-disabled-color',
 };

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePickerBase.styles.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePickerBase.styles.ts
@@ -31,7 +31,9 @@ export const baseCalendarTokens = `
     ${calendarBaseTokens.calendarRangeBackground}: var(${tokens.calendarRangeBackground});
     ${calendarBaseTokens.calendarOutlineFocusColor}: var(${tokens.calendarOutlineFocusColor});
     ${calendarBaseTokens.calendarContentPrimaryColor}: var(${tokens.calendarContentPrimaryColor});
+    ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(${tokens.calendarContentPrimaryDisabledColor});
     ${calendarBaseTokens.calendarContentSecondaryColor}: var(${tokens.calendarContentSecondaryColor});
+    ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(${tokens.calendarContentSecondaryDisabledColor});
 
     ${calendarBaseTokens.iconButtonColor}: var(${tokens.iconButtonColor});
     ${calendarBaseTokens.iconButtonBackgroundColor}: var(${tokens.iconButtonBackgroundColor});

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/CalendarBase.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/CalendarBase.config.ts
@@ -24,7 +24,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: ${calendarBaseTokens.calendarContentPrimaryColor};
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/CalendarDouble.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Calendar/CalendarDouble.config.ts
@@ -26,8 +26,10 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: ${calendarDoubleTokens.calendarContentPrimaryColor};
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 0.4;
 
                 ${calendarDoubleTokens.iconButtonColor}: var(--text-primary);

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.config.ts
@@ -63,8 +63,10 @@ export const config = {
                 ${tokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${tokens.calendarHeaderArrowColor}: ${tokens.calendarContentPrimaryColor};
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
 
                 ${tokens.iconButtonColor}: var(--text-primary);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-clear);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/CalendarBase.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/CalendarBase.config.ts
@@ -24,7 +24,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: ${calendarBaseTokens.calendarContentPrimaryColor};
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/CalendarDouble.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Calendar/CalendarDouble.config.ts
@@ -26,8 +26,10 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: ${calendarDoubleTokens.calendarContentPrimaryColor};
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 0.4;
 
                 ${calendarDoubleTokens.iconButtonColor}: var(--text-primary);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/DatePicker/DatePicker.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/DatePicker/DatePicker.config.ts
@@ -65,8 +65,10 @@ export const config = {
                 ${tokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${tokens.calendarHeaderArrowColor}: ${tokens.calendarContentPrimaryColor};
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
 
                 ${tokens.iconButtonColor}: var(--text-primary);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-clear);

--- a/packages/plasma-web/src/components/Calendar/CalendarBase.config.ts
+++ b/packages/plasma-web/src/components/Calendar/CalendarBase.config.ts
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: ${calendarBaseTokens.calendarContentPrimaryColor};
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;

--- a/packages/plasma-web/src/components/Calendar/CalendarDouble.config.ts
+++ b/packages/plasma-web/src/components/Calendar/CalendarDouble.config.ts
@@ -24,8 +24,10 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: ${calendarDoubleTokens.calendarContentPrimaryColor};
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 0.4;
 
                 ${calendarDoubleTokens.iconButtonColor}: var(--text-primary);

--- a/packages/plasma-web/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/plasma-web/src/components/DatePicker/DatePicker.config.ts
@@ -63,8 +63,10 @@ export const config = {
                 ${tokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${tokens.calendarHeaderArrowColor}: ${tokens.calendarContentPrimaryColor};
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
 
                 ${tokens.iconButtonColor}: var(--text-primary);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-clear);

--- a/packages/sdds-cs/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/sdds-cs/src/components/Calendar/Calendar.stories.tsx
@@ -27,6 +27,7 @@ const meta: Meta<CalendarProps> = {
             },
         },
         ...disableProps([
+            'size',
             'value',
             'onChangeValue',
             'date',

--- a/packages/sdds-cs/src/components/Calendar/Calendar.stories.tsx
+++ b/packages/sdds-cs/src/components/Calendar/Calendar.stories.tsx
@@ -26,12 +26,6 @@ const meta: Meta<CalendarProps> = {
                 type: 'date',
             },
         },
-        size: {
-            options: ['s'],
-            control: {
-                type: 'inline-radio',
-            },
-        },
         ...disableProps([
             'value',
             'onChangeValue',

--- a/packages/sdds-cs/src/components/Calendar/CalendarBase.config.ts
+++ b/packages/sdds-cs/src/components/Calendar/CalendarBase.config.ts
@@ -11,7 +11,7 @@ export const config = {
                 ${calendarBaseTokens.calendarSelectedItemBackground}: var(--surface-accent);
                 ${calendarBaseTokens.calendarSelectedItemColor}: var(--inverse-text-primary);
                 ${calendarBaseTokens.calendarSelectableItemBackgroundHover}: var(--surface-transparent-accent);
-                ${calendarBaseTokens.calendarCurrentItemBorderColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarCurrentItemBorderColor}: var(--inverse-outline-solid-secondary);
                 ${calendarBaseTokens.calendarCurrentItemBackgroundHover}: transparent;
                 ${calendarBaseTokens.calendarCurrentItemColorHover}: var(--text-primary);
                 ${calendarBaseTokens.calendarCurrentItemChildBackgroundHover}: var(--surface-transparent-accent);
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-accent);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-primary);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: var(--text-accent);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 1;

--- a/packages/sdds-cs/src/components/Calendar/CalendarDouble.config.ts
+++ b/packages/sdds-cs/src/components/Calendar/CalendarDouble.config.ts
@@ -11,7 +11,7 @@ export const config = {
                 ${calendarDoubleTokens.calendarSelectedItemBackground}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarSelectedItemColor}: var(--inverse-text-primary);
                 ${calendarDoubleTokens.calendarSelectableItemBackgroundHover}: var(--surface-transparent-accent);
-                ${calendarDoubleTokens.calendarCurrentItemBorderColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarCurrentItemBorderColor}: var(--inverse-outline-solid-secondary);
                 ${calendarDoubleTokens.calendarCurrentItemBackgroundHover}: transparent;
                 ${calendarDoubleTokens.calendarCurrentItemColorHover}: var(--text-primary);
                 ${calendarDoubleTokens.calendarCurrentItemChildBackgroundHover}: var(--surface-transparent-accent);
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-accent);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-primary);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: var(--text-accent);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 1;

--- a/packages/sdds-cs/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/sdds-cs/src/components/DatePicker/DatePicker.config.ts
@@ -56,7 +56,7 @@ export const config = {
                 ${tokens.calendarSelectedItemBackground}: var(--surface-accent);
                 ${tokens.calendarSelectedItemColor}: var(--inverse-text-primary);
                 ${tokens.calendarSelectableItemBackgroundHover}: var(--surface-transparent-accent);
-                ${tokens.calendarCurrentItemBorderColor}: var(--surface-solid-default);
+                ${tokens.calendarCurrentItemBorderColor}: var(--inverse-outline-solid-secondary);
                 ${tokens.calendarCurrentItemBackgroundHover}: transparent;
                 ${tokens.calendarCurrentItemColorHover}: var(--text-primary);
                 ${tokens.calendarCurrentItemChildBackgroundHover}: var(--surface-transparent-accent);
@@ -68,6 +68,8 @@ export const config = {
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--text-primary);
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${tokens.calendarHeaderArrowColor}: var(--text-accent);
                 ${tokens.calendarBorderColor}: var(--outline-solid-primary);
                 ${tokens.calendarDayOfWeekColor}: var(--text-secondary);

--- a/packages/sdds-cs/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/sdds-cs/src/components/DatePicker/DatePicker.stories.tsx
@@ -15,7 +15,6 @@ const onFocus = action('onFocus');
 const onChangeFirstValue = action('onChangeFirstValue');
 const onChangeSecondValue = action('onChangeSecondValue');
 
-const sizes = ['s'];
 const views = ['default'];
 const dividers = ['none', 'dash', 'icon'];
 const labelPlacements = ['outer', 'inner'];
@@ -27,12 +26,6 @@ const meta: Meta = {
     argTypes: {
         view: {
             options: views,
-            control: {
-                type: 'inline-radio',
-            },
-        },
-        size: {
-            options: sizes,
             control: {
                 type: 'inline-radio',
             },
@@ -66,7 +59,7 @@ const meta: Meta = {
             },
             if: { arg: 'required', truthy: true },
         },
-        ...disableProps(['view']),
+        ...disableProps(['view', 'size']),
     },
 };
 

--- a/packages/sdds-dfa/src/components/Calendar/CalendarBase.config.ts
+++ b/packages/sdds-dfa/src/components/Calendar/CalendarBase.config.ts
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: ${calendarBaseTokens.calendarContentPrimaryColor};
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;

--- a/packages/sdds-dfa/src/components/Calendar/CalendarDouble.config.ts
+++ b/packages/sdds-dfa/src/components/Calendar/CalendarDouble.config.ts
@@ -24,8 +24,10 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: ${calendarDoubleTokens.calendarContentPrimaryColor};
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 0.4;
 
                 ${calendarDoubleTokens.iconButtonColor}: var(--text-primary);

--- a/packages/sdds-dfa/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/sdds-dfa/src/components/DatePicker/DatePicker.config.ts
@@ -61,8 +61,10 @@ export const config = {
                 ${tokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${tokens.calendarHeaderArrowColor}: ${tokens.calendarContentPrimaryColor};
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
 
                 ${tokens.iconButtonColor}: var(--text-primary);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-clear);

--- a/packages/sdds-finportal/src/components/Calendar/CalendarBase.config.ts
+++ b/packages/sdds-finportal/src/components/Calendar/CalendarBase.config.ts
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: ${calendarBaseTokens.calendarContentPrimaryColor};
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;

--- a/packages/sdds-finportal/src/components/Calendar/CalendarDouble.config.ts
+++ b/packages/sdds-finportal/src/components/Calendar/CalendarDouble.config.ts
@@ -24,8 +24,10 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: ${calendarDoubleTokens.calendarContentPrimaryColor};
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 0.4;
 
                 ${calendarDoubleTokens.iconButtonColor}: var(--text-primary);

--- a/packages/sdds-finportal/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/sdds-finportal/src/components/DatePicker/DatePicker.config.ts
@@ -61,8 +61,10 @@ export const config = {
                 ${tokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${tokens.calendarHeaderArrowColor}: ${tokens.calendarContentPrimaryColor};
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
 
                 ${tokens.iconButtonColor}: var(--text-primary);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-clear);

--- a/packages/sdds-insol/src/components/Calendar/CalendarBase.config.ts
+++ b/packages/sdds-insol/src/components/Calendar/CalendarBase.config.ts
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;
 

--- a/packages/sdds-serv/src/components/Calendar/CalendarBase.config.ts
+++ b/packages/sdds-serv/src/components/Calendar/CalendarBase.config.ts
@@ -22,7 +22,9 @@ export const config = {
                 ${calendarBaseTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarBaseTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarBaseTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarBaseTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarBaseTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarBaseTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarHeaderArrowColor}: ${calendarBaseTokens.calendarContentPrimaryColor};
                 ${calendarBaseTokens.calendarDayOfWeekColor}: var(--text-secondary);
                 ${calendarBaseTokens.calendarDisabledOpacity}: 0.4;

--- a/packages/sdds-serv/src/components/Calendar/CalendarDouble.config.ts
+++ b/packages/sdds-serv/src/components/Calendar/CalendarDouble.config.ts
@@ -24,8 +24,10 @@ export const config = {
                 ${calendarDoubleTokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${calendarDoubleTokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${calendarDoubleTokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${calendarDoubleTokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${calendarDoubleTokens.calendarHeaderArrowColor}: ${calendarDoubleTokens.calendarContentPrimaryColor};
                 ${calendarDoubleTokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${calendarDoubleTokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
                 ${calendarDoubleTokens.calendarDisabledOpacity}: 0.4;
 
                 ${calendarDoubleTokens.iconButtonColor}: var(--text-primary);

--- a/packages/sdds-serv/src/components/DatePicker/DatePicker.config.ts
+++ b/packages/sdds-serv/src/components/DatePicker/DatePicker.config.ts
@@ -61,8 +61,10 @@ export const config = {
                 ${tokens.calendarRangeBackground}: var(--surface-transparent-secondary);
                 ${tokens.calendarOutlineFocusColor}: var(--surface-accent);
                 ${tokens.calendarContentPrimaryColor}: var(--surface-solid-default);
+                ${tokens.calendarContentPrimaryDisabledColor}: var(--surface-solid-default);
                 ${tokens.calendarHeaderArrowColor}: ${tokens.calendarContentPrimaryColor};
                 ${tokens.calendarContentSecondaryColor}: var(--text-secondary);
+                ${tokens.calendarContentSecondaryDisabledColor}: var(--text-secondary);
 
                 ${tokens.iconButtonColor}: var(--text-primary);
                 ${tokens.iconButtonBackgroundColor}: var(--surface-clear);


### PR DESCRIPTION
## Core

### Calendar

- Добавлены новые токены цвета текста при `disabled`

### Datepicker

- Добавлены новые токены цвета текста при `disabled`

### What/why changed



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.294.0-canary.1785.13559387548.0
  npm install @salutejs/plasma-b2c@1.536.0-canary.1785.13559387548.0
  npm install @salutejs/plasma-giga@0.263.0-canary.1785.13559387548.0
  npm install @salutejs/plasma-new-hope@0.280.0-canary.1785.13559387548.0
  npm install @salutejs/plasma-web@1.538.0-canary.1785.13559387548.0
  npm install @salutejs/sdds-cs@0.271.0-canary.1785.13559387548.0
  npm install @salutejs/sdds-dfa@0.266.0-canary.1785.13559387548.0
  npm install @salutejs/sdds-finportal@0.259.0-canary.1785.13559387548.0
  npm install @salutejs/sdds-insol@0.263.0-canary.1785.13559387548.0
  npm install @salutejs/sdds-serv@0.267.0-canary.1785.13559387548.0
  # or 
  yarn add @salutejs/plasma-asdk@0.294.0-canary.1785.13559387548.0
  yarn add @salutejs/plasma-b2c@1.536.0-canary.1785.13559387548.0
  yarn add @salutejs/plasma-giga@0.263.0-canary.1785.13559387548.0
  yarn add @salutejs/plasma-new-hope@0.280.0-canary.1785.13559387548.0
  yarn add @salutejs/plasma-web@1.538.0-canary.1785.13559387548.0
  yarn add @salutejs/sdds-cs@0.271.0-canary.1785.13559387548.0
  yarn add @salutejs/sdds-dfa@0.266.0-canary.1785.13559387548.0
  yarn add @salutejs/sdds-finportal@0.259.0-canary.1785.13559387548.0
  yarn add @salutejs/sdds-insol@0.263.0-canary.1785.13559387548.0
  yarn add @salutejs/sdds-serv@0.267.0-canary.1785.13559387548.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
