### PR TITLE
PLASMA: fix usePopoverOffset hook deps

### DIFF
--- a/packages/plasma-new-hope/src/components/Popover/hooks/usePopoverOffset.ts
+++ b/packages/plasma-new-hope/src/components/Popover/hooks/usePopoverOffset.ts
@@ -56,7 +56,7 @@ export const usePopoverOffset = ({ handleRef, placement, offsetOuter }: UsePopov
         }
 
         setOffset([offsetX, offsetY]);
-    }, [handleRef, placement, offsetOuter]);
+    }, [handleRef, placement, offsetOuter[0], offsetOuter[1]]);
 
     return offset;
 };

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentProps, useEffect, useRef, useState } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { IconPlaceholder } from '@salutejs/plasma-sb-utils';
+import { disableProps, IconPlaceholder } from '@salutejs/plasma-sb-utils';
 
 import { WithTheme } from '../../../_helpers';
 import { IconButton } from '../IconButton/IconButton';


### PR DESCRIPTION
## Core

### Popover

- исправлена зависимость useEffect в  usePopoverOffset

**Before**:

<img width="1407" alt="image" src="https://github.com/user-attachments/assets/5f26456e-6e90-4c96-9d9f-d0a1befe37dd" />

**After**:

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/3dfad2ef-7c82-47b8-a1c9-9c1cdaab3988" />

### What/why changed

Исправлена зависимость useEffect в  usePopoverOffset

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.288.0-canary.1788.13492486250.0
  npm install @salutejs/plasma-b2c@1.530.0-canary.1788.13492486250.0
  npm install @salutejs/plasma-giga@0.257.0-canary.1788.13492486250.0
  npm install @salutejs/plasma-new-hope@0.276.0-canary.1788.13492486250.0
  npm install @salutejs/plasma-web@1.532.0-canary.1788.13492486250.0
  npm install @salutejs/sdds-cs@0.265.0-canary.1788.13492486250.0
  npm install @salutejs/sdds-dfa@0.260.0-canary.1788.13492486250.0
  npm install @salutejs/sdds-finportal@0.253.0-canary.1788.13492486250.0
  npm install @salutejs/sdds-insol@0.257.0-canary.1788.13492486250.0
  npm install @salutejs/sdds-serv@0.261.0-canary.1788.13492486250.0
  # or 
  yarn add @salutejs/plasma-asdk@0.288.0-canary.1788.13492486250.0
  yarn add @salutejs/plasma-b2c@1.530.0-canary.1788.13492486250.0
  yarn add @salutejs/plasma-giga@0.257.0-canary.1788.13492486250.0
  yarn add @salutejs/plasma-new-hope@0.276.0-canary.1788.13492486250.0
  yarn add @salutejs/plasma-web@1.532.0-canary.1788.13492486250.0
  yarn add @salutejs/sdds-cs@0.265.0-canary.1788.13492486250.0
  yarn add @salutejs/sdds-dfa@0.260.0-canary.1788.13492486250.0
  yarn add @salutejs/sdds-finportal@0.253.0-canary.1788.13492486250.0
  yarn add @salutejs/sdds-insol@0.257.0-canary.1788.13492486250.0
  yarn add @salutejs/sdds-serv@0.261.0-canary.1788.13492486250.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
