### PR TITLE
PLASMA-4491: open Dropdown by right click

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -1937,6 +1937,7 @@ default: PolymorphicClassName;
     onHover?: ((index: number) => void) | undefined;
     onItemSelect?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     trigger?: DropdownTrigger | undefined;
+    openByRightClick?: boolean | undefined;
     placement?: DropdownPlacement | undefined;
     offset?: [number, number] | undefined;
     listWidth?: Property.Width<string | number> | undefined;

--- a/packages/plasma-b2c/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-b2c/src/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<DropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<DropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/plasma-giga/api/plasma-giga.api.md
+++ b/packages/plasma-giga/api/plasma-giga.api.md
@@ -1649,6 +1649,7 @@ default: PolymorphicClassName;
     onHover?: ((index: number) => void) | undefined;
     onItemSelect?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     trigger?: DropdownTrigger | undefined;
+    openByRightClick?: boolean | undefined;
     placement?: DropdownPlacement | undefined;
     offset?: [number, number] | undefined;
     listWidth?: Property.Width<string | number> | undefined;

--- a/packages/plasma-giga/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-giga/src/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<DropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<DropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useReducer, useRef } from 'react';
+import React, { forwardRef, useCallback, useReducer, useRef } from 'react';
 import { safeUseId } from '@salutejs/plasma-core';
 
 import { RootProps } from '../../engines';
@@ -44,6 +44,7 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, Omit<DropdownProps,
                 onItemSelect,
                 onItemClick,
                 trigger = 'click',
+                openByRightClick = false,
                 variant = 'normal',
                 hasArrow = true,
                 alwaysOpened = false,
@@ -58,6 +59,8 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, Omit<DropdownProps,
         ) => {
             const [path, dispatchPath] = useReducer(pathReducer, []);
             const [focusedPath, dispatchFocusedPath] = useReducer(focusedPathReducer, []);
+
+            const isCurrentListOpen = alwaysOpened || Boolean(path[0]);
 
             const [pathMap, focusedToValueMap] = useHashMaps(items);
 
@@ -94,6 +97,19 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, Omit<DropdownProps,
                 }
             };
 
+            const onContextMenu = useCallback(
+                (e: React.MouseEvent) => {
+                    e.preventDefault();
+
+                    if (alwaysOpened) {
+                        return;
+                    }
+
+                    handleGlobalToggle(!isCurrentListOpen, e);
+                },
+                [handleGlobalToggle, isCurrentListOpen, alwaysOpened],
+            );
+
             const { onKeyDown } = useKeyNavigation({
                 focusedPath,
                 dispatchFocusedPath,
@@ -106,8 +122,6 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, Omit<DropdownProps,
                 onItemSelect,
                 onItemClick,
             });
-
-            const isCurrentListOpen = alwaysOpened || Boolean(path[0]);
 
             return (
                 <Context.Provider
@@ -142,6 +156,7 @@ export const dropdownRoot = (Root: RootProps<HTMLDivElement, Omit<DropdownProps,
                                 ? getItemId(treeId, activeDescendantItemValue.toString())
                                 : '',
                             onKeyDown,
+                            onContextMenu: openByRightClick ? onContextMenu : undefined,
                         })}
                         zIndex={zIndex}
                     >

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
@@ -35,17 +35,22 @@ export type DropdownProps<T extends DropdownItemOption = DropdownItemOption> = {
      */
     onItemSelect?: (item: T, event: SyntheticEvent) => void;
     /**
-     * Способ открытия дропдауна окна - наведение или клик мышью.
+     * Способ открытия Dropdown окна - наведение или клик мышью.
      * @default click
      */
     trigger?: DropdownTrigger;
     /**
-     * Сторона открытия дропдауна относительно target элемента.
+     * Открывает дропдаун окно по правому клику мышью
+     * @default false
+     */
+    openByRightClick?: boolean;
+    /**
+     * Сторона открытия Dropdown относительно target элемента.
      * @default bottom
      */
     placement?: DropdownPlacement;
     /**
-     * Отступ дропдауна относительно элемента, у которого оно вызвано.
+     * Отступ Dropdown относительно элемента, у которого оно вызвано.
      * @default [0, 0]
      */
     offset?: [number, number];
@@ -66,12 +71,12 @@ export type DropdownProps<T extends DropdownItemOption = DropdownItemOption> = {
      */
     closeOnSelect?: boolean;
     /**
-     * Закрывать окно при нажатии вне области дропдауна.
+     * Закрывать окно при нажатии вне области Dropdown.
      * @default true
      */
     closeOnOverlayClick?: boolean;
     /**
-     * Событие сворачивания/разворачивания дропдауна.
+     * Событие сворачивания/разворачивания Dropdown.
      */
     onToggle?: (isOpen: boolean, event: SyntheticEvent | Event) => void;
     size?: string;

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<StoryDropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<StoryDropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<StoryDropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<StoryDropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -1939,6 +1939,7 @@ default: PolymorphicClassName;
     onHover?: ((index: number) => void) | undefined;
     onItemSelect?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     trigger?: DropdownTrigger | undefined;
+    openByRightClick?: boolean | undefined;
     placement?: DropdownPlacement | undefined;
     offset?: [number, number] | undefined;
     listWidth?: Property.Width<string | number> | undefined;

--- a/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<DropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<DropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -1521,6 +1521,7 @@ default: PolymorphicClassName;
     onHover?: ((index: number) => void) | undefined;
     onItemSelect?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     trigger?: DropdownTrigger | undefined;
+    openByRightClick?: boolean | undefined;
     placement?: DropdownPlacement | undefined;
     offset?: [number, number] | undefined;
     listWidth?: Property.Width<string | number> | undefined;

--- a/packages/sdds-cs/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-cs/src/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<DropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<DropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -1605,6 +1605,7 @@ default: PolymorphicClassName;
     onHover?: ((index: number) => void) | undefined;
     onItemSelect?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     trigger?: DropdownTrigger | undefined;
+    openByRightClick?: boolean | undefined;
     placement?: DropdownPlacement | undefined;
     offset?: [number, number] | undefined;
     listWidth?: Property.Width<string | number> | undefined;

--- a/packages/sdds-dfa/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-dfa/src/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<DropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<DropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -1655,6 +1655,7 @@ default: PolymorphicClassName;
     onHover?: ((index: number) => void) | undefined;
     onItemSelect?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     trigger?: DropdownTrigger | undefined;
+    openByRightClick?: boolean | undefined;
     placement?: DropdownPlacement | undefined;
     offset?: [number, number] | undefined;
     listWidth?: Property.Width<string | number> | undefined;

--- a/packages/sdds-finportal/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-finportal/src/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<DropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<DropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -1375,6 +1375,7 @@ default: PolymorphicClassName;
     onHover?: ((index: number) => void) | undefined;
     onItemSelect?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     trigger?: DropdownTrigger | undefined;
+    openByRightClick?: boolean | undefined;
     placement?: DropdownPlacement | undefined;
     offset?: [number, number] | undefined;
     listWidth?: Property.Width<string | number> | undefined;

--- a/packages/sdds-insol/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-insol/src/components/Dropdown/Dropdown.stories.tsx
@@ -34,6 +34,11 @@ const meta: Meta<DropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -63,6 +68,7 @@ const meta: Meta<DropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -1657,6 +1657,7 @@ default: PolymorphicClassName;
     onHover?: ((index: number) => void) | undefined;
     onItemSelect?: ((item: DropdownItemOption, event: React_2.SyntheticEvent<Element, Event>) => void) | undefined;
     trigger?: DropdownTrigger | undefined;
+    openByRightClick?: boolean | undefined;
     placement?: DropdownPlacement | undefined;
     offset?: [number, number] | undefined;
     listWidth?: Property.Width<string | number> | undefined;

--- a/packages/sdds-serv/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/sdds-serv/src/components/Dropdown/Dropdown.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<DropdownProps> = {
                 type: 'select',
             },
         },
+        openByRightClick: {
+            control: {
+                type: 'boolean',
+            },
+        },
         size: {
             options: size,
             control: {
@@ -62,6 +67,7 @@ const meta: Meta<DropdownProps> = {
         variant: 'normal',
         placement: 'bottom-start',
         trigger: 'click',
+        openByRightClick: false,
         offset: [0, 0],
         listWidth: '300px',
         hasArrow: true,


### PR DESCRIPTION
## Core

### Dropdown

- добавлено свойство openByRightClick для открытия по правому клику

### What/why changed

расширен функционал

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.288.0-canary.1791.13484791679.0
  npm install @salutejs/plasma-b2c@1.530.0-canary.1791.13484791679.0
  npm install @salutejs/plasma-giga@0.257.0-canary.1791.13484791679.0
  npm install @salutejs/plasma-new-hope@0.276.0-canary.1791.13484791679.0
  npm install @salutejs/plasma-web@1.532.0-canary.1791.13484791679.0
  npm install @salutejs/sdds-cs@0.265.0-canary.1791.13484791679.0
  npm install @salutejs/sdds-dfa@0.260.0-canary.1791.13484791679.0
  npm install @salutejs/sdds-finportal@0.253.0-canary.1791.13484791679.0
  npm install @salutejs/sdds-insol@0.257.0-canary.1791.13484791679.0
  npm install @salutejs/sdds-serv@0.261.0-canary.1791.13484791679.0
  # or 
  yarn add @salutejs/plasma-asdk@0.288.0-canary.1791.13484791679.0
  yarn add @salutejs/plasma-b2c@1.530.0-canary.1791.13484791679.0
  yarn add @salutejs/plasma-giga@0.257.0-canary.1791.13484791679.0
  yarn add @salutejs/plasma-new-hope@0.276.0-canary.1791.13484791679.0
  yarn add @salutejs/plasma-web@1.532.0-canary.1791.13484791679.0
  yarn add @salutejs/sdds-cs@0.265.0-canary.1791.13484791679.0
  yarn add @salutejs/sdds-dfa@0.260.0-canary.1791.13484791679.0
  yarn add @salutejs/sdds-finportal@0.253.0-canary.1791.13484791679.0
  yarn add @salutejs/sdds-insol@0.257.0-canary.1791.13484791679.0
  yarn add @salutejs/sdds-serv@0.261.0-canary.1791.13484791679.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
