### PR TITLE
PLASMA-4517: new architecture in Autocomplete

### DIFF
--- a/packages/plasma-b2c/src/components/Autocomplete/Autocomplete.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Autocomplete/Autocomplete.component-test.tsx
@@ -453,11 +453,11 @@ describe('plasma-b2c: Autocomplete', () => {
 
         cy.get('input').click();
         cy.focused().type('ал');
-        cy.get('.popover-root').should('not.be.visible');
+        cy.get('ul[role="listbox"]').should('not.exist');
         cy.realPress('Tab');
         cy.get('input').click();
         cy.focused().type('е');
-        cy.get('.popover-root').should('be.visible');
+        cy.get('ul[role="listbox"]').should('be.visible');
     });
 
     it('prop: portal', () => {
@@ -467,8 +467,11 @@ describe('plasma-b2c: Autocomplete', () => {
             </CypressTestDecoratorWithTypo>,
         );
 
+        cy.get('input').click();
+        cy.focused().type('алек');
+
         // Проверяем, что Popover лежит выше в DOM, чем без portal
-        cy.get('[id=parentId] > div').eq(1).find('div').and('have.class', 'popover-root');
+        cy.get('[id=parentId] > div').eq(1).and('have.attr', 'data-floating-ui-portal');
     });
 
     it('prop: required, requiredPlacement', () => {
@@ -599,7 +602,7 @@ describe('plasma-b2c: Autocomplete', () => {
         cy.get('input').click();
         cy.realPress('ArrowDown');
         cy.realPress('Enter');
-        cy.get('ul').should('not.be.visible');
+        cy.get('ul').should('not.exist');
         cy.get('input').should('have.value', 'Алексей Смирнов');
 
         // Tab

--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.styles.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.styles.ts
@@ -1,26 +1,10 @@
 import { styled } from '@linaria/react';
 import { css } from '@linaria/core';
 
-import { popoverClasses, popoverConfig } from '../Popover';
-import { component } from '../../engines';
-
 import { AutocompleteProps } from './Autocomplete.types';
 import { tokens } from './Autocomplete.tokens';
 
-export const base = css`
-    .${popoverClasses.wrapper}, .${popoverClasses.target} {
-        display: block;
-    }
-`;
-
-const Popover = component(popoverConfig);
-
-export const StyledPopover = styled(Popover)<{ listWidth: AutocompleteProps['listWidth'] }>`
-    .${String(popoverClasses.root)} {
-        display: block;
-        width: ${({ listWidth }) => listWidth || '100%'};
-    }
-`;
+export const base = css``;
 
 export const Ul = styled.ul<{
     listMaxHeight: AutocompleteProps['listMaxHeight'];
@@ -38,27 +22,6 @@ export const Ul = styled.ul<{
 
     margin: var(${tokens.margin}) 0 0 0;
     padding: var(${tokens.padding});
-`;
-
-export const LeftHelper = styled.div<{
-    disabled: AutocompleteProps['disabled'];
-    readOnly: AutocompleteProps['readOnly'];
-}>`
-    color: ${({ readOnly, disabled }) =>
-        readOnly && !disabled
-            ? `var(${tokens.textFieldLeftHelperColorReadOnly})`
-            : `var(${tokens.textFieldLeftHelperColor})`};
-    margin-top: var(${tokens.textFieldLeftHelperOffset});
-
-    font-family: var(${tokens.textFieldLeftHelperFontFamily});
-    font-size: var(${tokens.textFieldLeftHelperFontSize});
-    font-style: var(${tokens.textFieldLeftHelperFontStyle});
-    font-weight: var(${tokens.textFieldLeftHelperFontWeight});
-    letter-spacing: var(${tokens.textFieldLeftHelperLetterSpacing});
-    line-height: var(${tokens.textFieldLeftHelperLineHeight});
-
-    opacity: var(${tokens.textFieldDisabledOpacity});
-    cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'auto')};
 `;
 
 export const InfiniteLoaderWrapper = styled.li`

--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes, ReactNode } from 'react';
+import React, { InputHTMLAttributes, ReactNode } from 'react';
 
 import { DistributiveOmit } from '../../types';
 import { TextFieldPropsBase } from '../TextField/TextField.types';
@@ -107,3 +107,12 @@ export type AutocompleteProps = BaseProps &
         'chips' | 'onChangeChips' | 'enumerationType' | 'labelPlacement' | 'chipView' | 'chipValidator' | 'chipType'
     > &
     Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'required'>;
+
+export type FloatingPopoverProps = {
+    target: React.ReactNode | ((ref: React.MutableRefObject<HTMLElement | null>) => React.ReactNode);
+    children: React.ReactNode;
+    opened: boolean;
+    portal?: BaseProps['portal'];
+    listWidth?: BaseProps['listWidth'];
+    offset?: number;
+};

--- a/packages/plasma-new-hope/src/components/Autocomplete/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Autocomplete/FloatingPopover.tsx
@@ -1,0 +1,75 @@
+import { flip, shift, size, useFloating, FloatingPortal } from '@floating-ui/react';
+import React, { forwardRef } from 'react';
+import { safeUseId } from '@salutejs/plasma-core';
+
+import type { FloatingPopoverProps } from './Autocomplete.types';
+
+const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
+    ({ target, children, opened, portal, listWidth }, ref) => {
+        const { refs, floatingStyles } = useFloating({
+            placement: 'bottom-start',
+            open: opened,
+            middleware: [
+                flip({ fallbackAxisSideDirection: 'end' }),
+                shift(),
+                size({
+                    apply({ rects, elements }) {
+                        Object.assign(elements.floating.style, {
+                            width: listWidth || `${rects.reference.width}px`,
+                        });
+                    },
+                }),
+            ],
+        });
+
+        const wrappedId = safeUseId();
+
+        // Проверка на target. Это может быть как ReactNode, так и функция, в которую пробрасывается ref.
+        // Это нужно для более тонкой настройки reference-элемента, вокруг которого и будет позиционироваться выпадашка.
+        // Пример: когда в Textfield под инпутом находится helperText (или еще что-либо),
+        // но выпадающий список должен позиционироваться непосредственно возле самого инпута.
+        const isTargetAsFunction = typeof target === 'function';
+
+        return (
+            <div ref={ref} id={wrappedId} style={{ position: 'relative' }}>
+                <div ref={isTargetAsFunction ? undefined : refs.setReference}>
+                    {typeof target === 'function' ? target(refs.setReference as any) : target}
+                </div>
+
+                {opened && (
+                    // root - принимает ref контейнера портала.
+                    // id - если есть портал - не используется, если портала нет - подставляется 'wrappedId'.
+                    <FloatingPortal {...getFloatingPortalProps(portal, wrappedId)}>
+                        <div ref={refs.setFloating} style={{ ...floatingStyles, zIndex: 1000 }}>
+                            {children}
+                        </div>
+                    </FloatingPortal>
+                )}
+            </div>
+        );
+    },
+);
+
+type FloatingPortalReturnedProps = {
+    root?: React.RefObject<HTMLElement>;
+    id?: string;
+};
+
+// root - принимает ref контейнера портала.
+// id - если есть портал - не используется, если портала нет - подставляется 'wrappedId'.
+const getFloatingPortalProps = (
+    portal: FloatingPopoverProps['portal'],
+    wrappedId: string,
+): FloatingPortalReturnedProps => {
+    if (!portal) {
+        return { id: wrappedId };
+    }
+
+    if (typeof portal === 'string') {
+        return { id: portal };
+    }
+
+    return { root: portal };
+};
+
+export { FloatingPopover };

--- a/packages/plasma-web/src/components/Autocomplete/Autocomplete.component-test.tsx
+++ b/packages/plasma-web/src/components/Autocomplete/Autocomplete.component-test.tsx
@@ -453,11 +453,11 @@ describe('plasma-web: Autocomplete', () => {
 
         cy.get('input').click();
         cy.focused().type('ал');
-        cy.get('.popover-root').should('not.be.visible');
+        cy.get('ul[role="listbox"]').should('not.exist');
         cy.realPress('Tab');
         cy.get('input').click();
         cy.focused().type('е');
-        cy.get('.popover-root').should('be.visible');
+        cy.get('ul[role="listbox"]').should('be.visible');
     });
 
     it('prop: portal', () => {
@@ -467,8 +467,11 @@ describe('plasma-web: Autocomplete', () => {
             </CypressTestDecoratorWithTypo>,
         );
 
+        cy.get('input').click();
+        cy.focused().type('алек');
+
         // Проверяем, что Popover лежит выше в DOM, чем без portal
-        cy.get('[id=parentId] > div').eq(1).find('div').and('have.class', 'popover-root');
+        cy.get('[id=parentId] > div').eq(1).and('have.attr', 'data-floating-ui-portal');
     });
 
     it('prop: required, requiredPlacement', () => {
@@ -599,7 +602,7 @@ describe('plasma-web: Autocomplete', () => {
         cy.get('input').click();
         cy.realPress('ArrowDown');
         cy.realPress('Enter');
-        cy.get('ul').should('not.be.visible');
+        cy.get('ul').should('not.exist');
         cy.get('input').should('have.value', 'Алексей Смирнов');
 
         // Tab


### PR DESCRIPTION
## Core

### Autocomplete

- переведен на **новую** архитектуру с использованием `@floating-ui`

### What/why changed

Автокомплит переведен на новую архитектуру, по примеру комбобокса, селекта и дропдауна.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.292.0-canary.1794.13544543346.0
  npm install @salutejs/plasma-b2c@1.534.0-canary.1794.13544543346.0
  npm install @salutejs/plasma-giga@0.261.0-canary.1794.13544543346.0
  npm install @salutejs/plasma-new-hope@0.279.0-canary.1794.13544543346.0
  npm install @salutejs/plasma-web@1.536.0-canary.1794.13544543346.0
  npm install @salutejs/sdds-cs@0.269.0-canary.1794.13544543346.0
  npm install @salutejs/sdds-dfa@0.264.0-canary.1794.13544543346.0
  npm install @salutejs/sdds-finportal@0.257.0-canary.1794.13544543346.0
  npm install @salutejs/sdds-insol@0.261.0-canary.1794.13544543346.0
  npm install @salutejs/sdds-serv@0.265.0-canary.1794.13544543346.0
  # or 
  yarn add @salutejs/plasma-asdk@0.292.0-canary.1794.13544543346.0
  yarn add @salutejs/plasma-b2c@1.534.0-canary.1794.13544543346.0
  yarn add @salutejs/plasma-giga@0.261.0-canary.1794.13544543346.0
  yarn add @salutejs/plasma-new-hope@0.279.0-canary.1794.13544543346.0
  yarn add @salutejs/plasma-web@1.536.0-canary.1794.13544543346.0
  yarn add @salutejs/sdds-cs@0.269.0-canary.1794.13544543346.0
  yarn add @salutejs/sdds-dfa@0.264.0-canary.1794.13544543346.0
  yarn add @salutejs/sdds-finportal@0.257.0-canary.1794.13544543346.0
  yarn add @salutejs/sdds-insol@0.261.0-canary.1794.13544543346.0
  yarn add @salutejs/sdds-serv@0.265.0-canary.1794.13544543346.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
