### PR TITLE
PLASMA-4399: add explicit types export from Tree component

### DIFF
--- a/packages/plasma-b2c/api/plasma-b2c.api.md
+++ b/packages/plasma-b2c/api/plasma-b2c.api.md
@@ -331,7 +331,9 @@ import { ToolbarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { toolbarTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
 import { transformStyles } from '@salutejs/plasma-core';
-import { TreeProps } from '@salutejs/plasma-new-hope/types/components/Tree/Tree.types';
+import { TreeItem } from '@salutejs/plasma-new-hope';
+import { TreeProps } from '@salutejs/plasma-new-hope';
+import { TreeProps as TreeProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { TypographyOldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Old/TypographyOld';
 import { TypographyVariants } from '@salutejs/plasma-new-hope/types/components/Editable/Editable.types';
 import { Upload } from '@salutejs/plasma-hope';
@@ -4534,7 +4536,11 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & TreeProps & RefAttributes<HTMLDivElement>>;
+}> & TreeProps_2 & RefAttributes<HTMLDivElement>>;
+
+export { TreeItem }
+
+export { TreeProps }
 
 // @public (undocumented)
 export const Underline: FunctionComponent<PropsType<    {

--- a/packages/plasma-b2c/src/components/Tree/index.ts
+++ b/packages/plasma-b2c/src/components/Tree/index.ts
@@ -1,1 +1,3 @@
 export { Tree } from './Tree';
+
+export type { TreeProps, TreeItem } from '@salutejs/plasma-new-hope';

--- a/packages/plasma-giga/api/plasma-giga.api.md
+++ b/packages/plasma-giga/api/plasma-giga.api.md
@@ -245,7 +245,9 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { ToolbarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { toolbarTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
-import { TreeProps } from '@salutejs/plasma-new-hope/types/components/Tree/Tree.types';
+import { TreeItem } from '@salutejs/plasma-new-hope';
+import { TreeProps } from '@salutejs/plasma-new-hope';
+import { TreeProps as TreeProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
@@ -4390,7 +4392,11 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & TreeProps & RefAttributes<HTMLDivElement>>;
+}> & TreeProps_2 & RefAttributes<HTMLDivElement>>;
+
+export { TreeItem }
+
+export { TreeProps }
 
 export { usePopupContext }
 

--- a/packages/plasma-giga/src/components/Tree/index.ts
+++ b/packages/plasma-giga/src/components/Tree/index.ts
@@ -1,1 +1,3 @@
 export { Tree } from './Tree';
+
+export type { TreeProps, TreeItem } from '@salutejs/plasma-new-hope';

--- a/packages/plasma-new-hope/src/components/Tree/Tree.types.ts
+++ b/packages/plasma-new-hope/src/components/Tree/Tree.types.ts
@@ -25,7 +25,7 @@ interface CheckInfo {
     halfCheckedKeys?: Key[];
 }
 
-type TreeItem = {
+export type TreeItem = {
     /**
      * Уникальный идентификатор элемента.
      */
@@ -51,6 +51,10 @@ type TreeItem = {
      * Иконка для текущего элемента.
      */
     icon?: ReactNode;
+    /**
+     * Дочерние items.
+     */
+    children?: TreeItem[];
 };
 
 export interface TreeProps extends HTMLAttributes<HTMLElement> {

--- a/packages/plasma-new-hope/src/components/Tree/index.ts
+++ b/packages/plasma-new-hope/src/components/Tree/index.ts
@@ -1,2 +1,3 @@
 export { treeConfig } from './Tree';
 export { treeTokens } from './Tree.tokens';
+export type { TreeProps, TreeItem } from './Tree.types';

--- a/packages/plasma-web/api/plasma-web.api.md
+++ b/packages/plasma-web/api/plasma-web.api.md
@@ -331,7 +331,9 @@ import { ToolbarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { toolbarTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
 import { transformStyles } from '@salutejs/plasma-core';
-import { TreeProps } from '@salutejs/plasma-new-hope/types/components/Tree/Tree.types';
+import { TreeItem } from '@salutejs/plasma-new-hope';
+import { TreeProps } from '@salutejs/plasma-new-hope';
+import { TreeProps as TreeProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { TypographyOldProps } from '@salutejs/plasma-new-hope/types/components/Typography/Old/TypographyOld';
 import { TypographyVariants } from '@salutejs/plasma-new-hope/types/components/Editable/Editable.types';
 import { Upload } from '@salutejs/plasma-hope';
@@ -4533,7 +4535,11 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & TreeProps & RefAttributes<HTMLDivElement>>;
+}> & TreeProps_2 & RefAttributes<HTMLDivElement>>;
+
+export { TreeItem }
+
+export { TreeProps }
 
 // @public (undocumented)
 export const Underline: FunctionComponent<PropsType<    {

--- a/packages/plasma-web/src/components/Tree/index.ts
+++ b/packages/plasma-web/src/components/Tree/index.ts
@@ -1,1 +1,3 @@
 export { Tree } from './Tree';
+
+export type { TreeProps, TreeItem } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -239,7 +239,9 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { ToolbarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { toolbarTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
-import { TreeProps } from '@salutejs/plasma-new-hope/types/components/Tree/Tree.types';
+import { TreeItem } from '@salutejs/plasma-new-hope';
+import { TreeProps } from '@salutejs/plasma-new-hope';
+import { TreeProps as TreeProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
@@ -3950,7 +3952,11 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & TreeProps & RefAttributes<HTMLDivElement>>;
+}> & TreeProps_2 & RefAttributes<HTMLDivElement>>;
+
+export { TreeItem }
+
+export { TreeProps }
 
 export { usePopupContext }
 

--- a/packages/sdds-cs/src/components/Tree/index.ts
+++ b/packages/sdds-cs/src/components/Tree/index.ts
@@ -1,1 +1,3 @@
 export { Tree } from './Tree';
+
+export type { TreeProps, TreeItem } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-dfa/api/sdds-dfa.api.md
+++ b/packages/sdds-dfa/api/sdds-dfa.api.md
@@ -235,7 +235,9 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { ToolbarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { toolbarTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
-import { TreeProps } from '@salutejs/plasma-new-hope/types/components/Tree/Tree.types';
+import { TreeItem } from '@salutejs/plasma-new-hope';
+import { TreeProps } from '@salutejs/plasma-new-hope';
+import { TreeProps as TreeProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
@@ -4308,7 +4310,11 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & TreeProps & RefAttributes<HTMLDivElement>>;
+}> & TreeProps_2 & RefAttributes<HTMLDivElement>>;
+
+export { TreeItem }
+
+export { TreeProps }
 
 export { usePopupContext }
 

--- a/packages/sdds-dfa/src/components/Tree/index.ts
+++ b/packages/sdds-dfa/src/components/Tree/index.ts
@@ -1,1 +1,3 @@
 export { Tree } from './Tree';
+
+export type { TreeProps, TreeItem } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-finportal/api/sdds-finportal.api.md
+++ b/packages/sdds-finportal/api/sdds-finportal.api.md
@@ -243,7 +243,9 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { ToolbarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { toolbarTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
-import { TreeProps } from '@salutejs/plasma-new-hope/types/components/Tree/Tree.types';
+import { TreeItem } from '@salutejs/plasma-new-hope';
+import { TreeProps } from '@salutejs/plasma-new-hope';
+import { TreeProps as TreeProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
@@ -4352,7 +4354,11 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & TreeProps & RefAttributes<HTMLDivElement>>;
+}> & TreeProps_2 & RefAttributes<HTMLDivElement>>;
+
+export { TreeItem }
+
+export { TreeProps }
 
 export { usePopupContext }
 

--- a/packages/sdds-finportal/src/components/Tree/index.ts
+++ b/packages/sdds-finportal/src/components/Tree/index.ts
@@ -1,1 +1,3 @@
 export { Tree } from './Tree';
+
+export type { TreeProps, TreeItem } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-insol/api/sdds-insol.api.md
+++ b/packages/sdds-insol/api/sdds-insol.api.md
@@ -246,7 +246,9 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { ToolbarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { toolbarTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
-import { TreeProps } from '@salutejs/plasma-new-hope/types/components/Tree/Tree.types';
+import { TreeItem } from '@salutejs/plasma-new-hope';
+import { TreeProps } from '@salutejs/plasma-new-hope';
+import { TreeProps as TreeProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
@@ -3793,7 +3795,11 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & TreeProps & RefAttributes<HTMLDivElement>>;
+}> & TreeProps_2 & RefAttributes<HTMLDivElement>>;
+
+export { TreeItem }
+
+export { TreeProps }
 
 export { usePopupContext }
 

--- a/packages/sdds-insol/src/components/Tree/index.ts
+++ b/packages/sdds-insol/src/components/Tree/index.ts
@@ -1,1 +1,3 @@
 export { Tree } from './Tree';
+
+export type { TreeProps, TreeItem } from '@salutejs/plasma-new-hope';

--- a/packages/sdds-serv/api/sdds-serv.api.md
+++ b/packages/sdds-serv/api/sdds-serv.api.md
@@ -245,7 +245,9 @@ import { ToastRole } from '@salutejs/plasma-new-hope/styled-components';
 import { ToolbarProps } from '@salutejs/plasma-new-hope/styled-components';
 import { toolbarTokens } from '@salutejs/plasma-new-hope/styled-components';
 import { TooltipProps } from '@salutejs/plasma-new-hope/styled-components';
-import { TreeProps } from '@salutejs/plasma-new-hope/types/components/Tree/Tree.types';
+import { TreeItem } from '@salutejs/plasma-new-hope';
+import { TreeProps } from '@salutejs/plasma-new-hope';
+import { TreeProps as TreeProps_2 } from '@salutejs/plasma-new-hope/styled-components';
 import { usePopupContext } from '@salutejs/plasma-new-hope/styled-components';
 import { useSegment } from '@salutejs/plasma-new-hope/styled-components';
 import { useToast } from '@salutejs/plasma-new-hope/styled-components';
@@ -4397,7 +4399,11 @@ m: PolymorphicClassName;
 s: PolymorphicClassName;
 xs: PolymorphicClassName;
 };
-}> & TreeProps & RefAttributes<HTMLDivElement>>;
+}> & TreeProps_2 & RefAttributes<HTMLDivElement>>;
+
+export { TreeItem }
+
+export { TreeProps }
 
 export { usePopupContext }
 

--- a/packages/sdds-serv/src/components/Tree/index.ts
+++ b/packages/sdds-serv/src/components/Tree/index.ts
@@ -1,1 +1,3 @@
 export { Tree } from './Tree';
+
+export type { TreeProps, TreeItem } from '@salutejs/plasma-new-hope';


### PR DESCRIPTION
## Core

### Tree

- добавлен явный экспорт типов;

### What/why changed
добавлены явные экспорты `TreeProps` и `TreeItem` во все внешние библиотеки.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.297.0-canary.1798.13587991554.0
  npm install @salutejs/plasma-b2c@1.539.0-canary.1798.13587991554.0
  npm install @salutejs/plasma-giga@0.266.0-canary.1798.13587991554.0
  npm install @salutejs/plasma-new-hope@0.283.0-canary.1798.13587991554.0
  npm install @salutejs/plasma-web@1.541.0-canary.1798.13587991554.0
  npm install @salutejs/sdds-cs@0.274.0-canary.1798.13587991554.0
  npm install @salutejs/sdds-dfa@0.269.0-canary.1798.13587991554.0
  npm install @salutejs/sdds-finportal@0.262.0-canary.1798.13587991554.0
  npm install @salutejs/sdds-insol@0.266.0-canary.1798.13587991554.0
  npm install @salutejs/sdds-serv@0.270.0-canary.1798.13587991554.0
  # or 
  yarn add @salutejs/plasma-asdk@0.297.0-canary.1798.13587991554.0
  yarn add @salutejs/plasma-b2c@1.539.0-canary.1798.13587991554.0
  yarn add @salutejs/plasma-giga@0.266.0-canary.1798.13587991554.0
  yarn add @salutejs/plasma-new-hope@0.283.0-canary.1798.13587991554.0
  yarn add @salutejs/plasma-web@1.541.0-canary.1798.13587991554.0
  yarn add @salutejs/sdds-cs@0.274.0-canary.1798.13587991554.0
  yarn add @salutejs/sdds-dfa@0.269.0-canary.1798.13587991554.0
  yarn add @salutejs/sdds-finportal@0.262.0-canary.1798.13587991554.0
  yarn add @salutejs/sdds-insol@0.266.0-canary.1798.13587991554.0
  yarn add @salutejs/sdds-serv@0.270.0-canary.1798.13587991554.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
