### PR TITLE
PLASMA-4364: add case for StarOS TV for detectDevice method

### DIFF
--- a/packages/plasma-ui/src/utils/deviceDetection.ts
+++ b/packages/plasma-ui/src/utils/deviceDetection.ts
@@ -69,7 +69,9 @@ export const isTV = (): boolean => {
         ua.includes('(tv; tv)') ||
         ua.includes('(tv; huawei)') ||
         ua.includes('(huawei-tv; huawei)') ||
-        ua.includes('(huawei-tv; huawei tv)')
+        ua.includes('(huawei-tv; huawei tv)') ||
+        ua.includes('staros') ||
+        ua.includes('uifamily=tv')
     );
 };
 
@@ -82,6 +84,7 @@ export const detectDevice = (): DeviceKind => {
     if (typeof navigator === 'undefined') {
         return DeviceKindList.sberBox;
     }
+
     switch (true) {
         case isSberPortal():
             return DeviceKindList.sberPortal;


### PR DESCRIPTION
## PLASMA-UI

- добавлена поддержка `StarOS` устройств

### What/why changed

Нужно было поддержать линейку устройств со следующим `userAgent` 

```
Mozilla/5.0 (Linux; Android 14; SK63S Build/UP1A.231005.007.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.6367.82 Mobile Safari/537.36 ASDK/24.10.2.2281 (Android) StarOS/1.98.20250121043554-b12386 (tv_cvte_aml_963_968_d4; TV) uiFamily=TV

Mozilla/5.0 (Linux; Android 14; SK63S Build/UP1A.231005.007.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.6367.82 Mobile Safari/537.36 ASDK/24.10.2.2281 (Android) StarOS/1.98.20250121043554-b12446 (tv_cvte_aml_963_968_d4; TV) uiFamily=TV
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-ui@1.310.0-canary.1800.13646507668.0
  # or 
  yarn add @salutejs/plasma-ui@1.310.0-canary.1800.13646507668.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
