### PR TITLE
 PLASMA-4584:Add `onDark` view for `ViewContainer` component [sdds-cs]

### DIFF
--- a/packages/sdds-cs/api/sdds-cs.api.md
+++ b/packages/sdds-cs/api/sdds-cs.api.md
@@ -3962,6 +3962,7 @@ export { useToast }
 export const ViewContainer: FunctionComponent<PropsType<    {
 view: {
 onLight: PolymorphicClassName;
+onDark: PolymorphicClassName;
 };
 }> & HTMLAttributes<HTMLDivElement> & ViewContainerCustomProps & RefAttributes<HTMLAnchorElement>>;
 

--- a/packages/sdds-cs/src/components/ViewContainer/ViewContainer.config.ts
+++ b/packages/sdds-cs/src/components/ViewContainer/ViewContainer.config.ts
@@ -7,6 +7,9 @@ export const config = {
             onLight: css`
                 ${viewContainer.light}
             `,
+            onDark: css`
+                ${viewContainer.dark}
+            `,
         },
     },
 };

--- a/website/sdds-cs-docs/docs/components/Tooltip.mdx
+++ b/website/sdds-cs-docs/docs/components/Tooltip.mdx
@@ -64,3 +64,26 @@ export function App() {
     );
 }
 ```
+
+## Применение `onDark` и `onLight`
+
+Для изменение режима отображения компонента необходимо использовать компонент-обёртку [ViewContainer](./ViewContainer.mdx) с указанием нужного `view`.
+
+```tsx live
+import React from 'react';
+import { Tooltip, Button, ViewContainer } from '@salutejs/sdds-cs';
+
+export function App() {
+    return (
+        <>
+            <ViewContainer view="onDark">
+                <Tooltip usePortal={false} target={(<Button>trigger: click - onDark</Button>)} text="OnDark" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+            </ViewContainer>
+            <br />
+            <ViewContainer view="onLight">
+                <Tooltip usePortal={false} target={(<Button>trigger: click - onLight</Button>)} text="OnLight" placement="right" hasArrow trigger="click" closeOnEsc closeOnOverlayClick />
+            </ViewContainer>
+        </>
+    );
+}
+```


### PR DESCRIPTION
## SDDS-CS

### ViewContainer

-  Добавлена view `onDark`

### Tooltip

- Добавлена документация для компонента, описывающая возможность использования `ViewContainer`

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-cs@0.272.0-canary.1804.13584347001.0
  # or 
  yarn add @salutejs/sdds-cs@0.272.0-canary.1804.13584347001.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
