### PR TITLE
PLASMA-4302: `Button` and `IconButton` hover and active tokens updated

### DIFF
--- a/packages/plasma-asdk/src/components/Button/Button.config.ts
+++ b/packages/plasma-asdk/src/components/Button/Button.config.ts
@@ -13,10 +13,8 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             /**
              * @deprecated
@@ -27,19 +25,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent-main);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-main-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-main-active);
             `,
             secondary: css`
@@ -47,9 +41,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -57,19 +49,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -77,9 +65,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
@@ -87,9 +73,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -97,20 +81,16 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
@@ -118,9 +98,7 @@ export const config = {
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
                 ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/plasma-asdk/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-asdk/src/components/Button/Button.stories.tsx
@@ -3,14 +3,15 @@ import type { ComponentProps } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import { IconMic } from '@salutejs/plasma-icons';
-import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+
+import { config } from './Button.config';
 
 import { Button } from '.';
 
 type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['accent', 'default', 'secondary', 'success', 'warning', 'critical', 'clear', 'dark', 'black', 'white'];
-const sizes = ['xl', 'l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -22,7 +23,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -63,7 +64,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },

--- a/packages/plasma-b2c/src/components/Button/Button.config.ts
+++ b/packages/plasma-b2c/src/components/Button/Button.config.ts
@@ -13,10 +13,8 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             /**
              * @deprecated
@@ -27,19 +25,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -47,9 +41,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -57,19 +49,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -77,9 +65,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
@@ -87,9 +73,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -97,20 +81,16 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
@@ -118,9 +98,7 @@ export const config = {
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
                 ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/plasma-b2c/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-b2c/src/components/Button/Button.stories.tsx
@@ -3,14 +3,16 @@ import type { ComponentProps } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import { IconMic } from '@salutejs/plasma-icons';
-import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+
+import { config } from './Button.config';
 
 import { Button } from '.';
 
 type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['default', 'accent', 'success', 'warning', 'critical', 'dark', 'light'];
-const sizes = ['xl', 'l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
+
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -22,7 +24,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -63,7 +65,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },

--- a/packages/plasma-b2c/src/components/IconButton/IconButton.config.ts
+++ b/packages/plasma-b2c/src/components/IconButton/IconButton.config.ts
@@ -12,91 +12,71 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
                 ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/plasma-giga/src/components/Button/Button.config.ts
+++ b/packages/plasma-giga/src/components/Button/Button.config.ts
@@ -16,19 +16,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -36,9 +32,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -46,19 +40,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -66,9 +56,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
@@ -76,9 +64,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -86,30 +72,24 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/plasma-giga/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-giga/src/components/Button/Button.stories.tsx
@@ -3,16 +3,15 @@ import type { ComponentProps } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import { IconMic } from '@salutejs/plasma-icons';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
-import { InSpacingDecorator, disableProps } from '../../helpers';
+import { config } from './Button.config';
 
 import { Button } from '.';
-import type { ButtonProps as Base } from '.';
 
-type ButtonProps = ComponentProps<Base>;
+type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['default', 'accent', 'success', 'warning', 'critical', 'dark', 'light'];
-const sizes = ['l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -24,7 +23,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -65,7 +64,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },

--- a/packages/plasma-giga/src/components/IconButton/IconButton.config.ts
+++ b/packages/plasma-giga/src/components/IconButton/IconButton.config.ts
@@ -12,91 +12,71 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
                 ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.config.ts
@@ -15,19 +15,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -35,9 +31,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -45,19 +39,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             positive: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -65,9 +55,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             negative: css`
@@ -75,9 +63,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -85,9 +71,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
             `,
             black: css`
@@ -95,9 +79,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
             `,
             white: css`
@@ -105,9 +87,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.config.ts
@@ -71,24 +71,24 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Button/Button.stories.tsx
@@ -22,7 +22,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 const sizeMap = {
     xxs: '0.75rem', // 12px
     xs: '1rem', // 16px
@@ -62,7 +62,7 @@ const meta: Meta<typeof Button> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },
@@ -80,7 +80,7 @@ const meta: Meta<typeof Button> = {
             },
             table: { defaultValue: { summary: 'bottom' } },
         },
-        ...disableProps(['value', 'focused', 'pin']),
+        ...disableProps(['focused', 'pin']),
     },
 };
 
@@ -112,6 +112,7 @@ export const Default: StoryObj<StoryPropsDefault> = {
 
 export const WithValue: StoryObj<StoryPropsDefault> = {
     args: {
+        value: 'Value',
         enableContentLeft: false,
     },
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/IconButton/IconButton.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/IconButton/IconButton.config.ts
@@ -14,90 +14,70 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/IconButton/IconButton.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/IconButton/IconButton.config.ts
@@ -63,22 +63,22 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.config.ts
@@ -15,19 +15,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -35,9 +31,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -45,19 +39,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             positive: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -65,9 +55,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             negative: css`
@@ -75,9 +63,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -85,9 +71,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
             `,
             black: css`
@@ -95,9 +79,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
             `,
             white: css`
@@ -105,9 +87,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.config.ts
@@ -71,24 +71,24 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Button/Button.stories.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
-import { disableProps } from '@salutejs/plasma-sb-utils';
+import { disableProps, getConfigVariations } from '@salutejs/plasma-sb-utils';
 
 import { IconMic } from '../../../../components/_Icon';
 import { WithTheme } from '../../../_helpers';
 
 import { Button } from './Button';
+import { config } from './Button.config';
 
-const views = ['default', 'accent', 'positive', 'warning', 'negative', 'dark', 'light'];
-const sizes = ['xl', 'l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
+
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -21,7 +22,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 const sizeMap = {
     xxs: '0.75rem', // 12px
     xs: '1rem', // 16px
@@ -61,7 +62,7 @@ const meta: Meta<typeof Button> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },
@@ -79,7 +80,7 @@ const meta: Meta<typeof Button> = {
             },
             table: { defaultValue: { summary: 'bottom' } },
         },
-        ...disableProps(['value', 'pin', 'focused']),
+        ...disableProps(['pin', 'focused']),
     },
 };
 
@@ -121,6 +122,7 @@ export const Default: StoryObj<StoryPropsDefault> = {
 
 export const WithValue: StoryObj<StoryPropsDefault> = {
     args: {
+        value: 'Value',
         enableContentLeft: false,
     },
     argTypes: {

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/IconButton/IconButton.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/IconButton/IconButton.config.ts
@@ -14,90 +14,70 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/IconButton/IconButton.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/IconButton/IconButton.config.ts
@@ -63,22 +63,22 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/plasma-web/src/components/Button/Button.config.ts
+++ b/packages/plasma-web/src/components/Button/Button.config.ts
@@ -13,10 +13,8 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             /**
              * @deprecated
@@ -27,19 +25,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -47,9 +41,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -57,19 +49,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -77,9 +65,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
@@ -87,9 +73,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -97,20 +81,16 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
@@ -118,9 +98,7 @@ export const config = {
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
                 ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/plasma-web/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-web/src/components/Button/Button.stories.tsx
@@ -3,14 +3,15 @@ import type { ComponentProps } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import { IconMic } from '@salutejs/plasma-icons';
-import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
+
+import { config } from './Button.config';
 
 import { Button } from '.';
 
 type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['default', 'accent', 'success', 'warning', 'critical', 'dark', 'light'];
-const sizes = ['xl', 'l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -22,7 +23,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -63,7 +64,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },

--- a/packages/plasma-web/src/components/IconButton/IconButton.config.ts
+++ b/packages/plasma-web/src/components/IconButton/IconButton.config.ts
@@ -12,91 +12,71 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
                 ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/sdds-cs/src/components/Button/Button.config.ts
+++ b/packages/sdds-cs/src/components/Button/Button.config.ts
@@ -13,9 +13,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-accent-minor);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -34,10 +32,8 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-accent-minor);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(--surface-transparent-accent);
-                ${buttonTokens.buttonColorHover}: var(--text-accent);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-accent);
-                ${buttonTokens.buttonColorActive}: var(--text-accent);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-accent-active);
             `,
         },
         size: {

--- a/packages/sdds-cs/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-cs/src/components/Button/Button.stories.tsx
@@ -3,16 +3,15 @@ import type { ComponentProps } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import { IconMic } from '@salutejs/plasma-icons';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
-import { InSpacingDecorator, disableProps } from '../../helpers';
+import { config } from './Button.config';
 
 import { Button } from '.';
-import type { ButtonProps as Base } from '.';
 
-type ButtonProps = ComponentProps<Base>;
+type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['accent', 'secondary', 'clear'];
-const sizes = ['s'];
+const { views, sizes } = getConfigVariations(config);
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -24,7 +23,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -65,7 +64,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },
@@ -84,6 +83,7 @@ const meta: Meta<ButtonProps> = {
             table: { defaultValue: { summary: 'bottom' } },
         },
         ...disableProps([
+            'size',
             'theme',
             'loader',
             'onClick',

--- a/packages/sdds-cs/src/components/IconButton/IconButton.config.ts
+++ b/packages/sdds-cs/src/components/IconButton/IconButton.config.ts
@@ -12,9 +12,7 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -30,10 +28,8 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--text-accent);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(--surface-transparent-accent);
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-accent);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-accent);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-accent);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-accent-active);
             `,
         },
         size: {

--- a/packages/sdds-cs/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/sdds-cs/src/components/IconButton/IconButton.stories.tsx
@@ -44,6 +44,7 @@ const meta: Meta<StoryButtonProps> = {
             table: { defaultValue: { summary: 'bottom' } },
         },
         ...disableProps([
+            'size',
             'focused',
             'children',
             'theme',

--- a/packages/sdds-dfa/src/components/Button/Button.config.ts
+++ b/packages/sdds-dfa/src/components/Button/Button.config.ts
@@ -13,19 +13,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -33,9 +29,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -43,19 +37,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -63,9 +53,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
@@ -73,9 +61,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -83,30 +69,24 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/sdds-dfa/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-dfa/src/components/Button/Button.stories.tsx
@@ -3,16 +3,15 @@ import type { ComponentProps } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import { IconMic } from '@salutejs/plasma-icons';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
-import { InSpacingDecorator, disableProps } from '../../helpers';
+import { config } from './Button.config';
 
 import { Button } from '.';
-import type { ButtonProps as Base } from '.';
 
-type ButtonProps = ComponentProps<Base>;
+type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['default', 'accent', 'success', 'warning', 'critical', 'dark', 'light'];
-const sizes = ['xl', 'l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -24,7 +23,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -65,7 +64,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },

--- a/packages/sdds-dfa/src/components/IconButton/IconButton.config.ts
+++ b/packages/sdds-dfa/src/components/IconButton/IconButton.config.ts
@@ -12,91 +12,71 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
                 ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/sdds-finportal/src/components/Button/Button.config.ts
+++ b/packages/sdds-finportal/src/components/Button/Button.config.ts
@@ -13,19 +13,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -33,9 +29,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -43,19 +37,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -63,9 +53,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
@@ -73,9 +61,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -83,30 +69,24 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/sdds-finportal/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-finportal/src/components/Button/Button.stories.tsx
@@ -3,16 +3,15 @@ import type { ComponentProps } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import { IconMic } from '@salutejs/plasma-icons';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
-import { InSpacingDecorator, disableProps } from '../../helpers';
+import { config } from './Button.config';
 
 import { Button } from '.';
-import type { ButtonProps as Base } from '.';
 
-type ButtonProps = ComponentProps<Base>;
+type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['default', 'accent', 'success', 'warning', 'critical', 'dark', 'light'];
-const sizes = ['xl', 'l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -24,7 +23,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -65,7 +64,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },

--- a/packages/sdds-finportal/src/components/IconButton/IconButton.config.ts
+++ b/packages/sdds-finportal/src/components/IconButton/IconButton.config.ts
@@ -12,91 +12,71 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
                 ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/sdds-insol/src/components/Button/Button.config.ts
+++ b/packages/sdds-insol/src/components/Button/Button.config.ts
@@ -13,19 +13,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             'accent-gradient': css`
@@ -43,9 +39,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -53,19 +47,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -73,9 +63,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
@@ -83,9 +71,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -93,30 +79,24 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/sdds-insol/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-insol/src/components/Button/Button.stories.tsx
@@ -4,16 +4,15 @@ import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import styled from 'styled-components';
 import { IconMic } from '@salutejs/plasma-icons';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
-import { InSpacingDecorator, disableProps } from '../../helpers';
+import { config } from './Button.config';
 
 import { Button } from '.';
-import type { ButtonProps as Base } from '.';
 
-type ButtonProps = ComponentProps<Base>;
+type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['default', 'accent', 'accent-gradient', 'success', 'warning', 'critical', 'dark', 'light'];
-const sizes = ['xl', 'l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -25,7 +24,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -66,7 +65,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },

--- a/packages/sdds-insol/src/components/IconButton/IconButton.config.ts
+++ b/packages/sdds-insol/src/components/IconButton/IconButton.config.ts
@@ -12,91 +12,71 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
                 ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {

--- a/packages/sdds-serv/src/components/Button/Button.config.ts
+++ b/packages/sdds-serv/src/components/Button/Button.config.ts
@@ -13,19 +13,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--inverse-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--inverse-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-accent);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-accent-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
@@ -33,9 +29,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-transparent-secondary);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${buttonTokens.buttonColorActive}: var(--text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
@@ -43,19 +37,15 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-clear);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--text-primary-hover);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-clear);
-                ${buttonTokens.buttonColorActive}: var(--text-primary-active);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-clear);
+                ${buttonTokens.buttonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${buttonTokens.buttonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-positive);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-positive-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
@@ -63,9 +53,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-warning);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-warning-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
@@ -73,9 +61,7 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--surface-negative);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorHover}: var(--surface-negative-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
@@ -83,30 +69,24 @@ export const config = {
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${buttonTokens.buttonColor}: var(--on-dark-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-dark-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-dark-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${buttonTokens.buttonColor}: var(--on-light-text-primary);
                 ${buttonTokens.buttonValueColor}: var(--on-light-text-secondary);
                 ${buttonTokens.buttonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${buttonTokens.buttonLoadingBackgroundColor}: var(${buttonTokens.buttonBackgroundColor});
-                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
-                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary);
-                ${buttonTokens.buttonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
+                ${buttonTokens.buttonColorHover}: var(--on-light-text-primary-hover);
+                ${buttonTokens.buttonColorActive}: var(--on-light-text-primary-active);
             `,
         },
         size: {

--- a/packages/sdds-serv/src/components/Button/Button.stories.tsx
+++ b/packages/sdds-serv/src/components/Button/Button.stories.tsx
@@ -3,16 +3,15 @@ import type { ComponentProps } from 'react';
 import { action } from '@storybook/addon-actions';
 import type { StoryObj, Meta } from '@storybook/react';
 import { IconMic } from '@salutejs/plasma-icons';
+import { disableProps, getConfigVariations, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
 
-import { InSpacingDecorator, disableProps } from '../../helpers';
+import { config } from './Button.config';
 
 import { Button } from '.';
-import type { ButtonProps as Base } from '.';
 
-type ButtonProps = ComponentProps<Base>;
+type ButtonProps = ComponentProps<typeof Button>;
 
-const views = ['default', 'accent', 'success', 'warning', 'critical', 'dark', 'light'];
-const sizes = ['xl', 'l', 'm', 's', 'xs', 'xxs'];
+const { views, sizes } = getConfigVariations(config);
 const stretchingValues = ['auto', 'filled', 'fixed'];
 const pinValues = [
     '',
@@ -24,7 +23,7 @@ const pinValues = [
     'circle-clear',
     'circle-circle',
 ];
-const contentPlacinValues = ['default', 'relaxed'];
+const contentPlacingValues = ['default', 'relaxed'];
 
 const onClick = action('onClick');
 const onFocus = action('onFocus');
@@ -65,7 +64,7 @@ const meta: Meta<ButtonProps> = {
             },
         },
         contentPlacing: {
-            options: contentPlacinValues,
+            options: contentPlacingValues,
             control: {
                 type: 'select',
             },

--- a/packages/sdds-serv/src/components/IconButton/IconButton.config.ts
+++ b/packages/sdds-serv/src/components/IconButton/IconButton.config.ts
@@ -12,91 +12,71 @@ export const config = {
                 ${iconButtonTokens.iconButtonColor}: var(--inverse-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--inverse-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--inverse-text-primary-active);
             `,
             accent: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-accent);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-accent-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-accent-active);
             `,
             secondary: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-transparent-secondary);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             clear: css`
                 ${iconButtonTokens.iconButtonColor}: var(--text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-clear);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-clear);
-                ${iconButtonTokens.iconButtonColorActive}: var(--text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-clear);
+                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-transparent-secondary-hover);
+                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-transparent-secondary-active);
             `,
             success: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-positive);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-positive-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-positive-active);
             `,
             warning: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-warning);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-warning-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-warning-active);
             `,
             critical: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--surface-negative);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--surface-negative-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--surface-negative-active);
             `,
             dark: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-transparent-deep);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-transparent-deep-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-transparent-deep-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             black: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-dark-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-light-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
-                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-light-surface-solid-default-hover);
-                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-light-surface-solid-default-active);
+                ${iconButtonTokens.iconButtonColorHover}: var(--on-dark-text-primary-hover);
+                ${iconButtonTokens.iconButtonColorActive}: var(--on-dark-text-primary-active);
             `,
             white: css`
                 ${iconButtonTokens.iconButtonColor}: var(--on-light-text-primary);
                 ${iconButtonTokens.iconButtonBackgroundColor}: var(--on-dark-surface-solid-default);
                 ${iconButtonTokens.iconButtonLoadingBackgroundColor}: var(${iconButtonTokens.iconButtonBackgroundColor});
                 ${iconButtonTokens.iconButtonColorHover}: var(--on-light-text-primary-hover);
-                ${iconButtonTokens.iconButtonBackgroundColorHover}: var(--on-dark-surface-solid-default-hover);
                 ${iconButtonTokens.iconButtonColorActive}: var(--on-light-text-primary-active);
-                ${iconButtonTokens.iconButtonBackgroundColorActive}: var(--on-dark-surface-solid-default-active);
             `,
         },
         size: {


### PR DESCRIPTION
## Core

### Button
- исправлены токены `hover`,  `active`
- исправлены примеры в `storybook`

### IconButton
- исправлены токены `hover`,  `active`

### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.305.1-canary.1809.13721628038.0
  npm install @salutejs/plasma-b2c@1.547.1-canary.1809.13721628038.0
  npm install @salutejs/plasma-giga@0.274.1-canary.1809.13721628038.0
  npm install @salutejs/plasma-new-hope@0.291.1-canary.1809.13721628038.0
  npm install @salutejs/plasma-web@1.549.1-canary.1809.13721628038.0
  npm install @salutejs/sdds-cs@0.283.1-canary.1809.13721628038.0
  npm install @salutejs/sdds-dfa@0.277.1-canary.1809.13721628038.0
  npm install @salutejs/sdds-finportal@0.270.1-canary.1809.13721628038.0
  npm install @salutejs/sdds-insol@0.274.1-canary.1809.13721628038.0
  npm install @salutejs/sdds-serv@0.278.1-canary.1809.13721628038.0
  # or 
  yarn add @salutejs/plasma-asdk@0.305.1-canary.1809.13721628038.0
  yarn add @salutejs/plasma-b2c@1.547.1-canary.1809.13721628038.0
  yarn add @salutejs/plasma-giga@0.274.1-canary.1809.13721628038.0
  yarn add @salutejs/plasma-new-hope@0.291.1-canary.1809.13721628038.0
  yarn add @salutejs/plasma-web@1.549.1-canary.1809.13721628038.0
  yarn add @salutejs/sdds-cs@0.283.1-canary.1809.13721628038.0
  yarn add @salutejs/sdds-dfa@0.277.1-canary.1809.13721628038.0
  yarn add @salutejs/sdds-finportal@0.270.1-canary.1809.13721628038.0
  yarn add @salutejs/sdds-insol@0.274.1-canary.1809.13721628038.0
  yarn add @salutejs/sdds-serv@0.278.1-canary.1809.13721628038.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
