### PR TITLE
PLASMA-3884[DRAFT]: datepicker + react-hook-form async variant

### DIFF
--- a/packages/plasma-new-hope/package-lock.json
+++ b/packages/plasma-new-hope/package-lock.json
@@ -69,6 +69,7 @@
         "default-browser-id": "2.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-hook-form": "7.54.2",
         "rollup": "^3.28.0",
         "storybook": "7.6.17",
         "styled-components": "5.3.1",
@@ -12905,6 +12906,22 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-html-attributes": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.6.tgz",
@@ -24191,6 +24208,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "dev": true
     },
     "react-html-attributes": {
       "version": "1.4.6",

--- a/packages/plasma-new-hope/package.json
+++ b/packages/plasma-new-hope/package.json
@@ -103,6 +103,7 @@
     "default-browser-id": "2.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "7.54.2",
     "rollup": "^3.28.0",
     "storybook": "7.6.17",
     "styled-components": "5.3.1",

--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
@@ -83,13 +83,14 @@ export const datePickerRoot = (
         ) => {
             const inputRef = useRef<HTMLInputElement | null>(null);
             const innerRef = useRef<HTMLInputElement | null>(null);
-            const inputForkRef = useForkRef(inputRef, ref);
+            // const inputForkRef = useForkRef(inputRef, ref);
+            const inputForkRef = useForkRef(innerRef, ref);
             const [isInnerOpen, setIsInnerOpen] = useState(opened);
 
-            const [calendarValue, setCalendarValue] = useState(formatCalendarValue(value || defaultDate, format, lang));
-            const [inputValue, setInputValue] = useState(
-                formatInputValue({ value: value || defaultDate, format, lang }),
-            );
+            const externalDate = innerRef?.current?.value || value || defaultDate;
+
+            const [calendarValue, setCalendarValue] = useState(formatCalendarValue(externalDate, format, lang));
+            const [inputValue, setInputValue] = useState(formatInputValue({ value: externalDate, format, lang }));
 
             const dateFormatDelimiter = useCallback(() => getDateFormatDelimiter(format), [format]);
 
@@ -148,22 +149,24 @@ export const datePickerRoot = (
             });
 
             useEffect(() => {
-                console.log(inputRef, 'inputValue', ref);
-            });
+                console.log(innerRef?.current?.value, 'inputValue');
+            }, [innerRef?.current?.value]);
 
             useEffect(() => {
                 setIsInnerOpen((prevOpen) => prevOpen !== opened && opened);
             }, [opened]);
 
-            useEffect(() => {
-                console.log('value from setter', inputRef?.current?.value);
+            useLayoutEffect(() => {
+                // setTimeout(() => {
+                console.log('value from setter', innerRef?.current?.value);
+                // }, 1100);
                 const externalDate = value || defaultDate;
                 updateExternalDate(externalDate, setInputValue, setCalendarValue);
-            }, [inputRef, value, defaultDate, format, lang]);
+            }, [innerRef?.current?.value, value, defaultDate, format, lang]);
 
             const DatePickerInput = (
                 <StyledInput
-                    ref={inputForkRef}
+                    ref={inputRef}
                     className={cx(datePickerErrorClass, datePickerSuccessClass)}
                     value={inputValue}
                     size={size}
@@ -247,7 +250,7 @@ export const datePickerRoot = (
                         datatype="datepicker-single"
                         name={name}
                         value={inputValue}
-                        ref={innerRef}
+                        ref={inputForkRef}
                         {...noop}
                     />
                 </Root>

--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, SyntheticEvent, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
+import { useForkRef } from '@salutejs/plasma-core';
 
 import type { RootProps } from '../../../engines';
 import { cx, getPlacements, noop } from '../../../utils';
@@ -82,6 +83,7 @@ export const datePickerRoot = (
         ) => {
             const inputRef = useRef<HTMLInputElement | null>(null);
             const innerRef = useRef<HTMLInputElement | null>(null);
+            const inputForkRef = useForkRef(inputRef, ref);
             const [isInnerOpen, setIsInnerOpen] = useState(opened);
 
             const [calendarValue, setCalendarValue] = useState(formatCalendarValue(value || defaultDate, format, lang));
@@ -145,9 +147,13 @@ export const datePickerRoot = (
                 closeOnEsc,
             });
 
+            useEffect(() => {
+                console.log(inputValue, 'inputValue', inputRef?.current?.value);
+            });
+
             const DatePickerInput = (
                 <StyledInput
-                    ref={inputRef}
+                    ref={inputForkRef}
                     className={cx(datePickerErrorClass, datePickerSuccessClass)}
                     value={inputValue}
                     size={size}
@@ -187,7 +193,7 @@ export const datePickerRoot = (
                     className={cx(classes.datePickerRoot, className)}
                     disabled={disabled}
                     readOnly={!disabled && readOnly}
-                    ref={ref}
+                    // ref={ref}
                     {...rest}
                 >
                     <StyledPopover

--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
@@ -148,8 +148,18 @@ export const datePickerRoot = (
             });
 
             useEffect(() => {
-                console.log(inputValue, 'inputValue', inputRef?.current?.value);
+                console.log(inputRef, 'inputValue', ref);
             });
+
+            useEffect(() => {
+                setIsInnerOpen((prevOpen) => prevOpen !== opened && opened);
+            }, [opened]);
+
+            useEffect(() => {
+                console.log('value from setter', inputRef?.current?.value);
+                const externalDate = value || defaultDate;
+                updateExternalDate(externalDate, setInputValue, setCalendarValue);
+            }, [inputRef, value, defaultDate, format, lang]);
 
             const DatePickerInput = (
                 <StyledInput
@@ -177,15 +187,6 @@ export const datePickerRoot = (
                 />
             );
 
-            useEffect(() => {
-                setIsInnerOpen((prevOpen) => prevOpen !== opened && opened);
-            }, [opened]);
-
-            useLayoutEffect(() => {
-                const externalDate = value || defaultDate;
-                updateExternalDate(externalDate, setInputValue, setCalendarValue);
-            }, [value, defaultDate, format, lang]);
-
             return (
                 <Root
                     view={view}
@@ -193,7 +194,6 @@ export const datePickerRoot = (
                     className={cx(classes.datePickerRoot, className)}
                     disabled={disabled}
                     readOnly={!disabled && readOnly}
-                    // ref={ref}
                     {...rest}
                 >
                     <StyledPopover

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
@@ -2,9 +2,11 @@ import React, { ComponentProps, useEffect, useRef, useState } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { disableProps, IconPlaceholder } from '@salutejs/plasma-sb-utils';
+import { useForm } from 'react-hook-form';
 
 import { WithTheme } from '../../../_helpers';
 import { IconButton } from '../IconButton/IconButton';
+import { Button } from '../Button/Button';
 import { RangeInputRefs } from '../../../../components/Range/Range.types';
 
 import { DatePicker, DatePickerRange } from './DatePicker';
@@ -397,4 +399,41 @@ export const Deferred: StoryObj<StoryPropsDefault> = {
         valueSuccess: false,
     },
     render: (args) => <StoryDeferred {...args} />,
+};
+
+const StoryHookForm = () => {
+    const { register, handleSubmit, setValue, getValues } = useForm();
+
+    // Simulate an asynchronous operation (e.g., fetching data from an API)
+    useEffect(() => {
+        const fetchData = async () => {
+            // Simulate an API call delay
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            // Assume this is the data fetched from the API
+            const asyncData = { date: `${new Date()}` };
+
+            // Set the value of the input field asynchronously
+            setValue('date', asyncData.date);
+            console.log({ ...register('date') });
+            console.log(getValues('date'));
+        };
+
+        fetchData();
+    }, [setValue]);
+
+    const onSubmit = (data) => {
+        console.log(data);
+    };
+
+    return (
+        <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+            <DatePicker {...register('date')} />
+            <Button type="submit">Отправить</Button>
+        </form>
+    );
+};
+
+export const HookForm = {
+    render: () => <StoryHookForm />,
 };

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
@@ -408,15 +408,15 @@ const StoryHookForm = () => {
     useEffect(() => {
         const fetchData = async () => {
             // Simulate an API call delay
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            // await new Promise((resolve) => setTimeout(resolve, 1000));
 
             // Assume this is the data fetched from the API
             const asyncData = { date: `${new Date()}` };
 
             // Set the value of the input field asynchronously
             setValue('date', asyncData.date);
-            console.log({ ...register('date') });
-            console.log(getValues('date'));
+            // console.log({ ...register('date') });
+            // console.log(getValues('date'));
         };
 
         fetchData();

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/DatePicker/DatePicker.stories.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 import { WithTheme } from '../../../_helpers';
 import { IconButton } from '../IconButton/IconButton';
 import { Button } from '../Button/Button';
+import { TextField } from '../TextField/TextField';
 import { RangeInputRefs } from '../../../../components/Range/Range.types';
 
 import { DatePicker, DatePickerRange } from './DatePicker';
@@ -402,21 +403,24 @@ export const Deferred: StoryObj<StoryPropsDefault> = {
 };
 
 const StoryHookForm = () => {
-    const { register, handleSubmit, setValue, getValues } = useForm();
+    const { register, handleSubmit, setValue } = useForm();
+
+    // const date = watch('date');
 
     // Simulate an asynchronous operation (e.g., fetching data from an API)
     useEffect(() => {
         const fetchData = async () => {
             // Simulate an API call delay
-            // await new Promise((resolve) => setTimeout(resolve, 1000));
+            await new Promise((resolve) => setTimeout(resolve, 1000));
 
             // Assume this is the data fetched from the API
-            const asyncData = { date: `${new Date()}` };
+            const asyncData = { date: `${new Date()}`, text: 'asynchronous' };
 
             // Set the value of the input field asynchronously
             setValue('date', asyncData.date);
+            setValue('text', asyncData.text);
             // console.log({ ...register('date') });
-            // console.log(getValues('date'));
+            // console.log('******', watch('date'));
         };
 
         fetchData();
@@ -429,6 +433,7 @@ const StoryHookForm = () => {
     return (
         <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
             <DatePicker {...register('date')} />
+            <TextField {...register('text')} />
             <Button type="submit">Отправить</Button>
         </form>
     );


### PR DESCRIPTION
## Core

### DatePicker


### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.301.0-canary.1815.13652119489.0
  npm install @salutejs/plasma-b2c@1.543.0-canary.1815.13652119489.0
  npm install @salutejs/plasma-giga@0.270.0-canary.1815.13652119489.0
  npm install @salutejs/plasma-new-hope@0.287.0-canary.1815.13652119489.0
  npm install @salutejs/plasma-web@1.545.0-canary.1815.13652119489.0
  npm install @salutejs/sdds-cs@0.279.0-canary.1815.13652119489.0
  npm install @salutejs/sdds-dfa@0.273.0-canary.1815.13652119489.0
  npm install @salutejs/sdds-finportal@0.266.0-canary.1815.13652119489.0
  npm install @salutejs/sdds-insol@0.270.0-canary.1815.13652119489.0
  npm install @salutejs/sdds-serv@0.274.0-canary.1815.13652119489.0
  # or 
  yarn add @salutejs/plasma-asdk@0.301.0-canary.1815.13652119489.0
  yarn add @salutejs/plasma-b2c@1.543.0-canary.1815.13652119489.0
  yarn add @salutejs/plasma-giga@0.270.0-canary.1815.13652119489.0
  yarn add @salutejs/plasma-new-hope@0.287.0-canary.1815.13652119489.0
  yarn add @salutejs/plasma-web@1.545.0-canary.1815.13652119489.0
  yarn add @salutejs/sdds-cs@0.279.0-canary.1815.13652119489.0
  yarn add @salutejs/sdds-dfa@0.273.0-canary.1815.13652119489.0
  yarn add @salutejs/sdds-finportal@0.266.0-canary.1815.13652119489.0
  yarn add @salutejs/sdds-insol@0.270.0-canary.1815.13652119489.0
  yarn add @salutejs/sdds-serv@0.274.0-canary.1815.13652119489.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
