### PR TITLE
PLASMA-4498: feat(plasma-typo): Add `medium` tokens and props

### DIFF
--- a/packages/plasma-typo/src/archetypes/mage.ts
+++ b/packages/plasma-typo/src/archetypes/mage.ts
@@ -12,6 +12,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '5.75rem',
     },
+    'dspl-l-medium': {
+        'font-size': '5.5rem',
+        'font-weight': '500',
+        'line-height': '5.75rem',
+    },
     'dspl-m': {
         'font-size': '3.5rem',
         'font-weight': '300',
@@ -20,6 +25,11 @@ export const baseTypoS: TypoProps = {
     'dspl-m-bold': {
         'font-size': '3.5rem',
         'font-weight': '600',
+        'line-height': '3.875rem',
+    },
+    'dspl-m-medium': {
+        'font-size': '3.5rem',
+        'font-weight': '500',
         'line-height': '3.875rem',
     },
     'dspl-s': {
@@ -32,6 +42,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '2.875rem',
     },
+    'dspl-s-medium': {
+        'font-size': '2.5rem',
+        'font-weight': '500',
+        'line-height': '2.875rem',
+    },
     h1: {
         'font-size': '1.75rem',
         'font-weight': '400',
@@ -40,6 +55,11 @@ export const baseTypoS: TypoProps = {
     'h1-bold': {
         'font-size': '1.75rem',
         'font-weight': '600',
+        'line-height': '2.125rem',
+    },
+    'h1-medium': {
+        'font-size': '1.75rem',
+        'font-weight': '500',
         'line-height': '2.125rem',
     },
     h2: {
@@ -52,6 +72,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.875rem',
     },
+    'h2-medium': {
+        'font-size': '1.5rem',
+        'font-weight': '500',
+        'line-height': '1.875rem',
+    },
     h3: {
         'font-size': '1.25rem',
         'font-weight': '400',
@@ -60,6 +85,11 @@ export const baseTypoS: TypoProps = {
     'h3-bold': {
         'font-size': '1.25rem',
         'font-weight': '600',
+        'line-height': '1.625rem',
+    },
+    'h3-medium': {
+        'font-size': '1.25rem',
+        'font-weight': '500',
         'line-height': '1.625rem',
     },
     h4: {
@@ -72,6 +102,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.5rem',
     },
+    'h4-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.5rem',
+    },
     h5: {
         'font-size': '1rem',
         'font-weight': '400',
@@ -80,6 +115,11 @@ export const baseTypoS: TypoProps = {
     'h5-bold': {
         'font-size': '1rem',
         'font-weight': '600',
+        'line-height': '1.375rem',
+    },
+    'h5-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
         'line-height': '1.375rem',
     },
     'body-l': {
@@ -92,6 +132,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.375rem',
     },
+    'body-l-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.375rem',
+    },
     'body-m': {
         'font-size': '1rem',
         'font-weight': '400',
@@ -100,6 +145,11 @@ export const baseTypoS: TypoProps = {
     'body-m-bold': {
         'font-size': '1rem',
         'font-weight': '600',
+        'line-height': '1.25rem',
+    },
+    'body-m-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
         'line-height': '1.25rem',
     },
     'body-s': {
@@ -112,6 +162,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.125rem',
     },
+    'body-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.125rem',
+    },
     'body-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -120,6 +175,11 @@ export const baseTypoS: TypoProps = {
     'body-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '0.875rem',
+    },
+    'body-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '0.875rem',
     },
     'body-xxs': {
@@ -132,6 +192,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '0.75rem',
     },
+    'body-xxs-medium': {
+        'font-size': '0.625rem',
+        'font-weight': '500',
+        'line-height': '0.75rem',
+    },
     'text-l': {
         'font-size': '1.125rem',
         'font-weight': '400',
@@ -140,6 +205,11 @@ export const baseTypoS: TypoProps = {
     'text-l-bold': {
         'font-size': '1.125rem',
         'font-weight': '600',
+        'line-height': '1.625rem',
+    },
+    'text-l-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
         'line-height': '1.625rem',
     },
     'text-m': {
@@ -152,6 +222,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.5rem',
     },
+    'text-m-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
+        'line-height': '1.5rem',
+    },
     'text-s': {
         'font-size': '0.875rem',
         'font-weight': '400',
@@ -162,6 +237,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.25rem',
     },
+    'text-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.25rem',
+    },
     'text-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -170,6 +250,11 @@ export const baseTypoS: TypoProps = {
     'text-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '1rem',
+    },
+    'text-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '1rem',
     },
 };
@@ -185,6 +270,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '7rem',
     },
+    'dspl-l-medium': {
+        'font-size': '7rem',
+        'font-weight': '500',
+        'line-height': '7rem',
+    },
     'dspl-m': {
         'font-size': '4.5rem',
         'font-weight': '300',
@@ -193,6 +283,11 @@ export const baseTypoM = {
     'dspl-m-bold': {
         'font-size': '4.5rem',
         'font-weight': '600',
+        'line-height': '4.75rem',
+    },
+    'dspl-m-medium': {
+        'font-size': '4.5rem',
+        'font-weight': '500',
         'line-height': '4.75rem',
     },
     'dspl-s': {
@@ -205,6 +300,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '3.375rem',
     },
+    'dspl-s-medium': {
+        'font-size': '3rem',
+        'font-weight': '500',
+        'line-height': '3.375rem',
+    },
     h1: {
         'font-size': '2.5rem',
         'font-weight': '400',
@@ -213,6 +313,11 @@ export const baseTypoM = {
     'h1-bold': {
         'font-size': '2.5rem',
         'font-weight': '600',
+        'line-height': '2.875rem',
+    },
+    'h1-medium': {
+        'font-size': '2.5rem',
+        'font-weight': '500',
         'line-height': '2.875rem',
     },
     h2: {
@@ -225,6 +330,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '2.125rem',
     },
+    'h2-medium': {
+        'font-size': '1.75rem',
+        'font-weight': '500',
+        'line-height': '2.125rem',
+    },
     h3: {
         'font-size': '1.25rem',
         'font-weight': '400',
@@ -233,6 +343,11 @@ export const baseTypoM = {
     'h3-bold': {
         'font-size': '1.25rem',
         'font-weight': '600',
+        'line-height': '1.625rem',
+    },
+    'h3-medium': {
+        'font-size': '1.25rem',
+        'font-weight': '500',
         'line-height': '1.625rem',
     },
     h4: {
@@ -245,6 +360,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '1.5rem',
     },
+    'h4-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.5rem',
+    },
     h5: {
         'font-size': '1rem',
         'font-weight': '400',
@@ -253,6 +373,11 @@ export const baseTypoM = {
     'h5-bold': {
         'font-size': '1rem',
         'font-weight': '600',
+        'line-height': '1.375rem',
+    },
+    'h5-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
         'line-height': '1.375rem',
     },
     'body-l': {
@@ -265,6 +390,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '1.375rem',
     },
+    'body-l-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.375rem',
+    },
     'body-m': {
         'font-size': '1rem',
         'font-weight': '400',
@@ -273,6 +403,11 @@ export const baseTypoM = {
     'body-m-bold': {
         'font-size': '1rem',
         'font-weight': '600',
+        'line-height': '1.25rem',
+    },
+    'body-m-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
         'line-height': '1.25rem',
     },
     'body-s': {
@@ -285,6 +420,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '1.125rem',
     },
+    'body-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.125rem',
+    },
     'body-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -293,6 +433,11 @@ export const baseTypoM = {
     'body-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '0.875rem',
+    },
+    'body-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '0.875rem',
     },
     'body-xxs': {
@@ -305,6 +450,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '0.75rem',
     },
+    'body-xxs-medium': {
+        'font-size': '0.625rem',
+        'font-weight': '500',
+        'line-height': '0.75rem',
+    },
     'text-l': {
         'font-size': '1.25rem',
         'font-weight': '400',
@@ -313,6 +463,11 @@ export const baseTypoM = {
     'text-l-bold': {
         'font-size': '1.25rem',
         'font-weight': '600',
+        'line-height': '1.75rem',
+    },
+    'text-l-medium': {
+        'font-size': '1.25rem',
+        'font-weight': '500',
         'line-height': '1.75rem',
     },
     'text-m': {
@@ -325,6 +480,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '1.5rem',
     },
+    'text-m-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
+        'line-height': '1.5rem',
+    },
     'text-s': {
         'font-size': '0.875rem',
         'font-weight': '400',
@@ -335,6 +495,11 @@ export const baseTypoM = {
         'font-weight': '600',
         'line-height': '1.25rem',
     },
+    'text-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.25rem',
+    },
     'text-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -343,6 +508,11 @@ export const baseTypoM = {
     'text-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '1rem',
+    },
+    'text-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '1rem',
     },
 };
@@ -358,6 +528,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '8rem',
     },
+    'dspl-l-medium': {
+        'font-size': '8rem',
+        'font-weight': '500',
+        'line-height': '8rem',
+    },
     'dspl-m': {
         'font-size': '5.5rem',
         'font-weight': '300',
@@ -366,6 +541,11 @@ export const baseTypoL = {
     'dspl-m-bold': {
         'font-size': '5.5rem',
         'font-weight': '600',
+        'line-height': '5.75rem',
+    },
+    'dspl-m-medium': {
+        'font-size': '5.5rem',
+        'font-weight': '500',
         'line-height': '5.75rem',
     },
     'dspl-s': {
@@ -378,6 +558,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '4.25rem',
     },
+    'dspl-s-medium': {
+        'font-size': '4rem',
+        'font-weight': '500',
+        'line-height': '4.25rem',
+    },
     h1: {
         'font-size': '3rem',
         'font-weight': '400',
@@ -386,6 +571,11 @@ export const baseTypoL = {
     'h1-bold': {
         'font-size': '3rem',
         'font-weight': '600',
+        'line-height': '3.375rem',
+    },
+    'h1-medium': {
+        'font-size': '3rem',
+        'font-weight': '500',
         'line-height': '3.375rem',
     },
     h2: {
@@ -398,6 +588,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '2.375rem',
     },
+    'h2-medium': {
+        'font-size': '2rem',
+        'font-weight': '500',
+        'line-height': '2.375rem',
+    },
     h3: {
         'font-size': '1.5rem',
         'font-weight': '400',
@@ -406,6 +601,11 @@ export const baseTypoL = {
     'h3-bold': {
         'font-size': '1.5rem',
         'font-weight': '600',
+        'line-height': '1.875rem',
+    },
+    'h3-medium': {
+        'font-size': '1.5rem',
+        'font-weight': '500',
         'line-height': '1.875rem',
     },
     h4: {
@@ -418,6 +618,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.625rem',
     },
+    'h4-medium': {
+        'font-size': '1.25rem',
+        'font-weight': '500',
+        'line-height': '1.625rem',
+    },
     h5: {
         'font-size': '1.125rem',
         'font-weight': '400',
@@ -426,6 +631,11 @@ export const baseTypoL = {
     'h5-bold': {
         'font-size': '1.125rem',
         'font-weight': '600',
+        'line-height': '1.5rem',
+    },
+    'h5-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
         'line-height': '1.5rem',
     },
     'body-l': {
@@ -438,6 +648,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.375rem',
     },
+    'body-l-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.375rem',
+    },
     'body-m': {
         'font-size': '1rem',
         'font-weight': '400',
@@ -446,6 +661,11 @@ export const baseTypoL = {
     'body-m-bold': {
         'font-size': '1rem',
         'font-weight': '600',
+        'line-height': '1.25rem',
+    },
+    'body-m-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
         'line-height': '1.25rem',
     },
     'body-s': {
@@ -458,6 +678,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.125rem',
     },
+    'body-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.125rem',
+    },
     'body-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -466,6 +691,11 @@ export const baseTypoL = {
     'body-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '0.875rem',
+    },
+    'body-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '0.875rem',
     },
     'body-xxs': {
@@ -478,6 +708,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '0.75rem',
     },
+    'body-xxs-medium': {
+        'font-size': '0.625rem',
+        'font-weight': '500',
+        'line-height': '0.75rem',
+    },
     'text-l': {
         'font-size': '1.5rem',
         'font-weight': '400',
@@ -486,6 +721,11 @@ export const baseTypoL = {
     'text-l-bold': {
         'font-size': '1.5rem',
         'font-weight': '600',
+        'line-height': '2rem',
+    },
+    'text-l-medium': {
+        'font-size': '1.5rem',
+        'font-weight': '500',
         'line-height': '2rem',
     },
     'text-m': {
@@ -498,6 +738,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.625rem',
     },
+    'text-m-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.625rem',
+    },
     'text-s': {
         'font-size': '0.875rem',
         'font-weight': '400',
@@ -508,6 +753,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.25rem',
     },
+    'text-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.25rem',
+    },
     'text-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -516,6 +766,11 @@ export const baseTypoL = {
     'text-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '1rem',
+    },
+    'text-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '1rem',
     },
 };
@@ -531,12 +786,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'dspl-l-medium': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     'dspl-m': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'dspl-m-bold': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'dspl-m-medium': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -551,12 +816,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'dspl-s-medium': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     h1: {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'h1-bold': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'h1-medium': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -571,12 +846,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'h2-medium': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     h3: {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'h3-bold': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'h3-medium': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -591,12 +876,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'h4-medium': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     h5: {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'h5-bold': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'h5-medium': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -611,12 +906,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
     },
+    'body-l-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02em',
+        'font-style': 'normal',
+    },
     'body-m': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
     },
     'body-m-bold': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02em',
+        'font-style': 'normal',
+    },
+    'body-m-medium': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
@@ -631,12 +936,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
     },
+    'body-s-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02em',
+        'font-style': 'normal',
+    },
     'body-xs': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
     },
     'body-xs-bold': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02em',
+        'font-style': 'normal',
+    },
+    'body-xs-medium': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
@@ -651,12 +966,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
     },
+    'body-xxs-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02em',
+        'font-style': 'normal',
+    },
     'text-l': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
     },
     'text-l-bold': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02em',
+        'font-style': 'normal',
+    },
+    'text-l-medium': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
@@ -671,6 +996,11 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
     },
+    'text-m-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02em',
+        'font-style': 'normal',
+    },
     'text-s': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
@@ -681,12 +1011,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': '-0.02emm',
         'font-style': 'normal',
     },
+    'text-s-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02emm',
+        'font-style': 'normal',
+    },
     'text-xs': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
         'font-style': 'normal',
     },
     'text-xs-bold': {
+        'font-family': textFontFamily,
+        'letter-spacing': '-0.02em',
+        'font-style': 'normal',
+    },
+    'text-xs-medium': {
         'font-family': textFontFamily,
         'letter-spacing': '-0.02em',
         'font-style': 'normal',

--- a/packages/plasma-typo/src/archetypes/plasma.ts
+++ b/packages/plasma-typo/src/archetypes/plasma.ts
@@ -10,11 +10,17 @@ const typo = {
     'dspl-l-bold': {
         'font-weight': '700',
     },
+    'dspl-l-medium': {
+        'font-weight': '500',
+    },
     'dspl-m': {
         'font-weight': '400',
     },
     'dspl-m-bold': {
         'font-weight': '700',
+    },
+    'dspl-m-medium': {
+        'font-weight': '500',
     },
     'dspl-s': {
         'font-weight': '400',
@@ -22,11 +28,17 @@ const typo = {
     'dspl-s-bold': {
         'font-weight': '700',
     },
+    'dspl-s-medium': {
+        'font-weight': '500',
+    },
     h1: {
         'font-weight': '400',
     },
     'h1-bold': {
         'font-weight': '700',
+    },
+    'h1-medium': {
+        'font-weight': '500',
     },
     h2: {
         'font-weight': '400',
@@ -34,11 +46,17 @@ const typo = {
     'h2-bold': {
         'font-weight': '700',
     },
+    'h2-medium': {
+        'font-weight': '500',
+    },
     h3: {
         'font-weight': '400',
     },
     'h3-bold': {
         'font-weight': '700',
+    },
+    'h3-medium': {
+        'font-weight': '500',
     },
     h4: {
         'font-weight': '400',
@@ -46,11 +64,17 @@ const typo = {
     'h4-bold': {
         'font-weight': '700',
     },
+    'h4-medium': {
+        'font-weight': '500',
+    },
     h5: {
         'font-weight': '400',
     },
     'h5-bold': {
         'font-weight': '700',
+    },
+    'h5-medium': {
+        'font-weight': '500',
     },
     'body-l': {
         'font-weight': '400',
@@ -58,11 +82,17 @@ const typo = {
     'body-l-bold': {
         'font-weight': '700',
     },
+    'body-l-medium': {
+        'font-weight': '500',
+    },
     'body-m': {
         'font-weight': '400',
     },
     'body-m-bold': {
         'font-weight': '700',
+    },
+    'body-m-medium': {
+        'font-weight': '500',
     },
     'body-s': {
         'font-weight': '400',
@@ -70,11 +100,17 @@ const typo = {
     'body-s-bold': {
         'font-weight': '700',
     },
+    'body-s-medium': {
+        'font-weight': '500',
+    },
     'body-xs': {
         'font-weight': '400',
     },
     'body-xs-bold': {
         'font-weight': '700',
+    },
+    'body-xs-medium': {
+        'font-weight': '500',
     },
     'body-xxs': {
         'font-weight': '400',
@@ -82,11 +118,17 @@ const typo = {
     'body-xxs-bold': {
         'font-weight': '700',
     },
+    'body-xxs-medium': {
+        'font-weight': '500',
+    },
     'text-l': {
         'font-weight': '400',
     },
     'text-l-bold': {
         'font-weight': '700',
+    },
+    'text-l-medium': {
+        'font-weight': '500',
     },
     'text-m': {
         'font-weight': '400',
@@ -94,17 +136,26 @@ const typo = {
     'text-m-bold': {
         'font-weight': '700',
     },
+    'text-m-medium': {
+        'font-weight': '500',
+    },
     'text-s': {
         'font-weight': '400',
     },
     'text-s-bold': {
         'font-weight': '700',
     },
+    'text-s-medium': {
+        'font-weight': '500',
+    },
     'text-xs': {
         'font-weight': '400',
     },
     'text-xs-bold': {
         'font-weight': '700',
+    },
+    'text-xs-medium': {
+        'font-weight': '500',
     },
 };
 

--- a/packages/plasma-typo/src/archetypes/ruler.ts
+++ b/packages/plasma-typo/src/archetypes/ruler.ts
@@ -10,10 +10,16 @@ const typo = {
     'dspl-l-bold': {
         'font-weight': '500',
     },
+    'dspl-l-medium': {
+        'font-weight': '500',
+    },
     'dspl-m': {
         'font-weight': '400',
     },
     'dspl-m-bold': {
+        'font-weight': '500',
+    },
+    'dspl-m-medium': {
         'font-weight': '500',
     },
     'dspl-s': {
@@ -22,10 +28,16 @@ const typo = {
     'dspl-s-bold': {
         'font-weight': '500',
     },
+    'dspl-s-medium': {
+        'font-weight': '500',
+    },
     h1: {
         'font-weight': '400',
     },
     'h1-bold': {
+        'font-weight': '500',
+    },
+    'h1-medium': {
         'font-weight': '500',
     },
     h2: {
@@ -34,10 +46,16 @@ const typo = {
     'h2-bold': {
         'font-weight': '500',
     },
+    'h2-medium': {
+        'font-weight': '500',
+    },
     h3: {
         'font-weight': '400',
     },
     'h3-bold': {
+        'font-weight': '500',
+    },
+    'h3-medium': {
         'font-weight': '500',
     },
     h4: {
@@ -46,10 +64,16 @@ const typo = {
     'h4-bold': {
         'font-weight': '500',
     },
+    'h4-medium': {
+        'font-weight': '500',
+    },
     h5: {
         'font-weight': '400',
     },
     'h5-bold': {
+        'font-weight': '500',
+    },
+    'h5-medium': {
         'font-weight': '500',
     },
     'body-l': {
@@ -58,10 +82,16 @@ const typo = {
     'body-l-bold': {
         'font-weight': '500',
     },
+    'body-l-medium': {
+        'font-weight': '500',
+    },
     'body-m': {
         'font-weight': '400',
     },
     'body-m-bold': {
+        'font-weight': '500',
+    },
+    'body-m-medium': {
         'font-weight': '500',
     },
     'body-s': {
@@ -70,10 +100,16 @@ const typo = {
     'body-s-bold': {
         'font-weight': '500',
     },
+    'body-s-medium': {
+        'font-weight': '500',
+    },
     'body-xs': {
         'font-weight': '400',
     },
     'body-xs-bold': {
+        'font-weight': '500',
+    },
+    'body-xs-medium': {
         'font-weight': '500',
     },
     'body-xxs': {
@@ -82,10 +118,16 @@ const typo = {
     'body-xxs-bold': {
         'font-weight': '500',
     },
+    'body-xxs-medium': {
+        'font-weight': '500',
+    },
     'text-l': {
         'font-weight': '400',
     },
     'text-l-bold': {
+        'font-weight': '500',
+    },
+    'text-l-medium': {
         'font-weight': '500',
     },
     'text-m': {
@@ -94,16 +136,25 @@ const typo = {
     'text-m-bold': {
         'font-weight': '500',
     },
+    'text-m-medium': {
+        'font-weight': '500',
+    },
     'text-s': {
         'font-weight': '400',
     },
     'text-s-bold': {
         'font-weight': '500',
     },
+    'text-s-medium': {
+        'font-weight': '500',
+    },
     'text-xs': {
         'font-weight': '400',
     },
     'text-xs-bold': {
+        'font-weight': '500',
+    },
+    'text-xs-medium': {
         'font-weight': '500',
     },
 };

--- a/packages/plasma-typo/src/archetypes/sage.ts
+++ b/packages/plasma-typo/src/archetypes/sage.ts
@@ -10,11 +10,17 @@ const typo = {
     'dspl-l-bold': {
         'font-weight': '600',
     },
+    'dspl-l-medium': {
+        'font-weight': '500',
+    },
     'dspl-m': {
         'font-weight': '400',
     },
     'dspl-m-bold': {
         'font-weight': '600',
+    },
+    'dspl-m-medium': {
+        'font-weight': '500',
     },
     'dspl-s': {
         'font-weight': '400',
@@ -22,11 +28,17 @@ const typo = {
     'dspl-s-bold': {
         'font-weight': '600',
     },
+    'dspl-s-medium': {
+        'font-weight': '500',
+    },
     h1: {
         'font-weight': '400',
     },
     'h1-bold': {
         'font-weight': '600',
+    },
+    'h1-medium': {
+        'font-weight': '500',
     },
     h2: {
         'font-weight': '400',
@@ -34,11 +46,17 @@ const typo = {
     'h2-bold': {
         'font-weight': '600',
     },
+    'h2-medium': {
+        'font-weight': '500',
+    },
     h3: {
         'font-weight': '400',
     },
     'h3-bold': {
         'font-weight': '600',
+    },
+    'h3-medium': {
+        'font-weight': '500',
     },
     h4: {
         'font-weight': '400',
@@ -46,11 +64,17 @@ const typo = {
     'h4-bold': {
         'font-weight': '600',
     },
+    'h4-medium': {
+        'font-weight': '500',
+    },
     h5: {
         'font-weight': '400',
     },
     'h5-bold': {
         'font-weight': '600',
+    },
+    'h5-medium': {
+        'font-weight': '500',
     },
     'body-l': {
         'font-weight': '400',
@@ -58,11 +82,17 @@ const typo = {
     'body-l-bold': {
         'font-weight': '600',
     },
+    'body-l-medium': {
+        'font-weight': '500',
+    },
     'body-m': {
         'font-weight': '400',
     },
     'body-m-bold': {
         'font-weight': '600',
+    },
+    'body-m-medium': {
+        'font-weight': '500',
     },
     'body-s': {
         'font-weight': '400',
@@ -70,11 +100,17 @@ const typo = {
     'body-s-bold': {
         'font-weight': '600',
     },
+    'body-s-medium': {
+        'font-weight': '500',
+    },
     'body-xs': {
         'font-weight': '400',
     },
     'body-xs-bold': {
         'font-weight': '600',
+    },
+    'body-xs-medium': {
+        'font-weight': '500',
     },
     'body-xxs': {
         'font-weight': '400',
@@ -82,11 +118,17 @@ const typo = {
     'body-xxs-bold': {
         'font-weight': '600',
     },
+    'body-xxs-medium': {
+        'font-weight': '500',
+    },
     'text-l': {
         'font-weight': '400',
     },
     'text-l-bold': {
         'font-weight': '600',
+    },
+    'text-l-medium': {
+        'font-weight': '500',
     },
     'text-m': {
         'font-weight': '400',
@@ -94,17 +136,26 @@ const typo = {
     'text-m-bold': {
         'font-weight': '600',
     },
+    'text-m-medium': {
+        'font-weight': '500',
+    },
     'text-s': {
         'font-weight': '400',
     },
     'text-s-bold': {
         'font-weight': '600',
     },
+    'text-s-medium': {
+        'font-weight': '500',
+    },
     'text-xs': {
         'font-weight': '400',
     },
     'text-xs-bold': {
         'font-weight': '600',
+    },
+    'text-xs-medium': {
+        'font-weight': '500',
     },
 };
 

--- a/packages/plasma-typo/src/archetypes/sbermarket.ts
+++ b/packages/plasma-typo/src/archetypes/sbermarket.ts
@@ -12,6 +12,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '700',
         'line-height': '5.75rem',
     },
+    'dspl-l-medium': {
+        'font-size': '5.5rem',
+        'font-weight': '500',
+        'line-height': '5.75rem',
+    },
     'dspl-m': {
         'font-size': '3.5rem',
         'font-weight': '400',
@@ -20,6 +25,11 @@ export const baseTypoS: TypoProps = {
     'dspl-m-bold': {
         'font-size': '3.5rem',
         'font-weight': '700',
+        'line-height': '3.75rem',
+    },
+    'dspl-m-medium': {
+        'font-size': '3.5rem',
+        'font-weight': '500',
         'line-height': '3.75rem',
     },
     'dspl-s': {
@@ -32,6 +42,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '700',
         'line-height': '2.75rem',
     },
+    'dspl-s-medium': {
+        'font-size': '2.5rem',
+        'font-weight': '500',
+        'line-height': '2.75rem',
+    },
     h1: {
         'font-size': '2rem',
         'font-weight': '400',
@@ -40,6 +55,11 @@ export const baseTypoS: TypoProps = {
     'h1-bold': {
         'font-size': '2rem',
         'font-weight': '700',
+        'line-height': '2.5rem',
+    },
+    'h1-medium': {
+        'font-size': '2rem',
+        'font-weight': '500',
         'line-height': '2.5rem',
     },
     h2: {
@@ -52,6 +72,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '700',
         'line-height': '2rem',
     },
+    'h2-medium': {
+        'font-size': '1.5rem',
+        'font-weight': '500',
+        'line-height': '2rem',
+    },
     h3: {
         'font-size': '1.25rem',
         'font-weight': '400',
@@ -60,6 +85,11 @@ export const baseTypoS: TypoProps = {
     'h3-bold': {
         'font-size': '1.25rem',
         'font-weight': '700',
+        'line-height': '1.625rem',
+    },
+    'h3-medium': {
+        'font-size': '1.25rem',
+        'font-weight': '500',
         'line-height': '1.625rem',
     },
     h4: {
@@ -72,6 +102,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '700',
         'line-height': '1.5rem',
     },
+    'h4-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.5rem',
+    },
     h5: {
         'font-size': '0.9375rem',
         'font-weight': '400',
@@ -80,6 +115,11 @@ export const baseTypoS: TypoProps = {
     'h5-bold': {
         'font-size': '0.9375rem',
         'font-weight': '700',
+        'line-height': '1.25rem',
+    },
+    'h5-medium': {
+        'font-size': '0.9375rem',
+        'font-weight': '500',
         'line-height': '1.25rem',
     },
     'body-l': {
@@ -92,6 +132,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.5rem',
     },
+    'body-l-medium': {
+        'font-size': '1.0625rem',
+        'font-weight': '500',
+        'line-height': '1.5rem',
+    },
     'body-m': {
         'font-size': '0.9375rem',
         'font-weight': '400',
@@ -100,6 +145,11 @@ export const baseTypoS: TypoProps = {
     'body-m-bold': {
         'font-size': '0.9375rem',
         'font-weight': '600',
+        'line-height': '1.25rem',
+    },
+    'body-m-medium': {
+        'font-size': '0.9375rem',
+        'font-weight': '500',
         'line-height': '1.25rem',
     },
     'body-s': {
@@ -112,6 +162,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.125rem',
     },
+    'body-s-medium': {
+        'font-size': '0.8125rem',
+        'font-weight': '500',
+        'line-height': '1.125rem',
+    },
     'body-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -120,6 +175,11 @@ export const baseTypoS: TypoProps = {
     'body-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '1rem',
+    },
+    'body-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '1rem',
     },
     'body-xxs': {
@@ -132,6 +192,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '0.75rem',
     },
+    'body-xxs-medium': {
+        'font-size': '0.625rem',
+        'font-weight': '500',
+        'line-height': '0.75rem',
+    },
     'text-l': {
         'font-size': '1.125rem',
         'font-weight': '400',
@@ -140,6 +205,11 @@ export const baseTypoS: TypoProps = {
     'text-l-bold': {
         'font-size': '1.125rem',
         'font-weight': '600',
+        'line-height': '1.75rem',
+    },
+    'text-l-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
         'line-height': '1.75rem',
     },
     'text-m': {
@@ -152,6 +222,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.5rem',
     },
+    'text-m-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
+        'line-height': '1.5rem',
+    },
     'text-s': {
         'font-size': '0.875rem',
         'font-weight': '400',
@@ -162,6 +237,11 @@ export const baseTypoS: TypoProps = {
         'font-weight': '600',
         'line-height': '1.25rem',
     },
+    'text-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.25rem',
+    },
     'text-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -170,6 +250,11 @@ export const baseTypoS: TypoProps = {
     'text-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '1rem',
+    },
+    'text-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '1rem',
     },
 };
@@ -185,6 +270,11 @@ export const baseTypoL = {
         'font-weight': '700',
         'line-height': '8rem',
     },
+    'dspl-l-medium': {
+        'font-size': '8rem',
+        'font-weight': '500',
+        'line-height': '8rem',
+    },
     'dspl-m': {
         'font-size': '5.5rem',
         'font-weight': '400',
@@ -193,6 +283,11 @@ export const baseTypoL = {
     'dspl-m-bold': {
         'font-size': '5.5rem',
         'font-weight': '700',
+        'line-height': '5.75rem',
+    },
+    'dspl-m-medium': {
+        'font-size': '5.5rem',
+        'font-weight': '500',
         'line-height': '5.75rem',
     },
     'dspl-s': {
@@ -205,6 +300,11 @@ export const baseTypoL = {
         'font-weight': '700',
         'line-height': '4.25rem',
     },
+    'dspl-s-medium': {
+        'font-size': '4rem',
+        'font-weight': '500',
+        'line-height': '4.25rem',
+    },
     h1: {
         'font-size': '2.5rem',
         'font-weight': '400',
@@ -213,6 +313,11 @@ export const baseTypoL = {
     'h1-bold': {
         'font-size': '2.5rem',
         'font-weight': '700',
+        'line-height': '3rem',
+    },
+    'h1-medium': {
+        'font-size': '2.5rem',
+        'font-weight': '500',
         'line-height': '3rem',
     },
     h2: {
@@ -225,6 +330,11 @@ export const baseTypoL = {
         'font-weight': '700',
         'line-height': '2.25rem',
     },
+    'h2-medium': {
+        'font-size': '2rem',
+        'font-weight': '500',
+        'line-height': '2.25rem',
+    },
     h3: {
         'font-size': '1.5rem',
         'font-weight': '400',
@@ -233,6 +343,11 @@ export const baseTypoL = {
     'h3-bold': {
         'font-size': '1.5rem',
         'font-weight': '700',
+        'line-height': '1.875rem',
+    },
+    'h3-medium': {
+        'font-size': '1.5rem',
+        'font-weight': '500',
         'line-height': '1.875rem',
     },
     h4: {
@@ -245,6 +360,11 @@ export const baseTypoL = {
         'font-weight': '700',
         'line-height': '1.625rem',
     },
+    'h4-medium': {
+        'font-size': '1.25rem',
+        'font-weight': '500',
+        'line-height': '1.625rem',
+    },
     h5: {
         'font-size': '1.125rem',
         'font-weight': '400',
@@ -253,6 +373,11 @@ export const baseTypoL = {
     'h5-bold': {
         'font-size': '1.125rem',
         'font-weight': '700',
+        'line-height': '1.5rem',
+    },
+    'h5-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
         'line-height': '1.5rem',
     },
     'body-l': {
@@ -265,6 +390,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.5rem',
     },
+    'body-l-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.5rem',
+    },
     'body-m': {
         'font-size': '1rem',
         'font-weight': '400',
@@ -273,6 +403,11 @@ export const baseTypoL = {
     'body-m-bold': {
         'font-size': '1rem',
         'font-weight': '600',
+        'line-height': '1.25rem',
+    },
+    'body-m-medium': {
+        'font-size': '1rem',
+        'font-weight': '500',
         'line-height': '1.25rem',
     },
     'body-s': {
@@ -285,6 +420,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.125rem',
     },
+    'body-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.125rem',
+    },
     'body-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -293,6 +433,11 @@ export const baseTypoL = {
     'body-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '1rem',
+    },
+    'body-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '1rem',
     },
     'body-xxs': {
@@ -305,6 +450,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '0.75rem',
     },
+    'body-xxs-medium': {
+        'font-size': '0.625rem',
+        'font-weight': '500',
+        'line-height': '0.75rem',
+    },
     'text-l': {
         'font-size': '1.5rem',
         'font-weight': '400',
@@ -313,6 +463,11 @@ export const baseTypoL = {
     'text-l-bold': {
         'font-size': '1.5rem',
         'font-weight': '600',
+        'line-height': '2rem',
+    },
+    'text-l-medium': {
+        'font-size': '1.5rem',
+        'font-weight': '500',
         'line-height': '2rem',
     },
     'text-m': {
@@ -325,6 +480,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.625rem',
     },
+    'text-m-medium': {
+        'font-size': '1.125rem',
+        'font-weight': '500',
+        'line-height': '1.625rem',
+    },
     'text-s': {
         'font-size': '0.875rem',
         'font-weight': '400',
@@ -335,6 +495,11 @@ export const baseTypoL = {
         'font-weight': '600',
         'line-height': '1.25rem',
     },
+    'text-s-medium': {
+        'font-size': '0.875rem',
+        'font-weight': '500',
+        'line-height': '1.25rem',
+    },
     'text-xs': {
         'font-size': '0.75rem',
         'font-weight': '400',
@@ -343,6 +508,11 @@ export const baseTypoL = {
     'text-xs-bold': {
         'font-size': '0.75rem',
         'font-weight': '600',
+        'line-height': '1rem',
+    },
+    'text-xs-medium': {
+        'font-size': '0.75rem',
+        'font-weight': '500',
         'line-height': '1rem',
     },
 };
@@ -358,12 +528,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'dspl-l-medium': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     'dspl-m': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'dspl-m-bold': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'dspl-m-medium': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -378,12 +558,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'dspl-s-medium': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     h1: {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'h1-bold': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'h1-medium': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -398,12 +588,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'h2-medium': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     h3: {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'h3-bold': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'h3-medium': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -418,12 +618,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'h4-medium': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     h5: {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'h5-bold': {
+        'font-family': displayFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'h5-medium': {
         'font-family': displayFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -438,12 +648,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': '0.02em',
         'font-style': 'normal',
     },
+    'body-l-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': '0.02em',
+        'font-style': 'normal',
+    },
     'body-m': {
         'font-family': textFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'body-m-bold': {
+        'font-family': textFontFamily,
+        'letter-spacing': '0.02em',
+        'font-style': 'normal',
+    },
+    'body-m-medium': {
         'font-family': textFontFamily,
         'letter-spacing': '0.02em',
         'font-style': 'normal',
@@ -458,12 +678,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': '0.02em',
         'font-style': 'normal',
     },
+    'body-s-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': '0.02em',
+        'font-style': 'normal',
+    },
     'body-xs': {
         'font-family': textFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'body-xs-bold': {
+        'font-family': textFontFamily,
+        'letter-spacing': '0.02em',
+        'font-style': 'normal',
+    },
+    'body-xs-medium': {
         'font-family': textFontFamily,
         'letter-spacing': '0.02em',
         'font-style': 'normal',
@@ -478,12 +708,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': '0.02em',
         'font-style': 'normal',
     },
+    'body-xxs-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': '0.02em',
+        'font-style': 'normal',
+    },
     'text-l': {
         'font-family': textFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'text-l-bold': {
+        'font-family': textFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'text-l-medium': {
         'font-family': textFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
@@ -498,6 +738,11 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'text-m-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     'text-s': {
         'font-family': textFontFamily,
         'letter-spacing': 'normal',
@@ -508,12 +753,22 @@ export const typoCommonProps = (displayFontFamily: string, textFontFamily: strin
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
+    'text-s-medium': {
+        'font-family': textFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
     'text-xs': {
         'font-family': textFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',
     },
     'text-xs-bold': {
+        'font-family': textFontFamily,
+        'letter-spacing': 'normal',
+        'font-style': 'normal',
+    },
+    'text-xs-medium': {
         'font-family': textFontFamily,
         'letter-spacing': 'normal',
         'font-style': 'normal',

--- a/packages/plasma-typo/src/archetypes/soulmate.ts
+++ b/packages/plasma-typo/src/archetypes/soulmate.ts
@@ -10,11 +10,17 @@ const typo = {
     'dspl-l-bold': {
         'font-weight': '700',
     },
+    'dspl-l-medium': {
+        'font-weight': '500',
+    },
     'dspl-m': {
         'font-weight': '400',
     },
     'dspl-m-bold': {
         'font-weight': '700',
+    },
+    'dspl-m-medium': {
+        'font-weight': '500',
     },
     'dspl-s': {
         'font-weight': '400',
@@ -22,11 +28,17 @@ const typo = {
     'dspl-s-bold': {
         'font-weight': '700',
     },
+    'dspl-s-medium': {
+        'font-weight': '500',
+    },
     h1: {
         'font-weight': '400',
     },
     'h1-bold': {
         'font-weight': '700',
+    },
+    'h1-medium': {
+        'font-weight': '500',
     },
     h2: {
         'font-weight': '400',
@@ -34,11 +46,17 @@ const typo = {
     'h2-bold': {
         'font-weight': '700',
     },
+    'h2-medium': {
+        'font-weight': '500',
+    },
     h3: {
         'font-weight': '400',
     },
     'h3-bold': {
         'font-weight': '700',
+    },
+    'h3-medium': {
+        'font-weight': '500',
     },
     h4: {
         'font-weight': '400',
@@ -46,11 +64,17 @@ const typo = {
     'h4-bold': {
         'font-weight': '700',
     },
+    'h4-medium': {
+        'font-weight': '500',
+    },
     h5: {
         'font-weight': '400',
     },
     'h5-bold': {
         'font-weight': '700',
+    },
+    'h5-medium': {
+        'font-weight': '500',
     },
     'body-l': {
         'font-weight': '400',
@@ -58,11 +82,17 @@ const typo = {
     'body-l-bold': {
         'font-weight': '700',
     },
+    'body-l-medium': {
+        'font-weight': '500',
+    },
     'body-m': {
         'font-weight': '400',
     },
     'body-m-bold': {
         'font-weight': '700',
+    },
+    'body-m-medium': {
+        'font-weight': '500',
     },
     'body-s': {
         'font-weight': '400',
@@ -70,11 +100,17 @@ const typo = {
     'body-s-bold': {
         'font-weight': '700',
     },
+    'body-s-medium': {
+        'font-weight': '500',
+    },
     'body-xs': {
         'font-weight': '400',
     },
     'body-xs-bold': {
         'font-weight': '700',
+    },
+    'body-xs-medium': {
+        'font-weight': '500',
     },
     'body-xxs': {
         'font-weight': '400',
@@ -82,11 +118,17 @@ const typo = {
     'body-xxs-bold': {
         'font-weight': '700',
     },
+    'body-xxs-medium': {
+        'font-weight': '500',
+    },
     'text-l': {
         'font-weight': '400',
     },
     'text-l-bold': {
         'font-weight': '700',
+    },
+    'text-l-medium': {
+        'font-weight': '500',
     },
     'text-m': {
         'font-weight': '400',
@@ -94,17 +136,26 @@ const typo = {
     'text-m-bold': {
         'font-weight': '700',
     },
+    'text-m-medium': {
+        'font-weight': '500',
+    },
     'text-s': {
         'font-weight': '400',
     },
     'text-s-bold': {
         'font-weight': '700',
     },
+    'text-s-medium': {
+        'font-weight': '500',
+    },
     'text-xs': {
         'font-weight': '400',
     },
     'text-xs-bold': {
         'font-weight': '700',
+    },
+    'text-xs-medium': {
+        'font-weight': '500',
     },
 };
 

--- a/packages/plasma-typo/src/components/Body.tsx
+++ b/packages/plasma-typo/src/components/Body.tsx
@@ -5,39 +5,49 @@ import type { BreakWordProps, SpacingProps } from '../mixins';
 import {
     bodyL,
     bodyLBold,
+    bodyLMedium,
     bodyM,
     bodyMBold,
+    bodyMMedium,
     bodyS,
     bodySBold,
+    bodySMedium,
     bodyXS,
     bodyXSBold,
+    bodyXSMedium,
     bodyXXS,
     bodyXXSBold,
+    bodyXXSMedium,
 } from '../tokens';
-import type { BoldProps } from '../types';
+import type { BoldProps, MediumProps } from '../types';
 
-export const BodyL = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const BodyL = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? bodyLBold : bodyL)}
+    ${({ medium }) => (medium ? bodyLMedium : bodyL)}
 `;
-export const BodyM = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const BodyM = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? bodyMBold : bodyM)}
+    ${({ medium }) => (medium ? bodyMMedium : bodyM)}
 `;
-export const BodyS = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const BodyS = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? bodySBold : bodyS)}
+    ${({ medium }) => (medium ? bodySMedium : bodyS)}
 `;
-export const BodyXS = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const BodyXS = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? bodyXSBold : bodyXS)}
+    ${({ medium }) => (medium ? bodyXSMedium : bodyXS)}
 `;
-export const BodyXXS = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const BodyXXS = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? bodyXXSBold : bodyXXS)}
+    ${({ medium }) => (medium ? bodyXXSMedium : bodyXXS)}
 `;

--- a/packages/plasma-typo/src/components/Dspl.tsx
+++ b/packages/plasma-typo/src/components/Dspl.tsx
@@ -2,21 +2,24 @@ import styled from 'styled-components';
 
 import { applyHyphens, applySpacing } from '../mixins';
 import type { BreakWordProps, SpacingProps } from '../mixins';
-import { dsplL, dsplLBold, dsplM, dsplMBold, dsplS, dsplSBold } from '../tokens';
-import type { BoldProps } from '../types';
+import { dsplL, dsplLBold, dsplLMedium, dsplM, dsplMBold, dsplMMedium, dsplS, dsplSBold, dsplSMedium } from '../tokens';
+import type { BoldProps, MediumProps } from '../types';
 
-export const DsplL = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const DsplL = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold = true }) => (bold ? dsplLBold : dsplL)}
+    ${({ medium = true }) => (medium ? dsplLMedium : dsplL)}
 `;
-export const DsplM = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const DsplM = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold = true }) => (bold ? dsplMBold : dsplM)}
+    ${({ medium = true }) => (medium ? dsplMMedium : dsplM)}
 `;
-export const DsplS = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const DsplS = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold = true }) => (bold ? dsplSBold : dsplS)}
+    ${({ medium = true }) => (medium ? dsplSMedium : dsplS)}
 `;

--- a/packages/plasma-typo/src/components/H.tsx
+++ b/packages/plasma-typo/src/components/H.tsx
@@ -2,31 +2,52 @@ import styled from 'styled-components';
 
 import { applyHyphens, applySpacing } from '../mixins';
 import type { BreakWordProps, SpacingProps } from '../mixins';
-import { h1, h1Bold, h2, h2Bold, h3, h3Bold, h4, h4Bold, h5, h5Bold } from '../tokens';
-import type { BoldProps } from '../types';
+import {
+    h1,
+    h1Bold,
+    h1Medium,
+    h2,
+    h2Bold,
+    h2Medium,
+    h3,
+    h3Bold,
+    h3Medium,
+    h4,
+    h4Bold,
+    h4Medium,
+    h5,
+    h5Bold,
+    h5Medium,
+} from '../tokens';
+import type { BoldProps, MediumProps } from '../types';
 
-export const H1 = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const H1 = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold = true }) => (bold ? h1Bold : h1)}
+    ${({ medium = true }) => (medium ? h1Medium : h1)}
 `;
-export const H2 = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const H2 = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold = true }) => (bold ? h2Bold : h2)}
+    ${({ medium = true }) => (medium ? h2Medium : h2)}
 `;
-export const H3 = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const H3 = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold = true }) => (bold ? h3Bold : h3)}
+    ${({ medium = true }) => (medium ? h3Medium : h3)}
 `;
-export const H4 = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const H4 = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold = true }) => (bold ? h4Bold : h4)}
+    ${({ medium = true }) => (medium ? h4Medium : h4)}
 `;
-export const H5 = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const H5 = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold = true }) => (bold ? h5Bold : h5)}
+    ${({ medium = true }) => (medium ? h5Medium : h5)}
 `;

--- a/packages/plasma-typo/src/components/Text.tsx
+++ b/packages/plasma-typo/src/components/Text.tsx
@@ -2,26 +2,43 @@ import styled from 'styled-components';
 
 import { applyHyphens, applySpacing } from '../mixins';
 import type { BreakWordProps, SpacingProps } from '../mixins';
-import { textL, textLBold, textM, textMBold, textS, textSBold, textXS, textXSBold } from '../tokens';
-import type { BoldProps } from '../types';
+import {
+    textL,
+    textLBold,
+    textLMedium,
+    textM,
+    textMBold,
+    textMMedium,
+    textS,
+    textSBold,
+    textSMedium,
+    textXS,
+    textXSBold,
+    textXSMedium,
+} from '../tokens';
+import type { BoldProps, MediumProps } from '../types';
 
-export const TextL = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const TextL = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? textLBold : textL)}
+    ${({ medium }) => (medium ? textLMedium : textL)}
 `;
-export const TextM = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const TextM = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? textMBold : textM)}
+    ${({ medium }) => (medium ? textMMedium : textM)}
 `;
-export const TextS = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const TextS = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? textSBold : textS)}
+    ${({ medium }) => (medium ? textSMedium : textS)}
 `;
-export const TextXS = styled.div<SpacingProps & BoldProps & BreakWordProps>`
+export const TextXS = styled.div<SpacingProps & (BoldProps | MediumProps) & BreakWordProps>`
     ${applyHyphens}
     ${applySpacing}
     ${({ bold }) => (bold ? textXSBold : textXS)}
+    ${({ medium }) => (medium ? textXSMedium : textXS)}
 `;

--- a/packages/plasma-typo/src/tokens.ts
+++ b/packages/plasma-typo/src/tokens.ts
@@ -14,6 +14,11 @@ export const dsplLBold = ({
     fontWeight: 'var(--plasma-typo-dspl-l-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const dsplLMedium = ({
+    ...dsplL,
+    fontWeight: 'var(--plasma-typo-dspl-l-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const dsplM = ({
     fontFamily: 'var(--plasma-typo-dspl-m-font-family)',
     fontSize: 'var(--plasma-typo-dspl-m-font-size)',
@@ -26,6 +31,11 @@ export const dsplM = ({
 export const dsplMBold = ({
     ...dsplM,
     fontWeight: 'var(--plasma-typo-dspl-m-bold-font-weight)',
+} as unknown) as CSSObject;
+
+export const dsplMMedium = ({
+    ...dsplM,
+    fontWeight: 'var(--plasma-typo-dspl-m-medium-font-weight)',
 } as unknown) as CSSObject;
 
 export const dsplS = ({
@@ -42,6 +52,11 @@ export const dsplSBold = ({
     fontWeight: 'var(--plasma-typo-dspl-s-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const dsplSMedium = ({
+    ...dsplS,
+    fontWeight: 'var(--plasma-typo-dspl-s-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const h1 = ({
     fontFamily: 'var(--plasma-typo-h1-font-family)',
     fontSize: 'var(--plasma-typo-h1-font-size)',
@@ -54,6 +69,11 @@ export const h1 = ({
 export const h1Bold = ({
     ...h1,
     fontWeight: 'var(--plasma-typo-h1-bold-font-weight)',
+} as unknown) as CSSObject;
+
+export const h1Medium = ({
+    ...h1,
+    fontWeight: 'var(--plasma-typo-h1-medium-font-weight)',
 } as unknown) as CSSObject;
 
 export const h2 = ({
@@ -70,6 +90,11 @@ export const h2Bold = ({
     fontWeight: 'var(--plasma-typo-h2-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const h2Medium = ({
+    ...h2,
+    fontWeight: 'var(--plasma-typo-h2-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const h3 = ({
     fontFamily: 'var(--plasma-typo-h3-font-family)',
     fontSize: 'var(--plasma-typo-h3-font-size)',
@@ -82,6 +107,11 @@ export const h3 = ({
 export const h3Bold = ({
     ...h3,
     fontWeight: 'var(--plasma-typo-h3-bold-font-weight)',
+} as unknown) as CSSObject;
+
+export const h3Medium = ({
+    ...h3,
+    fontWeight: 'var(--plasma-typo-h3-medium-font-weight)',
 } as unknown) as CSSObject;
 
 export const h4 = ({
@@ -98,6 +128,11 @@ export const h4Bold = ({
     fontWeight: 'var(--plasma-typo-h4-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const h4Medium = ({
+    ...h4,
+    fontWeight: 'var(--plasma-typo-h4-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const h5 = ({
     fontFamily: 'var(--plasma-typo-h5-font-family)',
     fontSize: 'var(--plasma-typo-h5-font-size)',
@@ -110,6 +145,11 @@ export const h5 = ({
 export const h5Bold = ({
     ...h5,
     fontWeight: 'var(--plasma-typo-h5-bold-font-weight)',
+} as unknown) as CSSObject;
+
+export const h5Medium = ({
+    ...h5,
+    fontWeight: 'var(--plasma-typo-h5-medium-font-weight)',
 } as unknown) as CSSObject;
 
 export const bodyL = ({
@@ -126,6 +166,11 @@ export const bodyLBold = ({
     fontWeight: 'var(--plasma-typo-body-l-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const bodyLMedium = ({
+    ...bodyL,
+    fontWeight: 'var(--plasma-typo-body-l-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const bodyM = ({
     fontFamily: 'var(--plasma-typo-body-m-font-family)',
     fontSize: 'var(--plasma-typo-body-m-font-size)',
@@ -138,6 +183,11 @@ export const bodyM = ({
 export const bodyMBold = ({
     ...bodyM,
     fontWeight: 'var(--plasma-typo-body-m-bold-font-weight)',
+} as unknown) as CSSObject;
+
+export const bodyMMedium = ({
+    ...bodyM,
+    fontWeight: 'var(--plasma-typo-body-m-medium-font-weight)',
 } as unknown) as CSSObject;
 
 export const bodyS = ({
@@ -154,6 +204,11 @@ export const bodySBold = ({
     fontWeight: 'var(--plasma-typo-body-s-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const bodySMedium = ({
+    ...bodyS,
+    fontWeight: 'var(--plasma-typo-body-s-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const bodyXS = ({
     fontFamily: 'var(--plasma-typo-body-xs-font-family)',
     fontSize: 'var(--plasma-typo-body-xs-font-size)',
@@ -166,6 +221,11 @@ export const bodyXS = ({
 export const bodyXSBold = ({
     ...bodyXS,
     fontWeight: 'var(--plasma-typo-body-xs-bold-font-weight)',
+} as unknown) as CSSObject;
+
+export const bodyXSMedium = ({
+    ...bodyXS,
+    fontWeight: 'var(--plasma-typo-body-xs-medium-font-weight)',
 } as unknown) as CSSObject;
 
 export const bodyXXS = ({
@@ -182,6 +242,11 @@ export const bodyXXSBold = ({
     fontWeight: 'var(--plasma-typo-body-xxs-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const bodyXXSMedium = ({
+    ...bodyXXS,
+    fontWeight: 'var(--plasma-typo-body-xxs-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const textL = ({
     fontFamily: 'var(--plasma-typo-text-l-font-family)',
     fontSize: 'var(--plasma-typo-text-l-font-size)',
@@ -194,6 +259,11 @@ export const textL = ({
 export const textLBold = ({
     ...textL,
     fontWeight: 'var(--plasma-typo-text-l-bold-font-weight)',
+} as unknown) as CSSObject;
+
+export const textLMedium = ({
+    ...textL,
+    fontWeight: 'var(--plasma-typo-text-l-medium-font-weight)',
 } as unknown) as CSSObject;
 
 export const textM = ({
@@ -210,6 +280,11 @@ export const textMBold = ({
     fontWeight: 'var(--plasma-typo-text-m-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const textMMedium = ({
+    ...textM,
+    fontWeight: 'var(--plasma-typo-text-m-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const textS = ({
     fontFamily: 'var(--plasma-typo-text-s-font-family)',
     fontSize: 'var(--plasma-typo-text-s-font-size)',
@@ -224,6 +299,11 @@ export const textSBold = ({
     fontWeight: 'var(--plasma-typo-text-s-bold-font-weight)',
 } as unknown) as CSSObject;
 
+export const textSMedium = ({
+    ...textS,
+    fontWeight: 'var(--plasma-typo-text-s-medium-font-weight)',
+} as unknown) as CSSObject;
+
 export const textXS = ({
     fontFamily: 'var(--plasma-typo-text-xs-font-family)',
     fontSize: 'var(--plasma-typo-text-xs-font-size)',
@@ -236,4 +316,9 @@ export const textXS = ({
 export const textXSBold = ({
     ...textXS,
     fontWeight: 'var(--plasma-typo-text-xs-bold-font-weight)',
+} as unknown) as CSSObject;
+
+export const textXSMedium = ({
+    ...textXS,
+    fontWeight: 'var(--plasma-typo-text-xs-medium-font-weight)',
 } as unknown) as CSSObject;

--- a/packages/plasma-typo/src/types.ts
+++ b/packages/plasma-typo/src/types.ts
@@ -3,6 +3,15 @@ export interface BoldProps {
      * Полужирное начертание.
      */
     bold?: boolean;
+    medium?: never;
+}
+
+export interface MediumProps {
+    /**
+     * Среднее начертание.
+     */
+    medium?: boolean;
+    bold?: never;
 }
 
 export type FontFamily =
@@ -36,38 +45,55 @@ export interface CreateVariablesByArcheTypeProps {
 export type TypoPropName =
     | 'dspl-l'
     | 'dspl-l-bold'
+    | 'dspl-l-medium'
     | 'dspl-m'
     | 'dspl-m-bold'
+    | 'dspl-m-medium'
     | 'dspl-s'
     | 'dspl-s-bold'
+    | 'dspl-s-medium'
     | 'h1'
     | 'h1-bold'
+    | 'h1-medium'
     | 'h2'
     | 'h2-bold'
+    | 'h2-medium'
     | 'h3'
     | 'h3-bold'
+    | 'h3-medium'
     | 'h4'
     | 'h4-bold'
+    | 'h4-medium'
     | 'h5'
     | 'h5-bold'
+    | 'h5-medium'
     | 'body-l'
     | 'body-l-bold'
+    | 'body-l-medium'
     | 'body-m'
     | 'body-m-bold'
+    | 'body-m-medium'
     | 'body-s'
     | 'body-s-bold'
+    | 'body-s-medium'
     | 'body-xs'
     | 'body-xs-bold'
+    | 'body-xs-medium'
     | 'body-xxs'
     | 'body-xxs-bold'
+    | 'body-xxs-medium'
     | 'text-l'
     | 'text-l-bold'
+    | 'text-l-medium'
     | 'text-m'
     | 'text-m-bold'
+    | 'text-m-medium'
     | 'text-s'
     | 'text-s-bold'
+    | 'text-s-medium'
     | 'text-xs'
-    | 'text-xs-bold';
+    | 'text-xs-bold'
+    | 'text-xs-medium';
 
 export type TypoCSSPropName = 'font-size' | 'font-weight' | 'line-height' | 'letter-spacing' | 'font-style';
 


### PR DESCRIPTION
## PLASMA-TYPO

### Typogrphay

- Добавлены варианты начертания `medium` во все архетипы 
- Добавлены новые токены с постфиксом `medium`, например `bodyXSMedium` и т.д.
- Добавлено свойство `medium` во все компоненты типографики

### What/why changed

