### PR TITLE
PLASMA-4518: virtual prop in Autocomplete

### DIFF
--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.styles.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.styles.ts
@@ -8,6 +8,7 @@ export const base = css``;
 
 export const Ul = styled.ul<{
     listMaxHeight: AutocompleteProps['listMaxHeight'];
+    virtual: AutocompleteProps['virtual'];
 }>`
     box-sizing: border-box;
 
@@ -16,8 +17,8 @@ export const Ul = styled.ul<{
 
     border-radius: var(${tokens.borderRadius});
     height: auto;
-    max-height: ${({ listMaxHeight }) => listMaxHeight || 'none'};
-    overflow-y: scroll;
+    max-height: ${({ listMaxHeight, virtual }) => (virtual ? 'auto' : listMaxHeight || 'none')};
+    overflow-y: ${({ virtual }) => (virtual ? 'none' : 'scroll')};
     border: var(${tokens.dropdownBorderWidth}) solid var(${tokens.dropdownBorderColor});
 
     margin: var(${tokens.margin}) 0 0 0;

--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
@@ -99,6 +99,11 @@ export type BaseProps = {
      * Ячейка для контента в конце выпадающего списка.
      */
     afterList?: ReactNode;
+    /**
+     * Виртуализация в выпадающем списке.
+     * @default false
+     */
+    virtual?: boolean;
 };
 
 export type AutocompleteProps = BaseProps &

--- a/packages/plasma-new-hope/src/components/Autocomplete/ui/VirtualList/VirtualList.tsx
+++ b/packages/plasma-new-hope/src/components/Autocomplete/ui/VirtualList/VirtualList.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import List from 'rc-virtual-list';
+
+import type { SuggestionItemType } from '../../Autocomplete.types';
+import { SuggestionItem } from '../SuggestionItem/SuggestionItem';
+
+const getHeight = (listMaxHeight?: string) => {
+    if (!listMaxHeight) return 300;
+
+    return parseInt(listMaxHeight, 10);
+};
+
+interface Props {
+    items: SuggestionItemType[];
+    onClick: (e: SuggestionItemType) => void;
+    listId: string;
+    listMaxHeight?: string;
+    onScroll?: (e: React.UIEvent<HTMLUListElement>) => void;
+}
+
+export const VirtualList: React.FC<Props> = ({ items, onClick, listId, listMaxHeight, onScroll }) => {
+    return (
+        <List data={items} height={getHeight(listMaxHeight)} itemHeight={100} itemKey="id" onScroll={onScroll}>
+            {(item, index, props) => (
+                <div {...props}>
+                    <SuggestionItem item={item} onClick={onClick} id={`${listId}/${index}`} focused={false} />
+                </div>
+            )}
+        </List>
+    );
+};

--- a/packages/plasma-new-hope/src/components/Autocomplete/ui/index.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/ui/index.ts
@@ -1,2 +1,3 @@
 export * from './TextField/TextField';
 export * from './SuggestionItem/SuggestionItem';
+export * from './VirtualList/VirtualList';

--- a/website/plasma-b2c-docs/docs/components/Autocomplete.mdx
+++ b/website/plasma-b2c-docs/docs/components/Autocomplete.mdx
@@ -480,6 +480,25 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listMaxHeight`.
+        Примечание: работает только при количестве отфильтрованных suggestions > 10, в противном случае виртуализация выключается автоматически.
+
+       ```tsx live
+        import React from 'react';
+        import { Autocomplete } from '@salutejs/plasma-b2c';
+
+        export function App() {
+            const items = Array(10000).fill(1).map((_, i) => ({ label: i.toString() }));
+
+            return (
+                <div style={{ display: 'block', height: "350px" }}>
+                    <Autocomplete suggestions={items} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите цифры" virtual />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/plasma-giga-docs/docs/components/Autocomplete.mdx
+++ b/website/plasma-giga-docs/docs/components/Autocomplete.mdx
@@ -547,6 +547,25 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listMaxHeight`.
+        Примечание: работает только при количестве отфильтрованных suggestions > 10, в противном случае виртуализация выключается автоматически.
+
+       ```tsx live
+        import React from 'react';
+        import { Autocomplete } from '@salutejs/plasma-giga';
+
+        export function App() {
+            const items = Array(10000).fill(1).map((_, i) => ({ label: i.toString() }));
+
+            return (
+                <div style={{ display: 'block', height: "350px" }}>
+                    <Autocomplete suggestions={items} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите цифры" virtual />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/plasma-web-docs/docs/components/Autocomplete.mdx
+++ b/website/plasma-web-docs/docs/components/Autocomplete.mdx
@@ -549,6 +549,25 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listMaxHeight`.
+        Примечание: работает только при количестве отфильтрованных suggestions > 10, в противном случае виртуализация выключается автоматически.
+
+       ```tsx live
+        import React from 'react';
+        import { Autocomplete } from '@salutejs/plasma-web';
+
+        export function App() {
+            const items = Array(10000).fill(1).map((_, i) => ({ label: i.toString() }));
+
+            return (
+                <div style={{ display: 'block', height: "350px" }}>
+                    <Autocomplete suggestions={items} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите цифры" virtual />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/sdds-cs-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-cs-docs/docs/components/Autocomplete.mdx
@@ -547,6 +547,25 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listMaxHeight`.
+        Примечание: работает только при количестве отфильтрованных suggestions > 10, в противном случае виртуализация выключается автоматически.
+
+       ```tsx live
+        import React from 'react';
+        import { Autocomplete } from '@salutejs/sdds-cs';
+
+        export function App() {
+            const items = Array(10000).fill(1).map((_, i) => ({ label: i.toString() }));
+
+            return (
+                <div style={{ display: 'block', height: "350px" }}>
+                    <Autocomplete suggestions={items} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите цифры" virtual />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/sdds-dfa-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-dfa-docs/docs/components/Autocomplete.mdx
@@ -547,6 +547,25 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listMaxHeight`.
+        Примечание: работает только при количестве отфильтрованных suggestions > 10, в противном случае виртуализация выключается автоматически.
+
+       ```tsx live
+        import React from 'react';
+        import { Autocomplete } from '@salutejs/sdds-dfa';
+
+        export function App() {
+            const items = Array(10000).fill(1).map((_, i) => ({ label: i.toString() }));
+
+            return (
+                <div style={{ display: 'block', height: "350px" }}>
+                    <Autocomplete suggestions={items} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите цифры" virtual />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/sdds-insol-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-insol-docs/docs/components/Autocomplete.mdx
@@ -547,6 +547,25 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listMaxHeight`.
+        Примечание: работает только при количестве отфильтрованных suggestions > 10, в противном случае виртуализация выключается автоматически.
+
+       ```tsx live
+        import React from 'react';
+        import { Autocomplete } from '@salutejs/sdds-insol';
+
+        export function App() {
+            const items = Array(10000).fill(1).map((_, i) => ({ label: i.toString() }));
+
+            return (
+                <div style={{ display: 'block', height: "350px" }}>
+                    <Autocomplete suggestions={items} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите цифры" virtual />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация

--- a/website/sdds-serv-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-serv-docs/docs/components/Autocomplete.mdx
@@ -547,6 +547,25 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="virtual" label="Virtual">
+        Свойство `virtual` позволяет виртуализировать выпадающий список. Для настройки высоты списка можно использовать свойство `listMaxHeight`.
+        Примечание: работает только при количестве отфильтрованных suggestions > 10, в противном случае виртуализация выключается автоматически.
+
+       ```tsx live
+        import React from 'react';
+        import { Autocomplete } from '@salutejs/sdds-serv';
+
+        export function App() {
+            const items = Array(10000).fill(1).map((_, i) => ({ label: i.toString() }));
+
+            return (
+                <div style={{ display: 'block', height: "350px" }}>
+                    <Autocomplete suggestions={items} listMaxHeight="250px" label="Label" placeholder="Placeholder" leftHelper="Введите цифры" virtual />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация


### PR DESCRIPTION
## Core

### Autocomplete

- добавлена опциональная виртуализация в выпадающий список;

### What/why changed
Пропс `virtual` для виртуализации выпадающего списка.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.301.0-canary.1817.13658365689.0
  npm install @salutejs/plasma-b2c@1.543.0-canary.1817.13658365689.0
  npm install @salutejs/plasma-giga@0.270.0-canary.1817.13658365689.0
  npm install @salutejs/plasma-new-hope@0.287.0-canary.1817.13658365689.0
  npm install @salutejs/plasma-web@1.545.0-canary.1817.13658365689.0
  npm install @salutejs/sdds-cs@0.279.0-canary.1817.13658365689.0
  npm install @salutejs/sdds-dfa@0.273.0-canary.1817.13658365689.0
  npm install @salutejs/sdds-finportal@0.266.0-canary.1817.13658365689.0
  npm install @salutejs/sdds-insol@0.270.0-canary.1817.13658365689.0
  npm install @salutejs/sdds-serv@0.274.0-canary.1817.13658365689.0
  # or 
  yarn add @salutejs/plasma-asdk@0.301.0-canary.1817.13658365689.0
  yarn add @salutejs/plasma-b2c@1.543.0-canary.1817.13658365689.0
  yarn add @salutejs/plasma-giga@0.270.0-canary.1817.13658365689.0
  yarn add @salutejs/plasma-new-hope@0.287.0-canary.1817.13658365689.0
  yarn add @salutejs/plasma-web@1.545.0-canary.1817.13658365689.0
  yarn add @salutejs/sdds-cs@0.279.0-canary.1817.13658365689.0
  yarn add @salutejs/sdds-dfa@0.273.0-canary.1817.13658365689.0
  yarn add @salutejs/sdds-finportal@0.266.0-canary.1817.13658365689.0
  yarn add @salutejs/sdds-insol@0.270.0-canary.1817.13658365689.0
  yarn add @salutejs/sdds-serv@0.274.0-canary.1817.13658365689.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
