### PR TITLE
PLASMA-4432: set switch off toggle color

### DIFF
--- a/packages/plasma-b2c/src/components/Switch/Switch.config.ts
+++ b/packages/plasma-b2c/src/components/Switch/Switch.config.ts
@@ -85,6 +85,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);

--- a/packages/plasma-giga/src/components/Switch/Switch.config.ts
+++ b/packages/plasma-giga/src/components/Switch/Switch.config.ts
@@ -85,6 +85,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);

--- a/packages/plasma-new-hope/src/components/Switch/Switch.styles.ts
+++ b/packages/plasma-new-hope/src/components/Switch/Switch.styles.ts
@@ -41,6 +41,14 @@ export const StyledContent = styled.div`
 
 export const StyledDescription = styled.div`
     position: relative;
+
+    ${applyEllipsis()}
+
+    display: -webkit-box;
+    line-clamp: var(${tokens.descriptionMaxLines});
+    -webkit-line-clamp: var(${tokens.descriptionMaxLines}); /* Ограничиваем количество строк */
+    -webkit-box-orient: vertical;
+    white-space: wrap;
 `;
 
 export const StyledInput = styled.input`

--- a/packages/plasma-new-hope/src/components/Switch/Switch.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Switch/Switch.tokens.ts
@@ -21,6 +21,7 @@ export const tokens = {
     /* Цвет описания */
     descriptionColor: '--plasma-switch__description-color',
     descriptionOffset: '--plasma-switch__description-offset',
+    descriptionMaxLines: '--plasma-switch__description-max-lines',
 
     /** Прозрачность для всего компонента в состоянии disabled */
     disabledOpacity: '--plasma-switch-disabled-opacity',

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Switch/Switch.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Switch/Switch.config.ts
@@ -87,6 +87,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Switch/Switch.outline.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Switch/Switch.outline.config.ts
@@ -87,6 +87,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBorderWidthOn}: 0.0625rem;
                 ${switchTokens.trackBorderWidthOff}: 0.0625rem;
                 ${switchTokens.trackBorderColorOn}: var(--outline-accent);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Switch/Switch.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Switch/Switch.config.ts
@@ -87,6 +87,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Switch/Switch.outline.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Switch/Switch.outline.config.ts
@@ -87,6 +87,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBorderWidthOn}: 0.0625rem;
                 ${switchTokens.trackBorderWidthOff}: 0.0625rem;
                 ${switchTokens.trackBorderColorOn}: var(--outline-accent);

--- a/packages/plasma-web/src/components/Switch/Switch.config.ts
+++ b/packages/plasma-web/src/components/Switch/Switch.config.ts
@@ -85,6 +85,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);

--- a/packages/sdds-cs/src/components/Switch/Switch.config.ts
+++ b/packages/sdds-cs/src/components/Switch/Switch.config.ts
@@ -53,6 +53,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: 2;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-solid-card);

--- a/packages/sdds-cs/src/components/Switch/Switch.config.ts
+++ b/packages/sdds-cs/src/components/Switch/Switch.config.ts
@@ -55,8 +55,8 @@ export const config = {
                 ${switchTokens.descriptionColor}: var(--text-secondary);
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
-                ${switchTokens.trackBackgroundColorOff}: transparent;
-                ${switchTokens.trackBackgroundColorOffHover}: transparent;
+                ${switchTokens.trackBackgroundColorOff}: var(--surface-solid-card);
+                ${switchTokens.trackBackgroundColorOffHover}: var(--surface-solid-card-hover);
                 ${switchTokens.trackBorderWidthOn}: 0;
                 ${switchTokens.trackBorderWidthOff}: 0.125rem;
                 ${switchTokens.trackBorderColorOn}: var(--outline-accent);

--- a/packages/sdds-dfa/src/components/Switch/Switch.config.ts
+++ b/packages/sdds-dfa/src/components/Switch/Switch.config.ts
@@ -85,6 +85,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);

--- a/packages/sdds-finportal/src/components/Switch/Switch.config.ts
+++ b/packages/sdds-finportal/src/components/Switch/Switch.config.ts
@@ -85,6 +85,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);

--- a/packages/sdds-insol/src/components/Switch/Switch.config.ts
+++ b/packages/sdds-insol/src/components/Switch/Switch.config.ts
@@ -85,6 +85,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);

--- a/packages/sdds-serv/src/components/Switch/Switch.config.ts
+++ b/packages/sdds-serv/src/components/Switch/Switch.config.ts
@@ -85,6 +85,7 @@ export const config = {
             default: css`
                 ${switchTokens.labelColor}: var(--text-primary);
                 ${switchTokens.descriptionColor}: var(--text-secondary);
+                ${switchTokens.descriptionMaxLines}: initial;
                 ${switchTokens.trackBackgroundColorOn}: var(--surface-accent);
                 ${switchTokens.trackBackgroundColorOnHover}: var(--surface-accent-hover);
                 ${switchTokens.trackBackgroundColorOff}: var(--surface-transparent-tertiary);


### PR DESCRIPTION
## Core

### Switch
- Добавлен новый токен, для изменения кол-ва строк в `description`

## SDDS-CS

### Switch
- Изменены токены цвета при `off` состоянии

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.308.0-canary.1819.13844598368.0
  npm install @salutejs/plasma-b2c@1.550.0-canary.1819.13844598368.0
  npm install @salutejs/plasma-giga@0.277.0-canary.1819.13844598368.0
  npm install @salutejs/plasma-new-hope@0.294.0-canary.1819.13844598368.0
  npm install @salutejs/plasma-web@1.552.0-canary.1819.13844598368.0
  npm install @salutejs/sdds-cs@0.286.0-canary.1819.13844598368.0
  npm install @salutejs/sdds-dfa@0.280.0-canary.1819.13844598368.0
  npm install @salutejs/sdds-finportal@0.273.0-canary.1819.13844598368.0
  npm install @salutejs/sdds-insol@0.277.0-canary.1819.13844598368.0
  npm install @salutejs/sdds-serv@0.281.0-canary.1819.13844598368.0
  # or 
  yarn add @salutejs/plasma-asdk@0.308.0-canary.1819.13844598368.0
  yarn add @salutejs/plasma-b2c@1.550.0-canary.1819.13844598368.0
  yarn add @salutejs/plasma-giga@0.277.0-canary.1819.13844598368.0
  yarn add @salutejs/plasma-new-hope@0.294.0-canary.1819.13844598368.0
  yarn add @salutejs/plasma-web@1.552.0-canary.1819.13844598368.0
  yarn add @salutejs/sdds-cs@0.286.0-canary.1819.13844598368.0
  yarn add @salutejs/sdds-dfa@0.280.0-canary.1819.13844598368.0
  yarn add @salutejs/sdds-finportal@0.273.0-canary.1819.13844598368.0
  yarn add @salutejs/sdds-insol@0.277.0-canary.1819.13844598368.0
  yarn add @salutejs/sdds-serv@0.281.0-canary.1819.13844598368.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
