### PR TITLE
PLASMA-4478: Extend NotificationPlacement prop

### DIFF
--- a/packages/plasma-b2c/src/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-b2c/src/components/Notification/Notification.stories.tsx
@@ -23,7 +23,17 @@ const titles = ['Выполнено', 'Внимание', 'Ошибка'];
 const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
 const size = ['xs', 'xxs'];
 const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
 const views = ['default', 'negative', 'positive', 'warning', 'info'];
 
 const longText = `JavaScript frameworks are an essential part of modern front-end web development,

--- a/packages/plasma-giga/src/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-giga/src/components/Notification/Notification.stories.tsx
@@ -21,7 +21,17 @@ const titles = ['Выполнено', 'Внимание', 'Ошибка'];
 const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
 const size = ['xs', 'xxs'];
 const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
 const views = ['default', 'negative', 'positive', 'warning', 'info'];
 
 const longText = `JavaScript frameworks are an essential part of modern front-end web development,

--- a/packages/plasma-new-hope/src/components/Notification/Notification.styles.ts
+++ b/packages/plasma-new-hope/src/components/Notification/Notification.styles.ts
@@ -150,6 +150,14 @@ export const StyledItemWrapper = styled.div<{ isHidden: boolean }>`
         &.${classes.notificationLeftToRightAnimation} {
             animation: 0.4s showLeftToRightAnimation ease-out;
         }
+
+        &.${classes.notificationTopToCenterAnimation} {
+            animation: 0.4s showTopToCenterAnimation ease-out;
+        }
+
+        &.${classes.notificationBottomToCenterAnimation} {
+            animation: 0.4s showBottomToCenterAnimation ease-out;
+        }
     }
 
     &&.${classes.notificationItemHidden} {
@@ -157,6 +165,30 @@ export const StyledItemWrapper = styled.div<{ isHidden: boolean }>`
 
         &.${classes.notificationLeftToRightAnimation} {
             animation: 0.4s hideLeftToRightAnimation ease-out;
+        }
+    }
+
+    @keyframes showTopToCenterAnimation {
+        0% {
+            transform: translateY(-100%);
+            opacity: 0;
+        }
+
+        100% {
+            transform: translateY(0);
+            opacity: 1;
+        }
+    }
+
+    @keyframes showBottomToCenterAnimation {
+        0% {
+            transform: translateY(100%);
+            opacity: 0;
+        }
+
+        100% {
+            transform: translateY(0);
+            opacity: 1;
         }
     }
 

--- a/packages/plasma-new-hope/src/components/Notification/Notification.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Notification/Notification.template-doc.mdx
@@ -17,6 +17,8 @@ import { PropsTable, Description } from '@site/src/components';
 Также есть часть `actions`, в которой предполагается отображение кнопок для взаимодействия.
 
 ### Провайдер контекста
+<PropsTable name="NotificationsProvider" />
+
 Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна.
 В качестве свойств можно указать контейнер для оповещений через `frame` и расположение в контейнере через свойство `placement`, как `bottom-right` _(по умолчанию)_ или `bottom-left`.
 
@@ -40,19 +42,63 @@ ReactDOM.render(
 Оповещение закроется автоматически по истечению указанного `timeout` в миллисекундах или будет висеть вечно, если передан `0` или `null`.
 
 ```tsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/{{ package }}';
 
 export function App() {
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
             children: 'Принять?',
-        }, 1000);
+        }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
+        closeNotification('incoming-call');
+    }, []);
+
+    return (
+        <NotificationsProvider>
+            <ButtonGroup>
+                <Button text="Показать оповещение" onClick={handleShow} />
+                <Button text="Скрыть оповещение" onClick={handleHide} />
+            </ButtonGroup>
+        </NotificationsProvider>
+    );
+}
+```
+
+## Вид иконки и текста
+:::tip
+Чтобы компонент иконки наследовал `color` от `view` используйте значение `inherit`.
+
+```tsx
+<IconBell color="inherit" size="xs" />
+```
+:::
+
+Также имеются свойства `titleColor, textColor` для **переопределения** `color` текста контента и заголовка.
+
+```jsx live
+import React, { useCallback } from 'react';
+import { IconBell } from '@salutejs/plasma-icons';
+import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/{{ package }}';
+
+export function App() {
+    const handleShow = useCallback(() => {
+        addNotification({
+            id: 'incoming-call',
+            title: 'Входящий вызов',
+            icon: <IconBell color="inherit" size="xs" />,
+            children: 'Принять?',
+            view: 'positive',
+            textColor: 'black',
+            titleColor: 'blue'
+        }, 3000);
+    }, []);
+
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 

--- a/packages/plasma-new-hope/src/components/Notification/Notification.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Notification/Notification.tokens.ts
@@ -1,6 +1,6 @@
 export const classes = {
-    textbox: 'notificaiton-textbox',
-    contentBox: 'notificaiton-content-box',
+    textbox: 'notification-textbox',
+    contentBox: 'notification-content-box',
     title: 'notification-title',
     text: 'notification-text',
     wrapper: 'notification-wrapper',
@@ -17,10 +17,12 @@ export const classes = {
     notificationItemOpened: 'notification-item-opened',
     notificationItemHidden: 'notification-item-hidden',
     notificationLeftToRightAnimation: 'notification-left-to-right-animation',
+    notificationTopToCenterAnimation: 'notification-top-to-center-animation',
+    notificationBottomToCenterAnimation: 'notification-bottom-to-center-animation',
 };
 
 export const tokens = {
-    background: '--plasma-notification-backgorund',
+    background: '--plasma-notification-background',
     padding: '--plasma-notification-padding',
     horizontalLayoutPadding: '--plasma-notification-horizontal-layout-padding',
     width: '--plasma-notification-width',

--- a/packages/plasma-new-hope/src/components/Notification/Notification.types.ts
+++ b/packages/plasma-new-hope/src/components/Notification/Notification.types.ts
@@ -2,6 +2,7 @@ import type { AsProps } from '@salutejs/plasma-core';
 import { HTMLAttributes, ReactNode } from 'react';
 
 import { ComponentConfig, PropsType, Variants } from '../../engines/types';
+import type { PopupPlacement } from '../Popup';
 
 export const layouts = {
     horizontal: 'horizontal',
@@ -16,7 +17,7 @@ export const placements = {
 };
 
 export type NotificationIconPlacement = keyof typeof placements;
-export type NotificationPlacement = 'bottom-right' | 'bottom-left';
+export type NotificationPlacement = PopupPlacement;
 
 export type LayoutType = {
     layout?: NotificationLayout;
@@ -44,7 +45,7 @@ export interface NotificationProps extends AsProps, Omit<HTMLAttributes<HTMLDivE
      */
     actions?: ReactNode;
     /**
-     * Cхема расположение блоков Notification.
+     * Схема расположение блоков Notification.
      */
     layout?: NotificationLayout;
     /**
@@ -62,7 +63,7 @@ export interface NotificationProps extends AsProps, Omit<HTMLAttributes<HTMLDivE
      */
     showCloseIcon?: boolean;
     /**
-     * Колбек при нажатии на кнопку закрытия.
+     * Callback при нажатии на кнопку закрытия.
      */
     onCloseButtonClick?: () => void;
     /**
@@ -104,7 +105,7 @@ export interface NotificationProps extends AsProps, Omit<HTMLAttributes<HTMLDivE
 
 export interface NotificationPortalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
     /**
-     * Конфиг компонента Notification.
+     * Конфигурация компонента Notification.
      */
     config: ComponentConfig<string, Variants, PropsType<Variants>, NotificationProps & HTMLAttributes<HTMLDivElement>>;
     /**

--- a/packages/plasma-new-hope/src/components/Notification/NotificationsPortal.tsx
+++ b/packages/plasma-new-hope/src/components/Notification/NotificationsPortal.tsx
@@ -37,6 +37,8 @@ export const NotificationsPortal: FC<NotificationPortalProps> = ({
         [],
     );
 
+    const hasLeftAnimationClass = ['left', 'bottom-left', 'top-left'].includes(placement);
+
     return (
         <PopupProvider UNSAFE_SSR_ENABLED={UNSAFE_SSR_ENABLED}>
             {notifications.length > 0 && (
@@ -47,7 +49,9 @@ export const NotificationsPortal: FC<NotificationPortalProps> = ({
                                 key={id}
                                 className={cx(
                                     isHidden ? classes.notificationItemHidden : classes.notificationItemOpened,
-                                    placement === 'bottom-left' && classes.notificationLeftToRightAnimation,
+                                    hasLeftAnimationClass && classes.notificationLeftToRightAnimation,
+                                    placement === 'top' && classes.notificationTopToCenterAnimation,
+                                    placement === 'bottom' && classes.notificationBottomToCenterAnimation,
                                 )}
                                 isHidden={isHidden || false}
                             >

--- a/packages/plasma-new-hope/src/examples/fixtures/Notification.ts
+++ b/packages/plasma-new-hope/src/examples/fixtures/Notification.ts
@@ -1,0 +1,21 @@
+export const titles = ['Выполнено', 'Внимание', 'Ошибка'];
+export const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
+export const size = ['xs', 'xxs'];
+export const iconPlacement = ['top', 'left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
+
+export const longText = `JavaScript frameworks are an essential part of modern front-end web development,
+providing developers with proven tools for building scalable, interactive web applications.
+`;
+
+export const IconPlacements = ['top', 'left'];

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Notification/Notification.stories.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { styled } from '@linaria/react';
 import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
+import { getConfigVariations } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button/Button';
 import { Modal } from '../Modal/Modal';
@@ -10,24 +11,25 @@ import {
     NotificationIconPlacement,
     NotificationLayout,
     addNotification,
-} from '../../../../../src/components/Notification';
+} from '../../../../components/Notification';
 import { WithTheme } from '../../../_helpers';
 import { PopupProvider } from '../Popup/Popup';
-import { NotificationProps } from '../../../../components/Notification';
+import type { NotificationProps } from '../../../../components/Notification';
 import { IconDisclosureRight } from '../../../../components/_Icon';
+import {
+    titles,
+    size,
+    notificationsPlacements,
+    iconPlacement,
+    texts,
+    longText,
+    IconPlacements,
+} from '../../../fixtures/Notification';
 
 import { Notification, NotificationsProvider } from './Notification';
+import { config } from './Notification.config';
 
-const titles = ['Выполнено', 'Внимание', 'Ошибка'];
-const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
-const size = ['xs', 'xxs'];
-const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
-const views = ['default', 'negative', 'positive', 'warning', 'info'];
-
-const longText = `JavaScript frameworks are an essential part of modern front-end web development,
-providing developers with proven tools for building scalable, interactive web applications.
-`;
+const { views } = getConfigVariations(config);
 
 const StyledWrapper = styled.div`
     height: 100vh;
@@ -39,8 +41,6 @@ const getNotificationProps = (i: number) => ({
     size: size[i % 2],
     iconPlacement: iconPlacement[i % 2] as NotificationIconPlacement,
 });
-
-const placements = ['top', 'left'];
 
 const meta: Meta<NotificationProps> = {
     title: 'b2c/Overlay/Notification',
@@ -99,7 +99,7 @@ const StoryDefault = ({
 export const Default: StoryObj<StoryDefaultProps> = {
     argTypes: {
         iconPlacement: {
-            options: placements,
+            options: IconPlacements,
             control: {
                 type: 'select',
             },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Notification/Notification.stories.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { styled } from '@linaria/react';
 import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
+import { getConfigVariations } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button/Button';
 import { Modal } from '../Modal/Modal';
@@ -10,24 +11,25 @@ import {
     NotificationIconPlacement,
     NotificationLayout,
     addNotification,
-} from '../../../../../src/components/Notification';
+} from '../../../../components/Notification';
 import { WithTheme } from '../../../_helpers';
 import { PopupProvider } from '../Popup/Popup';
-import { NotificationProps } from '../../../../components/Notification';
+import type { NotificationProps } from '../../../../components/Notification';
 import { IconDisclosureRight } from '../../../../components/_Icon';
+import {
+    titles,
+    size,
+    notificationsPlacements,
+    iconPlacement,
+    texts,
+    longText,
+    IconPlacements,
+} from '../../../fixtures/Notification';
 
 import { Notification, NotificationsProvider } from './Notification';
+import { config } from './Notification.config';
 
-const titles = ['Выполнено', 'Внимание', 'Ошибка'];
-const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
-const size = ['xs', 'xxs'];
-const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
-const views = ['default', 'negative', 'positive', 'warning', 'info'];
-
-const longText = `JavaScript frameworks are an essential part of modern front-end web development,
-providing developers with proven tools for building scalable, interactive web applications.
-`;
+const { views } = getConfigVariations(config);
 
 const StyledWrapper = styled.div`
     height: 100vh;
@@ -40,8 +42,6 @@ const getNotificationProps = (i: number) => ({
     iconPlacement: iconPlacement[i % 2] as NotificationIconPlacement,
 });
 
-const placements = ['top', 'left'];
-
 const meta: Meta<NotificationProps> = {
     title: 'web/Overlay/Notification',
     decorators: [WithTheme],
@@ -52,7 +52,6 @@ export default meta;
 interface StoryDefaultProps {
     title: string;
     children: string;
-    iconColor?: string;
     showCloseIcon: boolean;
     showLeftIcon: boolean;
     layout: NotificationLayout;
@@ -60,6 +59,11 @@ interface StoryDefaultProps {
     closeIconType?: 'default' | 'thin';
     iconPlacement: NotificationIconPlacement;
     placement?: NotificationPlacement;
+    view: 'default';
+    iconColor?: string;
+    textColor?: string;
+    titleColor?: string;
+    backgroundColor?: string;
 }
 
 const StoryDefault = ({
@@ -70,6 +74,7 @@ const StoryDefault = ({
     layout,
     showLeftIcon,
     iconColor,
+    view,
     ...rest
 }: StoryDefaultProps) => {
     return (
@@ -77,6 +82,7 @@ const StoryDefault = ({
             title={title}
             icon={showLeftIcon ? <IconDisclosureRight color={iconColor || 'inherit'} /> : ''}
             iconPlacement={iconPlacement}
+            view={view}
             actions={
                 <Button
                     text="text"
@@ -96,7 +102,7 @@ const StoryDefault = ({
 export const Default: StoryObj<StoryDefaultProps> = {
     argTypes: {
         iconPlacement: {
-            options: placements,
+            options: IconPlacements,
             control: {
                 type: 'select',
             },
@@ -146,6 +152,7 @@ export const Default: StoryObj<StoryDefaultProps> = {
         iconPlacement: 'top',
         layout: 'vertical',
         closeIconType: 'default',
+        view: 'default',
         size: 'xs',
     },
     render: (args) => <StoryDefault {...args} />,
@@ -163,7 +170,11 @@ const StoryLiveDemo = ({ timeout, placement, ...rest }: StoryLiveDemoProps) => {
     const count = useRef(0);
     const handleClick = useCallback(() => {
         addNotification(
-            { icon: <IconDisclosureRight color="inherit" />, ...rest, ...getNotificationProps(count.current) },
+            {
+                icon: <IconDisclosureRight color="inherit" />,
+                ...rest,
+                ...getNotificationProps(count.current),
+            },
             timeout,
         );
         count.current++;

--- a/packages/plasma-web/src/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-web/src/components/Notification/Notification.stories.tsx
@@ -23,7 +23,17 @@ const titles = ['Выполнено', 'Внимание', 'Ошибка'];
 const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
 const size = ['xs', 'xxs'];
 const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
 const views = ['default', 'negative', 'positive', 'warning', 'info'];
 
 const longText = `JavaScript frameworks are an essential part of modern front-end web development,

--- a/packages/sdds-cs/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-cs/src/components/Notification/Notification.stories.tsx
@@ -21,7 +21,17 @@ const titles = ['Выполнено', 'Внимание', 'Ошибка'];
 const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
 const size = ['xs', 'xxs'];
 const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
 
 const longText = `JavaScript frameworks are an essential part of modern front-end web development,
 providing developers with proven tools for building scalable, interactive web applications.

--- a/packages/sdds-dfa/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-dfa/src/components/Notification/Notification.stories.tsx
@@ -21,7 +21,17 @@ const titles = ['Выполнено', 'Внимание', 'Ошибка'];
 const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
 const size = ['xs', 'xxs'];
 const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
 const views = ['default', 'negative', 'positive', 'warning', 'info'];
 
 const longText = `JavaScript frameworks are an essential part of modern front-end web development,

--- a/packages/sdds-finportal/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-finportal/src/components/Notification/Notification.stories.tsx
@@ -21,7 +21,17 @@ const titles = ['Выполнено', 'Внимание', 'Ошибка'];
 const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
 const size = ['xs', 'xxs'];
 const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
 const views = ['default', 'negative', 'positive', 'warning', 'info'];
 
 const longText = `JavaScript frameworks are an essential part of modern front-end web development,

--- a/packages/sdds-insol/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-insol/src/components/Notification/Notification.stories.tsx
@@ -21,7 +21,17 @@ const titles = ['Выполнено', 'Внимание', 'Ошибка'];
 const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
 const size = ['xs', 'xxs'];
 const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
 const views = ['default', 'negative', 'positive', 'warning', 'info'];
 
 const longText = `JavaScript frameworks are an essential part of modern front-end web development,

--- a/packages/sdds-serv/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-serv/src/components/Notification/Notification.stories.tsx
@@ -21,7 +21,17 @@ const titles = ['Выполнено', 'Внимание', 'Ошибка'];
 const texts = ['SSH ключ успешно скопирован', 'Нельзя скопировать SSH ключ', 'Не удалось скопировать SSH ключ'];
 const size = ['xs', 'xxs'];
 const iconPlacement = ['top', 'left'];
-const notificationsPlacements = ['bottom-right', 'bottom-left'];
+export const notificationsPlacements = [
+    'center',
+    'top',
+    'bottom',
+    'right',
+    'left',
+    'top-right',
+    'top-left',
+    'bottom-right',
+    'bottom-left',
+];
 const views = ['default', 'negative', 'positive', 'warning', 'info'];
 
 const longText = `JavaScript frameworks are an essential part of modern front-end web development,

--- a/website/plasma-b2c-docs/docs/components/Notification.mdx
+++ b/website/plasma-b2c-docs/docs/components/Notification.mdx
@@ -3,23 +3,24 @@ id: notification
 title: Notification
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description } from '@site/src/components';
 
 # Notification
 <Description name="Notification" />
 <PropsTable name="Notification" />
-<StorybookLink name="Notification" />
 
 ## Использование
 Компонент `Notification` может использоваться для создания собственных систем оповещения.
 Вид компонента контролируется свойствами (props).
-
-Текстовая часть оповещения состоит из `title` и `children`. Слева или сверху от нее, также можно пробросить иконку через свойство `icon`.
+Текстовая часть оповещения состоит из `title` и `children`.
+Слева или сверху от нее, также можно пробросить иконку через свойство `icon`.
 Также есть часть `actions`, в которой предполагается отображение кнопок для взаимодействия.
 
 ### Провайдер контекста
+<PropsTable name="NotificationsProvider" />
+
 Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна.
-В качестве свойств можно указать контейнер для оповещений через `frame` и расположение в контейнере через свойство `placement`, как `bottom-right` _(по умолчанию)_ или `bottom-left`.
+В качестве свойств можно указать контейнер для оповещений через `frame`.
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
@@ -35,17 +36,26 @@ ReactDOM.render(
 );
 ```
 
+### Позиционирование
+
+Позиционирование компонента регулируется с помощью свойства `placement`.
+
+```ts
+type NotificationPlacement = 'center' | 'top' | 'bottom' | 'right' | 'left';
+````
+И производные комбинации, например `bottom-left` или `top-right`.
+
 ### Вызов уведомления
 После подключения `NotificationsProvider` станет возможен вызов функции `addNotification`, который приведет к отображению оповещения.
 Функция принимает значения свойств компонента `Notification`, включая необязательное поле `id`. И возвращает сгенерированный или переданный `id`, по которому можно закрыть оповещение через вызов `closeNotification`.
 Оповещение закроется автоматически по истечению указанного `timeout` в миллисекундах или будет висеть вечно, если передан `0` или `null`.
 
 ```tsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/plasma-b2c';
 
 export function App() {
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
@@ -53,7 +63,7 @@ export function App() {
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 
@@ -69,30 +79,35 @@ export function App() {
 ```
 
 ## Вид иконки и текста
-Значения `positive`, `negative`, `warning` и `info` свойства `view` изменяют цвет иконки и текста.<br/>
-Чтобы цвет применился, установите в иконке свойство `color` со значением `inherit`:
+:::tip
+Чтобы компонент иконки наследовал `color` от `view` используйте значение `inherit`.
 
-Также для изменения цвета можно исипользовать свойства `iconColor` и `textColor`
+```tsx
+<IconBell color="inherit" size="xs" />
+```
+:::
+
+Также имеются свойства `titleColor, textColor` для **переопределения** `color` текста контента и заголовка.
 
 ```jsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { IconBell } from '@salutejs/plasma-icons';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/plasma-b2c';
 
 export function App() {
-    const Icon = () => <IconBell color="inherit" size="xs" />;
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
-            icon: <Icon />,
+            icon: <IconBell color="inherit" size="xs" />,
             children: 'Принять?',
             view: 'positive',
-            textColor: 'black'
+            textColor: 'black',
+            titleColor: 'blue'
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 

--- a/website/plasma-giga-docs/docs/components/Notification.mdx
+++ b/website/plasma-giga-docs/docs/components/Notification.mdx
@@ -17,8 +17,10 @@ import { PropsTable, Description } from '@site/src/components';
 Также есть часть `actions`, в которой предполагается отображение кнопок для взаимодействия.
 
 ### Провайдер контекста
+<PropsTable name="NotificationsProvider" />
+
 Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна.
-В качестве свойств можно указать контейнер для оповещений через `frame` и расположение в контейнере через свойство `placement`, как `bottom-right` _(по умолчанию)_ или `bottom-left`.
+В качестве свойств можно указать контейнер для оповещений через `frame`.
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
@@ -34,25 +36,34 @@ ReactDOM.render(
 );
 ```
 
+### Позиционирование
+
+Позиционирование компонента регулируется с помощью свойства `placement`.
+
+```ts
+type NotificationPlacement = 'center' | 'top' | 'bottom' | 'right' | 'left';
+````
+И производные комбинации, например `bottom-left` или `top-right`.
+
 ### Вызов уведомления
 После подключения `NotificationsProvider` станет возможен вызов функции `addNotification`, который приведет к отображению оповещения.
 Функция принимает значения свойств компонента `Notification`, включая необязательное поле `id`. И возвращает сгенерированный или переданный `id`, по которому можно закрыть оповещение через вызов `closeNotification`.
 Оповещение закроется автоматически по истечению указанного `timeout` в миллисекундах или будет висеть вечно, если передан `0` или `null`.
 
 ```tsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/plasma-giga';
 
 export function App() {
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
             children: 'Принять?',
-        }, 1000);
+        }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 
@@ -68,30 +79,35 @@ export function App() {
 ```
 
 ## Вид иконки и текста
-Значения `positive`, `negative`, `warning` и `info` свойства `view` изменяют цвет иконки и текста.<br/>
-Чтобы цвет применился, установите в иконке свойство `color` со значением `inherit`:
+:::tip
+Чтобы компонент иконки наследовал `color` от `view` используйте значение `inherit`.
 
-Также для изменения цвета можно исипользовать свойства `iconColor` и `textColor`
+```tsx
+<IconBell color="inherit" size="xs" />
+```
+:::
+
+Также имеются свойства `titleColor, textColor` для **переопределения** `color` текста контента и заголовка.
 
 ```jsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { IconBell } from '@salutejs/plasma-icons';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/plasma-giga';
 
 export function App() {
-    const Icon = () => <IconBell color="inherit" size="xs" />;
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
-            icon: <Icon />,
+            icon: <IconBell color="inherit" size="xs" />,
             children: 'Принять?',
             view: 'positive',
-            textColor: 'black'
+            textColor: 'black',
+            titleColor: 'blue'
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 

--- a/website/plasma-web-docs/docs/components/Notification.mdx
+++ b/website/plasma-web-docs/docs/components/Notification.mdx
@@ -3,22 +3,24 @@ id: notification
 title: Notification
 ---
 
-import { PropsTable, Description, StorybookLink } from '@site/src/components';
+import { PropsTable, Description } from '@site/src/components';
 
 # Notification
 <Description name="Notification" />
 <PropsTable name="Notification" />
-<StorybookLink name="Notification" />
 
 ## Использование
 Компонент `Notification` может использоваться для создания собственных систем оповещения.
 Вид компонента контролируется свойствами (props).
-Текстовая часть оповещения состоит из `title` и `children`. Слева или сверху от нее, также можно пробросить иконку через свойство `icon`.
+Текстовая часть оповещения состоит из `title` и `children`.
+Слева или сверху от нее, также можно пробросить иконку через свойство `icon`.
 Также есть часть `actions`, в которой предполагается отображение кнопок для взаимодействия.
 
 ### Провайдер контекста
+<PropsTable name="NotificationsProvider" />
+
 Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна.
-В качестве свойств можно указать контейнер для оповещений через `frame` и расположение в контейнере через свойство `placement`, как `bottom-right` _(по умолчанию)_ или `bottom-left`.
+В качестве свойств можно указать контейнер для оповещений через `frame`.
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
@@ -34,17 +36,26 @@ ReactDOM.render(
 );
 ```
 
+### Позиционирование
+
+Позиционирование компонента регулируется с помощью свойства `placement`.
+
+```ts
+type NotificationPlacement = 'center' | 'top' | 'bottom' | 'right' | 'left';
+````
+И производные комбинации, например `bottom-left` или `top-right`.
+
 ### Вызов уведомления
 После подключения `NotificationsProvider` станет возможен вызов функции `addNotification`, который приведет к отображению оповещения.
 Функция принимает значения свойств компонента `Notification`, включая необязательное поле `id`. И возвращает сгенерированный или переданный `id`, по которому можно закрыть оповещение через вызов `closeNotification`.
 Оповещение закроется автоматически по истечению указанного `timeout` в миллисекундах или будет висеть вечно, если передан `0` или `null`.
 
 ```tsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/plasma-web';
 
 export function App() {
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
@@ -52,7 +63,7 @@ export function App() {
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 
@@ -68,30 +79,35 @@ export function App() {
 ```
 
 ## Вид иконки и текста
-Значения `positive`, `negative`, `warning` и `info` свойства `view` изменяют цвет иконки и текста.<br/>
-Чтобы цвет применился, установите в иконке свойство `color` со значением `inherit`:
+:::tip
+Чтобы компонент иконки наследовал `color` от `view` используйте значение `inherit`.
 
-Также для изменения цвета можно исипользовать свойства `iconColor` и `textColor`
+```tsx
+<IconBell color="inherit" size="xs" />
+```
+:::
+
+Также имеются свойства `titleColor, textColor` для **переопределения** `color` текста контента и заголовка.
 
 ```jsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { IconBell } from '@salutejs/plasma-icons';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/plasma-web';
 
 export function App() {
-    const Icon = () => <IconBell color="inherit" size="xs" />;
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
-            icon: <Icon />,
+            icon: <IconBell color="inherit" size="xs" />,
             children: 'Принять?',
             view: 'positive',
-            textColor: 'black'
+            textColor: 'black',
+            titleColor: 'blue'
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 

--- a/website/sdds-cs-docs/docs/components/Notification.mdx
+++ b/website/sdds-cs-docs/docs/components/Notification.mdx
@@ -17,8 +17,10 @@ import { PropsTable, Description } from '@site/src/components';
 Также есть часть `actions`, в которой предполагается отображение кнопок для взаимодействия.
 
 ### Провайдер контекста
+<PropsTable name="NotificationsProvider" />
+
 Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна.
-В качестве свойств можно указать контейнер для оповещений через `frame` и расположение в контейнере через свойство `placement`, как `bottom-right` _(по умолчанию)_ или `bottom-left`.
+В качестве свойств можно указать контейнер для оповещений через `frame`.
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
@@ -34,17 +36,26 @@ ReactDOM.render(
 );
 ```
 
+### Позиционирование
+
+Позиционирование компонента регулируется с помощью свойства `placement`.
+
+```ts
+type NotificationPlacement = 'center' | 'top' | 'bottom' | 'right' | 'left';
+````
+И производные комбинации, например `bottom-left` или `top-right`.
+
 ### Вызов уведомления
 После подключения `NotificationsProvider` станет возможен вызов функции `addNotification`, который приведет к отображению оповещения.
 Функция принимает значения свойств компонента `Notification`, включая необязательное поле `id`. И возвращает сгенерированный или переданный `id`, по которому можно закрыть оповещение через вызов `closeNotification`.
 Оповещение закроется автоматически по истечению указанного `timeout` в миллисекундах или будет висеть вечно, если передан `0` или `null`.
 
 ```tsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/sdds-cs';
 
 export function App() {
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
@@ -52,7 +63,7 @@ export function App() {
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 
@@ -68,27 +79,35 @@ export function App() {
 ```
 
 ## Вид иконки и текста
-Для изменения цвета можно исипользовать свойства `iconColor` и `textColor`
-Чтобы цвет применился, установите в иконке свойство `color` со значением `inherit`:
+:::tip
+Чтобы компонент иконки наследовал `color` от `view` используйте значение `inherit`.
+
+```tsx
+<IconBell color="inherit" size="xs" />
+```
+:::
+
+Также имеются свойства `titleColor, textColor` для **переопределения** `color` текста контента и заголовка.
 
 ```jsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { IconBell } from '@salutejs/plasma-icons';
-import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/plasma-b2c';
+import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/sdds-cs';
 
 export function App() {
-    const Icon = () => <IconBell color="inherit" size="xs" />;
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
-            icon: <Icon />,
+            icon: <IconBell color="inherit" size="xs" />,
             children: 'Принять?',
-            textColor: 'green'
+            view: 'positive',
+            textColor: 'black',
+            titleColor: 'blue'
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 

--- a/website/sdds-dfa-docs/docs/components/Notification.mdx
+++ b/website/sdds-dfa-docs/docs/components/Notification.mdx
@@ -17,8 +17,10 @@ import { PropsTable, Description } from '@site/src/components';
 Также есть часть `actions`, в которой предполагается отображение кнопок для взаимодействия.
 
 ### Провайдер контекста
+<PropsTable name="NotificationsProvider" />
+
 Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна.
-В качестве свойств можно указать контейнер для оповещений через `frame` и расположение в контейнере через свойство `placement`, как `bottom-right` _(по умолчанию)_ или `bottom-left`.
+В качестве свойств можно указать контейнер для оповещений через `frame`.
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
@@ -34,17 +36,26 @@ ReactDOM.render(
 );
 ```
 
+### Позиционирование
+
+Позиционирование компонента регулируется с помощью свойства `placement`.
+
+```ts
+type NotificationPlacement = 'center' | 'top' | 'bottom' | 'right' | 'left';
+````
+И производные комбинации, например `bottom-left` или `top-right`.
+
 ### Вызов уведомления
 После подключения `NotificationsProvider` станет возможен вызов функции `addNotification`, который приведет к отображению оповещения.
 Функция принимает значения свойств компонента `Notification`, включая необязательное поле `id`. И возвращает сгенерированный или переданный `id`, по которому можно закрыть оповещение через вызов `closeNotification`.
 Оповещение закроется автоматически по истечению указанного `timeout` в миллисекундах или будет висеть вечно, если передан `0` или `null`.
 
 ```tsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/sdds-dfa';
 
 export function App() {
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
@@ -52,7 +63,7 @@ export function App() {
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 
@@ -68,30 +79,35 @@ export function App() {
 ```
 
 ## Вид иконки и текста
-Значения `positive`, `negative`, `warning` и `info` свойства `view` изменяют цвет иконки и текста.<br/>
-Чтобы цвет применился, установите в иконке свойство `color` со значением `inherit`:
+:::tip
+Чтобы компонент иконки наследовал `color` от `view` используйте значение `inherit`.
 
-Также для изменения цвета можно исипользовать свойства `iconColor` и `textColor`
+```tsx
+<IconBell color="inherit" size="xs" />
+```
+:::
+
+Также имеются свойства `titleColor, textColor` для **переопределения** `color` текста контента и заголовка.
 
 ```jsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { IconBell } from '@salutejs/plasma-icons';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/sdds-dfa';
 
 export function App() {
-    const Icon = () => <IconBell color="inherit" size="xs" />;
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
-            icon: <Icon />,
+            icon: <IconBell color="inherit" size="xs" />,
             children: 'Принять?',
             view: 'positive',
-            textColor: 'black'
+            textColor: 'black',
+            titleColor: 'blue'
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 

--- a/website/sdds-insol-docs/docs/components/Notification.mdx
+++ b/website/sdds-insol-docs/docs/components/Notification.mdx
@@ -17,7 +17,10 @@ import { PropsTable, Description } from '@site/src/components';
 Также есть часть `actions`, в которой предполагается отображение кнопок для взаимодействия.
 
 ### Провайдер контекста
-Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна:
+<PropsTable name="NotificationsProvider" />
+
+Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна.
+В качестве свойств можно указать контейнер для оповещений через `frame`.
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
@@ -33,56 +36,78 @@ ReactDOM.render(
 );
 ```
 
+### Позиционирование
+
+Позиционирование компонента регулируется с помощью свойства `placement`.
+
+```ts
+type NotificationPlacement = 'center' | 'top' | 'bottom' | 'right' | 'left';
+````
+И производные комбинации, например `bottom-left` или `top-right`.
+
 ### Вызов уведомления
 После подключения `NotificationsProvider` станет возможен вызов функции `addNotification`, который приведет к отображению оповещения.
 Функция принимает значения свойств компонента `Notification`, включая необязательное поле `id`. И возвращает сгенерированный или переданный `id`, по которому можно закрыть оповещение через вызов `closeNotification`.
 Оповещение закроется автоматически по истечению указанного `timeout` в миллисекундах или будет висеть вечно, если передан `0` или `null`.
 
 ```tsx live
-import React from 'react';
-import { Button, addNotification, NotificationsProvider } from '@salutejs/sdds-insol';
+import React, { useCallback } from 'react';
+import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/sdds-insol';
 
 export function App() {
-    const handleClick = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
+            id: 'incoming-call',
             title: 'Входящий вызов',
             children: 'Принять?',
-        }, 1000);
+        }, 3000);
+    }, []);
+
+    const handleHide = useCallback(() => {
+        closeNotification('incoming-call');
     }, []);
 
     return (
         <NotificationsProvider>
-            <Button text="Показать оповещение" onClick={handleClick} />
+            <ButtonGroup>
+                <Button text="Показать оповещение" onClick={handleShow} />
+                <Button text="Скрыть оповещение" onClick={handleHide} />
+            </ButtonGroup>
         </NotificationsProvider>
     );
 }
 ```
 
 ## Вид иконки и текста
-Значения `positive`, `negative`, `warning` и `info` свойства `view` изменяют цвет иконки и текста.<br/>
-Чтобы цвет применился, установите в иконке свойство `color` со значением `inherit`:
+:::tip
+Чтобы компонент иконки наследовал `color` от `view` используйте значение `inherit`.
 
-Также для изменения цвета можно исипользовать свойства `iconColor` и `textColor`
+```tsx
+<IconBell color="inherit" size="xs" />
+```
+:::
+
+Также имеются свойства `titleColor, textColor` для **переопределения** `color` текста контента и заголовка.
 
 ```jsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { IconBell } from '@salutejs/plasma-icons';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/sdds-insol';
 
 export function App() {
-    const Icon = () => <IconBell color="inherit" size="xs" />;
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
-            icon: <Icon />,
+            icon: <IconBell color="inherit" size="xs" />,
             children: 'Принять?',
             view: 'positive',
-            textColor: 'black'
+            textColor: 'black',
+            titleColor: 'blue'
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 

--- a/website/sdds-serv-docs/docs/components/Notification.mdx
+++ b/website/sdds-serv-docs/docs/components/Notification.mdx
@@ -17,8 +17,10 @@ import { PropsTable, Description } from '@site/src/components';
 Также есть часть `actions`, в которой предполагается отображение кнопок для взаимодействия.
 
 ### Провайдер контекста
+<PropsTable name="NotificationsProvider" />
+
 Поместите `NotificationsProvider` в [корень приложения](../../#корень-приложения) или там, где будете применять модальные окна.
-В качестве свойств можно указать контейнер для оповещений через `frame` и расположение в контейнере через свойство `placement`, как `bottom-right` _(по умолчанию)_ или `bottom-left`.
+В качестве свойств можно указать контейнер для оповещений через `frame`.
 
 ```tsx title="index.ts"
 import ReactDOM from 'react-dom';
@@ -34,17 +36,26 @@ ReactDOM.render(
 );
 ```
 
+### Позиционирование
+
+Позиционирование компонента регулируется с помощью свойства `placement`.
+
+```ts
+type NotificationPlacement = 'center' | 'top' | 'bottom' | 'right' | 'left';
+````
+И производные комбинации, например `bottom-left` или `top-right`.
+
 ### Вызов уведомления
 После подключения `NotificationsProvider` станет возможен вызов функции `addNotification`, который приведет к отображению оповещения.
 Функция принимает значения свойств компонента `Notification`, включая необязательное поле `id`. И возвращает сгенерированный или переданный `id`, по которому можно закрыть оповещение через вызов `closeNotification`.
 Оповещение закроется автоматически по истечению указанного `timeout` в миллисекундах или будет висеть вечно, если передан `0` или `null`.
 
 ```tsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/sdds-serv';
 
 export function App() {
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
@@ -52,7 +63,7 @@ export function App() {
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 
@@ -68,30 +79,35 @@ export function App() {
 ```
 
 ## Вид иконки и текста
-Значения `positive`, `negative`, `warning` и `info` свойства `view` изменяют цвет иконки и текста.<br/>
-Чтобы цвет применился, установите в иконке свойство `color` со значением `inherit`:
+:::tip
+Чтобы компонент иконки наследовал `color` от `view` используйте значение `inherit`.
 
-Также для изменения цвета можно исипользовать свойства `iconColor` и `textColor`
+```tsx
+<IconBell color="inherit" size="xs" />
+```
+:::
+
+Также имеются свойства `titleColor, textColor` для **переопределения** `color` текста контента и заголовка.
 
 ```jsx live
-import React from 'react';
+import React, { useCallback } from 'react';
 import { IconBell } from '@salutejs/plasma-icons';
 import { Button, ButtonGroup, addNotification, closeNotification, NotificationsProvider } from '@salutejs/sdds-serv';
 
 export function App() {
-    const Icon = () => <IconBell color="inherit" size="xs" />;
-    const handleShow = React.useCallback(() => {
+    const handleShow = useCallback(() => {
         addNotification({
             id: 'incoming-call',
             title: 'Входящий вызов',
-            icon: <Icon />,
+            icon: <IconBell color="inherit" size="xs" />,
             children: 'Принять?',
             view: 'positive',
-            textColor: 'black'
+            textColor: 'black',
+            titleColor: 'blue'
         }, 3000);
     }, []);
 
-    const handleHide = React.useCallback(() => {
+    const handleHide = useCallback(() => {
         closeNotification('incoming-call');
     }, []);
 


### PR DESCRIPTION
## Core

### Notification

- добавлены новые значения для `NotificationPlacement`. Top, center, left, bottom, right и производные комбинации.   

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.306.0-canary.1825.13765737233.0
  npm install @salutejs/plasma-b2c@1.548.0-canary.1825.13765737233.0
  npm install @salutejs/plasma-giga@0.275.0-canary.1825.13765737233.0
  npm install @salutejs/plasma-new-hope@0.292.0-canary.1825.13765737233.0
  npm install @salutejs/plasma-web@1.550.0-canary.1825.13765737233.0
  npm install @salutejs/sdds-cs@0.284.0-canary.1825.13765737233.0
  npm install @salutejs/sdds-dfa@0.278.0-canary.1825.13765737233.0
  npm install @salutejs/sdds-finportal@0.271.0-canary.1825.13765737233.0
  npm install @salutejs/sdds-insol@0.275.0-canary.1825.13765737233.0
  npm install @salutejs/sdds-serv@0.279.0-canary.1825.13765737233.0
  # or 
  yarn add @salutejs/plasma-asdk@0.306.0-canary.1825.13765737233.0
  yarn add @salutejs/plasma-b2c@1.548.0-canary.1825.13765737233.0
  yarn add @salutejs/plasma-giga@0.275.0-canary.1825.13765737233.0
  yarn add @salutejs/plasma-new-hope@0.292.0-canary.1825.13765737233.0
  yarn add @salutejs/plasma-web@1.550.0-canary.1825.13765737233.0
  yarn add @salutejs/sdds-cs@0.284.0-canary.1825.13765737233.0
  yarn add @salutejs/sdds-dfa@0.278.0-canary.1825.13765737233.0
  yarn add @salutejs/sdds-finportal@0.271.0-canary.1825.13765737233.0
  yarn add @salutejs/sdds-insol@0.275.0-canary.1825.13765737233.0
  yarn add @salutejs/sdds-serv@0.279.0-canary.1825.13765737233.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
