### PR TITLE
PLASMA-4517: Add i18n for Calendar

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
@@ -12,7 +12,7 @@ import React, {
 import type { Calendar, CalendarConfigProps, DateObject } from '../Calendar.types';
 import { getInitialState, reducer, sizeMap } from '../store/reducer';
 import { ActionType, CalendarState } from '../store/types';
-import { isValueUpdate } from '../utils';
+import { I18N, isValueUpdate } from '../utils';
 import { useKeyNavigation, useCalendarNavigation, useCalendarDateChange } from '../hooks';
 import { CalendarDays, CalendarHeader, CalendarMonths, CalendarQuarters, CalendarYears } from '../ui';
 import { RootProps } from '../../../engines';
@@ -134,7 +134,7 @@ export const calendarBaseRoot = (Root: RootProps<HTMLDivElement, HTMLAttributes<
             }, [value, prevValue]);
 
             return (
-                <Root ref={outerRootRef} aria-label="Выбор даты" {...rest}>
+                <Root ref={outerRootRef} aria-label={I18N.selectDate[locale]} {...rest}>
                     {isOutOfRange && (
                         <IsOutOfRange
                             key={outOfRangeKey}

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
@@ -10,7 +10,7 @@ import React, {
 } from 'react';
 
 import type { Calendar, CalendarConfigProps, DateObject } from '../Calendar.types';
-import { YEAR_RENDER_COUNT, getNextDate, isValueUpdate } from '../utils';
+import { YEAR_RENDER_COUNT, getNextDate, isValueUpdate, I18N } from '../utils';
 import { useKeyNavigation, useCalendarNavigation, useCalendarDateChange } from '../hooks';
 import { CalendarDays, CalendarHeader, CalendarMonths, CalendarQuarters, CalendarYears } from '../ui';
 import { RootProps } from '../../../engines/types';
@@ -180,7 +180,7 @@ export const calendarDoubleRoot = (Root: RootProps<HTMLDivElement, HTMLAttribute
             }, [date, calendarState]);
 
             return (
-                <Root ref={outerRootRef} aria-label="Выбор даты" {...rest}>
+                <Root ref={outerRootRef} aria-label={I18N.selectDate[locale]} {...rest}>
                     {isOutOfRange && (
                         <IsOutOfRange
                             key={outOfRangeKey}

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarDays/CalendarDays.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarDays/CalendarDays.tsx
@@ -10,6 +10,7 @@ import {
     isSelectProcess,
     ROW_STEP,
     SHORT_DAY_NAMES,
+    I18N,
 } from '../../utils';
 import { DateStructureItem } from '../DateStructureItem/DateStructureItem';
 import { DateItem } from '../../Calendar.types';
@@ -130,9 +131,7 @@ export const CalendarDays: React.FC<CalendarDaysProps> = ({
             onKeyDown={onKeyDown}
             onMouseLeave={handleMouseOutGrid}
         >
-            <StyledCalendarDaysHint id="withShift">
-                Для навигации только по доступным датам удерживайте клавишу Shift.
-            </StyledCalendarDaysHint>
+            <StyledCalendarDaysHint id="withShift">{I18N.navigationByShift[locale]}</StyledCalendarDaysHint>
             <StyledFlex role="row">
                 {SHORT_DAY_NAMES[locale].map((name) => (
                     <DateStructureItem

--- a/packages/plasma-new-hope/src/components/Calendar/ui/CalendarHeader/CalendarHeader.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/ui/CalendarHeader/CalendarHeader.tsx
@@ -3,7 +3,7 @@ import type { MouseEvent } from 'react';
 
 import { IconDisclosureLeft, IconDisclosureRight } from '../../../_Icon';
 import { CalendarState } from '../../store/types';
-import { getCalendarType, MONTH_NAMES, YEAR_RENDER_COUNT } from '../../utils';
+import { getCalendarType, MONTH_NAMES, YEAR_RENDER_COUNT, I18N } from '../../utils';
 import type { DateObject } from '../../Calendar.types';
 import { classes } from '../../Calendar.tokens';
 import { sizeMap } from '../../store/reducer';
@@ -104,12 +104,12 @@ export const CalendarHeader: React.FC<CalendarHeaderProps> = ({
         return '';
     };
 
-    const currentCalendarType = getCalendarType(type);
+    const currentCalendarType = getCalendarType(type, locale);
 
     const PreviousButton = () => (
         <StyledArrow
             className={cx(startYear <= 0 && classes.disabledPrevButton)}
-            aria-label={`Предыдущий ${currentCalendarType}`}
+            aria-label={`${I18N.previous[locale]} ${currentCalendarType}`}
             onClick={handlePrev}
         >
             <IconDisclosureLeft color="inherit" size={size === 'xs' ? 'xs' : 's'} />
@@ -117,7 +117,7 @@ export const CalendarHeader: React.FC<CalendarHeaderProps> = ({
     );
 
     const NextButton = () => (
-        <StyledArrow aria-label={`Следующий ${currentCalendarType}`} onClick={handleNext}>
+        <StyledArrow aria-label={`${I18N.next[locale]} ${currentCalendarType}`} onClick={handleNext}>
             <IconDisclosureRight color="inherit" size={size === 'xs' ? 'xs' : 's'} />
         </StyledArrow>
     );

--- a/packages/plasma-new-hope/src/components/Calendar/utils/calendarGridHelper.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/utils/calendarGridHelper.ts
@@ -1,8 +1,8 @@
-import type { CalendarValueType, DateObject, DisabledDay, EventDay, ItemProps } from '../Calendar.types';
+import type { CalendarValueType, DateObject, DisabledDay, EventDay, ItemProps, Locales } from '../Calendar.types';
 import type { CalendarStateType } from '../store/types';
 
 import { isSelectProcess } from './calendarRangeHelper';
-import { MONTHS, YEAR_RENDER_COUNT } from './constants';
+import { MONTHS, YEAR_RENDER_COUNT, I18N } from './constants';
 
 export const getDaysInMonth = (monthIndex: number, year: number) => new Date(year, monthIndex + 1, 0).getDate();
 
@@ -144,14 +144,14 @@ export const getMatrix = <T extends ItemProps>(items: T[], rowSize = 7): readonl
     return [result, selected] as const;
 };
 
-export const getCalendarType = (type: CalendarStateType) => {
+export const getCalendarType = (type: CalendarStateType, locale: Locales) => {
     switch (type) {
         case 'Months':
         case 'Quarters':
-            return 'год';
+            return I18N.year[locale];
         case 'Years':
-            return 'период';
+            return I18N.period[locale];
         default:
-            return 'месяц';
+            return I18N.month[locale];
     }
 };

--- a/packages/plasma-new-hope/src/components/Calendar/utils/constants.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/utils/constants.ts
@@ -104,3 +104,34 @@ export const MONTH_NAMES: LocalMap = {
     ru: MONTHS.map(callbackMonthFormatter('ru', { month: 'long' })),
     en: MONTHS.map(callbackMonthFormatter('en', { month: 'long' })),
 };
+
+export const I18N = {
+    next: {
+        ru: 'Следующий',
+        en: 'Next',
+    },
+    previous: {
+        ru: 'Предыдущий',
+        en: 'Previous',
+    },
+    selectDate: {
+        ru: 'Выбор даты',
+        en: 'Date selection',
+    },
+    navigationByShift: {
+        ru: 'Для навигации только по доступным датам удерживайте клавишу Shift.',
+        en: 'To navigate exclusively among the available dates, hold down the Shift key.',
+    },
+    year: {
+        ru: 'год',
+        en: 'year',
+    },
+    period: {
+        ru: 'период',
+        en: 'period',
+    },
+    month: {
+        ru: 'месяц',
+        en: 'month',
+    },
+};


### PR DESCRIPTION
## Core

### Calendar

- добавлены переводы на `eng` для aria-label 

### What/why changed

Раньше был зашит только русский, теперь при переключении locale текст будет на eng  

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.305.2-canary.1829.13784636905.0
  npm install @salutejs/plasma-b2c@1.547.2-canary.1829.13784636905.0
  npm install @salutejs/plasma-giga@0.274.2-canary.1829.13784636905.0
  npm install @salutejs/plasma-new-hope@0.291.2-canary.1829.13784636905.0
  npm install @salutejs/plasma-web@1.549.2-canary.1829.13784636905.0
  npm install @salutejs/sdds-cs@0.283.2-canary.1829.13784636905.0
  npm install @salutejs/sdds-dfa@0.277.2-canary.1829.13784636905.0
  npm install @salutejs/sdds-finportal@0.270.2-canary.1829.13784636905.0
  npm install @salutejs/sdds-insol@0.274.2-canary.1829.13784636905.0
  npm install @salutejs/sdds-serv@0.278.2-canary.1829.13784636905.0
  # or 
  yarn add @salutejs/plasma-asdk@0.305.2-canary.1829.13784636905.0
  yarn add @salutejs/plasma-b2c@1.547.2-canary.1829.13784636905.0
  yarn add @salutejs/plasma-giga@0.274.2-canary.1829.13784636905.0
  yarn add @salutejs/plasma-new-hope@0.291.2-canary.1829.13784636905.0
  yarn add @salutejs/plasma-web@1.549.2-canary.1829.13784636905.0
  yarn add @salutejs/sdds-cs@0.283.2-canary.1829.13784636905.0
  yarn add @salutejs/sdds-dfa@0.277.2-canary.1829.13784636905.0
  yarn add @salutejs/sdds-finportal@0.270.2-canary.1829.13784636905.0
  yarn add @salutejs/sdds-insol@0.274.2-canary.1829.13784636905.0
  yarn add @salutejs/sdds-serv@0.278.2-canary.1829.13784636905.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
