### PR TITLE
PLASMA-4676: fix read-only mode in Textfield

### DIFF
--- a/packages/plasma-new-hope/src/components/TextField/variations/_read-only/base.ts
+++ b/packages/plasma-new-hope/src/components/TextField/variations/_read-only/base.ts
@@ -16,7 +16,7 @@ export const base = css`
         :not(&.${classes.clear}) {
             ${InputWrapper} {
                 position: relative;
-
+                z-index: 0;
                 color: var(${tokens.colorReadOnly});
                 background: transparent;
                 box-shadow: none;


### PR DESCRIPTION
## Core

### Textfield
- исправлен баг в режиме `readOnly`;

### What/why changed
У псевдо-элемента before для режима readOnly стоит z-index: -1, и это приводило к багу, когда фон и тень (бордер) уходили ниже всех других компонентов на странице. Чтобы этого не происходило я поставил родительскому тегу z-index: 0, 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.315.0-canary.1838.13899379517.0
  npm install @salutejs/plasma-b2c@1.557.0-canary.1838.13899379517.0
  npm install @salutejs/plasma-giga@0.284.0-canary.1838.13899379517.0
  npm install @salutejs/plasma-new-hope@0.301.0-canary.1838.13899379517.0
  npm install @salutejs/plasma-web@1.559.0-canary.1838.13899379517.0
  npm install @salutejs/sdds-cs@0.293.0-canary.1838.13899379517.0
  npm install @salutejs/sdds-dfa@0.287.0-canary.1838.13899379517.0
  npm install @salutejs/sdds-finportal@0.280.0-canary.1838.13899379517.0
  npm install @salutejs/sdds-insol@0.284.0-canary.1838.13899379517.0
  npm install @salutejs/sdds-serv@0.288.0-canary.1838.13899379517.0
  # or 
  yarn add @salutejs/plasma-asdk@0.315.0-canary.1838.13899379517.0
  yarn add @salutejs/plasma-b2c@1.557.0-canary.1838.13899379517.0
  yarn add @salutejs/plasma-giga@0.284.0-canary.1838.13899379517.0
  yarn add @salutejs/plasma-new-hope@0.301.0-canary.1838.13899379517.0
  yarn add @salutejs/plasma-web@1.559.0-canary.1838.13899379517.0
  yarn add @salutejs/sdds-cs@0.293.0-canary.1838.13899379517.0
  yarn add @salutejs/sdds-dfa@0.287.0-canary.1838.13899379517.0
  yarn add @salutejs/sdds-finportal@0.280.0-canary.1838.13899379517.0
  yarn add @salutejs/sdds-insol@0.284.0-canary.1838.13899379517.0
  yarn add @salutejs/sdds-serv@0.288.0-canary.1838.13899379517.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
