### PR TITLE
PLASMA-4509: Add hover in range

### DIFF
--- a/packages/plasma-b2c/src/components/Range/Range.config.ts
+++ b/packages/plasma-b2c/src/components/Range/Range.config.ts
@@ -25,10 +25,13 @@ export const config = {
 
                 ${tokens.indicatorColor}: var(--surface-negative);
 
+                ${tokens.textFieldBackgroundColorHover}: var(--surface-transparent-primary-hover);
                 ${tokens.textFieldBackgroundColorFocus}: var(--surface-transparent-secondary);
                 ${tokens.textFieldBackgroundErrorColor}: var(--surface-transparent-negative);
+                ${tokens.textFieldBackgroundErrorColorHover}: var(--surface-transparent-negative-hover);
                 ${tokens.textFieldBackgroundErrorColorFocus}: var(--surface-transparent-negative-active);
                 ${tokens.textFieldBackgroundSuccessColor}: var(--surface-transparent-positive);
+                ${tokens.textFieldBackgroundSuccessColorHover}: var(--surface-transparent-positive-hover);
                 ${tokens.textFieldBackgroundSuccessColorFocus}: var(--surface-transparent-positive-active);
 
                 ${tokens.textFieldTextBeforeColor}: var(--text-tertiary);

--- a/packages/plasma-giga/src/components/Range/Range.config.ts
+++ b/packages/plasma-giga/src/components/Range/Range.config.ts
@@ -25,10 +25,13 @@ export const config = {
 
                 ${tokens.indicatorColor}: var(--surface-negative);
 
+                ${tokens.textFieldBackgroundColorHover}: var(--surface-transparent-primary-hover);
                 ${tokens.textFieldBackgroundColorFocus}: var(--surface-transparent-secondary);
                 ${tokens.textFieldBackgroundErrorColor}: var(--surface-transparent-negative);
+                ${tokens.textFieldBackgroundErrorColorHover}: var(--surface-transparent-negative-hover);
                 ${tokens.textFieldBackgroundErrorColorFocus}: var(--surface-transparent-negative-active);
                 ${tokens.textFieldBackgroundSuccessColor}: var(--surface-transparent-positive);
+                ${tokens.textFieldBackgroundSuccessColorHover}: var(--surface-transparent-positive-hover);
                 ${tokens.textFieldBackgroundSuccessColorFocus}: var(--surface-transparent-positive-active);
 
                 ${tokens.textFieldTextBeforeColor}: var(--text-tertiary);

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Range/Range.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Range/Range.config.ts
@@ -24,10 +24,13 @@ export const config = {
                 ${tokens.textFieldPlaceholderColor}: var(--text-secondary);
                 ${tokens.textFieldCaretColor}: var(--text-accent);
 
+                ${tokens.textFieldBackgroundColorHover}: var(--surface-transparent-primary-hover);
                 ${tokens.textFieldBackgroundColorFocus}: var(--surface-transparent-secondary);
                 ${tokens.textFieldBackgroundErrorColor}: var(--surface-transparent-negative);
+                ${tokens.textFieldBackgroundErrorColorHover}: var(--surface-transparent-negative-hover);
                 ${tokens.textFieldBackgroundErrorColorFocus}: var(--surface-transparent-negative-active);
                 ${tokens.textFieldBackgroundSuccessColor}: var(--surface-transparent-positive);
+                ${tokens.textFieldBackgroundSuccessColorHover}: var(--surface-transparent-positive-hover);
                 ${tokens.textFieldBackgroundSuccessColorFocus}: var(--surface-transparent-positive-active);
 
                 ${tokens.textFieldTextBeforeColor}: var(--text-tertiary);

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Range/Range.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Range/Range.config.ts
@@ -25,10 +25,13 @@ export const config = {
                 ${tokens.textFieldPlaceholderColor}: var(--text-secondary);
                 ${tokens.textFieldCaretColor}: var(--text-accent);
 
+                ${tokens.textFieldBorderColorHover}: var(--text-secondary);
                 ${tokens.textFieldBorderColorFocus}: var(--surface-accent);
                 ${tokens.textFieldBorderColorError}: var(--surface-negative);
+                ${tokens.textFieldBorderColorErrorHover}: var(--surface-negative-hover);
                 ${tokens.textFieldBorderColorErrorFocus}: var(--surface-accent);
                 ${tokens.textFieldBorderColorSuccess}: var(--surface-positive);
+                ${tokens.textFieldBorderColorSuccessHover}: var(--surface-positive-hover);
                 ${tokens.textFieldBorderColorSuccessFocus}: var(--surface-accent);
 
                 ${tokens.textFieldTextBeforeColor}: var(--text-tertiary);

--- a/packages/plasma-web/src/components/Range/Range.config.ts
+++ b/packages/plasma-web/src/components/Range/Range.config.ts
@@ -26,10 +26,13 @@ export const config = {
                 ${tokens.textFieldPlaceholderColorFocus}: var(--text-secondary);
                 ${tokens.textFieldCaretColor}: var(--text-accent);
 
+                ${tokens.textFieldBorderColorHover}: var(--text-secondary);
                 ${tokens.textFieldBorderColorFocus}: var(--surface-accent);
                 ${tokens.textFieldBorderColorError}: var(--surface-negative);
+                ${tokens.textFieldBorderColorErrorHover}: var(--surface-negative-hover);
                 ${tokens.textFieldBorderColorErrorFocus}: var(--surface-accent);
                 ${tokens.textFieldBorderColorSuccess}: var(--surface-positive);
+                ${tokens.textFieldBorderColorSuccessHover}: var(--surface-positive-hover);
                 ${tokens.textFieldBorderColorSuccessFocus}: var(--surface-accent);
 
                 ${tokens.textFieldTextBeforeColor}: var(--text-tertiary);

--- a/packages/sdds-cs/src/components/Range/Range.config.ts
+++ b/packages/sdds-cs/src/components/Range/Range.config.ts
@@ -26,6 +26,7 @@ export const config = {
                 ${tokens.textFieldPlaceholderColorFocus}: var(--text-tertiary);
                 ${tokens.textFieldCaretColor}: var(--text-accent);
 
+                ${tokens.textFieldBorderColorHover}: var(--outline-solid-primary-hover);
                 ${tokens.textFieldBorderColorFocus}: var(--outline-accent);
                 ${tokens.textFieldBorderColorError}: var(--outline-negative);
                 ${tokens.textFieldBorderColorErrorFocus}: var(--outline-negative);

--- a/packages/sdds-dfa/src/components/Range/Range.config.ts
+++ b/packages/sdds-dfa/src/components/Range/Range.config.ts
@@ -25,10 +25,13 @@ export const config = {
 
                 ${tokens.indicatorColor}: var(--surface-negative);
 
+                ${tokens.textFieldBackgroundColorHover}: var(--surface-transparent-primary-hover);
                 ${tokens.textFieldBackgroundColorFocus}: var(--surface-transparent-secondary);
                 ${tokens.textFieldBackgroundErrorColor}: var(--surface-transparent-negative);
+                ${tokens.textFieldBackgroundErrorColorHover}: var(--surface-transparent-negative-hover);
                 ${tokens.textFieldBackgroundErrorColorFocus}: var(--surface-transparent-negative-active);
                 ${tokens.textFieldBackgroundSuccessColor}: var(--surface-transparent-positive);
+                ${tokens.textFieldBackgroundSuccessColorHover}: var(--surface-transparent-positive-hover);
                 ${tokens.textFieldBackgroundSuccessColorFocus}: var(--surface-transparent-positive-active);
 
                 ${tokens.textFieldTextBeforeColor}: var(--text-tertiary);

--- a/packages/sdds-finportal/src/components/Range/Range.config.ts
+++ b/packages/sdds-finportal/src/components/Range/Range.config.ts
@@ -25,10 +25,13 @@ export const config = {
 
                 ${tokens.indicatorColor}: var(--surface-negative);
 
+                ${tokens.textFieldBackgroundColorHover}: var(--surface-transparent-primary-hover);
                 ${tokens.textFieldBackgroundColorFocus}: var(--surface-transparent-secondary);
                 ${tokens.textFieldBackgroundErrorColor}: var(--surface-transparent-negative);
+                ${tokens.textFieldBackgroundErrorColorHover}: var(--surface-transparent-negative-hover);
                 ${tokens.textFieldBackgroundErrorColorFocus}: var(--surface-transparent-negative-active);
                 ${tokens.textFieldBackgroundSuccessColor}: var(--surface-transparent-positive);
+                ${tokens.textFieldBackgroundSuccessColorHover}: var(--surface-transparent-positive-hover);
                 ${tokens.textFieldBackgroundSuccessColorFocus}: var(--surface-transparent-positive-active);
 
                 ${tokens.textFieldTextBeforeColor}: var(--text-tertiary);

--- a/packages/sdds-serv/src/components/Range/Range.config.ts
+++ b/packages/sdds-serv/src/components/Range/Range.config.ts
@@ -25,10 +25,13 @@ export const config = {
 
                 ${tokens.indicatorColor}: var(--surface-negative);
 
+                ${tokens.textFieldBackgroundColorHover}: var(--surface-transparent-primary-hover);
                 ${tokens.textFieldBackgroundColorFocus}: var(--surface-transparent-secondary);
                 ${tokens.textFieldBackgroundErrorColor}: var(--surface-transparent-negative);
+                ${tokens.textFieldBackgroundErrorColorHover}: var(--surface-transparent-negative-hover);
                 ${tokens.textFieldBackgroundErrorColorFocus}: var(--surface-transparent-negative-active);
                 ${tokens.textFieldBackgroundSuccessColor}: var(--surface-transparent-positive);
+                ${tokens.textFieldBackgroundSuccessColorHover}: var(--surface-transparent-positive-hover);
                 ${tokens.textFieldBackgroundSuccessColorFocus}: var(--surface-transparent-positive-active);
 
                 ${tokens.textFieldTextBeforeColor}: var(--text-tertiary);


### PR DESCRIPTION
## Core

### Range
- добавлен `hover` для `input` control в компоненте  

### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.325.0-canary.1839.13975685676.0
  npm install @salutejs/plasma-b2c@1.567.0-canary.1839.13975685676.0
  npm install @salutejs/plasma-giga@0.294.0-canary.1839.13975685676.0
  npm install @salutejs/plasma-new-hope@0.311.0-canary.1839.13975685676.0
  npm install @salutejs/plasma-web@1.569.0-canary.1839.13975685676.0
  npm install @salutejs/sdds-cs@0.303.0-canary.1839.13975685676.0
  npm install @salutejs/sdds-dfa@0.297.0-canary.1839.13975685676.0
  npm install @salutejs/sdds-finportal@0.290.0-canary.1839.13975685676.0
  npm install @salutejs/sdds-insol@0.294.0-canary.1839.13975685676.0
  npm install @salutejs/sdds-serv@0.298.0-canary.1839.13975685676.0
  # or 
  yarn add @salutejs/plasma-asdk@0.325.0-canary.1839.13975685676.0
  yarn add @salutejs/plasma-b2c@1.567.0-canary.1839.13975685676.0
  yarn add @salutejs/plasma-giga@0.294.0-canary.1839.13975685676.0
  yarn add @salutejs/plasma-new-hope@0.311.0-canary.1839.13975685676.0
  yarn add @salutejs/plasma-web@1.569.0-canary.1839.13975685676.0
  yarn add @salutejs/sdds-cs@0.303.0-canary.1839.13975685676.0
  yarn add @salutejs/sdds-dfa@0.297.0-canary.1839.13975685676.0
  yarn add @salutejs/sdds-finportal@0.290.0-canary.1839.13975685676.0
  yarn add @salutejs/sdds-insol@0.294.0-canary.1839.13975685676.0
  yarn add @salutejs/sdds-serv@0.298.0-canary.1839.13975685676.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
