### PR TITLE
PLASMA-4241: Add emptyStateDescription prop to Combobox

### DIFF
--- a/packages/plasma-b2c/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-b2c/src/components/Combobox/Combobox.stories.tsx
@@ -171,6 +171,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -199,6 +202,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {

--- a/packages/plasma-giga/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-giga/src/components/Combobox/Combobox.stories.tsx
@@ -171,6 +171,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -199,6 +202,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
@@ -76,6 +76,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             hintView,
             hintSize,
             onChangeValue,
+            emptyStateDescription,
             ...rest
         } = props;
 
@@ -502,7 +503,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
                                                 <StyledEmptyState
                                                     className={classes.emptyStateWrapper}
                                                     size={size}
-                                                    description="Ничего не найдено"
+                                                    description={emptyStateDescription || 'Ничего не найдено'}
                                                 />
                                             ) : (
                                                 filteredItems.map((item, index) => (

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
@@ -226,6 +226,10 @@ type BasicProps<T extends ItemOption = ItemOption> = {
      * Вид компонента.
      */
     view?: string;
+    /**
+     * Текст для состояния когда нет результата.
+     */
+    emptyStateDescription?: string;
 };
 
 export type ComboboxProps<T extends ItemOption = ItemOption> = BasicProps<T> &

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Combobox/Combobox.stories.tsx
@@ -172,6 +172,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -200,6 +203,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {
@@ -234,6 +238,7 @@ const meta: Meta<StorySelectProps> = {
                 'hintPlacement',
                 'hintWidth',
                 'hintHasArrow',
+                'emptyStateDescription',
             ],
         },
     },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Combobox/Combobox.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import type { ComponentProps } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
+import type { PopoverPlacement } from '../Popover/Popover';
 import { WithTheme } from '../../../_helpers';
 import { IconDone } from '../../../../components/_Icon';
 
@@ -171,6 +172,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -199,6 +203,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {
@@ -233,6 +238,7 @@ const meta: Meta<StorySelectProps> = {
                 'hintPlacement',
                 'hintWidth',
                 'hintHasArrow',
+                'emptyStateDescription',
             ],
         },
     },
@@ -454,7 +460,6 @@ const items = [
 
 const SingleStory = (args: StorySelectProps) => {
     const [value, setValue] = useState('');
-
     return (
         <div style={{ width: '400px' }}>
             <Combobox

--- a/packages/plasma-web/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/plasma-web/src/components/Combobox/Combobox.stories.tsx
@@ -171,6 +171,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -199,6 +202,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {

--- a/packages/sdds-cs/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-cs/src/components/Combobox/Combobox.stories.tsx
@@ -91,6 +91,9 @@ const meta: Meta<StorySelectProps> = {
             },
             if: { arg: 'required', truthy: false },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
         ...disableProps([
             'hintText',
             'hintTrigger',
@@ -122,6 +125,7 @@ const meta: Meta<StorySelectProps> = {
         required: false,
         requiredPlacement: 'right',
         hasRequiredIndicator: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {
@@ -149,6 +153,7 @@ const meta: Meta<StorySelectProps> = {
                 'required',
                 'requiredPlacement',
                 'hasRequiredIndicator',
+                'emptyStateDescription',
             ],
         },
     },

--- a/packages/sdds-dfa/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-dfa/src/components/Combobox/Combobox.stories.tsx
@@ -171,6 +171,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -199,6 +202,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {

--- a/packages/sdds-finportal/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-finportal/src/components/Combobox/Combobox.stories.tsx
@@ -171,6 +171,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -199,6 +202,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {

--- a/packages/sdds-insol/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-insol/src/components/Combobox/Combobox.stories.tsx
@@ -167,6 +167,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -194,6 +197,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {

--- a/packages/sdds-serv/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-serv/src/components/Combobox/Combobox.stories.tsx
@@ -171,6 +171,9 @@ const meta: Meta<StorySelectProps> = {
             control: { type: 'text' },
             if: { arg: 'hasHint', truthy: true },
         },
+        emptyStateDescription: {
+            control: { type: 'text' },
+        },
     },
     args: {
         label: 'Label',
@@ -199,6 +202,7 @@ const meta: Meta<StorySelectProps> = {
         hintPlacement: 'auto',
         hintWidth: '10rem',
         hintHasArrow: true,
+        emptyStateDescription: '',
     },
     parameters: {
         controls: {


### PR DESCRIPTION
## Core

### Combobox

- добавлено **новое** свойство `emptyStateDescription `   

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.316.0-canary.1844.13914817759.0
  npm install @salutejs/plasma-b2c@1.558.0-canary.1844.13914817759.0
  npm install @salutejs/plasma-giga@0.285.0-canary.1844.13914817759.0
  npm install @salutejs/plasma-new-hope@0.302.0-canary.1844.13914817759.0
  npm install @salutejs/plasma-web@1.560.0-canary.1844.13914817759.0
  npm install @salutejs/sdds-cs@0.294.0-canary.1844.13914817759.0
  npm install @salutejs/sdds-dfa@0.288.0-canary.1844.13914817759.0
  npm install @salutejs/sdds-finportal@0.281.0-canary.1844.13914817759.0
  npm install @salutejs/sdds-insol@0.285.0-canary.1844.13914817759.0
  npm install @salutejs/sdds-serv@0.289.0-canary.1844.13914817759.0
  # or 
  yarn add @salutejs/plasma-asdk@0.316.0-canary.1844.13914817759.0
  yarn add @salutejs/plasma-b2c@1.558.0-canary.1844.13914817759.0
  yarn add @salutejs/plasma-giga@0.285.0-canary.1844.13914817759.0
  yarn add @salutejs/plasma-new-hope@0.302.0-canary.1844.13914817759.0
  yarn add @salutejs/plasma-web@1.560.0-canary.1844.13914817759.0
  yarn add @salutejs/sdds-cs@0.294.0-canary.1844.13914817759.0
  yarn add @salutejs/sdds-dfa@0.288.0-canary.1844.13914817759.0
  yarn add @salutejs/sdds-finportal@0.281.0-canary.1844.13914817759.0
  yarn add @salutejs/sdds-insol@0.285.0-canary.1844.13914817759.0
  yarn add @salutejs/sdds-serv@0.289.0-canary.1844.13914817759.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
