### PR TITLE
PLASMA-3621: Fix outer label wrapper width textatea

### DIFF
--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.styles.ts
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.styles.ts
@@ -11,9 +11,10 @@ const Tooltip = component(mergedConfig);
 
 export const Hint = styled(Tooltip)``;
 
-export const OuterLabelWrapper = styled.div<{ isInnerLabel: boolean }>`
+export const OuterLabelWrapper = styled.div<{ isInnerLabel: boolean; width: string }>`
     display: flex;
     align-items: center;
+    max-width: ${({ width }) => width};
 
     margin-bottom: ${({ isInnerLabel }) =>
         isInnerLabel ? `var(${tokens.titleCaptionInnerLabelOffset})` : `var(${tokens.labelMarginBottom})`};

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -281,7 +281,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaRootPr
                 })}
             >
                 {(hasOuterLabel || titleCaption) && (
-                    <OuterLabelWrapper isInnerLabel={labelPlacement === 'inner'}>
+                    <OuterLabelWrapper width={helperWidth} isInnerLabel={labelPlacement === 'inner'}>
                         {hasOuterLabel && (
                             <StyledIndicatorWrapper>
                                 <StyledLabel>{label}</StyledLabel>


### PR DESCRIPTION
## Core

### Textarea

-   исправлен баг при вводе `col` и некорректном отображении `outerLabelWrapper`

### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.328.1-canary.1854.14203909655.0
  npm install @salutejs/plasma-b2c@1.570.1-canary.1854.14203909655.0
  npm install @salutejs/plasma-giga@0.297.1-canary.1854.14203909655.0
  npm install @salutejs/plasma-new-hope@0.314.1-canary.1854.14203909655.0
  npm install @salutejs/plasma-web@1.572.1-canary.1854.14203909655.0
  npm install @salutejs/sdds-clfd-auto@0.301.1-canary.1854.14203909655.0
  npm install @salutejs/sdds-cs@0.306.1-canary.1854.14203909655.0
  npm install @salutejs/sdds-dfa@0.300.1-canary.1854.14203909655.0
  npm install @salutejs/sdds-finportal@0.293.1-canary.1854.14203909655.0
  npm install @salutejs/sdds-insol@0.297.1-canary.1854.14203909655.0
  npm install @salutejs/sdds-serv@0.301.1-canary.1854.14203909655.0
  # or 
  yarn add @salutejs/plasma-asdk@0.328.1-canary.1854.14203909655.0
  yarn add @salutejs/plasma-b2c@1.570.1-canary.1854.14203909655.0
  yarn add @salutejs/plasma-giga@0.297.1-canary.1854.14203909655.0
  yarn add @salutejs/plasma-new-hope@0.314.1-canary.1854.14203909655.0
  yarn add @salutejs/plasma-web@1.572.1-canary.1854.14203909655.0
  yarn add @salutejs/sdds-clfd-auto@0.301.1-canary.1854.14203909655.0
  yarn add @salutejs/sdds-cs@0.306.1-canary.1854.14203909655.0
  yarn add @salutejs/sdds-dfa@0.300.1-canary.1854.14203909655.0
  yarn add @salutejs/sdds-finportal@0.293.1-canary.1854.14203909655.0
  yarn add @salutejs/sdds-insol@0.297.1-canary.1854.14203909655.0
  yarn add @salutejs/sdds-serv@0.301.1-canary.1854.14203909655.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
