### PR TITLE
PLASMA-4163: add autoUpdate in FloatingPopover

### DIFF
--- a/packages/plasma-new-hope/src/components/Autocomplete/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Autocomplete/FloatingPopover.tsx
@@ -1,4 +1,4 @@
-import { flip, shift, size, useFloating, FloatingPortal } from '@floating-ui/react';
+import { flip, shift, size, useFloating, FloatingPortal, autoUpdate } from '@floating-ui/react';
 import React, { forwardRef } from 'react';
 import { safeUseId } from '@salutejs/plasma-core';
 
@@ -7,6 +7,13 @@ import type { FloatingPopoverProps } from './Autocomplete.types';
 const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
     ({ target, children, opened, portal, listWidth }, ref) => {
         const { refs, floatingStyles } = useFloating({
+            whileElementsMounted(referenceEl, floatingEl, update) {
+                return autoUpdate(referenceEl, floatingEl, update, {
+                    ancestorScroll: false,
+                    ancestorResize: false,
+                    layoutShift: false,
+                });
+            },
             placement: 'bottom-start',
             open: opened,
             middleware: [

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/FloatingPopover.tsx
@@ -1,4 +1,12 @@
-import { flip, shift, size, useFloating, FloatingPortal, offset as offsetMiddleware } from '@floating-ui/react';
+import {
+    flip,
+    shift,
+    size,
+    useFloating,
+    FloatingPortal,
+    offset as offsetMiddleware,
+    autoUpdate,
+} from '@floating-ui/react';
 import React, { forwardRef } from 'react';
 import { safeUseId } from '@salutejs/plasma-core';
 
@@ -7,6 +15,13 @@ import type { FloatingPopoverProps } from './Combobox.types';
 const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
     ({ target, children, opened, onToggle, placement, portal, listWidth, offset = 0, zIndex }, ref) => {
         const { refs, floatingStyles } = useFloating({
+            whileElementsMounted(referenceEl, floatingEl, update) {
+                return autoUpdate(referenceEl, floatingEl, update, {
+                    ancestorScroll: false,
+                    ancestorResize: false,
+                    layoutShift: false,
+                });
+            },
             placement,
             open: opened,
             middleware: [

--- a/packages/plasma-new-hope/src/components/Dropdown/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/FloatingPopover.tsx
@@ -5,6 +5,7 @@ import {
     FloatingPortal,
     offset as offsetMiddleware,
     autoPlacement,
+    autoUpdate,
 } from '@floating-ui/react';
 import React, { forwardRef, MouseEvent } from 'react';
 import { safeUseId } from '@salutejs/plasma-core';
@@ -14,6 +15,13 @@ import { FloatingPopoverProps } from './Dropdown.types';
 const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
     ({ target, children, opened, onToggle, placement, portal, offset = [0, 0], isInner, trigger, zIndex }, ref) => {
         const { refs, floatingStyles } = useFloating({
+            whileElementsMounted(referenceEl, floatingEl, update) {
+                return autoUpdate(referenceEl, floatingEl, update, {
+                    ancestorScroll: false,
+                    ancestorResize: false,
+                    layoutShift: false,
+                });
+            },
             placement: placement === 'auto' ? undefined : placement,
             open: opened,
             middleware: [

--- a/packages/plasma-new-hope/src/components/Select/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Select/FloatingPopover.tsx
@@ -1,4 +1,12 @@
-import { flip, shift, size, useFloating, FloatingPortal, offset as offsetMiddleware } from '@floating-ui/react';
+import {
+    flip,
+    shift,
+    size,
+    useFloating,
+    FloatingPortal,
+    offset as offsetMiddleware,
+    autoUpdate,
+} from '@floating-ui/react';
 import React, { forwardRef } from 'react';
 import { safeUseId } from '@salutejs/plasma-core';
 
@@ -8,6 +16,13 @@ import type { FloatingPopoverProps } from './Select.types';
 const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
     ({ target, children, opened, onToggle, placement, portal, listWidth, offset = 0, zIndex }, ref) => {
         const { refs, floatingStyles } = useFloating({
+            whileElementsMounted(referenceEl, floatingEl, update) {
+                return autoUpdate(referenceEl, floatingEl, update, {
+                    ancestorScroll: false,
+                    ancestorResize: false,
+                    layoutShift: false,
+                });
+            },
             placement: getPlacement(placement),
             open: opened,
             middleware: [


### PR DESCRIPTION
## Core

### Autocomplete, Combobox
- исправлен баг с позиционированием выпадающего списка при динамическом изменении его высоты;

### What/why changed
Все сделано в рамках настройки floating-ui.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.320.0-canary.1858.13945612029.0
  npm install @salutejs/plasma-b2c@1.562.0-canary.1858.13945612029.0
  npm install @salutejs/plasma-giga@0.289.0-canary.1858.13945612029.0
  npm install @salutejs/plasma-new-hope@0.306.0-canary.1858.13945612029.0
  npm install @salutejs/plasma-web@1.564.0-canary.1858.13945612029.0
  npm install @salutejs/sdds-cs@0.298.0-canary.1858.13945612029.0
  npm install @salutejs/sdds-dfa@0.292.0-canary.1858.13945612029.0
  npm install @salutejs/sdds-finportal@0.285.0-canary.1858.13945612029.0
  npm install @salutejs/sdds-insol@0.289.0-canary.1858.13945612029.0
  npm install @salutejs/sdds-serv@0.293.0-canary.1858.13945612029.0
  # or 
  yarn add @salutejs/plasma-asdk@0.320.0-canary.1858.13945612029.0
  yarn add @salutejs/plasma-b2c@1.562.0-canary.1858.13945612029.0
  yarn add @salutejs/plasma-giga@0.289.0-canary.1858.13945612029.0
  yarn add @salutejs/plasma-new-hope@0.306.0-canary.1858.13945612029.0
  yarn add @salutejs/plasma-web@1.564.0-canary.1858.13945612029.0
  yarn add @salutejs/sdds-cs@0.298.0-canary.1858.13945612029.0
  yarn add @salutejs/sdds-dfa@0.292.0-canary.1858.13945612029.0
  yarn add @salutejs/sdds-finportal@0.285.0-canary.1858.13945612029.0
  yarn add @salutejs/sdds-insol@0.289.0-canary.1858.13945612029.0
  yarn add @salutejs/sdds-serv@0.293.0-canary.1858.13945612029.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
