### PR TITLE
PLASMA-3632: Add `readOnly` to Select

### DIFF
--- a/packages/plasma-b2c/src/components/Select/Select.config.ts
+++ b/packages/plasma-b2c/src/components/Select/Select.config.ts
@@ -732,18 +732,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -807,6 +825,19 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldReadOnlyOpacity}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/plasma-b2c/src/components/Select/Select.stories.tsx
+++ b/packages/plasma-b2c/src/components/Select/Select.stories.tsx
@@ -109,11 +109,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -203,6 +209,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -234,6 +241,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/plasma-giga/src/components/Select/Select.config.ts
+++ b/packages/plasma-giga/src/components/Select/Select.config.ts
@@ -732,18 +732,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -807,6 +825,19 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldReadOnlyOpacity}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/plasma-giga/src/components/Select/Select.stories.tsx
+++ b/packages/plasma-giga/src/components/Select/Select.stories.tsx
@@ -109,11 +109,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -203,6 +209,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -234,6 +241,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/plasma-new-hope/src/components/Select/Select.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.tokens.ts
@@ -8,6 +8,7 @@ export const classes = {
     selectChipIsFocused: 'select-chip-is-focused',
     selectWithoutBoxShadow: 'select-without-box-shadow',
     selectSpinner: 'select-spinner',
+    readOnly: 'readonly',
 };
 
 export const tokens = {
@@ -86,6 +87,13 @@ export const tokens = {
     textFieldPlaceholderColor: '--plasma-select-textfield-placeholder-color',
     textFieldPlaceholderColorFocus: '--plasma-select-textfield-placeholder-color-focus',
 
+    /** Цвета для read-only состояния */
+    textFieldColorReadOnly: '--plasma-select-textfield-color-readonly',
+    textFieldBackgroundColorReadOnly: '--plasma-select-textfield-bg-color-readonly',
+    textFieldBorderColorReadOnly: '--plasma-select-textfield-border-color-readonly',
+    textFieldPlaceholderColorReadOnly: '--plasma-select-textfield__placeholder-color-readonly',
+    textFieldDividerColorReadOnly: '--plasma-select-textfield-divider-color-readonly',
+
     textFieldHeight: '--plasma-select-textfield-height',
     textFieldBorderWidth: '--plasma-select-textfield-border-width',
     textFieldBorderRadius: '--plasma-select-textfield-border-radius',
@@ -116,6 +124,7 @@ export const tokens = {
     textFieldContentSlotRightColorActive: '--plasma-select-textfield-content-right-slot-color-active',
 
     textFieldLabelColor: '--plasma-select-textfield-label-color',
+    textFieldLabelColorReadOnly: '--plasma-select-textfield__label-color-readonly',
     textFieldLabelOffset: '--plasma-select-textfield-label-offset',
 
     textFieldLabelFontFamily: '--plasma-select-textfield-label-font-family',
@@ -136,6 +145,7 @@ export const tokens = {
     textFieldContentLabelInnerPadding: '--plasma-select-textfield-placement-inner-content-padding',
 
     textFieldTitleCaptionColor: '--plasma-select-textfield-title-caption-color',
+    textFieldTitleCaptionColorReadOnly: '--plasma-select-textfield__title-caption-color-readonly',
     textFieldTitleCaptionInnerLabelOffset: '--plasma-select-textfield-title-caption-label-inner-offset',
 
     textFieldTitleCaptionFontFamily: '--plasma-select-textfield-title-caption-font-family',
@@ -146,6 +156,7 @@ export const tokens = {
     textFieldTitleCaptionLineHeight: '--plasma-select-textfield-title-caption-line-height',
 
     textFieldLeftHelperColor: '--plasma-select-textfield-left-helper-color',
+    textFieldLeftHelperColorReadOnly: '--plasma-select-textfield__left-helper-color-readonly',
     textFieldLeftHelperOffset: '--plasma-select-textfield-left-helper-offset',
 
     textFieldLeftHelperFontFamily: '--plasma-select-textfield-left-helper-font-family',
@@ -161,6 +172,7 @@ export const tokens = {
     textFieldTextAfterMargin: '--plasma-select-textfield-after-text-margin',
 
     textFieldDisabledOpacity: '--plasma-select-textfield-disabled-opacity',
+    textFieldReadOnlyOpacity: '--plasma-select-textfield-readonly-opacity',
 
     /** Токены для tooltip */
     textFieldHintCustomIconTargetSize: '--plasma-select-textfield__hint-custom-icon-target-size',
@@ -202,6 +214,10 @@ export const tokens = {
     textFieldChipBackgroundHover: '--plasma-select-textfield-chip-background-hover',
     textFieldChipColorHover: '--plasma-select-textfield-chip-color-hover',
     textFieldChipScaleHover: '--plasma-select-textfield-chip-scale-hover',
+    textFieldChipBackgroundReadOnly: '--plasma-select-textfield__chip-background-readonly',
+    textFieldChipColorReadOnly: '--plasma-select-textfield__chip-color-readonly',
+    textFieldChipBackgroundReadOnlyHover: '--plasma-select-textfield__chip-background-readonly-hover',
+    textFieldChipColorReadOnlyHover: '--plasma-select-textfield__chip-color-readonly-hover',
     textFieldChipBackgroundActive: '--plasma-select-textfield-chip-background-active',
     textFieldChipColorActive: '--plasma-select-textfield-chip-color-active',
     textFieldChipScaleActive: '--plasma-select-textfield-chip-scale-active',
@@ -218,6 +234,7 @@ export const tokens = {
     textFieldChipLineHeight: '--plasma-select-textfield-chip-line-height',
     textFieldChipClearContentMarginLeft: '--plasma-select-textfield-chip-clear-content-margin-left',
     textFieldChipClearContentMarginRight: '--plasma-select-textfield-chip-clear-content-margin-right',
+    textFieldChipOpacityReadonly: '--plasma-select-textfield__chip-opacity-readonly',
 
     textFieldIndicatorColor: '--plasma-select-new-textfield-indicator-color',
     textFieldIndicatorSizeInner: '--plasma-select-new-textfield-indicator-size-inner',
@@ -240,6 +257,7 @@ export const tokens = {
     disclosureIconColorHover: '--plasma-select-disclosure-icon-color-hover',
     disclosureIconSize: '--plasma-select-disclosure-icon-size',
     disclosureIconMargin: '--plasma-select-disclosure-icon-margin',
+    disclosureIconOpacityReadOnly: '--plasma-select-disclosure-icon-opacity-readonly',
 };
 
 export const constants = {

--- a/packages/plasma-new-hope/src/components/Select/Select.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.tsx
@@ -51,6 +51,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
             placeholder,
             helperText,
             disabled = false,
+            readOnly = false,
             view: outerView,
             size,
             listOverflow,
@@ -106,7 +107,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
         const activeDescendantItemValue = getItemByFocused(focusedPath, focusedToValueMap)?.value.toString() || '';
         const closeAfterSelect = outerCloseAfterSelect ?? !props.multiselect;
         const treeId = safeUseId();
-        const view = target === 'textfield-like' && disabled ? 'default' : getView(status, outerView);
+        const view = target === 'textfield-like' && (disabled || readOnly) ? 'default' : getView(status, outerView);
 
         // Собираем объект с пропсами для required и прокидываем их напрямую в компонент Textfield.
         const requiredProps =
@@ -171,7 +172,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
         };
 
         const handleListToggle = (opened: boolean) => {
-            if (disabled) {
+            if (disabled || readOnly) {
                 return;
             }
 
@@ -330,6 +331,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
                 labelPlacement={labelPlacement}
                 chipView={chipView}
                 disabled={disabled}
+                readOnly={readOnly}
                 id={id}
                 {...(rest as any)}
             >
@@ -377,6 +379,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
                                 size={size}
                                 contentLeft={contentLeft}
                                 disabled={disabled}
+                                readOnly={readOnly}
                                 renderValue={renderValue}
                                 selectProps={props}
                                 inputWrapperRef={referenceRef as React.MutableRefObject<HTMLDivElement>}
@@ -402,6 +405,7 @@ export const selectRoot = (Root: RootProps<HTMLButtonElement, Omit<MergedSelectP
                             labelPlacement={labelPlacement}
                             chipView={chipView}
                             disabled={disabled}
+                            readOnly={readOnly}
                             {...(rest as any)}
                         >
                             <Ul

--- a/packages/plasma-new-hope/src/components/Select/Select.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.types.ts
@@ -121,6 +121,10 @@ export interface BasicProps<K extends ItemOption> {
      */
     disabled?: boolean;
     /**
+     * Компонент доступен только для чтения.
+     */
+    readOnly?: boolean;
+    /**
      * Вариант: обычный или сжатый
      * @default normal
      */
@@ -295,6 +299,10 @@ export type MergedSelectProps<T = any, K extends DropdownNode = DropdownNode> = 
          * @default false
          */
         disabled?: boolean;
+        /**
+         * Компонент доступен только для чтения.
+         */
+        readOnly?: boolean;
         /**
          * Список элементов.
          */

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/Target.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/Target.tsx
@@ -18,6 +18,7 @@ export const Target = forwardRef<HTMLButtonElement, TargetProps>(
             size,
             contentLeft,
             disabled,
+            readOnly,
             renderValue,
             selectProps,
             inputWrapperRef,
@@ -60,7 +61,7 @@ export const Target = forwardRef<HTMLButtonElement, TargetProps>(
                 onKeyDown={onKeyDown}
                 label={label}
                 size={size}
-                disabled={disabled}
+                disabled={disabled || readOnly}
                 renderValue={renderValue}
                 selectProps={selectProps}
                 separator={separator}
@@ -85,6 +86,7 @@ export const Target = forwardRef<HTMLButtonElement, TargetProps>(
                 treeId={treeId}
                 activeDescendantItemValue={activeDescendantItemValue}
                 disabled={disabled}
+                readOnly={readOnly}
                 isTargetAmount={isTargetAmount}
                 valueToItemMap={valueToItemMap}
                 renderValue={renderValue}

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/Target.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/Target.types.ts
@@ -15,6 +15,7 @@ export type TargetProps = Pick<
     | 'placeholder'
     | 'contentLeft'
     | 'disabled'
+    | 'readOnly'
     | 'renderValue'
     | 'multiselect'
     | 'helperText'

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.styles.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.styles.tsx
@@ -8,7 +8,7 @@ import { IconDisclosureDownCentered } from '../../../../../_Icon';
 const mergedConfig = mergeConfig(textFieldConfig);
 const TextField = component(mergedConfig);
 
-export const StyledTextField = styled(TextField)<{ opened: boolean }>`
+export const StyledTextField = styled(TextField)<{ opened: boolean; disabled?: boolean }>`
     ${textFieldTokens.color}: var(${tokens.textFieldColor});
     ${textFieldTokens.backgroundColor}: var(${tokens.textFieldBackgroundColor});
     ${textFieldTokens.borderColor}: var(${tokens.textFieldBorderColor});
@@ -172,24 +172,48 @@ export const StyledTextField = styled(TextField)<{ opened: boolean }>`
     ${textFieldTokens.indicatorLabelPlacementInnerRight}: var(${tokens.textFieldIndicatorLabelPlacementInnerRight});
     ${textFieldTokens.indicatorLabelPlacementOuterRight}: var(${tokens.textFieldIndicatorLabelPlacementOuterRight});
     ${textFieldTokens.clearIndicatorLabelPlacementInner}: var(${tokens.textFieldClearIndicatorLabelPlacementInner});
-    ${textFieldTokens.clearIndicatorLabelPlacementInnerRight}:
-        var(${tokens.textFieldClearIndicatorLabelPlacementInnerRight});
+    ${textFieldTokens.clearIndicatorLabelPlacementInnerRight}: var(${
+    tokens.textFieldClearIndicatorLabelPlacementInnerRight
+});
     ${textFieldTokens.clearIndicatorHintInnerRight}: var(${tokens.textFieldClearIndicatorHintInnerRight});
 
     ${textFieldTokens.focusColor}: var(${tokens.textFieldFocusColor});
 
-    ${textFieldTokens.boxShadow}: var(${tokens.textFieldBoxShadow});
+    ${textFieldTokens.boxShadow}: ${({ disabled }) => (disabled ? 'none' : `var(${tokens.textFieldBoxShadow})`)};
 
     /* TODO: #1544 */
+
     & div.input-wrapper:focus-within {
         background-color: var(${tokens.textFieldBackgroundColorFocus});
     }
+
+    /* TextField изначально в readOnly состоянии */
+
+    &.${classes.readOnly} {
+        ${textFieldTokens.colorReadOnly}: var(${tokens.textFieldColorReadOnly});
+        ${textFieldTokens.backgroundColorReadOnly}: var(${tokens.textFieldBackgroundColorReadOnly});
+        ${textFieldTokens.placeholderColorReadOnly}: var(${tokens.textFieldPlaceholderColorReadOnly});
+        ${textFieldTokens.dividerColorReadOnly}: var(${tokens.textFieldDividerColorReadOnly});
+        ${textFieldTokens.leftHelperColorReadOnly}: var(${tokens.textFieldLeftHelperColorReadOnly});
+        ${textFieldTokens.labelColorReadOnly}: var(${tokens.textFieldLabelColorReadOnly});
+        ${textFieldTokens.titleCaptionColorReadOnly}: var(${tokens.textFieldTitleCaptionColorReadOnly});
+        ${textFieldTokens.borderColorReadOnly}: var(${tokens.textFieldBorderColorReadOnly});
+        ${textFieldTokens.readOnlyOpacity}: var(${tokens.textFieldReadOnlyOpacity});
+
+        ${textFieldTokens.chipColorReadOnly}: var(${tokens.textFieldChipColorReadOnly});
+        ${textFieldTokens.chipColorReadOnlyHover}: var(${tokens.textFieldChipColorReadOnlyHover});
+        ${textFieldTokens.chipBackgroundReadOnly}: var(${tokens.textFieldChipBackgroundReadOnly});
+        ${textFieldTokens.chipBackgroundReadOnlyHover}: var(${tokens.textFieldChipBackgroundReadOnlyHover});
+        ${textFieldTokens.chipOpacityReadonly}: var(${tokens.textFieldChipOpacityReadonly});
+
+        ${textFieldTokens.boxShadow}: none;
+    }
 `;
 
-export const IconArrowWrapper = styled.div<{ disabled: boolean }>`
+export const IconArrowWrapper = styled.div<{ disabled?: boolean; readOnly?: boolean }>`
     line-height: 0;
     color: var(${tokens.disclosureIconColor});
-    cursor: ${({ disabled }) => (disabled ? 'inherit' : 'pointer')};
+    cursor: ${({ disabled, readOnly }) => (disabled || readOnly ? 'inherit' : 'pointer')};
 
     .${classes.arrowInverse} {
         transform: rotate(-180deg);
@@ -197,9 +221,11 @@ export const IconArrowWrapper = styled.div<{ disabled: boolean }>`
 
     &:hover,
     &:active {
-        color: ${({ disabled }) =>
-            disabled ? `var(${tokens.disclosureIconColor})` : `var(${tokens.disclosureIconColorHover})`};
+        color: ${({ disabled, readOnly }) =>
+            disabled || readOnly ? `var(${tokens.disclosureIconColor})` : `var(${tokens.disclosureIconColorHover})`};
     }
+
+    opacity: ${({ readOnly }) => (readOnly ? `var(${tokens.disclosureIconOpacityReadOnly})` : '')};
 `;
 
 // TODO: Удалить после поддержки JS переменных в конфиге компонент

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.tsx
@@ -25,6 +25,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
             treeId,
             activeDescendantItemValue,
             disabled,
+            readOnly,
             isTargetAmount,
             valueToItemMap,
             renderValue,
@@ -104,6 +105,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
                 ref={ref}
                 inputWrapperRef={inputWrapperRef}
                 readOnly
+                className={readOnly ? classes.readOnly : undefined}
                 value={getValue()}
                 size={size}
                 view={view}
@@ -114,7 +116,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
                 placeholder={value instanceof Array && value.length ? '' : placeholder}
                 contentLeft={contentLeft as React.ReactElement}
                 contentRight={
-                    <IconArrowWrapper disabled={Boolean(disabled)}>
+                    <IconArrowWrapper disabled={disabled} readOnly={readOnly}>
                         <StyledArrow color="inherit" size={sizeToIconSize(size)} className={withArrowInverse} />
                     </IconArrowWrapper>
                 }
@@ -137,7 +139,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
                 onEnterDisabled // Пропс для отключения обработчика Enter внутри Textfield
                 opened={opened}
                 // TODO: #1547
-                _forceChipManipulationWithReadonly
+                _forceChipManipulationWithReadonly={!readOnly}
                 {...requiredProps}
                 {...hintProps}
             />

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.types.ts
@@ -18,6 +18,7 @@ export type TextfieldProps = Pick<
     | 'treeId'
     | 'activeDescendantItemValue'
     | 'disabled'
+    | 'readOnly'
     | 'isTargetAmount'
     | 'valueToItemMap'
     | 'renderValue'

--- a/packages/plasma-new-hope/src/components/TextField/variations/_read-only/base.ts
+++ b/packages/plasma-new-hope/src/components/TextField/variations/_read-only/base.ts
@@ -73,5 +73,11 @@ export const base = css`
         &.${classes.outerLabelPlacement} ${Label} {
             color: var(${tokens.labelColorReadOnly});
         }
+
+        ${StyledContentRight} {
+            &:hover {
+                cursor: default;
+            }
+        }
     }
 `;

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Select/Select.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Select/Select.config.ts
@@ -734,18 +734,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -809,6 +827,19 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldReadOnlyOpacity}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/plasma-new-hope/src/examples/plasma_b2c/components/Select/Select.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_b2c/components/Select/Select.stories.tsx
@@ -110,6 +110,11 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
@@ -205,6 +210,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -236,6 +242,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Select/Select.config.ts
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Select/Select.config.ts
@@ -33,6 +33,7 @@ export const config = {
                 ${tokens.textFieldOptionalColor}: var(--text-tertiary);
 
                 ${tokens.textFieldBorderColor}: var(--surface-transparent-tertiary);
+                ${tokens.textFieldBorderColorFocus}: var(--surface-transparent-tertiary);
 
                 ${tokens.buttonColor}: var(--inverse-text-primary);
                 ${tokens.buttonColorHover}: var(--inverse-text-primary-hover);
@@ -71,6 +72,7 @@ export const config = {
                 ${tokens.textFieldOptionalColor}: var(--text-tertiary);
 
                 ${tokens.textFieldBorderColor}: var(--surface-positive);
+                ${tokens.textFieldBorderColorFocus}: var(--surface-positive);
 
                 ${tokens.buttonColor}: var(--on-dark-text-primary);
                 ${tokens.buttonColorHover}: var(--on-dark-text-primary-hover);
@@ -109,6 +111,7 @@ export const config = {
                 ${tokens.textFieldOptionalColor}: var(--text-tertiary);
 
                 ${tokens.textFieldBorderColor}: var(--surface-warning);
+                ${tokens.textFieldBorderColorFocus}: var(--surface-warning);
 
                 ${tokens.buttonColor}: var(--on-dark-text-primary);
                 ${tokens.buttonColorHover}: var(--on-dark-text-primary-hover);
@@ -147,6 +150,7 @@ export const config = {
                 ${tokens.textFieldOptionalColor}: var(--text-tertiary);
 
                 ${tokens.textFieldBorderColor}: var(--surface-negative);
+                ${tokens.textFieldBorderColorFocus}: var(--surface-negative);
 
                 ${tokens.buttonColor}: var(--on-dark-text-primary);
                 ${tokens.buttonColorHover}: var(--on-dark-text-primary-hover);
@@ -730,7 +734,7 @@ export const config = {
         },
         labelPlacement: {
             inner: css`
-                ${tokens.textFieldPlaceholderColor}: var(--plasma-input-label-color, var(--plasma-input-placeholder-color, var(--plasma-colors-secondary)));
+                ${tokens.textFieldPlaceholderColor}: var(--text-secondary);
                 ${tokens.textFieldLabelInnerFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${tokens.textFieldLabelInnerFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${tokens.textFieldLabelInnerFontStyle}: var(--plasma-typo-body-xs-font-style);
@@ -746,18 +750,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -821,6 +843,20 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldReadOnlyOpacity}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-clear);
+                ${tokens.textFieldBorderColorReadOnly}: var(--outline-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/plasma-new-hope/src/examples/plasma_web/components/Select/Select.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/plasma_web/components/Select/Select.stories.tsx
@@ -110,11 +110,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -204,6 +210,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -235,6 +242,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/plasma-web/src/components/Select/Select.config.ts
+++ b/packages/plasma-web/src/components/Select/Select.config.ts
@@ -748,18 +748,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -823,6 +841,20 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldReadOnlyOpacity}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-clear);
+                ${tokens.textFieldBorderColorReadOnly}: var(--outline-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/plasma-web/src/components/Select/Select.stories.tsx
+++ b/packages/plasma-web/src/components/Select/Select.stories.tsx
@@ -109,11 +109,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -203,6 +209,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -234,6 +241,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/sdds-cs/src/components/Select/Select.config.ts
+++ b/packages/sdds-cs/src/components/Select/Select.config.ts
@@ -206,6 +206,7 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         disabled: {
@@ -217,6 +218,18 @@ export const config = {
                 ${tokens.textFieldBorderColorHover}: var(--surface-solid-primary);
                 ${tokens.textFieldBorderColorFocus}: var(--surface-solid-primary);
                 ${tokens.textFieldColor}: var(--text-secondary);
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/sdds-cs/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-cs/src/components/Select/Select.stories.tsx
@@ -61,11 +61,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -118,6 +124,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -137,6 +144,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/sdds-dfa/src/components/Select/Select.config.ts
+++ b/packages/sdds-dfa/src/components/Select/Select.config.ts
@@ -732,18 +732,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -807,6 +825,19 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldReadOnlyOpacity}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/sdds-dfa/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-dfa/src/components/Select/Select.stories.tsx
@@ -109,11 +109,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -203,6 +209,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -234,6 +241,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/sdds-finportal/src/components/Select/Select.config.ts
+++ b/packages/sdds-finportal/src/components/Select/Select.config.ts
@@ -732,18 +732,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -807,6 +825,19 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldReadOnlyOpacity}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/sdds-finportal/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-finportal/src/components/Select/Select.stories.tsx
@@ -109,11 +109,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -203,6 +209,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -234,6 +241,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/sdds-insol/src/components/Select/Select.config.ts
+++ b/packages/sdds-insol/src/components/Select/Select.config.ts
@@ -793,18 +793,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -821,15 +839,19 @@ export const config = {
                 ${tokens.textFieldTooltipPaddingRight}: 0.875rem;
                 ${tokens.textFieldTooltipPaddingBottom}: 0.6875rem;
                 ${tokens.textFieldTooltipPaddingLeft}: 0.875rem;
+
                 ${tokens.textFieldTooltipMinHeight}: 2.5rem;
                 ${tokens.textFieldTooltipBorderRadius}: 0.625rem;
+
                 ${tokens.textFieldTooltipTextFontFamily}: var(--plasma-typo-body-s-font-family);
                 ${tokens.textFieldTooltipTextFontSize}: var(--plasma-typo-body-s-font-size);
                 ${tokens.textFieldTooltipTextFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${tokens.textFieldTooltipTextFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${tokens.textFieldTooltipTextFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${tokens.textFieldTooltipTextFontLineHeight}: var(--plasma-typo-body-s-line-height);
+
                 ${tokens.textFieldTooltipContentLeftMargin}: 0.375rem;
+
                 ${tokens.textFieldTooltipArrowMaskWidth}: 1.25rem;
                 ${tokens.textFieldTooltipArrowMaskHeight}: 1.25rem;
                 ${tokens.textFieldTooltipArrowMaskImage}: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtMC4xNywxMS44M2wyMCwwYy01LjUyLDAgLTEwLDMuNTkgLTEwLDhjMCwtNC40MSAtNC40OCwtOCAtMTAsLTh6IiBmaWxsPSIjMTcxNzE3IiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGlkPSJUYWlsIi8+Cjwvc3ZnPg==");
@@ -841,15 +863,19 @@ export const config = {
                 ${tokens.textFieldTooltipPaddingRight}: 0.75rem;
                 ${tokens.textFieldTooltipPaddingBottom}: 0.5rem;
                 ${tokens.textFieldTooltipPaddingLeft}: 0.75rem;
+
                 ${tokens.textFieldTooltipMinHeight}: 2rem;
                 ${tokens.textFieldTooltipBorderRadius}: 0.5rem;
+
                 ${tokens.textFieldTooltipTextFontFamily}: var(--plasma-typo-body-xs-font-family);
                 ${tokens.textFieldTooltipTextFontSize}: var(--plasma-typo-body-xs-font-size);
                 ${tokens.textFieldTooltipTextFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${tokens.textFieldTooltipTextFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${tokens.textFieldTooltipTextFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${tokens.textFieldTooltipTextFontLineHeight}: var(--plasma-typo-body-xs-line-height);
+
                 ${tokens.textFieldTooltipContentLeftMargin}: 0.25rem;
+
                 ${tokens.textFieldTooltipArrowMaskWidth}: 1rem;
                 ${tokens.textFieldTooltipArrowMaskHeight}: 1rem;
                 ${tokens.textFieldTooltipArrowMaskImage}: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtMCw5Ljg1bDE2LDBjLTQuNDEsMCAtOCwyLjY5IC04LDZjMCwtMy4zMSAtMy41OSwtNiAtOCwtNnoiIGZpbGw9IiMxNzE3MTciIGZpbGwtcnVsZT0iZXZlbm9kZCIgaWQ9IlRhaWwiLz4KPC9zdmc+");
@@ -860,6 +886,18 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-solid-secondary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/sdds-insol/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-insol/src/components/Select/Select.stories.tsx
@@ -112,11 +112,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -199,6 +205,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -229,6 +236,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',

--- a/packages/sdds-serv/src/components/Select/Select.config.ts
+++ b/packages/sdds-serv/src/components/Select/Select.config.ts
@@ -732,18 +732,36 @@ export const config = {
                 ${tokens.textFieldChipBackground}: var(--surface-solid-default);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-solid-default-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--inverse-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnly}: var(--inverse-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-solid-default);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--inverse-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             secondary: css`
                 ${tokens.textFieldChipColor}: var(--text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-transparent-secondary);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-transparent-secondary-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-transparent-secondary);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
             accent: css`
                 ${tokens.textFieldChipColor}: var(--on-dark-text-primary);
                 ${tokens.textFieldChipBackground}: var(--surface-accent);
                 ${tokens.textFieldChipBackgroundHover}: var(--surface-accent-hover);
                 ${tokens.textFieldChipCloseIconColor}: var(--on-dark-text-primary);
+
+                ${tokens.textFieldChipBackgroundReadOnly}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnly}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: var(--surface-accent);
+                ${tokens.textFieldChipColorReadOnlyHover}: var(--on-dark-text-primary);
+                ${tokens.textFieldChipOpacityReadonly}: 1;
             `,
         },
         hintView: {
@@ -807,6 +825,19 @@ export const config = {
         disabled: {
             true: css`
                 ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.disclosureIconOpacityReadOnly}: 0.4;
+                ${tokens.textFieldReadOnlyOpacity}: 0.4;
+                ${tokens.textFieldColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldBackgroundColorReadOnly}: var(--surface-transparent-primary);
+                ${tokens.textFieldPlaceholderColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLeftHelperColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldTitleCaptionColorReadOnly}: var(--text-secondary);
+                ${tokens.textFieldLabelColorReadOnly}: var(--text-primary);
+                ${tokens.textFieldDividerColorReadOnly}: var(--surface-transparent-primary);
             `,
         },
     },

--- a/packages/sdds-serv/src/components/Select/Select.stories.tsx
+++ b/packages/sdds-serv/src/components/Select/Select.stories.tsx
@@ -109,11 +109,17 @@ const meta: Meta<StorySelectProps> = {
                 eq: 'textfield-like',
             },
         },
+        readOnly: {
+            control: {
+                type: 'boolean',
+            },
+        },
         requiredPlacement: {
             options: ['left', 'right'],
             control: {
                 type: 'select',
             },
+            if: { arg: 'required', truthy: true },
         },
         required: {
             control: {
@@ -203,6 +209,7 @@ const meta: Meta<StorySelectProps> = {
         isTargetAmount: false,
         variant: 'normal',
         disabled: false,
+        readOnly: false,
         optional: false,
         required: false,
         requiredPlacement: 'right',
@@ -234,6 +241,7 @@ const meta: Meta<StorySelectProps> = {
                 'closeAfterSelect',
                 'variant',
                 'disabled',
+                'readOnly',
                 'listWidth',
                 'listOverflow',
                 'listMaxHeight',


### PR DESCRIPTION
## Core

### Select

-   Добавлено состояние read only, поправлено disabled

### What/why changed

Обновлен дизайн

Копия #1748
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.320.0-canary.1859.13945881812.0
  npm install @salutejs/plasma-b2c@1.562.0-canary.1859.13945881812.0
  npm install @salutejs/plasma-giga@0.289.0-canary.1859.13945881812.0
  npm install @salutejs/plasma-new-hope@0.306.0-canary.1859.13945881812.0
  npm install @salutejs/plasma-web@1.564.0-canary.1859.13945881812.0
  npm install @salutejs/sdds-cs@0.298.0-canary.1859.13945881812.0
  npm install @salutejs/sdds-dfa@0.292.0-canary.1859.13945881812.0
  npm install @salutejs/sdds-finportal@0.285.0-canary.1859.13945881812.0
  npm install @salutejs/sdds-insol@0.289.0-canary.1859.13945881812.0
  npm install @salutejs/sdds-serv@0.293.0-canary.1859.13945881812.0
  # or 
  yarn add @salutejs/plasma-asdk@0.320.0-canary.1859.13945881812.0
  yarn add @salutejs/plasma-b2c@1.562.0-canary.1859.13945881812.0
  yarn add @salutejs/plasma-giga@0.289.0-canary.1859.13945881812.0
  yarn add @salutejs/plasma-new-hope@0.306.0-canary.1859.13945881812.0
  yarn add @salutejs/plasma-web@1.564.0-canary.1859.13945881812.0
  yarn add @salutejs/sdds-cs@0.298.0-canary.1859.13945881812.0
  yarn add @salutejs/sdds-dfa@0.292.0-canary.1859.13945881812.0
  yarn add @salutejs/sdds-finportal@0.285.0-canary.1859.13945881812.0
  yarn add @salutejs/sdds-insol@0.289.0-canary.1859.13945881812.0
  yarn add @salutejs/sdds-serv@0.293.0-canary.1859.13945881812.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
