### PR TITLE
PLASMA-4576: Button fix margin with child

### DIFF
--- a/packages/plasma-new-hope/src/components/Button/Button.tsx
+++ b/packages/plasma-new-hope/src/components/Button/Button.tsx
@@ -51,7 +51,7 @@ export const buttonRoot = (Root: RootProps<HTMLButtonElement, ButtonProps>) =>
         } = props;
 
         const txt = typeof children === 'string' ? children : text;
-        const hasRightContentMargin = Boolean(txt || value || contentRight);
+        const hasRightContentMargin = Boolean(children || txt || value || contentRight);
         const hasLeftContentMargin = Boolean(contentLeft ? contentLeft && (txt || value) : txt || value);
 
         const stretchingClass = stretch


### PR DESCRIPTION
## Core

### Button

- добавлен `margin` при наличии `children` у `contentLeft`

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.329.0-canary.1878.14202614030.0
  npm install @salutejs/plasma-b2c@1.571.0-canary.1878.14202614030.0
  npm install @salutejs/plasma-giga@0.298.0-canary.1878.14202614030.0
  npm install @salutejs/plasma-new-hope@0.315.0-canary.1878.14202614030.0
  npm install @salutejs/plasma-web@1.573.0-canary.1878.14202614030.0
  npm install @salutejs/sdds-clfd-auto@0.302.0-canary.1878.14202614030.0
  npm install @salutejs/sdds-cs@0.307.0-canary.1878.14202614030.0
  npm install @salutejs/sdds-dfa@0.301.0-canary.1878.14202614030.0
  npm install @salutejs/sdds-finportal@0.294.0-canary.1878.14202614030.0
  npm install @salutejs/sdds-insol@0.298.0-canary.1878.14202614030.0
  npm install @salutejs/sdds-serv@0.302.0-canary.1878.14202614030.0
  # or 
  yarn add @salutejs/plasma-asdk@0.329.0-canary.1878.14202614030.0
  yarn add @salutejs/plasma-b2c@1.571.0-canary.1878.14202614030.0
  yarn add @salutejs/plasma-giga@0.298.0-canary.1878.14202614030.0
  yarn add @salutejs/plasma-new-hope@0.315.0-canary.1878.14202614030.0
  yarn add @salutejs/plasma-web@1.573.0-canary.1878.14202614030.0
  yarn add @salutejs/sdds-clfd-auto@0.302.0-canary.1878.14202614030.0
  yarn add @salutejs/sdds-cs@0.307.0-canary.1878.14202614030.0
  yarn add @salutejs/sdds-dfa@0.301.0-canary.1878.14202614030.0
  yarn add @salutejs/sdds-finportal@0.294.0-canary.1878.14202614030.0
  yarn add @salutejs/sdds-insol@0.298.0-canary.1878.14202614030.0
  yarn add @salutejs/sdds-serv@0.302.0-canary.1878.14202614030.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
