### PR TITLE
plasma-infra: Add retry logic for cypress tests 

### DIFF
--- a/.github/workflows/cypress-by-cron-every-day.yml
+++ b/.github/workflows/cypress-by-cron-every-day.yml
@@ -1,0 +1,21 @@
+name: Cypress component testing by schedule every day at midnight
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  cypress:
+    name: "Cypress with React 17"
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: [web,b2c,ui]
+
+    uses: ./.github/workflows/cypress-common.yml
+    with:
+      scope: ${{ matrix.scope }}
+      with-react-17: true
+      with-artifacts: true
+    secrets: inherit
+

--- a/.github/workflows/cypress-common.yml
+++ b/.github/workflows/cypress-common.yml
@@ -39,11 +39,21 @@ jobs:
           npm i --no-progress react@17 react-dom@17 @types/react@17.0.40 @types/react-dom@17 --prefix="./packages/plasma-web"
 
       - name: Lerna bootstrap
-        run: npx lerna bootstrap --scope=@salutejs/plasma-${{env.SCOPE}} --scope="@salutejs/platform-test" --scope="@salutejs/core-themes"
-
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_on: error
+          command: npx lerna bootstrap --scope=@salutejs/plasma-${{env.SCOPE}} --scope="@salutejs/platform-test" --scope="@salutejs/core-themes"
+          
       - name: Run Cypress CT for Plasma ${{ inputs.scope }}
         if: ${{ success() }}
-        run: npm run cy:${{ inputs.scope }}:run-ct
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 50
+          max_attempts: 3
+          retry_on: error
+          command: npm run cy:${{ inputs.scope }}:run-ct
 
       - name: Save artifacts
         if: ${{ failure() || inputs.with-artifacts }}

--- a/.github/workflows/cypress-common.yml
+++ b/.github/workflows/cypress-common.yml
@@ -50,7 +50,7 @@ jobs:
         if: ${{ success() }}
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 50
+          timeout_minutes: 120
           max_attempts: 3
           retry_on: error
           command: npm run cy:${{ inputs.scope }}:run-ct

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -33,17 +33,3 @@ jobs:
     with:
       scope: ${{ matrix.scope }}
     secrets: inherit
-
-  cypress-react-17:
-    needs: state
-    if: ${{ fromJSON(needs.state.outputs.STATE).HAS_PACKAGES_CYPRESS_RUN }}
-    strategy:
-      fail-fast: false
-      matrix:
-        scope: ${{ fromJson(needs.state.outputs.STATE).PACKAGES_CYPRESS_RUN }}
-
-    uses: ./.github/workflows/cypress-common.yml
-    with:
-      scope: ${{ matrix.scope }}
-      with-react-17: true
-    secrets: inherit

--- a/cypress/config/b2b-config.json
+++ b/cypress/config/b2b-config.json
@@ -15,5 +15,5 @@
         "threshold": 0
     },
     "video": false,
-    "retries": 3
+    "retries": 5
 }

--- a/cypress/config/b2c-config.json
+++ b/cypress/config/b2c-config.json
@@ -11,5 +11,5 @@
         "threshold": 0
     },
     "video": false,
-    "retries": 3
+    "retries": 5
 }

--- a/cypress/config/web-config.json
+++ b/cypress/config/web-config.json
@@ -11,5 +11,5 @@
         "threshold": 0
     },
     "video": false,
-    "retries": 3
+    "retries": 5
 }

--- a/packages/plasma-b2c/package.json
+++ b/packages/plasma-b2c/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salutejs/plasma-b2c",
   "version": "1.576.0",
-  "description": "Salute Design System / React UI kit for business-related web applications",
+  "description": "Salute Design System / React UI kit for business-related web applications.",
   "author": "Salute Frontend Team <salute.developers@gmail.com>",
   "license": "MIT",
   "main": "index.js",


### PR DESCRIPTION
### What/why changed

- добавлен retry для шагов
  - lerna bootstrap
  - запуск самих тестов

- запуск тестов в связке с react 17 теперь по cron каждый день в полночь  

Мотивация выноса тестов React 17 на расписание, уменьшить кол-во проверок в пр.  


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.576.1-canary.1884.14259946946.0
  # or 
  yarn add @salutejs/plasma-b2c@1.576.1-canary.1884.14259946946.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
