### PR TITLE
PLASMA-4499: feat(plasma-new-hope): Add `medium` prop for typography components

### DIFF
--- a/packages/plasma-asdk/src/components/Typography/Body.config.ts
+++ b/packages/plasma-asdk/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/plasma-asdk/src/components/Typography/Dspl.config.ts
+++ b/packages/plasma-asdk/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/plasma-asdk/src/components/Typography/Heading.config.ts
+++ b/packages/plasma-asdk/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/plasma-asdk/src/components/Typography/Text.config.ts
+++ b/packages/plasma-asdk/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/plasma-asdk/src/components/Typography/Typography.stories.tsx
+++ b/packages/plasma-asdk/src/components/Typography/Typography.stories.tsx
@@ -48,9 +48,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
     },
     args: {
-        breakWord: false,
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-b2c/src/components/Typography/Body.config.ts
+++ b/packages/plasma-b2c/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/plasma-b2c/src/components/Typography/Dspl.config.ts
+++ b/packages/plasma-b2c/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/plasma-b2c/src/components/Typography/Heading.config.ts
+++ b/packages/plasma-b2c/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/plasma-b2c/src/components/Typography/Text.config.ts
+++ b/packages/plasma-b2c/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/plasma-b2c/src/components/Typography/Typography.stories.tsx
+++ b/packages/plasma-b2c/src/components/Typography/Typography.stories.tsx
@@ -39,7 +39,7 @@ import {
     Underline,
 } from '.';
 
-const meta: Meta<SpacingProps> = {
+const meta: Meta = {
     title: 'Data Display/Typography',
     component: DsplL,
     argTypes: {
@@ -49,6 +49,24 @@ const meta: Meta<SpacingProps> = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-giga/src/components/Typography/Body.config.ts
+++ b/packages/plasma-giga/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/plasma-giga/src/components/Typography/Dspl.config.ts
+++ b/packages/plasma-giga/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/plasma-giga/src/components/Typography/Heading.config.ts
+++ b/packages/plasma-giga/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/plasma-giga/src/components/Typography/Text.config.ts
+++ b/packages/plasma-giga/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/plasma-giga/src/components/Typography/Typography.stories.tsx
+++ b/packages/plasma-giga/src/components/Typography/Typography.stories.tsx
@@ -32,6 +32,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/plasma-new-hope/src/components/Typography/Typography.styles.ts
+++ b/packages/plasma-new-hope/src/components/Typography/Typography.styles.ts
@@ -16,6 +16,10 @@ export const base = css`
         font-weight: var(${tokens.typoFontWeightBold});
     }
 
+    &.${classes.typoMedium} {
+        font-weight: var(${tokens.typoFontWeightMedium});
+    }
+
     &.${classes.typoWithNoWrap} {
         white-space: nowrap;
     }

--- a/packages/plasma-new-hope/src/components/Typography/Typography.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Typography/Typography.template-doc.mdx
@@ -52,12 +52,15 @@ export function App() {
         <div style=\{{ display: 'block' }}>
             <DsplL bold={false}>DsplL</DsplL>
             <DsplL>DsplL Bold</DsplL>
+            <DsplL medium>DsplL Medium</DsplL>
 
             <DsplM bold={false}>DsplM</DsplM>
             <DsplM>DsplM Bold</DsplM>
+            <DsplM medium>DsplM Medium</DsplM>
 
             <DsplS bold={false}>DsplS</DsplS>
             <DsplS>DsplS Bold</DsplS>
+            <DsplS medium>DsplS Medium</DsplS>
         </div>
     );
 }
@@ -74,18 +77,23 @@ export function App() {
         <div style=\{{ display: 'block' }}>
             <H1 bold={false}>H1</H1>
             <H1>H1 Bold</H1>
+            <H1 medium>H1 Medium</H1>
 
             <H2 bold={false}>H2</H2>
             <H2>H2 Bold</H2>
+            <H2 medium>H2 Medium</H2>
 
             <H3 bold={false}>H3</H3>
             <H3>H3 Bold</H3>
+            <H3 medium>H3 Medium</H3>
 
             <H4 bold={false}>H4</H4>
             <H4>H4 Bold</H4>
+            <H4 medium>H4 Medium</H4>
 
             <H5 bold={false}>H5</H5>
             <H5>H5 Bold</H5>
+            <H5 medium>H5 Medium</H5>
         </div>
     );
 }
@@ -102,19 +110,24 @@ export function App() {
     return (
         <div style=\{{ display: 'block' }}>
             <BodyL>BodyL</BodyL>
-            <BodyL bold>BodyL полужирный</BodyL>
+            <BodyL bold>BodyL Bold</BodyL>
+            <BodyL medium>BodyL Medium</BodyL>
 
             <BodyM>BodyM</BodyM>
-            <BodyM bold>BodyM полужирный</BodyM>
+            <BodyM bold>BodyM Bold</BodyM>
+            <BodyM medium>BodyM Medium</BodyM>
 
             <BodyS>BodyS</BodyS>
-            <BodyS bold>BodyS полужирный</BodyS>
+            <BodyS bold>BodyS Bold</BodyS>
+            <BodyS medium>BodyS Medium</BodyS>
 
             <BodyXS>BodyXS</BodyXS>
-            <BodyXS bold>BodyXS полужирный</BodyXS>
+            <BodyXS bold>BodyXS Bold</BodyXS>
+            <BodyXS medium>BodyXS Medium</BodyXS>
 
             <BodyXXS>BodyXXS</BodyXXS>
-            <BodyXXS bold>BodyXXS полужирный</BodyXXS>
+            <BodyXXS bold>BodyXXS Bold</BodyXXS>
+            <BodyXXS medium>BodyXXS Medium</BodyXXS>
         </div>
     );
 }
@@ -131,16 +144,20 @@ export function App() {
     return (
         <div style=\{{ display: 'block' }}>
             <TextL>TextL</TextL>
-            <TextL bold>TextL полужирный</TextL>
+            <TextL bold>TextL Bold</TextL>
+            <TextL medium>TextL Medium</TextL>
 
             <TextM>TextM</TextM>
-            <TextM bold>TextM полужирный</TextM>
+            <TextM bold>TextM Bold</TextM>
+            <TextM medium>TextM Medium</TextM>
 
             <TextS>TextS</TextS>
-            <TextS bold>TextS полужирный</TextS>
+            <TextS bold>TextS Bold</TextS>
+            <TextS medium>TextS Medium</TextS>
 
             <TextXS>TextXS</TextXS>
-            <TextXS bold>TextXS полужирный</TextXS>
+            <TextXS bold>TextXS Bold</TextXS>
+            <TextXS medium>TextXS Medium</TextXS>
         </div>
     );
 }

--- a/packages/plasma-new-hope/src/components/Typography/Typography.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Typography.tsx
@@ -17,6 +17,7 @@ export const typographyRootCompose = (defaultArgs?: { defaultBold?: boolean }) =
             breakWord,
             noWrap,
             bold = defaultArgs?.defaultBold,
+            medium,
             color,
             className,
             style,
@@ -31,10 +32,10 @@ export const typographyRootCompose = (defaultArgs?: { defaultBold?: boolean }) =
                     noWrap && classes.typoWithNoWrap,
                     breakWord && classes.typoWithBreakWord,
                     bold && classes.typoBold,
+                    medium && classes.typoMedium,
                     className,
                 )}
                 style={{ color, ...style, ...applySpacing(rest) }}
-                bold={bold}
                 {...rest}
             >
                 {children}

--- a/packages/plasma-new-hope/src/components/Typography/Typography.types.ts
+++ b/packages/plasma-new-hope/src/components/Typography/Typography.types.ts
@@ -3,21 +3,40 @@ import type { HTMLAttributes } from 'react';
 import { AsProps } from '../..';
 import type { SpacingProps } from '../../mixins/applySpacing';
 
-export type BoldProps = {
+export interface BoldProps {
     /**
      * Полужирное начертание.
      */
     bold?: boolean;
+    medium?: never | false;
+}
+
+export interface MediumProps {
+    /**
+     * Среднее начертание.
+     */
+    medium?: boolean;
+    bold?: never | false;
+}
+
+export type FontProps = {
+    /**
+     * Не переносить строки.
+     */
+    noWrap?: boolean;
+    /**
+     * Переносить слова.
+     */
+    breakWord?: boolean;
+    /**
+     * Кастомный цвет текста.
+     */
+    color?: string;
     /**
      * Размер текста.
      */
     size?: string;
-};
-export type FontProps = {
-    noWrap?: boolean;
-    breakWord?: boolean;
-    color?: string;
 } & SpacingProps &
-    BoldProps &
+    (BoldProps | MediumProps) &
     AsProps &
     HTMLAttributes<HTMLDivElement>;

--- a/packages/plasma-new-hope/src/components/Typography/tokens.ts
+++ b/packages/plasma-new-hope/src/components/Typography/tokens.ts
@@ -2,6 +2,7 @@ export const classes = {
     typoWithNoWrap: 'with-no-wrap',
     typoWithBreakWord: 'with-break-word',
     typoBold: 'typography-bold',
+    typoMedium: 'typography-medium',
 };
 
 export const tokens = {
@@ -10,6 +11,7 @@ export const tokens = {
     typoFontStyle: '--typo-font-style',
     typoFontWeight: '--typo-font-weight',
     typoFontWeightBold: '--typo-font-weight-bold',
+    typoFontWeightMedium: '--typo-font-weight-medium',
     typoFontLetterSpacing: '--typo-font-letter-spacing',
     typoFontLineHeight: '--typo-font-line-height',
 };

--- a/packages/plasma-new-hope/src/examples/typography/components/Body/Body.config.ts
+++ b/packages/plasma-new-hope/src/examples/typography/components/Body/Body.config.ts
@@ -14,6 +14,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -23,6 +24,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -32,6 +34,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -41,6 +44,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -50,6 +54,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/plasma-new-hope/src/examples/typography/components/Body/Body.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Body/Body.stories.tsx
@@ -22,11 +22,24 @@ const meta: Meta<typeof Body> = {
         as: {
             control: 'text',
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
     },
     args: {
         noWrap: false,
         breakWord: true,
         bold: false,
+        medium: false,
     },
 };
 

--- a/packages/plasma-new-hope/src/examples/typography/components/Dspl/Dspl.config.ts
+++ b/packages/plasma-new-hope/src/examples/typography/components/Dspl/Dspl.config.ts
@@ -14,6 +14,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -23,6 +24,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -32,6 +34,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/plasma-new-hope/src/examples/typography/components/Dspl/Dspl.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Dspl/Dspl.stories.tsx
@@ -22,11 +22,24 @@ const meta: Meta<typeof Dspl> = {
         as: {
             control: 'text',
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
     },
     args: {
         noWrap: false,
         breakWord: true,
         bold: false,
+        medium: false,
     },
 };
 

--- a/packages/plasma-new-hope/src/examples/typography/components/Heading/Heading.config.ts
+++ b/packages/plasma-new-hope/src/examples/typography/components/Heading/Heading.config.ts
@@ -14,6 +14,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -23,6 +24,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -32,6 +34,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -41,6 +44,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -50,6 +54,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/plasma-new-hope/src/examples/typography/components/Heading/Heading.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Heading/Heading.stories.tsx
@@ -22,11 +22,24 @@ const meta: Meta<typeof Heading> = {
         as: {
             control: 'text',
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
     },
     args: {
         noWrap: false,
         breakWord: true,
         bold: false,
+        medium: false,
     },
 };
 

--- a/packages/plasma-new-hope/src/examples/typography/components/Text/Text.config.ts
+++ b/packages/plasma-new-hope/src/examples/typography/components/Text/Text.config.ts
@@ -14,6 +14,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -23,6 +24,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -32,6 +34,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -41,6 +44,7 @@ export const config = {
                 ${tokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${tokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${tokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${tokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${tokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${tokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/plasma-new-hope/src/examples/typography/components/Text/Text.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/typography/components/Text/Text.stories.tsx
@@ -22,11 +22,24 @@ const meta: Meta<typeof Text> = {
         as: {
             control: 'text',
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
     },
     args: {
         noWrap: false,
         breakWord: true,
         bold: false,
+        medium: false,
     },
 };
 

--- a/packages/plasma-web/src/components/Typography/Body.config.ts
+++ b/packages/plasma-web/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/plasma-web/src/components/Typography/Dspl.config.ts
+++ b/packages/plasma-web/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/plasma-web/src/components/Typography/Heading.config.ts
+++ b/packages/plasma-web/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/plasma-web/src/components/Typography/Text.config.ts
+++ b/packages/plasma-web/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/plasma-web/src/components/Typography/Typography.stories.tsx
+++ b/packages/plasma-web/src/components/Typography/Typography.stories.tsx
@@ -50,6 +50,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/sdds-clfd-auto/src/components/Typography/Body.config.ts
+++ b/packages/sdds-clfd-auto/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/sdds-clfd-auto/src/components/Typography/Dspl.config.ts
+++ b/packages/sdds-clfd-auto/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/sdds-clfd-auto/src/components/Typography/Heading.config.ts
+++ b/packages/sdds-clfd-auto/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/sdds-clfd-auto/src/components/Typography/Text.config.ts
+++ b/packages/sdds-clfd-auto/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/sdds-clfd-auto/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-clfd-auto/src/components/Typography/Typography.stories.tsx
@@ -32,6 +32,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/sdds-cs/src/components/Typography/Body.config.ts
+++ b/packages/sdds-cs/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/sdds-cs/src/components/Typography/Dspl.config.ts
+++ b/packages/sdds-cs/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/sdds-cs/src/components/Typography/Heading.config.ts
+++ b/packages/sdds-cs/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/sdds-cs/src/components/Typography/Text.config.ts
+++ b/packages/sdds-cs/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/sdds-cs/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-cs/src/components/Typography/Typography.stories.tsx
@@ -32,6 +32,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/sdds-dfa/src/components/Typography/Body.config.ts
+++ b/packages/sdds-dfa/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/sdds-dfa/src/components/Typography/Dspl.config.ts
+++ b/packages/sdds-dfa/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/sdds-dfa/src/components/Typography/Heading.config.ts
+++ b/packages/sdds-dfa/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/sdds-dfa/src/components/Typography/Text.config.ts
+++ b/packages/sdds-dfa/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/sdds-dfa/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-dfa/src/components/Typography/Typography.stories.tsx
@@ -32,6 +32,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/sdds-finportal/src/components/Typography/Body.config.ts
+++ b/packages/sdds-finportal/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/sdds-finportal/src/components/Typography/Dspl.config.ts
+++ b/packages/sdds-finportal/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/sdds-finportal/src/components/Typography/Heading.config.ts
+++ b/packages/sdds-finportal/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/sdds-finportal/src/components/Typography/Text.config.ts
+++ b/packages/sdds-finportal/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/sdds-finportal/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-finportal/src/components/Typography/Typography.stories.tsx
@@ -32,6 +32,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/sdds-insol/src/components/Typography/Body.config.ts
+++ b/packages/sdds-insol/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/sdds-insol/src/components/Typography/Dspl.config.ts
+++ b/packages/sdds-insol/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/sdds-insol/src/components/Typography/Heading.config.ts
+++ b/packages/sdds-insol/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/sdds-insol/src/components/Typography/Text.config.ts
+++ b/packages/sdds-insol/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/sdds-insol/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-insol/src/components/Typography/Typography.stories.tsx
@@ -32,6 +32,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/packages/sdds-serv/src/components/Typography/Body.config.ts
+++ b/packages/sdds-serv/src/components/Typography/Body.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xs-line-height);
             `,
@@ -88,6 +92,7 @@ export const configXXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-body-xxs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-body-xxs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-body-xxs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-body-xxs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-body-xxs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-body-xxs-line-height);
             `,

--- a/packages/sdds-serv/src/components/Typography/Dspl.config.ts
+++ b/packages/sdds-serv/src/components/Typography/Dspl.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-dspl-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-dspl-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-dspl-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-dspl-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-dspl-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-dspl-s-line-height);
             `,

--- a/packages/sdds-serv/src/components/Typography/Heading.config.ts
+++ b/packages/sdds-serv/src/components/Typography/Heading.config.ts
@@ -12,6 +12,7 @@ export const configH1 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h1-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h1-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h1-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h1-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h1-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h1-line-height);
             `,
@@ -30,6 +31,7 @@ export const configH2 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h2-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h2-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h2-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h2-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h2-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h2-line-height);
             `,
@@ -48,6 +50,7 @@ export const configH3 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h3-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h3-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h3-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h3-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h3-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h3-line-height);
             `,
@@ -66,6 +69,7 @@ export const configH4 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h4-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h4-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h4-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h4-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h4-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h4-line-height);
             `,
@@ -84,6 +88,7 @@ export const configH5 = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-h5-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-h5-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-h5-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-h5-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-h5-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-h5-line-height);
             `,

--- a/packages/sdds-serv/src/components/Typography/Text.config.ts
+++ b/packages/sdds-serv/src/components/Typography/Text.config.ts
@@ -12,6 +12,7 @@ export const configL = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-l-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-l-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-l-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-l-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-l-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-l-line-height);
             `,
@@ -31,6 +32,7 @@ export const configM = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-m-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-m-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-m-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-m-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-m-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-m-line-height);
             `,
@@ -50,6 +52,7 @@ export const configS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-s-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-s-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-s-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-s-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-s-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-s-line-height);
             `,
@@ -69,6 +72,7 @@ export const configXS = {
                 ${typographyTokens.typoFontStyle}: var(--plasma-typo-text-xs-font-style);
                 ${typographyTokens.typoFontWeight}: var(--plasma-typo-text-xs-font-weight);
                 ${typographyTokens.typoFontWeightBold}: var(--plasma-typo-text-xs-bold-font-weight);
+                ${typographyTokens.typoFontWeightMedium}: var(--plasma-typo-text-xs-medium-font-weight);
                 ${typographyTokens.typoFontLetterSpacing}: var(--plasma-typo-text-xs-letter-spacing);
                 ${typographyTokens.typoFontLineHeight}: var(--plasma-typo-text-xs-line-height);
             `,

--- a/packages/sdds-serv/src/components/Typography/Typography.stories.tsx
+++ b/packages/sdds-serv/src/components/Typography/Typography.stories.tsx
@@ -32,6 +32,24 @@ const meta: Meta = {
                 type: 'color',
             },
         },
+        bold: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'medium', truthy: false },
+        },
+        medium: {
+            control: {
+                type: 'boolean',
+            },
+            if: { arg: 'bold', truthy: false },
+        },
+    },
+    args: {
+        noWrap: false,
+        breakWord: true,
+        bold: false,
+        medium: false,
     },
     decorators: [InSpacingDecorator],
 };

--- a/website/plasma-b2c-docs/docs/components/Typography.mdx
+++ b/website/plasma-b2c-docs/docs/components/Typography.mdx
@@ -32,7 +32,7 @@ import { StorybookLink } from '@site/src/components';
 
 ```tsx live
 import React from 'react';
-import { BodyM } from '@salutejs/plasma-b2c';
+import { BodyM } from '@salutejs/plasma-giga';
 
 export function App() {
     return (
@@ -56,12 +56,15 @@ export function App() {
         <div style={{ display: 'block' }}>
             <DsplL bold={false}>DsplL</DsplL>
             <DsplL>DsplL Bold</DsplL>
+            <DsplL medium>DsplL Medium</DsplL>
 
             <DsplM bold={false}>DsplM</DsplM>
             <DsplM>DsplM Bold</DsplM>
+            <DsplM medium>DsplM Medium</DsplM>
 
             <DsplS bold={false}>DsplS</DsplS>
             <DsplS>DsplS Bold</DsplS>
+            <DsplS medium>DsplS Medium</DsplS>
         </div>
     );
 }
@@ -78,18 +81,23 @@ export function App() {
         <div style={{ display: 'block' }}>
             <H1 bold={false}>H1</H1>
             <H1>H1 Bold</H1>
+            <H1 medium>H1 Medium</H1>
 
             <H2 bold={false}>H2</H2>
             <H2>H2 Bold</H2>
+            <H2 medium>H2 Medium</H2>
 
             <H3 bold={false}>H3</H3>
             <H3>H3 Bold</H3>
+            <H3 medium>H3 Medium</H3>
 
             <H4 bold={false}>H4</H4>
             <H4>H4 Bold</H4>
+            <H4 medium>H4 Medium</H4>
 
             <H5 bold={false}>H5</H5>
             <H5>H5 Bold</H5>
+            <H5 medium>H5 Medium</H5>
         </div>
     );
 }
@@ -106,19 +114,24 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <BodyL>BodyL</BodyL>
-            <BodyL bold>BodyL полужирный</BodyL>
+            <BodyL bold>BodyL Bold</BodyL>
+            <BodyL medium>BodyL Medium</BodyL>
 
             <BodyM>BodyM</BodyM>
-            <BodyM bold>BodyM полужирный</BodyM>
+            <BodyM bold>BodyM Bold</BodyM>
+            <BodyM medium>BodyM Medium</BodyM>
 
             <BodyS>BodyS</BodyS>
-            <BodyS bold>BodyS полужирный</BodyS>
+            <BodyS bold>BodyS Bold</BodyS>
+            <BodyS medium>BodyS Medium</BodyS>
 
             <BodyXS>BodyXS</BodyXS>
-            <BodyXS bold>BodyXS полужирный</BodyXS>
+            <BodyXS bold>BodyXS Bold</BodyXS>
+            <BodyXS medium>BodyXS Medium</BodyXS>
 
             <BodyXXS>BodyXXS</BodyXXS>
-            <BodyXXS bold>BodyXXS полужирный</BodyXXS>
+            <BodyXXS bold>BodyXXS Bold</BodyXXS>
+            <BodyXXS medium>BodyXXS Medium</BodyXXS>
         </div>
     );
 }
@@ -135,16 +148,20 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <TextL>TextL</TextL>
-            <TextL bold>TextL полужирный</TextL>
+            <TextL bold>TextL Bold</TextL>
+            <TextL medium>TextL Medium</TextL>
 
             <TextM>TextM</TextM>
-            <TextM bold>TextM полужирный</TextM>
+            <TextM bold>TextM Bold</TextM>
+            <TextM medium>TextM Medium</TextM>
 
             <TextS>TextS</TextS>
-            <TextS bold>TextS полужирный</TextS>
+            <TextS bold>TextS Bold</TextS>
+            <TextS medium>TextS Medium</TextS>
 
             <TextXS>TextXS</TextXS>
-            <TextXS bold>TextXS полужирный</TextXS>
+            <TextXS bold>TextXS Bold</TextXS>
+            <TextXS medium>TextXS Medium</TextXS>
         </div>
     );
 }

--- a/website/plasma-giga-docs/docs/components/Typography.mdx
+++ b/website/plasma-giga-docs/docs/components/Typography.mdx
@@ -52,12 +52,15 @@ export function App() {
         <div style={{ display: 'block' }}>
             <DsplL bold={false}>DsplL</DsplL>
             <DsplL>DsplL Bold</DsplL>
+            <DsplL medium>DsplL Medium</DsplL>
 
             <DsplM bold={false}>DsplM</DsplM>
             <DsplM>DsplM Bold</DsplM>
+            <DsplM medium>DsplM Medium</DsplM>
 
             <DsplS bold={false}>DsplS</DsplS>
             <DsplS>DsplS Bold</DsplS>
+            <DsplS medium>DsplS Medium</DsplS>
         </div>
     );
 }
@@ -74,18 +77,23 @@ export function App() {
         <div style={{ display: 'block' }}>
             <H1 bold={false}>H1</H1>
             <H1>H1 Bold</H1>
+            <H1 medium>H1 Medium</H1>
 
             <H2 bold={false}>H2</H2>
             <H2>H2 Bold</H2>
+            <H2 medium>H2 Medium</H2>
 
             <H3 bold={false}>H3</H3>
             <H3>H3 Bold</H3>
+            <H3 medium>H3 Medium</H3>
 
             <H4 bold={false}>H4</H4>
             <H4>H4 Bold</H4>
+            <H4 medium>H4 Medium</H4>
 
             <H5 bold={false}>H5</H5>
             <H5>H5 Bold</H5>
+            <H5 medium>H5 Medium</H5>
         </div>
     );
 }
@@ -102,19 +110,24 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <BodyL>BodyL</BodyL>
-            <BodyL bold>BodyL полужирный</BodyL>
+            <BodyL bold>BodyL Bold</BodyL>
+            <BodyL medium>BodyL Medium</BodyL>
 
             <BodyM>BodyM</BodyM>
-            <BodyM bold>BodyM полужирный</BodyM>
+            <BodyM bold>BodyM Bold</BodyM>
+            <BodyM medium>BodyM Medium</BodyM>
 
             <BodyS>BodyS</BodyS>
-            <BodyS bold>BodyS полужирный</BodyS>
+            <BodyS bold>BodyS Bold</BodyS>
+            <BodyS medium>BodyS Medium</BodyS>
 
             <BodyXS>BodyXS</BodyXS>
-            <BodyXS bold>BodyXS полужирный</BodyXS>
+            <BodyXS bold>BodyXS Bold</BodyXS>
+            <BodyXS medium>BodyXS Medium</BodyXS>
 
             <BodyXXS>BodyXXS</BodyXXS>
-            <BodyXXS bold>BodyXXS полужирный</BodyXXS>
+            <BodyXXS bold>BodyXXS Bold</BodyXXS>
+            <BodyXXS medium>BodyXXS Medium</BodyXXS>
         </div>
     );
 }
@@ -131,16 +144,20 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <TextL>TextL</TextL>
-            <TextL bold>TextL полужирный</TextL>
+            <TextL bold>TextL Bold</TextL>
+            <TextL medium>TextL Medium</TextL>
 
             <TextM>TextM</TextM>
-            <TextM bold>TextM полужирный</TextM>
+            <TextM bold>TextM Bold</TextM>
+            <TextM medium>TextM Medium</TextM>
 
             <TextS>TextS</TextS>
-            <TextS bold>TextS полужирный</TextS>
+            <TextS bold>TextS Bold</TextS>
+            <TextS medium>TextS Medium</TextS>
 
             <TextXS>TextXS</TextXS>
-            <TextXS bold>TextXS полужирный</TextXS>
+            <TextXS bold>TextXS Bold</TextXS>
+            <TextXS medium>TextXS Medium</TextXS>
         </div>
     );
 }

--- a/website/plasma-web-docs/docs/components/Typography.mdx
+++ b/website/plasma-web-docs/docs/components/Typography.mdx
@@ -56,12 +56,15 @@ export function App() {
         <div style={{ display: 'block' }}>
             <DsplL bold={false}>DsplL</DsplL>
             <DsplL>DsplL Bold</DsplL>
+            <DsplL medium>DsplL Medium</DsplL>
 
             <DsplM bold={false}>DsplM</DsplM>
             <DsplM>DsplM Bold</DsplM>
+            <DsplM medium>DsplM Medium</DsplM>
 
             <DsplS bold={false}>DsplS</DsplS>
             <DsplS>DsplS Bold</DsplS>
+            <DsplS medium>DsplS Medium</DsplS>
         </div>
     );
 }
@@ -78,18 +81,23 @@ export function App() {
         <div style={{ display: 'block' }}>
             <H1 bold={false}>H1</H1>
             <H1>H1 Bold</H1>
+            <H1 medium>H1 Medium</H1>
 
             <H2 bold={false}>H2</H2>
             <H2>H2 Bold</H2>
+            <H2 medium>H2 Medium</H2>
 
             <H3 bold={false}>H3</H3>
             <H3>H3 Bold</H3>
+            <H3 medium>H3 Medium</H3>
 
             <H4 bold={false}>H4</H4>
             <H4>H4 Bold</H4>
+            <H4 medium>H4 Medium</H4>
 
             <H5 bold={false}>H5</H5>
             <H5>H5 Bold</H5>
+            <H5 medium>H5 Medium</H5>
         </div>
     );
 }
@@ -106,19 +114,24 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <BodyL>BodyL</BodyL>
-            <BodyL bold>BodyL полужирный</BodyL>
+            <BodyL bold>BodyL Bold</BodyL>
+            <BodyL medium>BodyL Medium</BodyL>
 
             <BodyM>BodyM</BodyM>
-            <BodyM bold>BodyM полужирный</BodyM>
+            <BodyM bold>BodyM Bold</BodyM>
+            <BodyM medium>BodyM Medium</BodyM>
 
             <BodyS>BodyS</BodyS>
-            <BodyS bold>BodyS полужирный</BodyS>
+            <BodyS bold>BodyS Bold</BodyS>
+            <BodyS medium>BodyS Medium</BodyS>
 
             <BodyXS>BodyXS</BodyXS>
-            <BodyXS bold>BodyXS полужирный</BodyXS>
+            <BodyXS bold>BodyXS Bold</BodyXS>
+            <BodyXS medium>BodyXS Medium</BodyXS>
 
             <BodyXXS>BodyXXS</BodyXXS>
-            <BodyXXS bold>BodyXXS полужирный</BodyXXS>
+            <BodyXXS bold>BodyXXS Bold</BodyXXS>
+            <BodyXXS medium>BodyXXS Medium</BodyXXS>
         </div>
     );
 }
@@ -135,16 +148,20 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <TextL>TextL</TextL>
-            <TextL bold>TextL полужирный</TextL>
+            <TextL bold>TextL Bold</TextL>
+            <TextL medium>TextL Medium</TextL>
 
             <TextM>TextM</TextM>
-            <TextM bold>TextM полужирный</TextM>
+            <TextM bold>TextM Bold</TextM>
+            <TextM medium>TextM Medium</TextM>
 
             <TextS>TextS</TextS>
-            <TextS bold>TextS полужирный</TextS>
+            <TextS bold>TextS Bold</TextS>
+            <TextS medium>TextS Medium</TextS>
 
             <TextXS>TextXS</TextXS>
-            <TextXS bold>TextXS полужирный</TextXS>
+            <TextXS bold>TextXS Bold</TextXS>
+            <TextXS medium>TextXS Medium</TextXS>
         </div>
     );
 }

--- a/website/sdds-cs-docs/docs/components/Typography.mdx
+++ b/website/sdds-cs-docs/docs/components/Typography.mdx
@@ -52,12 +52,15 @@ export function App() {
         <div style={{ display: 'block' }}>
             <DsplL bold={false}>DsplL</DsplL>
             <DsplL>DsplL Bold</DsplL>
+            <DsplL medium>DsplL Medium</DsplL>
 
             <DsplM bold={false}>DsplM</DsplM>
             <DsplM>DsplM Bold</DsplM>
+            <DsplM medium>DsplM Medium</DsplM>
 
             <DsplS bold={false}>DsplS</DsplS>
             <DsplS>DsplS Bold</DsplS>
+            <DsplS medium>DsplS Medium</DsplS>
         </div>
     );
 }
@@ -74,18 +77,23 @@ export function App() {
         <div style={{ display: 'block' }}>
             <H1 bold={false}>H1</H1>
             <H1>H1 Bold</H1>
+            <H1 medium>H1 Medium</H1>
 
             <H2 bold={false}>H2</H2>
             <H2>H2 Bold</H2>
+            <H2 medium>H2 Medium</H2>
 
             <H3 bold={false}>H3</H3>
             <H3>H3 Bold</H3>
+            <H3 medium>H3 Medium</H3>
 
             <H4 bold={false}>H4</H4>
             <H4>H4 Bold</H4>
+            <H4 medium>H4 Medium</H4>
 
             <H5 bold={false}>H5</H5>
             <H5>H5 Bold</H5>
+            <H5 medium>H5 Medium</H5>
         </div>
     );
 }
@@ -102,19 +110,24 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <BodyL>BodyL</BodyL>
-            <BodyL bold>BodyL полужирный</BodyL>
+            <BodyL bold>BodyL Bold</BodyL>
+            <BodyL medium>BodyL Medium</BodyL>
 
             <BodyM>BodyM</BodyM>
-            <BodyM bold>BodyM полужирный</BodyM>
+            <BodyM bold>BodyM Bold</BodyM>
+            <BodyM medium>BodyM Medium</BodyM>
 
             <BodyS>BodyS</BodyS>
-            <BodyS bold>BodyS полужирный</BodyS>
+            <BodyS bold>BodyS Bold</BodyS>
+            <BodyS medium>BodyS Medium</BodyS>
 
             <BodyXS>BodyXS</BodyXS>
-            <BodyXS bold>BodyXS полужирный</BodyXS>
+            <BodyXS bold>BodyXS Bold</BodyXS>
+            <BodyXS medium>BodyXS Medium</BodyXS>
 
             <BodyXXS>BodyXXS</BodyXXS>
-            <BodyXXS bold>BodyXXS полужирный</BodyXXS>
+            <BodyXXS bold>BodyXXS Bold</BodyXXS>
+            <BodyXXS medium>BodyXXS Medium</BodyXXS>
         </div>
     );
 }
@@ -131,16 +144,20 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <TextL>TextL</TextL>
-            <TextL bold>TextL полужирный</TextL>
+            <TextL bold>TextL Bold</TextL>
+            <TextL medium>TextL Medium</TextL>
 
             <TextM>TextM</TextM>
-            <TextM bold>TextM полужирный</TextM>
+            <TextM bold>TextM Bold</TextM>
+            <TextM medium>TextM Medium</TextM>
 
             <TextS>TextS</TextS>
-            <TextS bold>TextS полужирный</TextS>
+            <TextS bold>TextS Bold</TextS>
+            <TextS medium>TextS Medium</TextS>
 
             <TextXS>TextXS</TextXS>
-            <TextXS bold>TextXS полужирный</TextXS>
+            <TextXS bold>TextXS Bold</TextXS>
+            <TextXS medium>TextXS Medium</TextXS>
         </div>
     );
 }

--- a/website/sdds-dfa-docs/docs/components/Typography.mdx
+++ b/website/sdds-dfa-docs/docs/components/Typography.mdx
@@ -52,12 +52,15 @@ export function App() {
         <div style={{ display: 'block' }}>
             <DsplL bold={false}>DsplL</DsplL>
             <DsplL>DsplL Bold</DsplL>
+            <DsplL medium>DsplL Medium</DsplL>
 
             <DsplM bold={false}>DsplM</DsplM>
             <DsplM>DsplM Bold</DsplM>
+            <DsplM medium>DsplM Medium</DsplM>
 
             <DsplS bold={false}>DsplS</DsplS>
             <DsplS>DsplS Bold</DsplS>
+            <DsplS medium>DsplS Medium</DsplS>
         </div>
     );
 }
@@ -74,18 +77,23 @@ export function App() {
         <div style={{ display: 'block' }}>
             <H1 bold={false}>H1</H1>
             <H1>H1 Bold</H1>
+            <H1 medium>H1 Medium</H1>
 
             <H2 bold={false}>H2</H2>
             <H2>H2 Bold</H2>
+            <H2 medium>H2 Medium</H2>
 
             <H3 bold={false}>H3</H3>
             <H3>H3 Bold</H3>
+            <H3 medium>H3 Medium</H3>
 
             <H4 bold={false}>H4</H4>
             <H4>H4 Bold</H4>
+            <H4 medium>H4 Medium</H4>
 
             <H5 bold={false}>H5</H5>
             <H5>H5 Bold</H5>
+            <H5 medium>H5 Medium</H5>
         </div>
     );
 }
@@ -102,19 +110,24 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <BodyL>BodyL</BodyL>
-            <BodyL bold>BodyL полужирный</BodyL>
+            <BodyL bold>BodyL Bold</BodyL>
+            <BodyL medium>BodyL Medium</BodyL>
 
             <BodyM>BodyM</BodyM>
-            <BodyM bold>BodyM полужирный</BodyM>
+            <BodyM bold>BodyM Bold</BodyM>
+            <BodyM medium>BodyM Medium</BodyM>
 
             <BodyS>BodyS</BodyS>
-            <BodyS bold>BodyS полужирный</BodyS>
+            <BodyS bold>BodyS Bold</BodyS>
+            <BodyS medium>BodyS Medium</BodyS>
 
             <BodyXS>BodyXS</BodyXS>
-            <BodyXS bold>BodyXS полужирный</BodyXS>
+            <BodyXS bold>BodyXS Bold</BodyXS>
+            <BodyXS medium>BodyXS Medium</BodyXS>
 
             <BodyXXS>BodyXXS</BodyXXS>
-            <BodyXXS bold>BodyXXS полужирный</BodyXXS>
+            <BodyXXS bold>BodyXXS Bold</BodyXXS>
+            <BodyXXS medium>BodyXXS Medium</BodyXXS>
         </div>
     );
 }
@@ -131,16 +144,20 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <TextL>TextL</TextL>
-            <TextL bold>TextL полужирный</TextL>
+            <TextL bold>TextL Bold</TextL>
+            <TextL medium>TextL Medium</TextL>
 
             <TextM>TextM</TextM>
-            <TextM bold>TextM полужирный</TextM>
+            <TextM bold>TextM Bold</TextM>
+            <TextM medium>TextM Medium</TextM>
 
             <TextS>TextS</TextS>
-            <TextS bold>TextS полужирный</TextS>
+            <TextS bold>TextS Bold</TextS>
+            <TextS medium>TextS Medium</TextS>
 
             <TextXS>TextXS</TextXS>
-            <TextXS bold>TextXS полужирный</TextXS>
+            <TextXS bold>TextXS Bold</TextXS>
+            <TextXS medium>TextXS Medium</TextXS>
         </div>
     );
 }

--- a/website/sdds-insol-docs/docs/components/Typography.mdx
+++ b/website/sdds-insol-docs/docs/components/Typography.mdx
@@ -52,12 +52,15 @@ export function App() {
         <div style={{ display: 'block' }}>
             <DsplL bold={false}>DsplL</DsplL>
             <DsplL>DsplL Bold</DsplL>
+            <DsplL medium>DsplL Medium</DsplL>
 
             <DsplM bold={false}>DsplM</DsplM>
             <DsplM>DsplM Bold</DsplM>
+            <DsplM medium>DsplM Medium</DsplM>
 
             <DsplS bold={false}>DsplS</DsplS>
             <DsplS>DsplS Bold</DsplS>
+            <DsplS medium>DsplS Medium</DsplS>
         </div>
     );
 }
@@ -74,18 +77,23 @@ export function App() {
         <div style={{ display: 'block' }}>
             <H1 bold={false}>H1</H1>
             <H1>H1 Bold</H1>
+            <H1 medium>H1 Medium</H1>
 
             <H2 bold={false}>H2</H2>
             <H2>H2 Bold</H2>
+            <H2 medium>H2 Medium</H2>
 
             <H3 bold={false}>H3</H3>
             <H3>H3 Bold</H3>
+            <H3 medium>H3 Medium</H3>
 
             <H4 bold={false}>H4</H4>
             <H4>H4 Bold</H4>
+            <H4 medium>H4 Medium</H4>
 
             <H5 bold={false}>H5</H5>
             <H5>H5 Bold</H5>
+            <H5 medium>H5 Medium</H5>
         </div>
     );
 }
@@ -102,19 +110,24 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <BodyL>BodyL</BodyL>
-            <BodyL bold>BodyL полужирный</BodyL>
+            <BodyL bold>BodyL Bold</BodyL>
+            <BodyL medium>BodyL Medium</BodyL>
 
             <BodyM>BodyM</BodyM>
-            <BodyM bold>BodyM полужирный</BodyM>
+            <BodyM bold>BodyM Bold</BodyM>
+            <BodyM medium>BodyM Medium</BodyM>
 
             <BodyS>BodyS</BodyS>
-            <BodyS bold>BodyS полужирный</BodyS>
+            <BodyS bold>BodyS Bold</BodyS>
+            <BodyS medium>BodyS Medium</BodyS>
 
             <BodyXS>BodyXS</BodyXS>
-            <BodyXS bold>BodyXS полужирный</BodyXS>
+            <BodyXS bold>BodyXS Bold</BodyXS>
+            <BodyXS medium>BodyXS Medium</BodyXS>
 
             <BodyXXS>BodyXXS</BodyXXS>
-            <BodyXXS bold>BodyXXS полужирный</BodyXXS>
+            <BodyXXS bold>BodyXXS Bold</BodyXXS>
+            <BodyXXS medium>BodyXXS Medium</BodyXXS>
         </div>
     );
 }
@@ -131,16 +144,20 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <TextL>TextL</TextL>
-            <TextL bold>TextL полужирный</TextL>
+            <TextL bold>TextL Bold</TextL>
+            <TextL medium>TextL Medium</TextL>
 
             <TextM>TextM</TextM>
-            <TextM bold>TextM полужирный</TextM>
+            <TextM bold>TextM Bold</TextM>
+            <TextM medium>TextM Medium</TextM>
 
             <TextS>TextS</TextS>
-            <TextS bold>TextS полужирный</TextS>
+            <TextS bold>TextS Bold</TextS>
+            <TextS medium>TextS Medium</TextS>
 
             <TextXS>TextXS</TextXS>
-            <TextXS bold>TextXS полужирный</TextXS>
+            <TextXS bold>TextXS Bold</TextXS>
+            <TextXS medium>TextXS Medium</TextXS>
         </div>
     );
 }

--- a/website/sdds-serv-docs/docs/components/Typography.mdx
+++ b/website/sdds-serv-docs/docs/components/Typography.mdx
@@ -52,12 +52,15 @@ export function App() {
         <div style={{ display: 'block' }}>
             <DsplL bold={false}>DsplL</DsplL>
             <DsplL>DsplL Bold</DsplL>
+            <DsplL medium>DsplL Medium</DsplL>
 
             <DsplM bold={false}>DsplM</DsplM>
             <DsplM>DsplM Bold</DsplM>
+            <DsplM medium>DsplM Medium</DsplM>
 
             <DsplS bold={false}>DsplS</DsplS>
             <DsplS>DsplS Bold</DsplS>
+            <DsplS medium>DsplS Medium</DsplS>
         </div>
     );
 }
@@ -74,18 +77,23 @@ export function App() {
         <div style={{ display: 'block' }}>
             <H1 bold={false}>H1</H1>
             <H1>H1 Bold</H1>
+            <H1 medium>H1 Medium</H1>
 
             <H2 bold={false}>H2</H2>
             <H2>H2 Bold</H2>
+            <H2 medium>H2 Medium</H2>
 
             <H3 bold={false}>H3</H3>
             <H3>H3 Bold</H3>
+            <H3 medium>H3 Medium</H3>
 
             <H4 bold={false}>H4</H4>
             <H4>H4 Bold</H4>
+            <H4 medium>H4 Medium</H4>
 
             <H5 bold={false}>H5</H5>
             <H5>H5 Bold</H5>
+            <H5 medium>H5 Medium</H5>
         </div>
     );
 }
@@ -102,19 +110,24 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <BodyL>BodyL</BodyL>
-            <BodyL bold>BodyL полужирный</BodyL>
+            <BodyL bold>BodyL Bold</BodyL>
+            <BodyL medium>BodyL Medium</BodyL>
 
             <BodyM>BodyM</BodyM>
-            <BodyM bold>BodyM полужирный</BodyM>
+            <BodyM bold>BodyM Bold</BodyM>
+            <BodyM medium>BodyM Medium</BodyM>
 
             <BodyS>BodyS</BodyS>
-            <BodyS bold>BodyS полужирный</BodyS>
+            <BodyS bold>BodyS Bold</BodyS>
+            <BodyS medium>BodyS Medium</BodyS>
 
             <BodyXS>BodyXS</BodyXS>
-            <BodyXS bold>BodyXS полужирный</BodyXS>
+            <BodyXS bold>BodyXS Bold</BodyXS>
+            <BodyXS medium>BodyXS Medium</BodyXS>
 
             <BodyXXS>BodyXXS</BodyXXS>
-            <BodyXXS bold>BodyXXS полужирный</BodyXXS>
+            <BodyXXS bold>BodyXXS Bold</BodyXXS>
+            <BodyXXS medium>BodyXXS Medium</BodyXXS>
         </div>
     );
 }
@@ -131,16 +144,20 @@ export function App() {
     return (
         <div style={{ display: 'block' }}>
             <TextL>TextL</TextL>
-            <TextL bold>TextL полужирный</TextL>
+            <TextL bold>TextL Bold</TextL>
+            <TextL medium>TextL Medium</TextL>
 
             <TextM>TextM</TextM>
-            <TextM bold>TextM полужирный</TextM>
+            <TextM bold>TextM Bold</TextM>
+            <TextM medium>TextM Medium</TextM>
 
             <TextS>TextS</TextS>
-            <TextS bold>TextS полужирный</TextS>
+            <TextS bold>TextS Bold</TextS>
+            <TextS medium>TextS Medium</TextS>
 
             <TextXS>TextXS</TextXS>
-            <TextXS bold>TextXS полужирный</TextXS>
+            <TextXS bold>TextXS Bold</TextXS>
+            <TextXS medium>TextXS Medium</TextXS>
         </div>
     );
 }


### PR DESCRIPTION
## Core

### Typography

- Добавлена поддержка свойства `medium`
- Добавлена документация с примерами

### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.331.0-canary.1886.14216115492.0
  npm install @salutejs/plasma-b2c@1.573.0-canary.1886.14216115492.0
  npm install @salutejs/plasma-giga@0.300.0-canary.1886.14216115492.0
  npm install @salutejs/plasma-new-hope@0.317.0-canary.1886.14216115492.0
  npm install @salutejs/plasma-web@1.575.0-canary.1886.14216115492.0
  npm install @salutejs/sdds-clfd-auto@0.304.0-canary.1886.14216115492.0
  npm install @salutejs/sdds-cs@0.309.0-canary.1886.14216115492.0
  npm install @salutejs/sdds-dfa@0.303.0-canary.1886.14216115492.0
  npm install @salutejs/sdds-finportal@0.296.0-canary.1886.14216115492.0
  npm install @salutejs/sdds-insol@0.300.0-canary.1886.14216115492.0
  npm install @salutejs/sdds-serv@0.304.0-canary.1886.14216115492.0
  # or 
  yarn add @salutejs/plasma-asdk@0.331.0-canary.1886.14216115492.0
  yarn add @salutejs/plasma-b2c@1.573.0-canary.1886.14216115492.0
  yarn add @salutejs/plasma-giga@0.300.0-canary.1886.14216115492.0
  yarn add @salutejs/plasma-new-hope@0.317.0-canary.1886.14216115492.0
  yarn add @salutejs/plasma-web@1.575.0-canary.1886.14216115492.0
  yarn add @salutejs/sdds-clfd-auto@0.304.0-canary.1886.14216115492.0
  yarn add @salutejs/sdds-cs@0.309.0-canary.1886.14216115492.0
  yarn add @salutejs/sdds-dfa@0.303.0-canary.1886.14216115492.0
  yarn add @salutejs/sdds-finportal@0.296.0-canary.1886.14216115492.0
  yarn add @salutejs/sdds-insol@0.300.0-canary.1886.14216115492.0
  yarn add @salutejs/sdds-serv@0.304.0-canary.1886.14216115492.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
