### PR TITLE
PLASMA-4781: Fix `PreviewGallery` stories example

### DIFF
--- a/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.stories.tsx
+++ b/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.stories.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import { IconTrash, IconTrashFilled, Icon } from '@salutejs/plasma-icons';
+import { IconTrash, IconTrashFilled, IconPlus } from '@salutejs/plasma-icons';
 import { surfaceSolid01 } from '@salutejs/plasma-tokens-b2c';
 
 import { arrayItemRemoving, arrayItemSelecting, arrayItemSwapping, PreviewGallery } from '.';
@@ -41,7 +41,7 @@ const StyledAddButton = styled.div`
     padding-top: 56.25%;
 `;
 
-const StyledIcon = styled(Icon)`
+const StyledIconPlus = styled(IconPlus)`
     position: absolute;
     top: calc(50% - 12px);
     left: calc(50% - 12px);
@@ -50,7 +50,7 @@ const StyledIcon = styled(Icon)`
 export const AddButton = () => {
     return (
         <StyledAddButton>
-            <StyledIcon icon="plus" />
+            <StyledIconPlus />
         </StyledAddButton>
     );
 };

--- a/packages/plasma-web/src/components/PreviewGallery/PreviewGallery.stories.tsx
+++ b/packages/plasma-web/src/components/PreviewGallery/PreviewGallery.stories.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import type { StoryObj, Meta } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
-import { IconTrash, IconTrashFilled, Icon } from '@salutejs/plasma-icons';
+import { IconTrash, IconTrashFilled, IconPlus } from '@salutejs/plasma-icons';
 import { surfaceSolid01 } from '@salutejs/plasma-tokens-web';
 
 import { arrayItemRemoving, arrayItemSelecting, arrayItemSwapping, PreviewGallery } from '.';
@@ -35,7 +35,7 @@ const StyledAddButton = styled.div`
     padding-top: 56.25%;
 `;
 
-const StyledIcon = styled(Icon)`
+const StyledIconPlus = styled(IconPlus)`
     position: absolute;
     top: calc(50% - 12px);
     left: calc(50% - 12px);
@@ -44,7 +44,7 @@ const StyledIcon = styled(Icon)`
 const AddButton = () => {
     return (
         <StyledAddButton>
-            <StyledIcon icon="plus" />
+            <StyledIconPlus />
         </StyledAddButton>
     );
 };


### PR DESCRIPTION
### What/why changed

Исправлен пример stories для компонента PreviewGallery


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.576.1-canary.1890.14258039816.0
  npm install @salutejs/plasma-web@1.578.1-canary.1890.14258039816.0
  # or 
  yarn add @salutejs/plasma-b2c@1.576.1-canary.1890.14258039816.0
  yarn add @salutejs/plasma-web@1.578.1-canary.1890.14258039816.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
