### PR TITLE
PLASMA-3890: Textfield text overflow ellipsis

### DIFF
--- a/packages/plasma-new-hope/src/components/NumberFormat/NumberFormat.tsx
+++ b/packages/plasma-new-hope/src/components/NumberFormat/NumberFormat.tsx
@@ -19,12 +19,16 @@ export const composeNumberFormat = <T extends InputComponentOmittedProps>(InputC
                 }
             };
 
+            const InputComponentWithoutEllipsis = (props: T) => {
+                return <InputComponent _textEllipsisEnable {...props} />;
+            };
+
             return (
                 <NumericFormat
                     thousandSeparator={thousandSeparator}
                     decimalScale={decimalScale}
                     decimalSeparator={decimalSeparator}
-                    customInput={InputComponent}
+                    customInput={InputComponentWithoutEllipsis}
                     getInputRef={outerRef}
                     onValueChange={handleChangeValue}
                     {...rest}

--- a/packages/plasma-new-hope/src/components/TextField/TextField.styles.ts
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.styles.ts
@@ -1,4 +1,5 @@
 import { styled } from '@linaria/react';
+import { applyEllipsis } from 'src/mixins';
 
 import { component, mergeConfig } from '../../engines';
 import { tooltipConfig } from '../Tooltip';
@@ -54,6 +55,10 @@ export const Input = styled.input`
     outline: none;
     width: 100%;
     z-index: 1;
+
+    &.${classes.inputTextEllipsis} {
+        ${applyEllipsis()}
+    }
 
     &::placeholder {
         opacity: 0;

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tokens.ts
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tokens.ts
@@ -14,6 +14,7 @@ export const classes = {
     textFieldGroupItem: 'text-field-group-item',
     requiredAlignRight: 'required-align-right',
     inputWrapper: 'input-wrapper',
+    inputTextEllipsis: 'textfield-input-text-ellipsis',
     contentRightCompensationMargin: 'textfield-content-right-compensation-margin',
 };
 

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -338,6 +338,12 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldRootProps
                 </StyledOptionalText>
             ) : null;
 
+            const classTextEllipsis =
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                // eslint-disable-next-line no-underscore-dangle
+                !(rest as any)._textEllipsisEnable && !textAfter ? classes.inputTextEllipsis : undefined;
+
             return (
                 <Root
                     view={view}
@@ -493,7 +499,7 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldRootProps
                                     aria-labelledby={labelId}
                                     aria-describedby={helperTextId}
                                     placeholder={innerPlaceholderValue}
-                                    className={cx(hasValueClass, keepPlaceholderClass)}
+                                    className={cx(hasValueClass, keepPlaceholderClass, classTextEllipsis)}
                                     disabled={disabled}
                                     readOnly={!disabled && readOnly}
                                     onInput={handleInput}


### PR DESCRIPTION
## Core

### Textfield

- Если текст не помещается, то ставятся 3 точки

<img width="832" alt="Снимок экрана 2025-04-23 в 01 04 32" src="https://github.com/user-attachments/assets/7a3bb763-dac9-412b-941e-483e26713058" />

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.335.1-canary.1937.14729137192.0
  npm install @salutejs/plasma-b2c@1.577.1-canary.1937.14729137192.0
  npm install @salutejs/plasma-giga@0.304.1-canary.1937.14729137192.0
  npm install @salutejs/plasma-hope@1.339.1-canary.1937.14729137192.0
  npm install @salutejs/plasma-new-hope@0.321.1-canary.1937.14729137192.0
  npm install @salutejs/plasma-ui@1.315.1-canary.1937.14729137192.0
  npm install @salutejs/plasma-web@1.579.1-canary.1937.14729137192.0
  npm install @salutejs/sdds-clfd-auto@0.308.1-canary.1937.14729137192.0
  npm install @salutejs/sdds-cs@0.313.1-canary.1937.14729137192.0
  npm install @salutejs/sdds-dfa@0.307.1-canary.1937.14729137192.0
  npm install @salutejs/sdds-finportal@0.300.1-canary.1937.14729137192.0
  npm install @salutejs/sdds-insol@0.304.1-canary.1937.14729137192.0
  npm install @salutejs/sdds-serv@0.308.1-canary.1937.14729137192.0
  npm install @salutejs/plasma-themes@0.32.1-canary.1937.14729137192.0
  npm install @salutejs/sdds-themes@0.35.1-canary.1937.14729137192.0
  npm install @salutejs/plasma-sb-utils@0.196.1-canary.1937.14729137192.0
  # or 
  yarn add @salutejs/plasma-asdk@0.335.1-canary.1937.14729137192.0
  yarn add @salutejs/plasma-b2c@1.577.1-canary.1937.14729137192.0
  yarn add @salutejs/plasma-giga@0.304.1-canary.1937.14729137192.0
  yarn add @salutejs/plasma-hope@1.339.1-canary.1937.14729137192.0
  yarn add @salutejs/plasma-new-hope@0.321.1-canary.1937.14729137192.0
  yarn add @salutejs/plasma-ui@1.315.1-canary.1937.14729137192.0
  yarn add @salutejs/plasma-web@1.579.1-canary.1937.14729137192.0
  yarn add @salutejs/sdds-clfd-auto@0.308.1-canary.1937.14729137192.0
  yarn add @salutejs/sdds-cs@0.313.1-canary.1937.14729137192.0
  yarn add @salutejs/sdds-dfa@0.307.1-canary.1937.14729137192.0
  yarn add @salutejs/sdds-finportal@0.300.1-canary.1937.14729137192.0
  yarn add @salutejs/sdds-insol@0.304.1-canary.1937.14729137192.0
  yarn add @salutejs/sdds-serv@0.308.1-canary.1937.14729137192.0
  yarn add @salutejs/plasma-themes@0.32.1-canary.1937.14729137192.0
  yarn add @salutejs/sdds-themes@0.35.1-canary.1937.14729137192.0
  yarn add @salutejs/plasma-sb-utils@0.196.1-canary.1937.14729137192.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
