### PR TITLE
PLASMA-3890: Fix var name in textfield

### DIFF
--- a/packages/plasma-new-hope/src/components/NumberFormat/NumberFormat.tsx
+++ b/packages/plasma-new-hope/src/components/NumberFormat/NumberFormat.tsx
@@ -20,7 +20,7 @@ export const composeNumberFormat = <T extends InputComponentOmittedProps>(InputC
             };
 
             const InputComponentWithoutEllipsis = (props: T) => {
-                return <InputComponent _textEllipsisEnable {...props} />;
+                return <InputComponent _textEllipsisDisable {...props} />;
             };
 
             return (

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -342,7 +342,7 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldRootProps
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 // eslint-disable-next-line no-underscore-dangle
-                !(rest as any)._textEllipsisEnable && !textAfter ? classes.inputTextEllipsis : undefined;
+                !(rest as any)._textEllipsisDisable && !textAfter ? classes.inputTextEllipsis : undefined;
 
             return (
                 <Root


### PR DESCRIPTION
## Core

### Textfield

- Исправлено название переменной

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.336.1-canary.1953.15016453238.0
  npm install @salutejs/plasma-b2c@1.578.1-canary.1953.15016453238.0
  npm install @salutejs/plasma-giga@0.305.1-canary.1953.15016453238.0
  npm install @salutejs/plasma-new-hope@0.322.1-canary.1953.15016453238.0
  npm install @salutejs/plasma-web@1.580.1-canary.1953.15016453238.0
  npm install @salutejs/sdds-clfd-auto@0.309.1-canary.1953.15016453238.0
  npm install @salutejs/sdds-cs@0.314.1-canary.1953.15016453238.0
  npm install @salutejs/sdds-dfa@0.308.1-canary.1953.15016453238.0
  npm install @salutejs/sdds-finportal@0.301.1-canary.1953.15016453238.0
  npm install @salutejs/sdds-insol@0.305.1-canary.1953.15016453238.0
  npm install @salutejs/sdds-serv@0.309.1-canary.1953.15016453238.0
  # or 
  yarn add @salutejs/plasma-asdk@0.336.1-canary.1953.15016453238.0
  yarn add @salutejs/plasma-b2c@1.578.1-canary.1953.15016453238.0
  yarn add @salutejs/plasma-giga@0.305.1-canary.1953.15016453238.0
  yarn add @salutejs/plasma-new-hope@0.322.1-canary.1953.15016453238.0
  yarn add @salutejs/plasma-web@1.580.1-canary.1953.15016453238.0
  yarn add @salutejs/sdds-clfd-auto@0.309.1-canary.1953.15016453238.0
  yarn add @salutejs/sdds-cs@0.314.1-canary.1953.15016453238.0
  yarn add @salutejs/sdds-dfa@0.308.1-canary.1953.15016453238.0
  yarn add @salutejs/sdds-finportal@0.301.1-canary.1953.15016453238.0
  yarn add @salutejs/sdds-insol@0.305.1-canary.1953.15016453238.0
  yarn add @salutejs/sdds-serv@0.309.1-canary.1953.15016453238.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
