### PR TITLE
PLASMA-4904: update story and docs for NumberFormat

### DIFF
--- a/packages/sdds-cs/src/components/NumberFormat/NumberFormat.stories.tsx
+++ b/packages/sdds-cs/src/components/NumberFormat/NumberFormat.stories.tsx
@@ -164,7 +164,7 @@ export const Default: StoryObj<StoryPropsDefault> = {
         fixedDecimalScale: false,
         allowNegative: true,
         allowLeadingZeros: false,
-        size: 'l',
+        size: 's',
         view: 'default',
         label: 'Лейбл',
         labelPlacement: 'outer',

--- a/website/sdds-cs-docs/docs/components/NumberFormat.mdx
+++ b/website/sdds-cs-docs/docs/components/NumberFormat.mdx
@@ -26,19 +26,19 @@ export function App() {
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             <NumberFormat
-                size="l"
+                size="s"
                 thousandSeparator=" "
                 decimalSeparator="."
                 defaultValue="123456.789"
             />
             <NumberFormat
-                size="l"
+                size="s"
                 thousandSeparator="/"
                 decimalSeparator=","
                 defaultValue="123456,789"
             />
             <NumberFormat
-                size="l"
+                size="s"
                 thousandSeparator=","
                 decimalSeparator="$"
                 defaultValue="123456$789"
@@ -63,25 +63,25 @@ export function App() {
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             <NumberFormat
-                size="l"
+                size="s"
                 thousandSeparator=" "
                 defaultValue="123456789"
                 thousandsGroupStyle="thousand"
             />
             <NumberFormat
-                size="l"
+                size="s"
                 thousandSeparator=" "
                 defaultValue="123456789"
                 thousandsGroupStyle="lakh"
             />
             <NumberFormat
-                size="l"
+                size="s"
                 thousandSeparator=" "
                 defaultValue="123456789"
                 thousandsGroupStyle="wan"
             />
             <NumberFormat
-                size="l"
+                size="s"
                 thousandSeparator=" "
                 defaultValue="123456789"
                 thousandsGroupStyle="none"
@@ -103,7 +103,7 @@ export function App() {
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             <NumberFormat
-                size="l"
+                size="s"
                 defaultValue="123"
                 thousandSeparator=" "
                 decimalSeparator="."
@@ -111,7 +111,7 @@ export function App() {
                 fixedDecimalScale
             />
             <NumberFormat
-                size="l"
+                size="s"
                 defaultValue="123.1"
                 thousandSeparator=" "
                 decimalSeparator="."
@@ -134,7 +134,7 @@ export function App() {
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             <NumberFormat
-                size="l"
+                size="s"
                 defaultValue="-123"
                 thousandSeparator=" "
                 decimalSeparator="."
@@ -156,7 +156,7 @@ export function App() {
     return (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
             <NumberFormat
-                size="l"
+                size="s"
                 defaultValue="000123.456"
                 thousandSeparator=" "
                 decimalSeparator="."


### PR DESCRIPTION
## SDDS-CS

### NumberFormat

- исправлены значения свойства `size` в примерах документации и storybook

### What/why changed

Исправлен размер в документации и в сторибуке

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-cs@0.316.0-canary.1961.15024816740.0
  # or 
  yarn add @salutejs/sdds-cs@0.316.0-canary.1961.15024816740.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
