### PR TITLE
PLASMA-5079: fix incorrect behaviour in readOnly mode in TextField

### DIFF
--- a/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-b2c/src/components/TextField/TextField.stories.tsx
@@ -21,7 +21,7 @@ const hintViews = ['default'];
 const hintSizes = ['m', 's'];
 const hintTriggers = ['hover', 'click'];
 const hintTargetPlacements = ['outer', 'inner'];
-const labelPlacements = ['label', 'placeholder'];
+const labelPlacements = ['outer', 'inner'];
 const placements: Array<PopoverPlacement> = [
     'top',
     'top-start',
@@ -107,12 +107,6 @@ const meta: Meta<typeof TextField> = {
             options: { ...TextFieldView, ...{ empty: '' } },
             control: {
                 type: 'select',
-            },
-        },
-        animatedHint: {
-            options: labelPlacements,
-            control: {
-                type: 'inline-radio',
             },
         },
         maxLength: {
@@ -339,7 +333,6 @@ export const Default: StoryObj<StoryPropsDefault> = {
         size: 'l',
         view: 'default',
         label: 'Лейбл',
-        animatedHint: undefined,
         labelPlacement: 'outer',
         keepPlaceholder: false,
         titleCaption: 'Подпись к полю',

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tokens.ts
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tokens.ts
@@ -16,6 +16,7 @@ export const classes = {
     inputWrapper: 'input-wrapper',
     inputTextEllipsis: 'textfield-input-text-ellipsis',
     contentRightCompensationMargin: 'textfield-content-right-compensation-margin',
+    readOnlyInput: 'textfield-readonly-input',
 };
 
 export const tokens = {

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tsx
@@ -499,7 +499,12 @@ export const textFieldRoot = (Root: RootProps<HTMLDivElement, TextFieldRootProps
                                     aria-labelledby={labelId}
                                     aria-describedby={helperTextId}
                                     placeholder={innerPlaceholderValue}
-                                    className={cx(hasValueClass, keepPlaceholderClass, classTextEllipsis)}
+                                    className={cx(
+                                        hasValueClass,
+                                        keepPlaceholderClass,
+                                        classTextEllipsis,
+                                        readOnly && classes.readOnlyInput,
+                                    )}
                                     disabled={disabled}
                                     readOnly={!disabled && readOnly}
                                     onInput={handleInput}

--- a/packages/plasma-new-hope/src/components/TextField/variations/_label-placement/base.ts
+++ b/packages/plasma-new-hope/src/components/TextField/variations/_label-placement/base.ts
@@ -18,7 +18,7 @@ export const base = css`
         }
 
         /* поднимает label вверх при фокусе, наличии значения */
-        ${Input}:focus ~ ${Label}, ${Input}.${classes.hasValue} ~ ${Label}, ${Input}.${classes.keepPlaceholder} ~ ${Label} {
+        ${Input}:not(.${classes.readOnlyInput}):focus ~ ${Label}, ${Input}.${classes.hasValue} ~ ${Label}, ${Input}.${classes.keepPlaceholder} ~ ${Label} {
             color: var(${tokens.placeholderColor});
             align-items: flex-start;
             padding: var(${tokens.labelInnerPadding});

--- a/packages/plasma-web/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.stories.tsx
@@ -364,7 +364,7 @@ export const Default: StoryObj<StoryPropsDefault> = {
     },
     parameters: {
         controls: {
-            exclude: ['chipType'],
+            exclude: ['chipType', 'labelPlacement'],
         },
     },
     render: (args) => <StoryDemo {...args} />,


### PR DESCRIPTION
## Core

### TextField
- исправлено некорректное поведение фокуса в режиме `readOnly`;

### What/why changed
Оригинально баг был в текстфилде, соответственно из селекта баг тоже изчез.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.337.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-b2c@1.579.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-core@1.196.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-giga@0.306.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-hope@1.340.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-new-hope@0.323.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-tokens-b2b@1.48.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-tokens-b2c@0.59.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-ui@1.316.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-web@1.581.1-canary.1971.15205193916.0
  npm install @salutejs/sdds-clfd-auto@0.310.1-canary.1971.15205193916.0
  npm install @salutejs/sdds-crm@0.310.1-canary.1971.15205193916.0
  npm install @salutejs/sdds-cs@0.315.1-canary.1971.15205193916.0
  npm install @salutejs/sdds-dfa@0.309.1-canary.1971.15205193916.0
  npm install @salutejs/sdds-finportal@0.302.1-canary.1971.15205193916.0
  npm install @salutejs/sdds-insol@0.306.1-canary.1971.15205193916.0
  npm install @salutejs/sdds-netology@0.310.1-canary.1971.15205193916.0
  npm install @salutejs/sdds-serv@0.310.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-cy-utils@0.127.1-canary.1971.15205193916.0
  npm install @salutejs/plasma-sb-utils@0.197.1-canary.1971.15205193916.0
  # or 
  yarn add @salutejs/plasma-asdk@0.337.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-b2c@1.579.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-core@1.196.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-giga@0.306.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-hope@1.340.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-new-hope@0.323.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-tokens-b2b@1.48.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-tokens-b2c@0.59.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-ui@1.316.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-web@1.581.1-canary.1971.15205193916.0
  yarn add @salutejs/sdds-clfd-auto@0.310.1-canary.1971.15205193916.0
  yarn add @salutejs/sdds-crm@0.310.1-canary.1971.15205193916.0
  yarn add @salutejs/sdds-cs@0.315.1-canary.1971.15205193916.0
  yarn add @salutejs/sdds-dfa@0.309.1-canary.1971.15205193916.0
  yarn add @salutejs/sdds-finportal@0.302.1-canary.1971.15205193916.0
  yarn add @salutejs/sdds-insol@0.306.1-canary.1971.15205193916.0
  yarn add @salutejs/sdds-netology@0.310.1-canary.1971.15205193916.0
  yarn add @salutejs/sdds-serv@0.310.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-cy-utils@0.127.1-canary.1971.15205193916.0
  yarn add @salutejs/plasma-sb-utils@0.197.1-canary.1971.15205193916.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
