### PR TITLE
PLASMA-5150: add frame as id to Popover

### DIFF
--- a/packages/plasma-new-hope/src/components/Popover/Popover.tsx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.tsx
@@ -202,6 +202,10 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
                     portal = frame.current;
                 }
 
+                if (typeof frame === 'string' && frame) {
+                    portal = document.getElementById(frame);
+                }
+
                 if (!usePortal && isValidElement(target)) {
                     portal = rootRef.current;
                 }


### PR DESCRIPTION
## Core

### Popover

- добавлена обработка случая, когда frame передан как ID

### What/why changed

При создании ref на портал не учитывался случай, когда во frame передавался ID портала. Из-за чего рендер Popover происходил не в ожидаемом месте

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.338.1-canary.2001.15297455776.0
  npm install @salutejs/plasma-b2c@1.580.1-canary.2001.15297455776.0
  npm install @salutejs/plasma-giga@0.307.1-canary.2001.15297455776.0
  npm install @salutejs/plasma-hope@1.341.1-canary.2001.15297455776.0
  npm install @salutejs/plasma-icons@1.217.1-canary.2001.15297455776.0
  npm install @salutejs/plasma-new-hope@0.324.1-canary.2001.15297455776.0
  npm install @salutejs/plasma-ui@1.317.1-canary.2001.15297455776.0
  npm install @salutejs/plasma-web@1.582.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-clfd-auto@0.311.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-crm@0.311.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-cs@0.316.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-dfa@0.310.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-finportal@0.303.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-insol@0.307.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-netology@0.311.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-scan@0.310.1-canary.2001.15297455776.0
  npm install @salutejs/sdds-serv@0.311.1-canary.2001.15297455776.0
  # or 
  yarn add @salutejs/plasma-asdk@0.338.1-canary.2001.15297455776.0
  yarn add @salutejs/plasma-b2c@1.580.1-canary.2001.15297455776.0
  yarn add @salutejs/plasma-giga@0.307.1-canary.2001.15297455776.0
  yarn add @salutejs/plasma-hope@1.341.1-canary.2001.15297455776.0
  yarn add @salutejs/plasma-icons@1.217.1-canary.2001.15297455776.0
  yarn add @salutejs/plasma-new-hope@0.324.1-canary.2001.15297455776.0
  yarn add @salutejs/plasma-ui@1.317.1-canary.2001.15297455776.0
  yarn add @salutejs/plasma-web@1.582.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-clfd-auto@0.311.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-crm@0.311.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-cs@0.316.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-dfa@0.310.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-finportal@0.303.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-insol@0.307.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-netology@0.311.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-scan@0.310.1-canary.2001.15297455776.0
  yarn add @salutejs/sdds-serv@0.311.1-canary.2001.15297455776.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
