### PR TITLE
PLASMA-5177: Simplify test diff artefacts structure

### DIFF
--- a/.github/workflows/cypress-by-cron-every-day.yml
+++ b/.github/workflows/cypress-by-cron-every-day.yml
@@ -32,6 +32,5 @@ jobs:
       scope: ${{ matrix.scope }}
       prefix: "sdds"
       with-react-17: true
-      with-artifacts: true
     secrets: inherit
 

--- a/.github/workflows/cypress-common.yml
+++ b/.github/workflows/cypress-common.yml
@@ -49,7 +49,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 45
-          max_attempts: 3
+          max_attempts: 2
           retry_on: error
           command: |
             if [ "${{ inputs.prefix }}" = "plasma" ]; then
@@ -57,20 +57,42 @@ jobs:
             else
               npx lerna bootstrap --scope=@salutejs/plasma-${{env.SCOPE}} --scope="@salutejs/platform-test" --scope="@salutejs/core-themes" --scope="@salutejs/${{ inputs.prefix }}-{${{ inputs.scope }},themes}"
             fi
-          
+
       - name: Run Cypress CT for Plasma ${{ inputs.scope }}
         if: ${{ success() }}
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 120
-          max_attempts: 3
+          max_attempts: 2
           retry_on: error
           command: npm run cy:${{ inputs.scope }}:run-ct
+
+      - name: Reorganize diff artifacts
+        if: ${{ failure() || inputs.with-artifacts }}
+        run: |
+          mkdir -p /tmp/artifacts
+            find /home/runner/work/plasma/plasma/cypress/snapshots -name "__diff_output__" -type d | while read dir; do
+            # Извлекаем package name из пути
+            package=$(echo "$dir" | sed 's|.*/snapshots/\([^/]*\)/.*|\1|')
+
+            # Проверяем, содержит ли путь /components/ и извлекаем component name
+            if [[ "$dir" == *"/components/"* ]]; then
+              component=$(echo "$dir" | sed 's|.*/components/\([^/]*\)/.*|\1|')
+            else
+              # Если нет /components/, берем последнюю значимую часть пути перед __diff_output__
+              component=$(echo "$dir" | sed 's|/__diff_output__$||' | sed 's|.*/||')
+            fi
+
+            target_dir="/tmp/artifacts/${package}/${component}"
+            mkdir -p "$target_dir"
+
+            cp "$dir"/* "$target_dir"/ 2>/dev/null || true
+          done
 
       - name: Save artifacts
         if: ${{ failure() || inputs.with-artifacts }}
         uses: actions/upload-artifact@v4
         with:
-          name: Test_Artifacts_${{ inputs.scope }}_
-          path: /home/runner/work/plasma/plasma/cypress
+          name: Failures_Tests_Artifact_${{ inputs.scope }}_
+          path: /tmp/artifacts/
           overwrite: true


### PR DESCRIPTION
### What/why changed

Сохраняем только скриншоты упавших тестов, сама структура стало проще    

```md
Package/Component/
 └── diff.png
``` 

ранее сохраняли всю директорию cypress, что было избыточно      

### Стало

<img width="1024" height="858" src="https://github.com/user-attachments/assets/0a069cc2-5f29-450a-8633-f30bb9b9ea5d" />
 


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.350.1-canary.2007.18030906219.0
  npm install @salutejs/plasma-b2c@1.592.1-canary.2007.18030906219.0
  npm install @salutejs/plasma-giga@0.319.1-canary.2007.18030906219.0
  npm install @salutejs/plasma-new-hope@0.336.1-canary.2007.18030906219.0
  npm install @salutejs/plasma-web@1.594.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-bizcom@0.324.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-crm@0.323.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-cs@0.328.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-dfa@0.322.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-finai@0.315.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-insol@0.319.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-netology@0.323.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-scan@0.322.1-canary.2007.18030906219.0
  npm install @salutejs/sdds-serv@0.323.1-canary.2007.18030906219.0
  # or 
  yarn add @salutejs/plasma-asdk@0.350.1-canary.2007.18030906219.0
  yarn add @salutejs/plasma-b2c@1.592.1-canary.2007.18030906219.0
  yarn add @salutejs/plasma-giga@0.319.1-canary.2007.18030906219.0
  yarn add @salutejs/plasma-new-hope@0.336.1-canary.2007.18030906219.0
  yarn add @salutejs/plasma-web@1.594.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-bizcom@0.324.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-crm@0.323.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-cs@0.328.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-dfa@0.322.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-finai@0.315.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-insol@0.319.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-netology@0.323.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-scan@0.322.1-canary.2007.18030906219.0
  yarn add @salutejs/sdds-serv@0.323.1-canary.2007.18030906219.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
