### PR TITLE
PLASMA-5202: add canUseDOM check to useOverflow

### DIFF
--- a/packages/plasma-new-hope/src/components/Sheet/hooks/useOverflow.ts
+++ b/packages/plasma-new-hope/src/components/Sheet/hooks/useOverflow.ts
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from 'react';
+import { canUseDOM } from 'src/utils';
 
 import { SheetHookArgs } from '../Sheet.types';
 
 export const useOverflow = ({ opened }: SheetHookArgs) => {
-    const overflow = useRef<string>(document.body.style.overflowY);
+    const overflow = useRef<string>(canUseDOM ? document.body.style.overflowY : 'initial');
 
     // linaria не поддерживает динамический global
     useEffect(() => {


### PR DESCRIPTION
## Core

### Sheet

- добавлена проверка `canUseDOM` перед использованием document

### What/why changed

Без проверки canUseDOM нельзя обращаться к document, иначе падает Next