### PR TITLE
PLASMA-5169: change popup items to map

### DIFF
--- a/packages/plasma-giga/src/components/Modal/Modal.stories.tsx
+++ b/packages/plasma-giga/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 

--- a/packages/plasma-new-hope/src/components/Drawer/Drawer.tsx
+++ b/packages/plasma-new-hope/src/components/Drawer/Drawer.tsx
@@ -1,11 +1,11 @@
 import React, { forwardRef, useMemo } from 'react';
-import { useForkRef, safeUseId } from '@salutejs/plasma-core';
+import { useForkRef } from '@salutejs/plasma-core';
+import { cx, getSizeValueFromProp, safeUseId } from 'src/utils';
+import type { RootProps } from 'src/engines';
 
-import type { RootProps } from '../../engines';
 import { usePopupContext } from '../Popup';
 import { Overlay } from '../Overlay';
 import { DEFAULT_Z_INDEX } from '../Popup/utils';
-import { cx, getSizeValueFromProp } from '../../utils';
 import { useFocusTrap } from '../../hooks';
 
 import { classes, tokens } from './Drawer.tokens';
@@ -79,7 +79,7 @@ export const drawerRoot = (Root: RootProps<HTMLDivElement, DrawerProps>) =>
                 popupInfo,
                 disableScroll: asModal,
             });
-            const transparent = useMemo(() => getIdLastDrawer(popupController.items) !== innerId, [
+            const transparent = useMemo(() => getIdLastDrawer(Array.from(popupController.items.values())) !== innerId, [
                 innerId,
                 popupController.items,
             ]);

--- a/packages/plasma-new-hope/src/components/Drawer/hooks/useDrawer.ts
+++ b/packages/plasma-new-hope/src/components/Drawer/hooks/useDrawer.ts
@@ -25,7 +25,10 @@ export const useDrawer = ({
             if (!closeOnEsc) {
                 return;
             }
-            if (event.keyCode === ESCAPE_KEYCODE && getIdLastDrawer(popupController.items) === id) {
+            if (
+                event.keyCode === ESCAPE_KEYCODE &&
+                getIdLastDrawer(Array.from(popupController.items.values())) === id
+            ) {
                 if (onEscKeyDown) {
                     onEscKeyDown(event);
                     return;
@@ -64,7 +67,7 @@ export const useDrawer = ({
             return;
         }
 
-        if (!isOpen && !hasDrawers(popupController.items)) {
+        if (!isOpen && !hasDrawers(Array.from(popupController.items.values()))) {
             document.body.style.overflow = overflow.current;
         }
     }, [isOpen, popupController.items]);

--- a/packages/plasma-new-hope/src/components/Modal/Modal.tsx
+++ b/packages/plasma-new-hope/src/components/Modal/Modal.tsx
@@ -1,11 +1,12 @@
 import React, { forwardRef, useCallback, useMemo } from 'react';
-import { useForkRef, safeUseId } from '@salutejs/plasma-core';
+import { useForkRef } from '@salutejs/plasma-core';
+import { safeUseId } from 'src/utils';
+import { RootProps, component } from 'src/engines';
+import { useFocusTrap } from 'src/hooks';
 
-import { RootProps, component } from '../../engines';
 import { popupConfig, usePopupContext } from '../Popup';
 import { Overlay } from '../Overlay';
 import { DEFAULT_Z_INDEX } from '../Popup/utils';
-import { useFocusTrap } from '../../hooks';
 import { IconClose } from '../_Icon/Icons/IconClose';
 
 import { classes, tokens } from './Modal.tokens';
@@ -70,7 +71,7 @@ export const modalRoot = (Root: RootProps<HTMLDivElement, ModalProps>) =>
                 popupInfo,
             });
 
-            const transparent = useMemo(() => getIdLastModal(popupController.items) !== innerId, [
+            const transparent = useMemo(() => getIdLastModal(Array.from(popupController.items.values())) !== innerId, [
                 innerId,
                 popupController.items,
             ]);

--- a/packages/plasma-new-hope/src/components/Modal/hooks/useModal.ts
+++ b/packages/plasma-new-hope/src/components/Modal/hooks/useModal.ts
@@ -15,7 +15,7 @@ export const useModal = ({ id, popupInfo, onEscKeyDown, onClose, closeOnEsc = tr
             if (!closeOnEsc) {
                 return;
             }
-            if (event.keyCode === ESCAPE_KEYCODE && getIdLastModal(popupController.items) === id) {
+            if (event.keyCode === ESCAPE_KEYCODE && getIdLastModal(Array.from(popupController.items.values())) === id) {
                 if (onEscKeyDown) {
                     onEscKeyDown(event);
                     return;

--- a/packages/plasma-new-hope/src/components/Popup/Popup.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef, useRef } from 'react';
-import { useForkRef, safeUseId } from '@salutejs/plasma-core';
+import { useForkRef } from '@salutejs/plasma-core';
+import { canUseDOM, cx, safeUseId } from 'src/utils';
+import { RootProps } from 'src/engines/types';
 
-import { RootProps } from '../../engines/types';
-import { canUseDOM, cx } from '../../utils';
 import { Portal } from '../Portal';
 
 import type { PopupPlacementBasic, PopupPlacement, PopupPositionType, PopupProps } from './Popup.types';

--- a/packages/plasma-new-hope/src/components/Popup/Popup.types.ts
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.types.ts
@@ -8,7 +8,7 @@ export interface PopupInfo {
 }
 
 export interface PopupContextType {
-    items: PopupInfo[];
+    items: Map<string, PopupInfo>;
     rootId: string;
     register: (info: PopupInfo) => void;
     unregister: (id: string) => void;

--- a/packages/sdds-crm/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-crm/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 

--- a/packages/sdds-cs/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-cs/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 

--- a/packages/sdds-dfa/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-dfa/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 

--- a/packages/sdds-finportal/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-finportal/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 

--- a/packages/sdds-insol/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-insol/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 

--- a/packages/sdds-netology/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-netology/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 

--- a/packages/sdds-scan/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-scan/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 

--- a/packages/sdds-serv/src/components/Modal/Modal.stories.tsx
+++ b/packages/sdds-serv/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { Meta, StoryObj } from '@storybook/react';
 import { InSpacingDecorator, disableProps } from '@salutejs/plasma-sb-utils';
 


### PR DESCRIPTION
## Core

### Popup, Modal, Drawer

- массив элементов контекста Popup заменен на Map
- исправлен импорт safeUseId

### What/why changed

При использовании useQuery из RTK происходило дублирование ID в массиве items PopupProvider. Чтобы исправить это поведение, массив был заменен на Map и были исправлены импорты
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.341.0-canary.2022.15758717316.0
  npm install @salutejs/plasma-b2c@1.583.0-canary.2022.15758717316.0
  npm install @salutejs/plasma-giga@0.310.0-canary.2022.15758717316.0
  npm install @salutejs/plasma-new-hope@0.327.0-canary.2022.15758717316.0
  npm install @salutejs/plasma-ui@1.320.0-canary.2022.15758717316.0
  npm install @salutejs/plasma-web@1.585.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-clfd-auto@0.314.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-crm@0.314.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-cs@0.319.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-dfa@0.313.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-finportal@0.306.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-insol@0.310.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-netology@0.314.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-scan@0.313.0-canary.2022.15758717316.0
  npm install @salutejs/sdds-serv@0.314.0-canary.2022.15758717316.0
  # or 
  yarn add @salutejs/plasma-asdk@0.341.0-canary.2022.15758717316.0
  yarn add @salutejs/plasma-b2c@1.583.0-canary.2022.15758717316.0
  yarn add @salutejs/plasma-giga@0.310.0-canary.2022.15758717316.0
  yarn add @salutejs/plasma-new-hope@0.327.0-canary.2022.15758717316.0
  yarn add @salutejs/plasma-ui@1.320.0-canary.2022.15758717316.0
  yarn add @salutejs/plasma-web@1.585.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-clfd-auto@0.314.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-crm@0.314.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-cs@0.319.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-dfa@0.313.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-finportal@0.306.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-insol@0.310.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-netology@0.314.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-scan@0.313.0-canary.2022.15758717316.0
  yarn add @salutejs/sdds-serv@0.314.0-canary.2022.15758717316.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
