### PR TITLE
HOTFIX DEV: 30.06.2025

### DIFF
--- a/packages/plasma-new-hope/package.json
+++ b/packages/plasma-new-hope/package.json
@@ -33,7 +33,7 @@
     "build:styled-components:esm": "rm -rf styled-components/es && swc ./src-sc -d ./styled-components/es --strip-leading-paths --config-file ./swc-sc.config.json -C module.type=es6",
     "postbuild:styled-components": "rm -rf src-sc",
     "postbuild:emotion": "rm -rf src-emotion",
-    "generate:typings": "tsc --outDir types --emitDeclarationOnly && tsc-alias",
+    "generate:typings": "rm -rf types && tsc && tsc-alias",
     "storybook": "storybook dev -p ${PORT:-7002} -c .storybook",
     "prestorybook:emotion": "npm run prebuild:emotion",
     "storybook:emotion": "USE_EMOTION_COMPONENTS=true storybook dev -p ${PORT:-7002} -c .storybook",

--- a/packages/plasma-new-hope/tsconfig.json
+++ b/packages/plasma-new-hope/tsconfig.json
@@ -9,6 +9,7 @@
         "sourceMap": true,
         "importHelpers": false,
         "downlevelIteration": true,
+        "emitDeclarationOnly": true,
 
         /* Strict Type-Checking Options */
         "strict": true,
@@ -34,8 +35,9 @@
         /* Advanced Options */
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
-        "outDir": "./",
+        "outDir": "./types",
         "rootDir": "./src",
+        "baseUrl": ".",
         "paths": {
             "src/*": ["./src/*"]
         }


### PR DESCRIPTION
### What/why changed
Убираем тесты для 17-го реакта.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.341.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-b2c@1.583.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-core@1.199.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-giga@0.310.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-hope@1.344.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-new-hope@0.327.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-ui@1.320.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-web@1.585.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-bizcom@0.314.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-clfd-auto@0.314.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-crm@0.314.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-cs@0.319.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-dfa@0.313.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-finportal@0.306.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-insol@0.310.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-netology@0.314.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-scan@0.313.1-canary.2055.15970067600.0
  npm install @salutejs/sdds-serv@0.314.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-cy-utils@0.130.1-canary.2055.15970067600.0
  npm install @salutejs/plasma-sb-utils@0.200.1-canary.2055.15970067600.0
  # or 
  yarn add @salutejs/plasma-asdk@0.341.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-b2c@1.583.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-core@1.199.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-giga@0.310.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-hope@1.344.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-new-hope@0.327.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-ui@1.320.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-web@1.585.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-bizcom@0.314.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-clfd-auto@0.314.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-crm@0.314.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-cs@0.319.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-dfa@0.313.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-finportal@0.306.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-insol@0.310.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-netology@0.314.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-scan@0.313.1-canary.2055.15970067600.0
  yarn add @salutejs/sdds-serv@0.314.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-cy-utils@0.130.1-canary.2055.15970067600.0
  yarn add @salutejs/plasma-sb-utils@0.200.1-canary.2055.15970067600.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
