### PR TITLE
PLASMA-5310: add check for value update in DatePicker

### DIFF
--- a/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.tsx
@@ -486,19 +486,27 @@ export const datePickerRangeRoot = (
             }, [calendarFirstValue, calendarSecondValue]);
 
             useLayoutEffect(() => {
-                updateExternalFirstDate(startExternalValue || undefined);
+                if (!defaultFirstDate) {
+                    updateExternalFirstDate(startExternalValue || undefined);
+                }
             }, [startExternalValue, format, lang]);
 
             useLayoutEffect(() => {
-                updateExternalSecondDate(endExternalValue || undefined);
+                if (!defaultSecondDate) {
+                    updateExternalSecondDate(endExternalValue || undefined);
+                }
             }, [endExternalValue, format, lang]);
 
             useLayoutEffect(() => {
-                updateExternalFirstDate(defaultFirstDate);
+                if (!startExternalValue) {
+                    updateExternalFirstDate(defaultFirstDate);
+                }
             }, [defaultFirstDate, format, lang]);
 
             useLayoutEffect(() => {
-                updateExternalSecondDate(defaultSecondDate);
+                if (!endExternalValue) {
+                    updateExternalSecondDate(defaultSecondDate);
+                }
             }, [defaultSecondDate, format, lang]);
 
             const RootWrapper = useCallback<RootWrapperProps>(

--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
@@ -256,11 +256,15 @@ export const datePickerRoot = (
             }, [opened]);
 
             useLayoutEffect(() => {
-                updateExternalDate(value);
+                if (!defaultDate) {
+                    updateExternalDate(value);
+                }
             }, [value, format, lang]);
 
             useLayoutEffect(() => {
-                updateExternalDate(defaultDate);
+                if (!value) {
+                    updateExternalDate(defaultDate);
+                }
             }, [defaultDate, format, lang]);
 
             return (


### PR DESCRIPTION
## Core

### DatePicker

- добавлена проверка при обновлении value/defaultValue

**Before**:

https://github.com/user-attachments/assets/fea399b1-8225-4b39-889b-b332664a4bcc

**After**:
https://github.com/user-attachments/assets/2e733867-15fb-4818-97f1-f0c024dc37cb

### What/why changed

Когда DatePicker используется внутри Drawer происходит анмаунт и маунт при закрытии и повторном открытии Drawer. Возникал конфликт при апдейте value/defaultValue.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.343.0-canary.2058.15994236534.0
  npm install @salutejs/plasma-b2c@1.585.0-canary.2058.15994236534.0
  npm install @salutejs/plasma-giga@0.312.0-canary.2058.15994236534.0
  npm install @salutejs/plasma-new-hope@0.329.0-canary.2058.15994236534.0
  npm install @salutejs/plasma-web@1.587.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-bizcom@0.316.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-clfd-auto@0.316.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-crm@0.316.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-cs@0.321.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-dfa@0.315.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-finportal@0.308.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-insol@0.312.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-netology@0.316.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-scan@0.315.0-canary.2058.15994236534.0
  npm install @salutejs/sdds-serv@0.316.0-canary.2058.15994236534.0
  # or 
  yarn add @salutejs/plasma-asdk@0.343.0-canary.2058.15994236534.0
  yarn add @salutejs/plasma-b2c@1.585.0-canary.2058.15994236534.0
  yarn add @salutejs/plasma-giga@0.312.0-canary.2058.15994236534.0
  yarn add @salutejs/plasma-new-hope@0.329.0-canary.2058.15994236534.0
  yarn add @salutejs/plasma-web@1.587.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-bizcom@0.316.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-clfd-auto@0.316.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-crm@0.316.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-cs@0.321.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-dfa@0.315.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-finportal@0.308.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-insol@0.312.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-netology@0.316.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-scan@0.315.0-canary.2058.15994236534.0
  yarn add @salutejs/sdds-serv@0.316.0-canary.2058.15994236534.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
