### PR TITLE
PLASMA-5353: support themes: bcp,procom [sdds-bizcom]

### DIFF
--- a/packages/sdds-bizcom/.storybook/decoratorThemes.tsx
+++ b/packages/sdds-bizcom/.storybook/decoratorThemes.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import type { Decorator } from '@storybook/react';
 import { createGlobalStyle } from 'styled-components';
-import { sdds_bizcom__light, sdds_bizcom__dark } from '@salutejs/sdds-themes';
+import {
+    sdds_bizcom__light,
+    sdds_bizcom__dark,
+    sdds_procom__light,
+    sdds_procom__dark,
+    sdds_bcp__light,
+    sdds_bcp__dark,
+} from '@salutejs/sdds-themes';
 
 import { ViewContainer } from '../src/components/ViewContainer/ViewContainer';
 
@@ -28,6 +35,10 @@ const DocumentStyle = createGlobalStyle`
 
 export const SDDS_BIZCOM_LIGHT_THEME = 'sdds-bizcom:light';
 export const SDDS_BIZCOM_DARK_THEME = 'sdds-bizcom:dark';
+export const SDDS_PROCOM_LIGHT_THEME = 'sdds-procom:light';
+export const SDDS_PROCOM_DARK_THEME = 'sdds-procom:dark';
+export const SDDS_BCP_LIGHT_THEME = 'sdds-bcp:light';
+export const SDDS_BCP_DARK_THEME = 'sdds-bcp:dark';
 export const DEFAULT_MODE = 'default';
 export const ON_DARK_MODE = 'onDark';
 export const ON_LIGHT_MODE = 'onLight';
@@ -35,6 +46,10 @@ export const ON_LIGHT_MODE = 'onLight';
 const themes = {
     [SDDS_BIZCOM_LIGHT_THEME]: createGlobalStyle(sdds_bizcom__light),
     [SDDS_BIZCOM_DARK_THEME]: createGlobalStyle(sdds_bizcom__dark),
+    [SDDS_PROCOM_LIGHT_THEME]: createGlobalStyle(sdds_procom__light),
+    [SDDS_PROCOM_DARK_THEME]: createGlobalStyle(sdds_procom__dark),
+    [SDDS_BCP_LIGHT_THEME]: createGlobalStyle(sdds_bcp__light),
+    [SDDS_BCP_DARK_THEME]: createGlobalStyle(sdds_bcp__dark),
 };
 
 type ViewType = {

--- a/packages/sdds-bizcom/.storybook/preview.tsx
+++ b/packages/sdds-bizcom/.storybook/preview.tsx
@@ -6,6 +6,10 @@ import {
     withTheme,
     SDDS_BIZCOM_DARK_THEME,
     SDDS_BIZCOM_LIGHT_THEME,
+    SDDS_PROCOM_LIGHT_THEME,
+    SDDS_PROCOM_DARK_THEME,
+    SDDS_BCP_LIGHT_THEME,
+    SDDS_BCP_DARK_THEME,
     DEFAULT_MODE,
     ON_DARK_MODE,
     ON_LIGHT_MODE,
@@ -25,7 +29,14 @@ const preview: Preview = {
             defaultValue: SDDS_BIZCOM_LIGHT_THEME,
             toolbar: {
                 title: 'Theme',
-                items: [SDDS_BIZCOM_LIGHT_THEME, SDDS_BIZCOM_DARK_THEME],
+                items: [
+                    SDDS_BIZCOM_LIGHT_THEME,
+                    SDDS_BIZCOM_DARK_THEME,
+                    SDDS_PROCOM_LIGHT_THEME,
+                    SDDS_PROCOM_DARK_THEME,
+                    SDDS_BCP_LIGHT_THEME,
+                    SDDS_BCP_DARK_THEME,
+                ],
             },
         },
         viewContainer: {

--- a/packages/sdds-bizcom/README.md
+++ b/packages/sdds-bizcom/README.md
@@ -134,6 +134,14 @@ export default function Home() {
     </li>
 </ul>
 
+**Примечание**:
+
+Пакет поддерживает работы с 3 темами:
+
+-   `sdds_bizcom__(dark/light)`
+-   `sdds_procom__(dark/light)`
+-   `sdds_bcp__(dark/light)`
+
 В файле, где происходит подключение всех стилей, например `index.css`
 
 ```css

--- a/packages/sdds-bizcom/src/components/Tokens/Colors/Colors.stories.tsx
+++ b/packages/sdds-bizcom/src/components/Tokens/Colors/Colors.stories.tsx
@@ -1,6 +1,13 @@
 import React, { FC } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
-import { sdds_bizcom__dark, sdds_bizcom__light } from '@salutejs/sdds-themes/es/themes';
+import {
+    sdds_bizcom__dark,
+    sdds_bizcom__light,
+    sdds_procom__light,
+    sdds_procom__dark,
+    sdds_bcp__light,
+    sdds_bcp__dark,
+} from '@salutejs/sdds-themes/es/themes';
 import { InSpacingDecorator, getGroupedTokens, upperFirstLetter } from '@salutejs/plasma-sb-utils';
 import type { GroupedTokens, TokenData } from '@salutejs/plasma-sb-utils';
 import { cx } from '@salutejs/plasma-new-hope';
@@ -45,6 +52,10 @@ export default meta;
 const themes: Record<string, GroupedTokens> = {
     'sdds-bizcom:light': getGroupedTokens(sdds_bizcom__light[0]),
     'sdds-bizcom:dark': getGroupedTokens(sdds_bizcom__dark[0]),
+    'sdds-procom:light': getGroupedTokens(sdds_procom__light[0]),
+    'sdds-procom:dark': getGroupedTokens(sdds_procom__dark[0]),
+    'sdds-bcp:light': getGroupedTokens(sdds_bcp__light[0]),
+    'sdds-bcp:dark': getGroupedTokens(sdds_bcp__dark[0]),
 };
 
 const ColorTokenData: FC<ColorTokenDataProps> = ({

--- a/packages/sdds-bizcom/src/components/Tokens/NumberTokens/CornerRadius.stories.tsx
+++ b/packages/sdds-bizcom/src/components/Tokens/NumberTokens/CornerRadius.stories.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
-import { sdds_bizcom__dark, sdds_bizcom__light } from '@salutejs/sdds-themes/es/themes';
+import {
+    sdds_bizcom__dark,
+    sdds_bizcom__light,
+    sdds_procom__light,
+    sdds_procom__dark,
+    sdds_bcp__light,
+    sdds_bcp__dark,
+} from '@salutejs/sdds-themes/es/themes';
 import { InSpacingDecorator, getGroupedSpacingTokens } from '@salutejs/plasma-sb-utils';
 import type { GroupedNumberTokens } from '@salutejs/plasma-sb-utils';
 
@@ -26,6 +33,10 @@ export default meta;
 const themes: Record<string, GroupedNumberTokens> = {
     'sdds-bizcom:light': getGroupedSpacingTokens(sdds_bizcom__light[0]),
     'sdds-bizcom:dark': getGroupedSpacingTokens(sdds_bizcom__dark[0]),
+    'sdds-procom:light': getGroupedSpacingTokens(sdds_procom__light[0]),
+    'sdds-procom:dark': getGroupedSpacingTokens(sdds_procom__dark[0]),
+    'sdds-bcp:light': getGroupedSpacingTokens(sdds_bcp__light[0]),
+    'sdds-bcp:dark': getGroupedSpacingTokens(sdds_bcp__dark[0]),
 };
 
 const StoryDemo = ({ context }) => {

--- a/packages/sdds-bizcom/src/components/Tokens/NumberTokens/Spacing.stories.tsx
+++ b/packages/sdds-bizcom/src/components/Tokens/NumberTokens/Spacing.stories.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
-import { sdds_bizcom__dark, sdds_bizcom__light } from '@salutejs/sdds-themes/es/themes';
+import {
+    sdds_bizcom__dark,
+    sdds_bizcom__light,
+    sdds_procom__light,
+    sdds_procom__dark,
+    sdds_bcp__light,
+    sdds_bcp__dark,
+} from '@salutejs/sdds-themes/es/themes';
 import { InSpacingDecorator, getGroupedCornerRadiusTokens } from '@salutejs/plasma-sb-utils';
 import type { GroupedNumberTokens } from '@salutejs/plasma-sb-utils';
 
@@ -26,6 +33,10 @@ export default meta;
 const themes: Record<string, GroupedNumberTokens> = {
     'sdds-bizcom:light': getGroupedCornerRadiusTokens(sdds_bizcom__light[0]),
     'sdds-bizcom:dark': getGroupedCornerRadiusTokens(sdds_bizcom__dark[0]),
+    'sdds-procom:light': getGroupedCornerRadiusTokens(sdds_procom__light[0]),
+    'sdds-procom:dark': getGroupedCornerRadiusTokens(sdds_procom__dark[0]),
+    'sdds-bcp:light': getGroupedCornerRadiusTokens(sdds_bcp__light[0]),
+    'sdds-bcp:dark': getGroupedCornerRadiusTokens(sdds_bcp__dark[0]),
 };
 
 const StoryDemo = ({ context }) => {

--- a/packages/sdds-bizcom/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-bizcom/src/components/Tokens/Typography/Typography.stories.tsx
@@ -1,12 +1,20 @@
 import React, { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
 import type { StoryObj, Meta } from '@storybook/react';
-import { sdds_bizcom__dark, sdds_bizcom__light } from '@salutejs/sdds-themes';
+import {
+    sdds_bizcom__dark,
+    sdds_bizcom__light,
+    sdds_procom__light,
+    sdds_procom__dark,
+    sdds_bcp__light,
+    sdds_bcp__dark,
+} from '@salutejs/sdds-themes';
 import {
     InSpacingDecorator,
     getGroupedTypographyTokens,
     typographyPangrams,
     upperFirstLetter,
     typographyToCssMap,
+    getGroupedTokens,
 } from '@salutejs/plasma-sb-utils';
 import type {
     TypographyStructure,
@@ -51,6 +59,10 @@ export default meta;
 const themes: Record<string, TypographyStructure> = {
     'sdds-bizcom:light': getGroupedTypographyTokens(sdds_bizcom__light[0]),
     'sdds-bizcom:dark': getGroupedTypographyTokens(sdds_bizcom__dark[0]),
+    'sdds-procom:light': getGroupedTypographyTokens(sdds_procom__light[0]),
+    'sdds-procom:dark': getGroupedTypographyTokens(sdds_procom__dark[0]),
+    'sdds-bcp:light': getGroupedTypographyTokens(sdds_bcp__light[0]),
+    'sdds-bcp:dark': getGroupedTypographyTokens(sdds_bcp__dark[0]),
 };
 
 type FontWeightControllerProps = {


### PR DESCRIPTION
## SDDS-BIZCOM

### Themes 

-   добавлена поддержка темы `sdds-procom`
-   добавлена поддержка темы `sdds-bcp`

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-bizcom@0.317.0-canary.2060.16049755319.0
  # or 
  yarn add @salutejs/sdds-bizcom@0.317.0-canary.2060.16049755319.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
