### PR TITLE
fix(icons): forward rest props in IconRoot component

### DIFF
--- a/packages/plasma-icons/scripts/utils.ts
+++ b/packages/plasma-icons/scripts/utils.ts
@@ -131,12 +131,14 @@ import { ${iconName} as Icon36 } from '../Icon.assets.36/${iconName}';
 import { IconProps, IconRoot, getIconComponent, sizeMap } from '../IconRoot';
 
 ${deprecationBlock}
-export const Icon${iconName}: React.FC<IconProps> = ({ size = 's', color, className }) => {
+export const Icon${iconName}: React.FC<IconProps> = ({ size = 's', color, className, ...rest }) => {
     const IconComponent = getIconComponent(Icon16, Icon24, Icon36, sizeMap[size].size);
+    
     if (!IconComponent) {
         return null;
     }
-    return <IconRoot className={className} size={size} color={color} icon={IconComponent} />;
+    
+    return <IconRoot className={className} size={size} color={color} icon={IconComponent} {...rest} />;
 };
 `;
 };

--- a/packages/plasma-icons/src/scalable/IconRoot.tsx
+++ b/packages/plasma-icons/src/scalable/IconRoot.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import type { CSSProperties } from 'react';
 import styled from 'styled-components';
 
@@ -26,7 +26,7 @@ export interface IconProps {
     style?: CSSProperties;
 }
 
-interface IconRootProps extends IconProps {
+interface IconRootProps extends IconProps, HTMLAttributes<HTMLDivElement> {
     size: IconSize;
     icon: React.FC<IconProps>;
 }
@@ -59,12 +59,15 @@ export const getIconComponent = (
     return icon16 || icon24 || icon36;
 };
 
-export const IconRoot: React.FC<IconRootProps> = ({ icon: Icon, size, color, className, style, ...rest }) => (
-    <IconsRoot
-        aria-hidden
-        style={{ '--icon-size': `${sizeMap[size].scale}rem`, ...style } as CSSProperties}
-        className={className || ''}
-    >
-        <Icon color={color || 'var(--plasma-colors-primary)'} size={size} {...rest} />
-    </IconsRoot>
-);
+export const IconRoot: React.FC<IconRootProps> = ({ icon: Icon, size, color, className, style, ...rest }) => {
+    return (
+        <IconsRoot
+            aria-hidden
+            style={{ '--icon-size': `${sizeMap[size].scale}rem`, ...style } as CSSProperties}
+            className={className || ''}
+            {...rest}
+        >
+            <Icon color={color || 'var(--plasma-colors-primary)'} size={size} />
+        </IconsRoot>
+    );
+};


### PR DESCRIPTION
## Core

### Icons

- добавлен `rest props` для IconRoot. Теперь есть возможность прокинуть `data-atrrs`      


### What/why changed

