### PR TITLE
PLASMA-5391: TimePicker api example

### DIFF
--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.types.ts
@@ -1,0 +1,16 @@
+import type { CSSProperties } from 'react';
+
+interface TextFieldProps {
+    // Свойства компонента текстфилд
+}
+
+type BasicProps = {
+    dropdownAlign?: 'left' | 'right';
+    dropdownWidth?: 'auto' | 'fullWidth' | CSSProperties['width'];
+    dropdownHeight?: CSSProperties['height'];
+    columnsQuantity?: 2 | 3;
+    onToggle?: (opened: boolean) => void;
+    size?: string;
+};
+
+export type TimePickerProps = BasicProps & TextFieldProps;


### PR DESCRIPTION
**Важно**: для начала нужно реализовать механизм маски времени для компонента TextField согласно макетам. После этого можно будет приступать к данному компоненту. 

Возможно будут полезны ответы на некоторые вопросы касаемо поведения компонента:
1. Какая ширина у выпадающего списка по умолчанию? - auto
2. Какая высота по умолчанию? как в макете, но можно настраивать
3. Placement только снизу? Если внизу нет достаточно места тогда сверху? да, как в автокомплите
4. В чем смысл включения/отключения скроллбара? Или речь только про внешний вид? автоматически, если мало места по высоте
5. Свойство selected тоже должно быть в коде? Какой смысл юзеру ставить false, ведь он тогда не увидит выбранное время в этом списке? не должно быть в коде, это только в макетах
6. При вводе цифр в инпут, должны ли они сразу выбираться в выпадающем списке? И наоборот? Какой у этого флоу? да, вписание цифр в инпут сразу триггерит сколл к нужным айтемам в списке
7. Плейсхолдер же не всегда может быть 00:00:00? Его юзер должен мочь менять? Если да, то должны ли быть подсвечены эти цифры в списке? - Не всегда, должен мочь менять, и цифры в списке должны быть подсвечены с этим временем
8. Выпадающий список должен открываться при клике на текстфилд? Или же еще и при фокусе через Tab? И в целом доступность реализовываем на наше усмотрение? Аналогия с датапикером