### PR TITLE
PLASMA-5486: Add ARIA for `Heading` components 

### DIFF
--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tsx
@@ -149,6 +149,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaRootPr
             hintOffset = HINT_DEFAULT_OFFSET,
             hintWidth,
             hintContentLeft,
+            labelAriaHidden = false,
             onChange,
             ...rest
         } = props;
@@ -260,6 +261,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaRootPr
                 labelPlacement,
                 value: value || uncontrolledValue || defaultValue,
                 rows,
+                labelAriaHidden,
             },
             focused,
         );
@@ -290,7 +292,7 @@ export const textAreaRoot = (Root: RootProps<HTMLTextAreaElement, TextAreaRootPr
                     <OuterLabelWrapper width={helperWidth} isInnerLabel={labelPlacement === 'inner'}>
                         {hasOuterLabel && (
                             <StyledIndicatorWrapper>
-                                <StyledLabel>{label}</StyledLabel>
+                                <StyledLabel aria-hidden={labelAriaHidden}>{label}</StyledLabel>
 
                                 {hintText && (
                                     <StyledHintWrapper>

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.types.tsx
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.types.tsx
@@ -226,9 +226,17 @@ type TextAreaPropsExtends = TextAreaPropsBase & {
     view?: string;
 };
 
+type TextAreaAriaProps = {
+    /**
+     * aria-hidden свойство для label
+     */
+    labelAriaHidden: boolean;
+};
+
 export type TextAreaProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'rows' | 'cols' | 'required'> &
     TextAreaPropsExtends &
-    TextAreaDimensionsProps;
+    TextAreaDimensionsProps &
+    TextAreaAriaProps;
 
 export type TextAreaRootProps = {
     size?: string;

--- a/packages/plasma-new-hope/src/components/Typography/Heading/Heading.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Heading/Heading.tsx
@@ -5,7 +5,7 @@ import { typographyRootCompose } from '../Typography';
 
 export type HeadingProps = FontProps;
 
-export const headingRoot = typographyRootCompose({ defaultBold: true });
+export const headingRoot = typographyRootCompose({ defaultBold: true, type: 'heading' });
 
 export const headingConfig = {
     name: 'Heading',

--- a/packages/plasma-new-hope/src/components/Typography/Typography.tsx
+++ b/packages/plasma-new-hope/src/components/Typography/Typography.tsx
@@ -7,7 +7,7 @@ import { cx } from '../../utils';
 import { classes } from './tokens';
 import { FontProps } from './Typography.types';
 
-export const typographyRootCompose = (defaultArgs?: { defaultBold?: boolean }) => (
+export const typographyRootCompose = (defaultArgs?: { defaultBold?: boolean; type?: string }) => (
     Root: RootProps<HTMLDivElement, FontProps>,
 ) =>
     forwardRef<HTMLDivElement, FontProps>((props, ref) => {
@@ -25,6 +25,11 @@ export const typographyRootCompose = (defaultArgs?: { defaultBold?: boolean }) =
             ...rest
         } = props;
 
+        // TODO: Временное решение. Основное решение будет основано на указание тега по-умолчанию в конфигурации
+        // TODO: компонента и сбросе стилей по-умолчанию для тега
+        const isHeading = defaultArgs?.type === 'heading';
+        const ariaHeadingLevel = isHeading ? size?.split('')[1] : null;
+
         return (
             <Root
                 size={size}
@@ -38,6 +43,8 @@ export const typographyRootCompose = (defaultArgs?: { defaultBold?: boolean }) =
                     className,
                 )}
                 style={{ color, ...style, ...applySpacing(rest) }}
+                aria-level={(ariaHeadingLevel as unknown) as number}
+                role={isHeading ? 'heading' : undefined}
                 {...rest}
             >
                 {children}


### PR DESCRIPTION
## Core

### Heading

- добавлена поддержка a11y для aria role heading  

### Textarea

- добавлено новое свойство `labelAriaHidden` для управления `aria-hidden`  


### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.344.0-canary.2097.16444622079.0
  npm install @salutejs/plasma-b2c@1.586.0-canary.2097.16444622079.0
  npm install @salutejs/plasma-giga@0.313.0-canary.2097.16444622079.0
  npm install @salutejs/plasma-hope@1.347.0-canary.2097.16444622079.0
  npm install @salutejs/plasma-icons@1.221.0-canary.2097.16444622079.0
  npm install @salutejs/plasma-new-hope@0.330.0-canary.2097.16444622079.0
  npm install @salutejs/plasma-ui@1.323.0-canary.2097.16444622079.0
  npm install @salutejs/plasma-web@1.588.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-bizcom@0.318.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-crm@0.317.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-cs@0.322.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-dfa@0.316.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-finportal@0.309.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-insol@0.313.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-netology@0.317.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-scan@0.316.0-canary.2097.16444622079.0
  npm install @salutejs/sdds-serv@0.317.0-canary.2097.16444622079.0
  # or 
  yarn add @salutejs/plasma-asdk@0.344.0-canary.2097.16444622079.0
  yarn add @salutejs/plasma-b2c@1.586.0-canary.2097.16444622079.0
  yarn add @salutejs/plasma-giga@0.313.0-canary.2097.16444622079.0
  yarn add @salutejs/plasma-hope@1.347.0-canary.2097.16444622079.0
  yarn add @salutejs/plasma-icons@1.221.0-canary.2097.16444622079.0
  yarn add @salutejs/plasma-new-hope@0.330.0-canary.2097.16444622079.0
  yarn add @salutejs/plasma-ui@1.323.0-canary.2097.16444622079.0
  yarn add @salutejs/plasma-web@1.588.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-bizcom@0.318.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-crm@0.317.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-cs@0.322.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-dfa@0.316.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-finportal@0.309.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-insol@0.313.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-netology@0.317.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-scan@0.316.0-canary.2097.16444622079.0
  yarn add @salutejs/sdds-serv@0.317.0-canary.2097.16444622079.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
