### PR TITLE
PLASMA-5551: fix paths for storybook

### DIFF
--- a/packages/plasma-new-hope/src/examples/components/Combobox/Combobox.ts
+++ b/packages/plasma-new-hope/src/examples/components/Combobox/Combobox.ts
@@ -1,7 +1,7 @@
 import type { ForwardedRef, ComponentProps, ReactElement } from 'react';
 
 import { component, mergeConfig } from '../../../engines';
-import { comboboxNewConfig } from '../../../..';
+import { comboboxNewConfig } from '../../..';
 import type { ComboboxProps, ItemOption } from '../../../components/Combobox';
 
 import { config } from './Combobox.config';

--- a/packages/plasma-new-hope/src/examples/components/Popover/Popover.ts
+++ b/packages/plasma-new-hope/src/examples/components/Popover/Popover.ts
@@ -3,7 +3,7 @@ import { component, mergeConfig } from '../../../engines';
 
 import { config } from './Popover.config';
 
-export type { PopoverProps, PopoverPlacement, PopoverTrigger } from '../../../..';
+export type { PopoverProps, PopoverPlacement, PopoverTrigger } from '../../..';
 
 const mergedConfig = mergeConfig(popoverConfig, config);
 

--- a/packages/plasma-new-hope/src/examples/components/Select/Select.config.ts
+++ b/packages/plasma-new-hope/src/examples/components/Select/Select.config.ts
@@ -1,6 +1,6 @@
 import { css } from '@linaria/core';
 
-import { selectTokens as tokens } from '../../../..';
+import { selectTokens as tokens } from '../../..';
 
 export const config = {
     defaults: {

--- a/packages/plasma-new-hope/src/examples/components/Select/Select.ts
+++ b/packages/plasma-new-hope/src/examples/components/Select/Select.ts
@@ -1,5 +1,5 @@
 import { component, mergeConfig } from '../../../engines';
-import { selectConfig } from '../../../..';
+import { selectConfig } from '../../..';
 
 import { config } from './Select.config';
 

--- a/packages/plasma-new-hope/src/examples/components/Table/Table.ts
+++ b/packages/plasma-new-hope/src/examples/components/Table/Table.ts
@@ -1,5 +1,5 @@
 import { component, mergeConfig } from '../../../engines';
-import { tableConfig } from '../../../..';
+import { tableConfig } from '../../..';
 
 import { config } from './Table.config';
 


### PR DESCRIPTION
### What/why changed

- исправлены пути для импортов в `examples` в storybook для `plasma-new-hope`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.345.1-canary.2102.16522537635.0
  npm install @salutejs/plasma-b2c@1.587.1-canary.2102.16522537635.0
  npm install @salutejs/plasma-giga@0.314.1-canary.2102.16522537635.0
  npm install @salutejs/plasma-new-hope@0.331.1-canary.2102.16522537635.0
  npm install @salutejs/plasma-web@1.589.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-bizcom@0.319.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-crm@0.318.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-cs@0.323.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-dfa@0.317.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-finportal@0.310.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-insol@0.314.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-netology@0.318.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-scan@0.317.1-canary.2102.16522537635.0
  npm install @salutejs/sdds-serv@0.318.1-canary.2102.16522537635.0
  # or 
  yarn add @salutejs/plasma-asdk@0.345.1-canary.2102.16522537635.0
  yarn add @salutejs/plasma-b2c@1.587.1-canary.2102.16522537635.0
  yarn add @salutejs/plasma-giga@0.314.1-canary.2102.16522537635.0
  yarn add @salutejs/plasma-new-hope@0.331.1-canary.2102.16522537635.0
  yarn add @salutejs/plasma-web@1.589.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-bizcom@0.319.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-crm@0.318.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-cs@0.323.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-dfa@0.317.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-finportal@0.310.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-insol@0.314.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-netology@0.318.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-scan@0.317.1-canary.2102.16522537635.0
  yarn add @salutejs/sdds-serv@0.318.1-canary.2102.16522537635.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
