### PR TITLE
PLASMA-5568: fix withSkeleton type

### DIFF
--- a/packages/plasma-new-hope/src/components/Skeleton/Skeleton.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Skeleton/Skeleton.template-doc.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/{{ package }}';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/packages/plasma-new-hope/src/components/Skeleton/hoc/withSkeleton.tsx
+++ b/packages/plasma-new-hope/src/components/Skeleton/hoc/withSkeleton.tsx
@@ -21,7 +21,7 @@ export const withSkeleton = <P extends WithSkeletonProps>(Component: FC<P>) => (
     skeleton,
     className,
     ...props
-}: P) => {
+}: P & WithSkeletonProps) => {
     const skeletonClass = skeleton ? 'apply-skeleton-gradient' : undefined;
     const skeletonGradientColor = getSkeletonColor({ lighter: true });
     const Wrapper = styled.div`

--- a/packages/plasma-ui/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/plasma-ui/src/components/Skeleton/Skeleton.stories.tsx
@@ -27,7 +27,7 @@ const textSizes = Object.keys(typography) as TypographyTypes[];
 
 const roundnessKeys = Object.keys(radiuses).map((r) => Number(r));
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 const h1Style = { marginTop: '0.75rem' };
 

--- a/packages/plasma-ui/src/hocs/hocs.md
+++ b/packages/plasma-ui/src/hocs/hocs.md
@@ -31,7 +31,7 @@ import React from 'react';
 import { Button, ButtonProps } from '@salutejs/plasma-core';
 import { withSkeleton, WithSkeletonProps } from '@salutejs/plasma-core/hocs';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export const Default = () => (
     <>

--- a/packages/plasma-ui/src/hocs/hocs.md
+++ b/packages/plasma-ui/src/hocs/hocs.md
@@ -31,7 +31,7 @@ import React from 'react';
 import { Button, ButtonProps } from '@salutejs/plasma-core';
 import { withSkeleton, WithSkeletonProps } from '@salutejs/plasma-core/hocs';
 
-const ButtonSkeleton = withSkeleton(Button);
+const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
 
 export const Default = () => (
     <>

--- a/website/plasma-b2c-docs/docs/components/Skeleton.mdx
+++ b/website/plasma-b2c-docs/docs/components/Skeleton.mdx
@@ -85,7 +85,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/plasma-b2c';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(BasicButton);
+const ButtonSkeleton = withSkeleton(BasicButton);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/plasma-b2c-docs/docs/functions/hocs.mdx
+++ b/website/plasma-b2c-docs/docs/functions/hocs.mdx
@@ -29,7 +29,7 @@ export const Default = () => {
 import React from 'react';
 import { withSkeleton, WithSkeletonProps, Button, ButtonProps } from '@salutejs/plasma-b2c';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export const Default = () => (
     <>

--- a/website/plasma-b2c-docs/docs/functions/hocs.mdx
+++ b/website/plasma-b2c-docs/docs/functions/hocs.mdx
@@ -27,7 +27,7 @@ export const Default = () => {
 
 ```tsx
 import React from 'react';
-import { withSkeleton, WithSkeletonProps, Button, ButtonProps } from '@salutejs/plasma-b2c';
+import { withSkeleton, Button, ButtonProps } from '@salutejs/plasma-b2c';
 
 const ButtonSkeleton = withSkeleton(Button);
 

--- a/website/plasma-giga-docs/docs/components/Skeleton.mdx
+++ b/website/plasma-giga-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/plasma-giga';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/plasma-ui-docs/docs/functions/hocs.mdx
+++ b/website/plasma-ui-docs/docs/functions/hocs.mdx
@@ -31,7 +31,7 @@ import React from 'react';
 import { Button, ButtonProps } from '@salutejs/plasma-core';
 import { withSkeleton, WithSkeletonProps } from '@salutejs/plasma-ui';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 return const Default = () => (
     <>

--- a/website/plasma-web-docs/docs/components/Skeleton.mdx
+++ b/website/plasma-web-docs/docs/components/Skeleton.mdx
@@ -85,7 +85,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/plasma-web';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(BasicButton);
+const ButtonSkeleton = withSkeleton(BasicButton);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/plasma-web-docs/docs/functions/hocs.mdx
+++ b/website/plasma-web-docs/docs/functions/hocs.mdx
@@ -31,7 +31,7 @@ import React from 'react';
 import { Button, ButtonProps } from '@salutejs/plasma-core';
 import { withSkeleton, WithSkeletonProps } from '@salutejs/plasma-web';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 return const Default = () => (
     <>

--- a/website/sdds-crm-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-crm-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/sdds-crm';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/sdds-cs-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-cs-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/sdds-cs';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/sdds-dfa-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-dfa-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/sdds-dfa';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/sdds-finportal-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-finportal-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/sdds-finportal';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/sdds-insol-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-insol-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/sdds-insol';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/sdds-netology-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-netology-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/sdds-netology';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/sdds-scan-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-scan-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/sdds-scan';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);

--- a/website/sdds-serv-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-serv-docs/docs/components/Skeleton.mdx
@@ -83,7 +83,7 @@ export function App() {
 import React, { useState } from 'react';
 import { Button } from '@salutejs/sdds-serv';
 
-const ButtonSkeleton = withSkeleton<ButtonProps & WithSkeletonProps>(Button);
+const ButtonSkeleton = withSkeleton(Button);
 
 export default function App () {
     const [skeleton, setSkeleton] = useState(false);


### PR DESCRIPTION
## Core

### Skeleton

- исправлена типизация пропсов внутри `withSkeleton`

### What/why changed

Исправлена типизация пропсов внутри `withSkeleton`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.346.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-b2c@1.588.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-core@1.204.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-giga@0.315.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-hope@1.349.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-new-hope@0.332.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-tokens@1.119.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-ui@1.325.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-web@1.590.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-bizcom@0.320.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-crm@0.319.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-cs@0.324.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-dfa@0.318.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-finportal@0.311.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-insol@0.315.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-netology@0.319.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-scan@0.318.0-canary.2116.16646069672.0
  npm install @salutejs/sdds-serv@0.319.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-themes@0.37.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-cy-utils@0.134.0-canary.2116.16646069672.0
  npm install @salutejs/plasma-sb-utils@0.204.0-canary.2116.16646069672.0
  # or 
  yarn add @salutejs/plasma-asdk@0.346.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-b2c@1.588.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-core@1.204.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-giga@0.315.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-hope@1.349.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-new-hope@0.332.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-tokens@1.119.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-ui@1.325.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-web@1.590.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-bizcom@0.320.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-crm@0.319.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-cs@0.324.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-dfa@0.318.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-finportal@0.311.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-insol@0.315.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-netology@0.319.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-scan@0.318.0-canary.2116.16646069672.0
  yarn add @salutejs/sdds-serv@0.319.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-themes@0.37.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-cy-utils@0.134.0-canary.2116.16646069672.0
  yarn add @salutejs/plasma-sb-utils@0.204.0-canary.2116.16646069672.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
