### PR TITLE
PLASMA-5352: Add attach customIcon

### DIFF
--- a/packages/plasma-new-hope/src/components/Attach/Attach.tsx
+++ b/packages/plasma-new-hope/src/components/Attach/Attach.tsx
@@ -40,6 +40,7 @@ export const attachRoot = (Root: RootProps<HTMLDivElement, AttachProps>) =>
             disabled,
             id,
             name,
+            customIcon,
             onChange,
             onClear,
             ...rest
@@ -66,7 +67,7 @@ export const attachRoot = (Root: RootProps<HTMLDivElement, AttachProps>) =>
 
         const accept = acceptedFileFormats?.join(',');
         const extension = extractExtension(filename);
-        const cellContentLeft = getFileicon(extension, size);
+        const cellContentLeft = customIcon || getFileicon(extension, size);
 
         useEffect(() => {
             emptyTextCellWidth.current = cellRef.current?.offsetWidth || 0;

--- a/packages/plasma-new-hope/src/components/Attach/Attach.types.ts
+++ b/packages/plasma-new-hope/src/components/Attach/Attach.types.ts
@@ -36,6 +36,10 @@ export type BaseAttachProps = {
      */
     helperTextView?: string;
     /**
+     * Вид кастомной иконки слева
+     */
+    customIcon?: React.ReactNode;
+    /**
      * Callback при удалении прикрепленного файла
      */
     onClear?: () => void;

--- a/packages/plasma-new-hope/src/components/Attach/utils/getFileicon.tsx
+++ b/packages/plasma-new-hope/src/components/Attach/utils/getFileicon.tsx
@@ -17,7 +17,11 @@ export const getFileicon = (extension?: string, size?: string) => {
             return <IconBlankPdfOutline size={iconSize} color="inherit" />;
         case 'doc':
             return <IconBlankDocOutline size={iconSize} color="inherit" />;
+        case 'docx':
+            return <IconBlankDocOutline size={iconSize} color="inherit" />;
         case 'xls':
+            return <IconBlankXlsOutline size={iconSize} color="inherit" />;
+        case 'xlsx':
             return <IconBlankXlsOutline size={iconSize} color="inherit" />;
         case 'txt':
             return <IconBlankTxtOutline size={iconSize} color="inherit" />;


### PR DESCRIPTION
## Core

### Attach

- Добавлен новый параметр `customIcon`
- Расширены типы файлов с вшитыми иконками `docx` , `xlsx`

### What/why changed

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.346.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-b2c@1.588.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-core@1.204.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-giga@0.315.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-hope@1.349.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-new-hope@0.332.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-tokens@1.119.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-ui@1.325.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-web@1.590.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-bizcom@0.320.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-crm@0.319.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-cs@0.324.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-dfa@0.318.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-finportal@0.311.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-insol@0.315.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-netology@0.319.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-scan@0.318.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-serv@0.319.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-themes@0.37.0-canary.2123.16716340557.0
  npm install @salutejs/sdds-themes@0.44.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-cy-utils@0.134.0-canary.2123.16716340557.0
  npm install @salutejs/plasma-sb-utils@0.204.0-canary.2123.16716340557.0
  # or 
  yarn add @salutejs/plasma-asdk@0.346.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-b2c@1.588.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-core@1.204.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-giga@0.315.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-hope@1.349.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-new-hope@0.332.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-tokens@1.119.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-ui@1.325.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-web@1.590.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-bizcom@0.320.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-crm@0.319.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-cs@0.324.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-dfa@0.318.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-finportal@0.311.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-insol@0.315.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-netology@0.319.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-scan@0.318.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-serv@0.319.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-themes@0.37.0-canary.2123.16716340557.0
  yarn add @salutejs/sdds-themes@0.44.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-cy-utils@0.134.0-canary.2123.16716340557.0
  yarn add @salutejs/plasma-sb-utils@0.204.0-canary.2123.16716340557.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
