### PR TITLE
PLASMA-4118: add isNewPage flag to callbacks in Pagination

### DIFF
--- a/packages/plasma-new-hope/src/components/Pagination/Pagination.tsx
+++ b/packages/plasma-new-hope/src/components/Pagination/Pagination.tsx
@@ -94,25 +94,27 @@ export const paginationRoot = (Root: RootPropsOmitOnChange<HTMLDivElement, Pagin
                 }
 
                 if (disabled.includes(newPageValue)) {
-                    return;
+                    return { newPageValue: pageInner, isNewPage: false };
                 }
+
+                const isNewPage = newPageValue === pageInner;
 
                 setPageInner(newPageValue);
 
-                return newPageValue;
+                return { newPageValue, isNewPage };
             };
 
             const handleSetPage = (pageValueCandidate?: number) => {
-                const newValue = pageSetter(pageValueCandidate);
+                const { newPageValue, isNewPage } = pageSetter(pageValueCandidate);
 
-                onChange?.(newValue, perPageValue);
-                onChangePageValue?.(newValue);
+                onChange?.(newPageValue, perPageValue, isNewPage);
+                onChangePageValue?.(newPageValue, isNewPage);
             };
 
             const handlerSetPerPage = (newPerPageValue: number) => {
                 setPerPageInner(newPerPageValue);
 
-                onChange?.(pageValue, newPerPageValue);
+                onChange?.(pageValue, newPerPageValue, false);
                 onChangePerPageValue?.(newPerPageValue);
             };
 

--- a/packages/plasma-new-hope/src/components/Pagination/Pagination.types.ts
+++ b/packages/plasma-new-hope/src/components/Pagination/Pagination.types.ts
@@ -127,11 +127,11 @@ export type CustomPaginationProps = {
     /*
      * Функция которая исполняeтся при изменении `page`, `perPage`
      */
-    onChange?: (page?: number, perPage?: number) => void;
+    onChange?: (page?: number, perPage?: number, isNewPage?: boolean) => void;
     /*
      * @deprecated - использовать onChange
      */
-    onChangePageValue?: (page?: number) => void;
+    onChangePageValue?: (page?: number, isNewPage?: boolean) => void;
     /*
      * @deprecated - использовать onChange
      */


### PR DESCRIPTION
## Core

### Pagination

- добавлен флаг `isNewPage` в `onChange` и `onChangePageValue`, который является индикатором перехода на новую страницу

### What/why changed

Добавлен флаг `isNewPage` в `onChange` и `onChangePageValue`, который является индикатором перехода на новую страницу
