### PR TITLE
PLASMA-5511: add providerFrame for PopupProvider

### DIFF
--- a/packages/plasma-new-hope/src/components/Popup/ClientOnlyPortal.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/ClientOnlyPortal.tsx
@@ -6,15 +6,36 @@ import { useIsomorphicLayoutEffect } from '../../hooks';
 
 // Полиморфная версия портала для рендера как на сервере, так и на клиенте.
 // Позволяет избежать ошибок, связанных с гидрацией.
-const ClientOnlyPortal: FC<{ children: ReactNode }> = ({ children }) => {
+const ClientOnlyPortal: FC<{
+    children: ReactNode;
+    providerFrame?: 'document' | string | React.RefObject<HTMLElement>;
+}> = ({ children, providerFrame }) => {
     const ref = useRef<HTMLElement | null>(null);
 
     const [mounted, setMounted] = useState(false);
 
     useIsomorphicLayoutEffect(() => {
-        ref.current = document.body;
-
         setMounted(true);
+
+        if (typeof providerFrame !== 'string' && providerFrame && providerFrame.current) {
+            ref.current = providerFrame.current;
+
+            return;
+        }
+
+        if (typeof providerFrame === 'string' && providerFrame !== 'document') {
+            const containerElement = document.getElementById(providerFrame as string);
+
+            if (!containerElement) {
+                ref.current = document.body;
+            }
+
+            ref.current = containerElement;
+
+            return;
+        }
+
+        ref.current = document.body;
     }, []);
 
     return mounted && ref.current ? createPortal(children, ref.current) : null;


### PR DESCRIPTION
## Core

### Popup

- добавлено свойство `providerFrame`, которое определяет элемент, в который поместится контейнер Popupов

### What/why changed


**After**:
<img width="1173" height="356" alt="image" src="https://github.com/user-attachments/assets/9c89876b-f36f-42c2-ab75-9ab0955b8d36" />
<img width="394" height="126" alt="image" src="https://github.com/user-attachments/assets/be1738cc-c035-490f-ba0a-013c7b00ddf7" />




<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.348.0-canary.2151.16970001275.0
  npm install @salutejs/plasma-b2c@1.590.0-canary.2151.16970001275.0
  npm install @salutejs/plasma-giga@0.317.0-canary.2151.16970001275.0
  npm install @salutejs/plasma-new-hope@0.334.0-canary.2151.16970001275.0
  npm install @salutejs/plasma-web@1.592.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-bizcom@0.322.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-crm@0.321.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-cs@0.326.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-dfa@0.320.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-finai@0.313.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-finportal@0.313.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-insol@0.317.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-netology@0.321.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-scan@0.320.0-canary.2151.16970001275.0
  npm install @salutejs/sdds-serv@0.321.0-canary.2151.16970001275.0
  # or 
  yarn add @salutejs/plasma-asdk@0.348.0-canary.2151.16970001275.0
  yarn add @salutejs/plasma-b2c@1.590.0-canary.2151.16970001275.0
  yarn add @salutejs/plasma-giga@0.317.0-canary.2151.16970001275.0
  yarn add @salutejs/plasma-new-hope@0.334.0-canary.2151.16970001275.0
  yarn add @salutejs/plasma-web@1.592.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-bizcom@0.322.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-crm@0.321.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-cs@0.326.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-dfa@0.320.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-finai@0.313.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-finportal@0.313.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-insol@0.317.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-netology@0.321.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-scan@0.320.0-canary.2151.16970001275.0
  yarn add @salutejs/sdds-serv@0.321.0-canary.2151.16970001275.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
