### PR TITLE
PLASMA-5582: use `onDark` as default view into tooltip [FinAi]

### DIFF
--- a/packages/sdds-finai/src/components/Tooltip/Tooltip.config.ts
+++ b/packages/sdds-finai/src/components/Tooltip/Tooltip.config.ts
@@ -61,9 +61,10 @@ export const config = {
         view: {
             // TODO заменить тень на токен https://github.com/salute-developers/plasma/issues/1131
             default: css`
-                ${tooltipTokens.backgroundColor}: var(--surface-solid-card-brightness);
+                ${tooltipTokens.backgroundColor}: var(--inverse-surface-solid-card-brightness);
                 ${tooltipTokens.boxShadow}: 0px 4px 12px 0px rgba(0, 0, 0, 0.16),0px 1px 4px 0px rgba(0, 0, 0, 0.08);
-                ${tooltipTokens.color}: var(--text-primary);
+                ${tooltipTokens.color}: var(--inverse-text-primary);
+                ${tooltipTokens.arrowBackground}: var(--inverse-surface-solid-card-brightness);
             `,
         },
     },


### PR DESCRIPTION
## SDDS-FINAI

### Tooltip

- токены инвертированы, и теперь по-умолчанию используется onDark значения
   
### What/why changed

По требованию команды внесли такие изменения   

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.347.1-canary.2154.16989970539.0
  npm install @salutejs/plasma-b2c@1.589.1-canary.2154.16989970539.0
  npm install @salutejs/plasma-giga@0.316.1-canary.2154.16989970539.0
  npm install @salutejs/plasma-new-hope@0.333.1-canary.2154.16989970539.0
  npm install @salutejs/plasma-web@1.591.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-bizcom@0.321.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-crm@0.320.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-cs@0.325.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-dfa@0.319.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-finai@0.312.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-finportal@0.312.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-insol@0.316.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-netology@0.320.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-scan@0.319.1-canary.2154.16989970539.0
  npm install @salutejs/sdds-serv@0.320.1-canary.2154.16989970539.0
  # or 
  yarn add @salutejs/plasma-asdk@0.347.1-canary.2154.16989970539.0
  yarn add @salutejs/plasma-b2c@1.589.1-canary.2154.16989970539.0
  yarn add @salutejs/plasma-giga@0.316.1-canary.2154.16989970539.0
  yarn add @salutejs/plasma-new-hope@0.333.1-canary.2154.16989970539.0
  yarn add @salutejs/plasma-web@1.591.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-bizcom@0.321.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-crm@0.320.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-cs@0.325.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-dfa@0.319.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-finai@0.312.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-finportal@0.312.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-insol@0.316.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-netology@0.320.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-scan@0.319.1-canary.2154.16989970539.0
  yarn add @salutejs/sdds-serv@0.320.1-canary.2154.16989970539.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
