### PR TITLE
PLASMA-5199: Добавлен пример очистки поля ввода для Autocomplete 

### DIFF
--- a/website/plasma-b2c-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/plasma-b2c-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/plasma-b2c';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/plasma-b2c-docs/docs/components/Autocomplete.mdx
+++ b/website/plasma-b2c-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -528,6 +530,9 @@ type SuggestionItem = {
             );
         }
         ```
+    </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
     </TabItem>
 </Tabs>
 

--- a/website/plasma-giga-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/plasma-giga-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/plasma-giga';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/plasma-giga-docs/docs/components/Autocomplete.mdx
+++ b/website/plasma-giga-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -596,13 +598,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/plasma-web-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/plasma-web-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/plasma-web';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/plasma-web-docs/docs/components/Autocomplete.mdx
+++ b/website/plasma-web-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -598,13 +600,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требованиям W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-crm-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/sdds-crm-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/sdds-crm';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/sdds-crm-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-crm-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -526,13 +528,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-cs-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/sdds-cs-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,41 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/sdds-cs';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/sdds-cs-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-cs-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -596,13 +598,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-dfa-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/sdds-dfa-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/sdds-dfa';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/sdds-dfa-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-dfa-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -596,13 +598,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-finai-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/sdds-finai-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/sdds-finai';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/sdds-finai-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-finai-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -596,13 +598,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-insol-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/sdds-insol-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/sdds-insol';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/sdds-insol-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-insol-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -596,13 +598,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-netology-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/sdds-netology-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/sdds-netology';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/sdds-netology-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-netology-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -526,13 +528,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-scan-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/sdds-scan-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/sdds-scan';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/sdds-scan-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-scan-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -525,13 +527,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-serv-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
+++ b/website/sdds-serv-docs/docs/_examples/_autocomplete/_autocomplete-clear-example.mdx
@@ -1,0 +1,42 @@
+```tsx live
+import React, { useState } from "react";
+import { IconClose } from "@salutejs/plasma-icons";
+import { Autocomplete, IconButton } from '@salutejs/sdds-serv';
+
+export function App() {
+  const [value, setValue] = useState("");
+
+  const items = [
+    { label: 'Алексей Смирнов' },
+    { label: 'Екатерина Иванова' },
+    { label: 'Дмитрий Петров' },
+    { label: 'Ольга Васильева' },
+  ]
+
+  return (
+    <div style={{ display: "block", height: "400px" }}>
+      <Autocomplete
+        value={value}
+        listMaxHeight="250px"
+        label="Label"
+        suggestions={items}
+        placeholder="Placeholder"
+        leftHelper="Введите имя Алексей"
+        contentRight={
+          <IconButton
+            size="xs"
+            view="clear"
+            onClick={() => {
+              setValue("");
+            }}
+          >
+            <IconClose color="inherit" size="xs" />
+          </IconButton>
+        }
+       onChange={(e) => setValue(e.target.value)}
+       onSuggestionSelect={(e) => setValue(e.label)}
+      />
+    </div>
+  );
+}
+```

--- a/website/sdds-serv-docs/docs/components/Autocomplete.mdx
+++ b/website/sdds-serv-docs/docs/components/Autocomplete.mdx
@@ -7,6 +7,8 @@ import { PropsTable, Description } from '@site/src/components';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import AutocompleteExampleClear from '../_examples/_autocomplete/_autocomplete-clear-example.mdx'
+
 # Autocomplete
 Поле ввода с подсказками в выпадающем списке.
 
@@ -596,13 +598,16 @@ type SuggestionItem = {
         }
         ```
     </TabItem>
+    <TabItem value="example clear" label="Clear input">
+        <AutocompleteExampleClear />
+    </TabItem>
 </Tabs>
 
 ## Клавиатурная навигация
 
 Данный компонент соответствует требования W3C: [Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/).
 
-- `Tab, Escape` - закрывает автокомплит. Перемещает фокус на следующий элемент на странице;
+- `Tab, Escape` - закрывает Autocomplete. Перемещает фокус на следующий элемент на странице;
 - `Enter` - выбираем подсказку из списка;
 - `Home` - перемещает фокус на первый элемент;
 - `End` - перемещает фокус на последний элемент;

--- a/website/sdds-serv-docs/docs/next.mdx
+++ b/website/sdds-serv-docs/docs/next.mdx
@@ -1,20 +1,20 @@
 ---
 id: next
 title: Работа с Next
-sidebar_position: 1
 ---
+Раздел описывает варианты и нюансы подключения библиотеки в рамках работы с `NextJs`.
 
-Подключение библиотеки и ее компонентов не отличается от стандартного варианта, за исключением некоторых нюансов, о которых ниже.
+:::caution RSC - React Server Components (App router)
+<p>Библиотека поддерживает работу с **RSC** только при **явном использовании** директивы **'use client'**.</p>
 
-:::caution
-    <span>Библиотека не поддерживает работу с <strong>React Server Components (App router)</strong>. За исключением тех мест в вашем проекте, где явно задана директива <strong>'use client'</strong>.</span>
+```ts
+'use client'
+
+import { Button } from '@salutejs/sdds-serv';
+
+...
+```
 :::
-
-<br />
-
-<blockquote>
-    В дальнейшем речь пойдет исключительно для <u><b>pages</b> router'a</u>, вне зависимости от версии Next.
-</blockquote>
 
 ## Подключение тем
 
@@ -22,11 +22,13 @@ sidebar_position: 1
 
 ### Styled Components
 
-<blockquote>
-    Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components. Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
-</blockquote>
+:::info
+Прежде всего убедитесь, что у вас правильно настроена работа со Styled Components.
 
-```jsx
+    Для справки: официальный [пример](https://github.com/vercel/next.js/tree/main/examples/with-styled-components) работающей реализации.
+:::
+
+```tsx
 import type { AppProps } from "next/app";
 import { sdds_serv__light } from '@salutejs/sdds-themes';
 import { createGlobalStyle } from "styled-components";
@@ -46,7 +48,7 @@ export default function App({ Component, pageProps }: AppProps) {
 
 ### Импорт CSS
 
-```jsx
+```tsx
 import type { AppProps } from "next/app";
 import '@salutejs/sdds-themes/css/sdds_serv__light.css';
 
@@ -91,17 +93,19 @@ export default function Home() {
 
 ### Пример с CSS
 
-:::caution
+:::tip
 Next не разрешает импорт CSS из сторонних модулей, поэтому важно не забыть добавить наши библиотеки в `next.config.js` следующим образом:
 :::
 
 ```js
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ['@salutejs/sdds-serv', '@salutejs/plasma-new-hope']
+  transpilePackages: ['@salutejs/sdds-serv', '@salutejs/plasma-new-hope', '@salutejs/plasma-icons']
 };
 ````
+
 И далее уже можно подключать наши компоненты:
+
 ```jsx
 import React from 'react';
 import { Button } from '@salutejs/sdds-serv'


### PR DESCRIPTION
## Core

### Autocomplete

- Добавлен пример очистки поля ввода


### What/why changed


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-b2c@1.590.1-canary.2165.17228756249.0
  npm install @salutejs/plasma-web@1.592.1-canary.2165.17228756249.0
  # or 
  yarn add @salutejs/plasma-b2c@1.590.1-canary.2165.17228756249.0
  yarn add @salutejs/plasma-web@1.592.1-canary.2165.17228756249.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
