### PR TITLE
PLASMA-5657: fix Pagination perPage list width

### DIFF
--- a/packages/plasma-new-hope/src/components/Pagination/Pagination.tsx
+++ b/packages/plasma-new-hope/src/components/Pagination/Pagination.tsx
@@ -55,7 +55,7 @@ export const paginationRoot = (Root: RootPropsOmitOnChange<HTMLDivElement, Pagin
                 leftContent,
                 rightContent,
 
-                listWidth,
+                listWidth = 'fit-content',
 
                 onChangePageValue,
                 onChangePerPageValue,

--- a/packages/plasma-new-hope/src/components/Pagination/Pagination.types.ts
+++ b/packages/plasma-new-hope/src/components/Pagination/Pagination.types.ts
@@ -8,112 +8,112 @@ import type { AsProps, NumericRange, CreateArrayWithLengthX } from '../../types'
 export type PaginationTypes = 'compact' | 'default';
 
 export type CustomPaginationProps = {
-    /*
+    /**
      * Вид
      */
     view?: string;
 
-    /*
+    /**
      *  Вид выбранной кнопки
      */
     viewCurrentPage?: string;
 
-    /*
+    /**
      *  Левый контент
      */
     leftContent?: ReactNode;
 
-    /*
+    /**
      *  Правый контент
      */
     rightContent?: ReactNode;
 
-    /*
+    /**
      *  Тип обычный или компактный
      */
     type?: PaginationTypes;
 
-    /*
+    /**
      * Размер
      */
     size?: string;
 
-    /*
+    /**
      * Количество страниц
      */
     count?: number;
 
-    /*
+    /**
      * Выбранная страница
      */
     value?: number;
 
-    /*
+    /**
      * Выбранная страница по умолчанию
      */
     defaultValue?: number;
 
-    /*
+    /**
      * Выбор страницы через Input
      */
     hasQuickJump?: boolean;
 
-    /*
+    /**
      * Выбор количества результатов на странице
      */
     hasPerPage?: boolean;
 
-    /*
+    /**
      * Выбранное количество результатов на странице
      */
     perPage?: number;
 
-    /*
+    /**
      * Выбранное количество результатов на странице по умолчанию
      */
     defaultPerPage?: number;
 
-    /*
+    /**
      * Список результатов на странице
      */
     perPageList?: number[];
 
-    /*
+    /**
      * Заблокированные страницы
      */
     disabledPages?: string[];
 
-    /*
+    /**
      * Количество PageButtons
      */
     slots?: NumericRange<CreateArrayWithLengthX<7>, 15>;
 
-    /*
+    /**
      * Скругление кнопки
      */
     pilled?: boolean;
 
-    /*
+    /**
      * Равная ширина и высота кнопки
      */
     square?: boolean;
 
-    /*
+    /**
      * Авто изменение стиля кнопок в ButtonGroup
      */
     isCommonButtonStyles?: boolean;
 
-    /*
+    /**
      * Placeholder TextField'a для быстрого прыжка на страницу
      */
     placeholderQuickJump?: string;
 
-    /*
+    /**
      * Текст для быстрого прыжка на страницу
      */
     textQuickJump?: string;
 
-    /*
+    /**
      * Текст для выбора кол-ва результатов на странице
      */
     textPerPage?: string;
@@ -124,15 +124,15 @@ export type CustomPaginationProps = {
      */
     listWidth?: CSSProperties['width'];
 
-    /*
+    /**
      * Функция которая исполняeтся при изменении `page`, `perPage`
      */
     onChange?: (page?: number, perPage?: number) => void;
-    /*
+    /**
      * @deprecated - использовать onChange
      */
     onChangePageValue?: (page?: number) => void;
-    /*
+    /**
      * @deprecated - использовать onChange
      */
     onChangePerPageValue?: (perPage?: number) => void;


### PR DESCRIPTION
## Docs

### Pagination

- исправлена ширина выпадающего списка `perPage`
- исправлена ошибка в экспорте типов (комментарии не попадали в таблицу с описанием свойств)

### What/why changed

**Before**:

<img width="168" height="224" alt="image" src="https://github.com/user-attachments/assets/af0c98f4-58be-42a4-8165-0654c2cf414e" />
<img width="979" height="484" alt="image" src="https://github.com/user-attachments/assets/9040c6be-e5a5-4263-82ec-4b1d7c73e33b" />


**After**:

<img width="141" height="228" alt="image" src="https://github.com/user-attachments/assets/ec35b8ba-7a1a-4347-b67e-555f75dba659" />

<img width="996" height="549" alt="image" src="https://github.com/user-attachments/assets/6354d3bb-3271-46ea-9f4e-330fde2f386c" />



Исправлена ширина выпадающего списка `perPage`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.350.0-canary.2206.17488115405.0
  npm install @salutejs/plasma-b2c@1.592.0-canary.2206.17488115405.0
  npm install @salutejs/plasma-giga@0.319.0-canary.2206.17488115405.0
  npm install @salutejs/plasma-new-hope@0.336.0-canary.2206.17488115405.0
  npm install @salutejs/plasma-web@1.594.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-bizcom@0.324.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-crm@0.323.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-cs@0.328.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-dfa@0.322.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-finai@0.315.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-insol@0.319.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-netology@0.323.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-scan@0.322.0-canary.2206.17488115405.0
  npm install @salutejs/sdds-serv@0.323.0-canary.2206.17488115405.0
  # or 
  yarn add @salutejs/plasma-asdk@0.350.0-canary.2206.17488115405.0
  yarn add @salutejs/plasma-b2c@1.592.0-canary.2206.17488115405.0
  yarn add @salutejs/plasma-giga@0.319.0-canary.2206.17488115405.0
  yarn add @salutejs/plasma-new-hope@0.336.0-canary.2206.17488115405.0
  yarn add @salutejs/plasma-web@1.594.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-bizcom@0.324.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-crm@0.323.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-cs@0.328.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-dfa@0.322.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-finai@0.315.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-insol@0.319.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-netology@0.323.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-scan@0.322.0-canary.2206.17488115405.0
  yarn add @salutejs/sdds-serv@0.323.0-canary.2206.17488115405.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
