### PR TITLE
PLASMA-5851: Fix Note issues 

### DIFF
--- a/packages/plasma-new-hope/src/components/Note/Note.tsx
+++ b/packages/plasma-new-hope/src/components/Note/Note.tsx
@@ -64,6 +64,7 @@ export const noteRoot = (Root: RootProps<HTMLDivElement, NoteProps>) =>
                 if (
                     !canUseDOM ||
                     !text ||
+                    typeof text !== 'string' ||
                     !contentWrapperRef?.current ||
                     !textRenderHelperRef?.current ||
                     (!width && !height)

--- a/packages/plasma-new-hope/src/components/Note/Note.types.ts
+++ b/packages/plasma-new-hope/src/components/Note/Note.types.ts
@@ -4,11 +4,11 @@ export type NoteProps = {
     /**
      * Заголовок к Note.
      */
-    title?: string;
+    title?: ReactNode;
     /**
      * Текст к Note.
      */
-    text?: string;
+    text?: ReactNode;
     /**
      * Слот под иконку слева от контента.
      */

--- a/packages/plasma-new-hope/src/components/Note/variations/_size/base.ts
+++ b/packages/plasma-new-hope/src/components/Note/variations/_size/base.ts
@@ -59,6 +59,6 @@ export const base = css`
         letter-spacing: var(${tokens.textLetterSpacing});
         line-height: var(${tokens.textLineHeight});
 
-        word-break: break-all;
+        overflow-wrap: break-word;
     }
 `;


### PR DESCRIPTION
## Core

### Note

- исправлена ошибка с некорректным переносом по буквам - правильно по словам
- расширен `type` до ReactNode для свойств `title, text`     


### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.351.0-canary.2247.17854524722.0
  npm install @salutejs/plasma-b2c@1.593.0-canary.2247.17854524722.0
  npm install @salutejs/plasma-giga@0.320.0-canary.2247.17854524722.0
  npm install @salutejs/plasma-new-hope@0.337.0-canary.2247.17854524722.0
  npm install @salutejs/plasma-web@1.595.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-bizcom@0.325.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-crm@0.324.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-cs@0.329.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-dfa@0.323.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-finai@0.316.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-insol@0.320.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-netology@0.324.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-scan@0.323.0-canary.2247.17854524722.0
  npm install @salutejs/sdds-serv@0.324.0-canary.2247.17854524722.0
  # or 
  yarn add @salutejs/plasma-asdk@0.351.0-canary.2247.17854524722.0
  yarn add @salutejs/plasma-b2c@1.593.0-canary.2247.17854524722.0
  yarn add @salutejs/plasma-giga@0.320.0-canary.2247.17854524722.0
  yarn add @salutejs/plasma-new-hope@0.337.0-canary.2247.17854524722.0
  yarn add @salutejs/plasma-web@1.595.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-bizcom@0.325.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-crm@0.324.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-cs@0.329.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-dfa@0.323.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-finai@0.316.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-insol@0.320.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-netology@0.324.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-scan@0.323.0-canary.2247.17854524722.0
  yarn add @salutejs/sdds-serv@0.324.0-canary.2247.17854524722.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
