### PR TITLE
PLASMA-5958: extend emptyStateDescription type in Combobox

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
@@ -246,7 +246,7 @@ type BasicProps<T extends ItemOption = ItemOption> = {
     /**
      * Текст для состояния когда нет результата.
      */
-    emptyStateDescription?: string;
+    emptyStateDescription?: React.ReactNode;
 
     /**
      * @deprecated Использовать listMaxHeight.

--- a/packages/plasma-new-hope/src/components/EmptyState/EmptyState.types.ts
+++ b/packages/plasma-new-hope/src/components/EmptyState/EmptyState.types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export interface Props extends React.HTMLAttributes<HTMLDivElement> {
-    description: string;
+    description: React.ReactNode;
     icon?: React.ReactNode;
     buttonText?: string;
     buttonAction?: () => void;


### PR DESCRIPTION
## Core

### Combobox
- тип свойства `emptyStateDescription` расширен до `ReactNode`;

### What/why changed
- тип свойства `emptyStateDescription` расширен до `ReactNode`;
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.353.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-b2c@1.595.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-core@1.209.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-giga@0.322.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-hope@1.355.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-icons@1.226.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-new-hope@0.339.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-tokens@1.123.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-ui@1.331.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-web@1.597.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-bizcom@0.327.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-crm@0.326.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-cs@0.331.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-dfa@0.325.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-finai@0.318.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-insol@0.322.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-netology@0.326.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-scan@0.325.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-serv@0.326.0-canary.2293.18842204322.0
  npm install @salutejs/sdds-themes@0.48.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-cy-utils@0.139.0-canary.2293.18842204322.0
  npm install @salutejs/plasma-sb-utils@0.209.0-canary.2293.18842204322.0
  # or 
  yarn add @salutejs/plasma-asdk@0.353.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-b2c@1.595.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-core@1.209.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-giga@0.322.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-hope@1.355.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-icons@1.226.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-new-hope@0.339.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-tokens@1.123.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-ui@1.331.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-web@1.597.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-bizcom@0.327.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-crm@0.326.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-cs@0.331.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-dfa@0.325.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-finai@0.318.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-insol@0.322.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-netology@0.326.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-scan@0.325.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-serv@0.326.0-canary.2293.18842204322.0
  yarn add @salutejs/sdds-themes@0.48.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-cy-utils@0.139.0-canary.2293.18842204322.0
  yarn add @salutejs/plasma-sb-utils@0.209.0-canary.2293.18842204322.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
