### PR TITLE
PLASMA-6045: fix async loading in Combobox in single mode

### DIFF
--- a/packages/plasma-b2c/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Combobox/Combobox.component-test.tsx
@@ -1986,6 +1986,39 @@ describe('plasma-b2c: Combobox', () => {
         cy.matchImageSnapshot();
     });
 
+    it('flow: single, async items loading with preset value', () => {
+        cy.viewport(500, 500);
+
+        const Component = () => {
+            const [value, setValue] = useState('north_america');
+            const [options, setOptions] = useState([]);
+
+            setTimeout(() => {
+                setOptions(items);
+            }, 100);
+
+            return (
+                <Combobox
+                    id="combobox"
+                    value={value}
+                    onChange={setValue}
+                    items={options}
+                    label="Label"
+                    placeholder="Placeholder"
+                />
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#combobox').should('have.value', 'north_america');
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(100);
+
+        cy.get('#combobox').should('have.value', 'Северная Америка');
+    });
+
     it('keyboard interactions: single', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-giga/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-giga/src/components/Combobox/Combobox.component-test.tsx
@@ -1986,6 +1986,39 @@ describe('plasma-giga: Combobox', () => {
         cy.matchImageSnapshot();
     });
 
+    it('flow: single, async items loading with preset value', () => {
+        cy.viewport(500, 500);
+
+        const Component = () => {
+            const [value, setValue] = useState('north_america');
+            const [options, setOptions] = useState([]);
+
+            setTimeout(() => {
+                setOptions(items);
+            }, 100);
+
+            return (
+                <Combobox
+                    id="combobox"
+                    value={value}
+                    onChange={setValue}
+                    items={options}
+                    label="Label"
+                    placeholder="Placeholder"
+                />
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#combobox').should('have.value', 'north_america');
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(100);
+
+        cy.get('#combobox').should('have.value', 'Северная Америка');
+    });
+
     it('keyboard interactions: single', () => {
         cy.viewport(1000, 500);
 

--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.tsx
@@ -422,6 +422,14 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             // А переменную, содержащую сложные типы данных, нельзя помещать в deps.
         }, [outerValue, internalValue, items]);
 
+        // Эффект для исключительных случаев, когда нужно обновить значение textValue при изменении items,
+        // но только если значение textValue совпадает с value в item.
+        useLayoutEffect(() => {
+            if (!multiple && value && valueToItemMap.get(value as string)?.value === textValue) {
+                setTextValue(valueToItemMap.get(value as string)?.label || value.toString());
+            }
+        }, [items]);
+
         // При изменении value нужно возвращать значение в инпуте к исходному.
         useDidMountLayoutEffect(() => {
             setTextValue(getTextValue(multiple, value, valueToItemMap, renderValue));

--- a/packages/plasma-web/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-web/src/components/Combobox/Combobox.component-test.tsx
@@ -1986,6 +1986,39 @@ describe('plasma-web: Combobox', () => {
         cy.matchImageSnapshot();
     });
 
+    it('flow: single, async items loading with preset value', () => {
+        cy.viewport(500, 500);
+
+        const Component = () => {
+            const [value, setValue] = useState('north_america');
+            const [options, setOptions] = useState([]);
+
+            setTimeout(() => {
+                setOptions(items);
+            }, 100);
+
+            return (
+                <Combobox
+                    id="combobox"
+                    value={value}
+                    onChange={setValue}
+                    items={options}
+                    label="Label"
+                    placeholder="Placeholder"
+                />
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#combobox').should('have.value', 'north_america');
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(100);
+
+        cy.get('#combobox').should('have.value', 'Северная Америка');
+    });
+
     it('keyboard interactions: single', () => {
         cy.viewport(1000, 500);
 

--- a/packages/sdds-cs/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/sdds-cs/src/components/Combobox/Combobox.component-test.tsx
@@ -1978,6 +1978,39 @@ describe('sdds-cs: Combobox', () => {
         cy.matchImageSnapshot();
     });
 
+    it('flow: single, async items loading with preset value', () => {
+        cy.viewport(500, 500);
+
+        const Component = () => {
+            const [value, setValue] = useState('north_america');
+            const [options, setOptions] = useState([]);
+
+            setTimeout(() => {
+                setOptions(items);
+            }, 100);
+
+            return (
+                <Combobox
+                    id="combobox"
+                    value={value}
+                    onChange={setValue}
+                    items={options}
+                    label="Label"
+                    placeholder="Placeholder"
+                />
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#combobox').should('have.value', 'north_america');
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(100);
+
+        cy.get('#combobox').should('have.value', 'Северная Америка');
+    });
+
     it('keyboard interactions: single', () => {
         cy.viewport(1000, 500);
 

--- a/packages/sdds-insol/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/sdds-insol/src/components/Combobox/Combobox.component-test.tsx
@@ -1984,6 +1984,39 @@ describe('sdds-insol: Combobox', () => {
         cy.matchImageSnapshot();
     });
 
+    it('flow: single, async items loading with preset value', () => {
+        cy.viewport(500, 500);
+
+        const Component = () => {
+            const [value, setValue] = useState('north_america');
+            const [options, setOptions] = useState([]);
+
+            setTimeout(() => {
+                setOptions(items);
+            }, 100);
+
+            return (
+                <Combobox
+                    id="combobox"
+                    value={value}
+                    onChange={setValue}
+                    items={options}
+                    label="Label"
+                    placeholder="Placeholder"
+                />
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#combobox').should('have.value', 'north_america');
+
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(100);
+
+        cy.get('#combobox').should('have.value', 'Северная Америка');
+    });
+
     it('keyboard interactions: single', () => {
         cy.viewport(1000, 500);
 


### PR DESCRIPTION
## Core

### Combobox
- исправлен баг в single-режиме, при котором в некоторых случаях значение поля ввода не обновлялось после изменения `items`;

### What/why changed
- исправлен баг в single-режиме, при котором в некоторых случаях значение поля ввода не обновлялось после изменения `items`;
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.353.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-b2c@1.595.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-core@1.209.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-giga@0.322.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-hope@1.355.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-icons@1.226.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-new-hope@0.339.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-tokens@1.123.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-ui@1.331.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-web@1.597.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-bizcom@0.327.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-crm@0.326.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-cs@0.331.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-dfa@0.325.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-finai@0.318.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-insol@0.322.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-netology@0.326.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-scan@0.325.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-serv@0.326.0-canary.2298.18772525373.0
  npm install @salutejs/sdds-themes@0.48.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-cy-utils@0.139.0-canary.2298.18772525373.0
  npm install @salutejs/plasma-sb-utils@0.209.0-canary.2298.18772525373.0
  # or 
  yarn add @salutejs/plasma-asdk@0.353.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-b2c@1.595.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-core@1.209.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-giga@0.322.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-hope@1.355.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-icons@1.226.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-new-hope@0.339.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-tokens@1.123.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-ui@1.331.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-web@1.597.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-bizcom@0.327.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-crm@0.326.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-cs@0.331.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-dfa@0.325.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-finai@0.318.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-insol@0.322.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-netology@0.326.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-scan@0.325.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-serv@0.326.0-canary.2298.18772525373.0
  yarn add @salutejs/sdds-themes@0.48.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-cy-utils@0.139.0-canary.2298.18772525373.0
  yarn add @salutejs/plasma-sb-utils@0.209.0-canary.2298.18772525373.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
