### PR TITLE
PLASMA-5711: reset default padding/margin/border [Typography]

### DIFF
--- a/packages/plasma-new-hope/src/components/Typography/Typography.styles.ts
+++ b/packages/plasma-new-hope/src/components/Typography/Typography.styles.ts
@@ -5,12 +5,17 @@ import { applyHyphens, applyHyphensNormal } from '../../mixins';
 import { classes, tokens } from './tokens';
 
 export const base = css`
+    margin: 0;
+    padding: 0;
+
     font-family: var(${tokens.typoFontFamily});
     font-size: var(${tokens.typoFontSize});
     font-style: var(${tokens.typoFontStyle});
     letter-spacing: var(${tokens.typoFontLetterSpacing});
     line-height: var(${tokens.typoFontLineHeight});
     font-weight: var(${tokens.typoFontWeight});
+
+    border: 0;
 
     &.${classes.typoBold} {
         font-weight: var(${tokens.typoFontWeightBold});


### PR DESCRIPTION
## Core

### Typography

- обнулили значения по-умолчанию (браузерные) для свойств `padding/margin/border`   

### What/why changed
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.352.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-b2c@1.594.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-core@1.208.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-giga@0.321.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-hope@1.354.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-icons@1.225.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-new-hope@0.338.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-tokens@1.122.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-ui@1.330.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-web@1.596.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-bizcom@0.326.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-crm@0.325.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-cs@0.330.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-dfa@0.324.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-finai@0.317.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-insol@0.321.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-netology@0.325.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-scan@0.324.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-serv@0.325.1-canary.2302.18837377760.0
  npm install @salutejs/sdds-themes@0.47.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-cy-utils@0.138.1-canary.2302.18837377760.0
  npm install @salutejs/plasma-sb-utils@0.208.1-canary.2302.18837377760.0
  # or 
  yarn add @salutejs/plasma-asdk@0.352.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-b2c@1.594.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-core@1.208.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-giga@0.321.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-hope@1.354.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-icons@1.225.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-new-hope@0.338.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-tokens@1.122.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-ui@1.330.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-web@1.596.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-bizcom@0.326.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-crm@0.325.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-cs@0.330.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-dfa@0.324.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-finai@0.317.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-insol@0.321.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-netology@0.325.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-scan@0.324.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-serv@0.325.1-canary.2302.18837377760.0
  yarn add @salutejs/sdds-themes@0.47.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-cy-utils@0.138.1-canary.2302.18837377760.0
  yarn add @salutejs/plasma-sb-utils@0.208.1-canary.2302.18837377760.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
