### PR TITLE
PLASMA-6954: fix typings in Combobox

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ComboboxNew/Combobox.types.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, ButtonHTMLAttributes, ChangeEventHandler, Dispatch } from 'react';
+import type { CSSProperties, InputHTMLAttributes, ChangeEventHandler, Dispatch } from 'react';
 import * as React from 'react';
 import { SafeExtract } from 'src/types';
 
@@ -302,7 +302,7 @@ export type ComboboxProps<T extends ItemOption = ItemOption> = BasicProps<T> &
     IsMultiselect<T> &
     RequiredProps &
     HintProps &
-    Omit<ButtonHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'name' | 'defaultValue' | 'onScroll'>;
+    Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'name' | 'defaultValue' | 'onScroll'>;
 
 export type FloatingPopoverProps = {
     target: React.ReactNode | ((ref: React.MutableRefObject<HTMLElement | null>) => React.ReactNode);

--- a/utils/api-tests/src/components/Combobox/Combobox.api.test.tsx
+++ b/utils/api-tests/src/components/Combobox/Combobox.api.test.tsx
@@ -211,6 +211,7 @@ describe('Basics', () => {
         expectTypeOf<ComboboxProps>().toHaveProperty('placeholder').toEqualTypeOf<string | undefined>();
         expectTypeOf<ComboboxProps>().toHaveProperty('aria-label').toEqualTypeOf<string | undefined>();
         expectTypeOf<ComboboxProps>().toHaveProperty('role').toEqualTypeOf<AriaRole | undefined>();
+        expectTypeOf<ComboboxProps>().toHaveProperty('autoComplete').toEqualTypeOf<string | undefined>();
     });
 });
 


### PR DESCRIPTION
## Core

### Combobox
- исправлена ошибка типов TS для свойства `autoComplete`;

### What/why changed
- теперь TS не ругается на свойство `autoComplete`;

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.372.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-b2c@1.614.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-core@1.223.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-giga@0.341.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-homeds@0.341.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-hope@1.369.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-icons@1.235.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-new-hope@0.358.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-tokens@1.135.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-ui@1.345.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-web@1.616.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-bizcom@0.346.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-cs@0.350.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-dfa@0.344.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-finai@0.337.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-insol@0.341.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-netology@0.345.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-os@0.16.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-platform-ai@0.345.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-sbcom@0.345.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-scan@0.344.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-serv@0.345.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-themes@0.47.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-themes@0.62.0-canary.2677.24142806186.0
  npm install @salutejs/sdds-api-tests@0.3.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-cy-utils@0.153.0-canary.2677.24142806186.0
  npm install @salutejs/plasma-sb-utils@0.223.0-canary.2677.24142806186.0
  # or 
  yarn add @salutejs/plasma-asdk@0.372.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-b2c@1.614.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-core@1.223.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-giga@0.341.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-homeds@0.341.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-hope@1.369.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-icons@1.235.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-new-hope@0.358.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-tokens@1.135.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-ui@1.345.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-web@1.616.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-bizcom@0.346.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-cs@0.350.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-dfa@0.344.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-finai@0.337.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-insol@0.341.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-netology@0.345.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-os@0.16.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-platform-ai@0.345.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-sbcom@0.345.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-scan@0.344.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-serv@0.345.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-themes@0.47.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-themes@0.62.0-canary.2677.24142806186.0
  yarn add @salutejs/sdds-api-tests@0.3.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-cy-utils@0.153.0-canary.2677.24142806186.0
  yarn add @salutejs/plasma-sb-utils@0.223.0-canary.2677.24142806186.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
