### PR TITLE
PLASMA-6945: correct vertical align in Popover's target

### DIFF
--- a/packages/plasma-icons/src/old/IconRoot.tsx
+++ b/packages/plasma-icons/src/old/IconRoot.tsx
@@ -23,10 +23,8 @@ interface IconRootProps extends IconProps {
 }
 
 const IconsRoot = styled.div`
-    display: inline-flex;
     width: var(--icon-size);
     height: var(--icon-size);
-    flex: 0 0 var(--icon-size);
 `;
 
 export const IconRoot: React.FC<IconRootProps> = ({ icon: Icon, size, color, className, style, ...rest }) => (

--- a/packages/plasma-icons/src/scalable/IconRoot.tsx
+++ b/packages/plasma-icons/src/scalable/IconRoot.tsx
@@ -32,10 +32,8 @@ interface IconRootProps extends IconProps, HTMLAttributes<HTMLDivElement> {
 }
 
 const IconsRoot = styled.div`
-    display: inline-flex;
     width: var(--icon-size);
     height: var(--icon-size);
-    flex: 0 0 var(--icon-size);
 `;
 
 export const getIconComponent = (

--- a/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.styles.ts
@@ -12,7 +12,7 @@ export const StyledRoot = styled.div`
 `;
 
 export const StyledWrapper = styled.div`
-    display: inline-block;
+    display: inline-flex;
 
     &.${classes.targetAsRef} {
         position: absolute;


### PR DESCRIPTION
## Core

### Popover
- исправлено вертикальное выравнивание у `img/svg` в target;

### What/why changed
- исправлено вертикальное выравнивание у `img/svg` в target;

До:
<img width="309" height="200" alt="Снимок экрана 2026-04-09 в 16 24 47" src="https://github.com/user-attachments/assets/1f6a2dc3-6ca8-4e18-8659-aa4157cb4208" />

После:
<img width="311" height="103" alt="Снимок экрана 2026-04-09 в 16 32 22" src="https://github.com/user-attachments/assets/cc32d85d-17f5-425b-8260-64231395a8c2" />


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.372.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-b2c@1.614.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-core@1.223.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-giga@0.341.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-homeds@0.341.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-hope@1.369.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-icons@1.235.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-new-hope@0.358.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-tokens@1.135.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-ui@1.345.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-web@1.616.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-bizcom@0.346.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-cs@0.350.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-dfa@0.344.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-finai@0.337.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-insol@0.341.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-netology@0.345.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-os@0.16.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-platform-ai@0.345.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-sbcom@0.345.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-scan@0.344.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-serv@0.345.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-themes@0.47.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-themes@0.62.0-canary.2680.24204766087.0
  npm install @salutejs/sdds-api-tests@0.3.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-cy-utils@0.153.0-canary.2680.24204766087.0
  npm install @salutejs/plasma-sb-utils@0.223.0-canary.2680.24204766087.0
  # or 
  yarn add @salutejs/plasma-asdk@0.372.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-b2c@1.614.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-core@1.223.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-giga@0.341.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-homeds@0.341.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-hope@1.369.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-icons@1.235.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-new-hope@0.358.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-tokens@1.135.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-ui@1.345.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-web@1.616.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-bizcom@0.346.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-cs@0.350.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-dfa@0.344.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-finai@0.337.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-insol@0.341.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-netology@0.345.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-os@0.16.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-platform-ai@0.345.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-sbcom@0.345.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-scan@0.344.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-serv@0.345.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-themes@0.47.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-themes@0.62.0-canary.2680.24204766087.0
  yarn add @salutejs/sdds-api-tests@0.3.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-cy-utils@0.153.0-canary.2680.24204766087.0
  yarn add @salutejs/plasma-sb-utils@0.223.0-canary.2680.24204766087.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
