### PR TITLE
PLASMA-5710: Улучшить типизацию `as` для компонент типографики

### DIFF
--- a/packages/plasma-asdk/src/components/Typography/Typography.tsx
+++ b/packages/plasma-asdk/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/plasma-b2c/src/components/Typography/Typography.tsx
+++ b/packages/plasma-b2c/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/plasma-giga/src/components/Typography/Typography.tsx
+++ b/packages/plasma-giga/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/plasma-homeds/src/components/Typography/Typography.tsx
+++ b/packages/plasma-homeds/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -34,55 +35,55 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/plasma-new-hope/src/components/Typography/Typography.types.ts
+++ b/packages/plasma-new-hope/src/components/Typography/Typography.types.ts
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react';
+import type { FunctionComponent, HTMLAttributes, ReactElement, RefAttributes } from 'react';
 import type { SpacingProps } from 'src/mixins';
 
 import { AsProps } from '../..';
@@ -60,4 +60,59 @@ export type FontProps = {
 } & SpacingProps &
     FontWeightProps &
     AsProps &
-    HTMLAttributes<HTMLDivElement>;
+    HTMLAttributes<HTMLDivElement> & { as?: keyof AllowedTextHTMLElements };
+
+export interface AllowedTextHTMLElements {
+    div: JSX.IntrinsicElements['div'];
+    p: JSX.IntrinsicElements['p'];
+    span: JSX.IntrinsicElements['span'];
+    i: JSX.IntrinsicElements['i'];
+    b: JSX.IntrinsicElements['b'];
+    strong: JSX.IntrinsicElements['strong'];
+    label: JSX.IntrinsicElements['label'];
+    h1: JSX.IntrinsicElements['h1'];
+    h2: JSX.IntrinsicElements['h2'];
+    h3: JSX.IntrinsicElements['h3'];
+    h4: JSX.IntrinsicElements['h4'];
+    h5: JSX.IntrinsicElements['h5'];
+    h6: JSX.IntrinsicElements['h6'];
+    legend: JSX.IntrinsicElements['legend'];
+    ol: JSX.IntrinsicElements['ol'];
+    ul: JSX.IntrinsicElements['ul'];
+    li: JSX.IntrinsicElements['li'];
+    blockquote: JSX.IntrinsicElements['blockquote'];
+    em: JSX.IntrinsicElements['em'];
+    small: JSX.IntrinsicElements['small'];
+    s: JSX.IntrinsicElements['s'];
+    u: JSX.IntrinsicElements['u'];
+    mark: JSX.IntrinsicElements['mark'];
+    sub: JSX.IntrinsicElements['sub'];
+    sup: JSX.IntrinsicElements['sup'];
+    code: JSX.IntrinsicElements['code'];
+    pre: JSX.IntrinsicElements['pre'];
+    q: JSX.IntrinsicElements['q'];
+    figcaption: JSX.IntrinsicElements['figcaption'];
+    address: JSX.IntrinsicElements['address'];
+    abbr: JSX.IntrinsicElements['abbr'];
+    cite: JSX.IntrinsicElements['cite'];
+    kbd: JSX.IntrinsicElements['kbd'];
+    samp: JSX.IntrinsicElements['samp'];
+    var: JSX.IntrinsicElements['var'];
+    del: JSX.IntrinsicElements['del'];
+    ins: JSX.IntrinsicElements['ins'];
+    dfn: JSX.IntrinsicElements['dfn'];
+    time: JSX.IntrinsicElements['time'];
+    data: JSX.IntrinsicElements['data'];
+    bdi: JSX.IntrinsicElements['bdi'];
+    bdo: JSX.IntrinsicElements['bdo'];
+    dt: JSX.IntrinsicElements['dt'];
+    dd: JSX.IntrinsicElements['dd'];
+}
+
+export type TypographyComponent<K> = <T extends keyof AllowedTextHTMLElements = 'div'>(
+    props: (K extends unknown ? Omit<K, 'as' | 'ref'> & { as?: T } : never) & RefAttributes<HTMLElementTagNameMap[T]>,
+) => ReactElement | null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const typographyComponent = <K extends Record<string, any>>(comp: FunctionComponent<K>) =>
+    (comp as unknown) as TypographyComponent<K>;

--- a/packages/plasma-new-hope/src/components/Typography/index.ts
+++ b/packages/plasma-new-hope/src/components/Typography/index.ts
@@ -13,3 +13,5 @@ export * from './Old/ParagraphText/ParagraphText';
 export * from './Old/Underline/Underline';
 export * from './Old/Subtitle/Subtitle';
 export { tokens as typographyTokens } from './tokens';
+export { typographyComponent } from './Typography.types';
+export type { TypographyComponent, AllowedTextHTMLElements } from './Typography.types';

--- a/packages/plasma-new-hope/src/examples/components/typography/components/Body/Body.ts
+++ b/packages/plasma-new-hope/src/examples/components/typography/components/Body/Body.ts
@@ -1,8 +1,8 @@
-import { bodyConfig } from '../../../../../components/Typography';
+import { bodyConfig, typographyComponent } from '../../../../../components/Typography';
 import { component, mergeConfig } from '../../../../../engines';
 
 import { config } from './Body.config';
 
 const mergedConfig = mergeConfig(bodyConfig, config);
 
-export const Body = component(mergedConfig);
+export const Body = typographyComponent(component(mergedConfig));

--- a/packages/plasma-new-hope/src/examples/components/typography/components/Dspl/Dspl.ts
+++ b/packages/plasma-new-hope/src/examples/components/typography/components/Dspl/Dspl.ts
@@ -1,8 +1,8 @@
-import { dsplConfig } from '../../../../../components/Typography';
+import { dsplConfig, typographyComponent } from '../../../../../components/Typography';
 import { component, mergeConfig } from '../../../../../engines';
 
 import { config } from './Dspl.config';
 
 const mergedConfig = mergeConfig(dsplConfig, config);
 
-export const Dspl = component(mergedConfig);
+export const Dspl = typographyComponent(component(mergedConfig));

--- a/packages/plasma-new-hope/src/examples/components/typography/components/Heading/Heading.ts
+++ b/packages/plasma-new-hope/src/examples/components/typography/components/Heading/Heading.ts
@@ -1,8 +1,8 @@
-import { headingConfig } from '../../../../../components/Typography';
+import { headingConfig, typographyComponent } from '../../../../../components/Typography';
 import { component, mergeConfig } from '../../../../../engines';
 
 import { config } from './Heading.config';
 
 const mergedConfig = mergeConfig(headingConfig, config);
 
-export const Heading = component(mergedConfig);
+export const Heading = typographyComponent(component(mergedConfig));

--- a/packages/plasma-new-hope/src/examples/components/typography/components/Text/Text.ts
+++ b/packages/plasma-new-hope/src/examples/components/typography/components/Text/Text.ts
@@ -1,8 +1,8 @@
-import { textConfig } from '../../../../../components/Typography';
+import { textConfig, typographyComponent } from '../../../../../components/Typography';
 import { component, mergeConfig } from '../../../../../engines';
 
 import { config } from './Text.config';
 
 const mergedConfig = mergeConfig(textConfig, config);
 
-export const Text = component(mergedConfig);
+export const Text = typographyComponent(component(mergedConfig));

--- a/packages/plasma-web/src/components/Typography/Typography.tsx
+++ b/packages/plasma-web/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-bizcom/src/components/Typography/Typography.tsx
+++ b/packages/sdds-bizcom/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-crm/src/components/Typography/Typography.tsx
+++ b/packages/sdds-crm/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-cs/src/components/Typography/Typography.tsx
+++ b/packages/sdds-cs/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/emotion';
 
@@ -34,55 +35,55 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-dfa/src/components/Typography/Typography.tsx
+++ b/packages/sdds-dfa/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-finai/src/components/Typography/Typography.tsx
+++ b/packages/sdds-finai/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-insol/src/components/Typography/Typography.tsx
+++ b/packages/sdds-insol/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -36,61 +37,61 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 const textSlimConfig = mergeConfig(textConfig, textConfigSlimCustom);
-const TextSlimComponent = component(textSlimConfig);
+const TextSlimComponent = typographyComponent(component(textSlimConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-netology/src/components/Typography/Typography.tsx
+++ b/packages/sdds-netology/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-os/src/components/Typography/Typography.tsx
+++ b/packages/sdds-os/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -34,55 +35,55 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-platform-ai/src/components/Typography/Typography.tsx
+++ b/packages/sdds-platform-ai/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-sbcom/src/components/Typography/Typography.tsx
+++ b/packages/sdds-sbcom/src/components/Typography/Typography.tsx
@@ -3,6 +3,7 @@ import {
     dsplConfig,
     headingConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -22,34 +23,34 @@ import {
 } from './Heading.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-scan/src/components/Typography/Typography.tsx
+++ b/packages/sdds-scan/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/packages/sdds-serv/src/components/Typography/Typography.tsx
+++ b/packages/sdds-serv/src/components/Typography/Typography.tsx
@@ -4,6 +4,7 @@ import {
     headingConfig,
     textConfig,
     component,
+    typographyComponent,
     mergeConfig,
 } from '@salutejs/plasma-new-hope/styled-components';
 
@@ -35,58 +36,58 @@ import {
 } from './Text.config';
 
 const bodyMConfig = mergeConfig(bodyConfig, bodyConfigMCustom);
-const BodyMComponent = component(bodyMConfig);
+const BodyMComponent = typographyComponent(component(bodyMConfig));
 
 const bodyLConfig = mergeConfig(bodyConfig, bodyConfigLCustom);
-const BodyLComponent = component(bodyLConfig);
+const BodyLComponent = typographyComponent(component(bodyLConfig));
 
 const bodySConfig = mergeConfig(bodyConfig, bodyConfigSCustom);
-const BodySComponent = component(bodySConfig);
+const BodySComponent = typographyComponent(component(bodySConfig));
 
 const bodyXSConfig = mergeConfig(bodyConfig, bodyConfigXSCustom);
-const BodyXSComponent = component(bodyXSConfig);
+const BodyXSComponent = typographyComponent(component(bodyXSConfig));
 
 const bodyXXSConfig = mergeConfig(bodyConfig, bodyConfigXXSCustom);
-const BodyXXSComponent = component(bodyXXSConfig);
+const BodyXXSComponent = typographyComponent(component(bodyXXSConfig));
 
 const dsplMConfig = mergeConfig(dsplConfig, dsplConfigMCustom);
-const DsplMComponent = component(dsplMConfig);
+const DsplMComponent = typographyComponent(component(dsplMConfig));
 
 const dsplLConfig = mergeConfig(dsplConfig, dsplConfigLCustom);
-const DsplLComponent = component(dsplLConfig);
+const DsplLComponent = typographyComponent(component(dsplLConfig));
 
 const dsplSConfig = mergeConfig(dsplConfig, dsplConfigSCustom);
-const DsplSComponent = component(dsplSConfig);
+const DsplSComponent = typographyComponent(component(dsplSConfig));
 
 const heading1Config = mergeConfig(headingConfig, headingConfigH1Custom);
-const Heading1Component = component(heading1Config);
+const Heading1Component = typographyComponent(component(heading1Config));
 
 const heading2Config = mergeConfig(headingConfig, headingConfigH2Custom);
-const Heading2Component = component(heading2Config);
+const Heading2Component = typographyComponent(component(heading2Config));
 
 const heading3Config = mergeConfig(headingConfig, headingConfigH3Custom);
-const Heading3Component = component(heading3Config);
+const Heading3Component = typographyComponent(component(heading3Config));
 
 const heading4Config = mergeConfig(headingConfig, headingConfigH4Custom);
-const Heading4Component = component(heading4Config);
+const Heading4Component = typographyComponent(component(heading4Config));
 
 const heading5Config = mergeConfig(headingConfig, headingConfigH5Custom);
-const Heading5Component = component(heading5Config);
+const Heading5Component = typographyComponent(component(heading5Config));
 
 const heading6Config = mergeConfig(headingConfig, headingConfigH6Custom);
-const Heading6Component = component(heading6Config);
+const Heading6Component = typographyComponent(component(heading6Config));
 
 const textMConfig = mergeConfig(textConfig, textConfigMCustom);
-const TextMComponent = component(textMConfig);
+const TextMComponent = typographyComponent(component(textMConfig));
 
 const textLConfig = mergeConfig(textConfig, textConfigLCustom);
-const TextLComponent = component(textLConfig);
+const TextLComponent = typographyComponent(component(textLConfig));
 
 const textSConfig = mergeConfig(textConfig, textConfigSCustom);
-const TextSComponent = component(textSConfig);
+const TextSComponent = typographyComponent(component(textSConfig));
 
 const textXSConfig = mergeConfig(textConfig, textConfigXSCustom);
-const TextXSComponent = component(textXSConfig);
+const TextXSComponent = typographyComponent(component(textXSConfig));
 
 export const BodyM = BodyMComponent;
 export const BodyL = BodyLComponent;

--- a/utils/api-tests/src/components/Typography/Typography.api.test.tsx
+++ b/utils/api-tests/src/components/Typography/Typography.api.test.tsx
@@ -1,0 +1,106 @@
+import React, { createRef } from 'react';
+import type { ComponentProps } from 'react';
+import { describe, it } from 'vitest';
+import { expectTypeOf } from 'expect-type';
+import { TextL } from '@salutejs/plasma-b2c';
+
+type TextLProps = ComponentProps<typeof TextL>;
+
+describe('Basics', () => {
+    it('Common props', () => {
+        expectTypeOf<TextLProps>().toHaveProperty('color').toEqualTypeOf<string | undefined>();
+        expectTypeOf<TextLProps>().toHaveProperty('noWrap').toEqualTypeOf<boolean | undefined>();
+        expectTypeOf<TextLProps>().toHaveProperty('breakWord').toEqualTypeOf<boolean | undefined>();
+        expectTypeOf<TextLProps>().toHaveProperty('isNumeric').toEqualTypeOf<boolean | undefined>();
+        expectTypeOf<TextLProps>().toHaveProperty('isItalic').toEqualTypeOf<boolean | undefined>();
+    });
+
+    it('Font weight props', () => {
+        expectTypeOf<TextLProps>().toHaveProperty('bold');
+        expectTypeOf<TextLProps>().toHaveProperty('medium');
+        expectTypeOf<TextLProps>().toHaveProperty('extraBold');
+    });
+
+    it('Font size props', () => {
+        expectTypeOf<TextLProps>().toHaveProperty('size');
+        expectTypeOf<TextLProps>({ size: 'l' });
+        // @ts-expect-error — Размера 'm' не существует
+        expectTypeOf<TextLProps>({ size: 'm' });
+    });
+});
+
+describe('Unions (FontWeight)', () => {
+    it('Allowed weight combinations', () => {
+        expectTypeOf<TextLProps>({ bold: true });
+        expectTypeOf<TextLProps>({ medium: true });
+        expectTypeOf<TextLProps>({ extraBold: true });
+        expectTypeOf<TextLProps>({ bold: false, medium: true });
+        expectTypeOf<TextLProps>({ bold: false, extraBold: true });
+        // @ts-expect-error - нельзя одновременно задавать medium=true и extraBold=true
+        expectTypeOf<TextLProps>({ bold: true, extraBold: true, medium: true });
+    });
+});
+
+describe('Generics (polymorphic `as`)', () => {
+    it('Allowed tags for `as`', () => {
+        expectTypeOf<TextLProps>({ as: 'div' });
+        expectTypeOf<TextLProps>({ as: 'p' });
+        expectTypeOf<TextLProps>({ as: 'span' });
+        expectTypeOf<TextLProps>({ as: 'h1' });
+        expectTypeOf<TextLProps>({ as: 'h2' });
+        expectTypeOf<TextLProps>({ as: 'h6' });
+        expectTypeOf<TextLProps>({ as: 'label' });
+        expectTypeOf<TextLProps>({ as: 'blockquote' });
+        expectTypeOf<TextLProps>({ as: 'em' });
+        expectTypeOf<TextLProps>({ as: 'code' });
+        // @ts-expect-error — тег 'use' не разрешён
+        expectTypeOf<TextLProps>({ as: 'use' });
+    });
+});
+
+describe('Ref typing (polymorphic ref)', () => {
+    it('as="h1" → ref: Ref<HTMLHeadingElement>', () => {
+        const ok = createRef<HTMLHeadingElement>();
+        const bad = createRef<HTMLBodyElement>();
+        expectTypeOf(<TextL as="h1" ref={ok} />);
+        // @ts-expect-error — HTMLBodyElement несовместим с HTMLHeadingElement
+        expectTypeOf(<TextL as="h1" ref={bad} />);
+    });
+
+    it('as="time" → ref: Ref<HTMLTimeElement>', () => {
+        const ok = createRef<HTMLTimeElement>();
+        const bad = createRef<HTMLBodyElement>();
+        expectTypeOf(<TextL as="time" ref={ok} />);
+        // @ts-expect-error — HTMLBodyElement несовместим с HTMLTimeElement
+        expectTypeOf(<TextL as="time" ref={bad} />);
+    });
+
+    it('as="p" → ref: Ref<HTMLParagraphElement>', () => {
+        const ok = createRef<HTMLParagraphElement>();
+        const bad = createRef<HTMLBodyElement>();
+        expectTypeOf(<TextL as="p" ref={ok} />);
+        // @ts-expect-error — HTMLBodyElement несовместим с HTMLParagraphElement
+        expectTypeOf(<TextL as="p" ref={bad} />);
+    });
+
+    it('as="label" → ref: Ref<HTMLLabelElement>', () => {
+        const ok = createRef<HTMLLabelElement>();
+        const bad = createRef<HTMLBodyElement>();
+        expectTypeOf(<TextL as="label" ref={ok} />);
+        // @ts-expect-error — HTMLBodyElement несовместим с HTMLLabelElement
+        expectTypeOf(<TextL as="label" ref={bad} />);
+    });
+
+    it('as="blockquote" → ref: Ref<HTMLQuoteElement>', () => {
+        const ok = createRef<HTMLQuoteElement>();
+        const bad = createRef<HTMLBodyElement>();
+        expectTypeOf(<TextL as="blockquote" ref={ok} />);
+        // @ts-expect-error — HTMLBodyElement несовместим с HTMLQuoteElement
+        expectTypeOf(<TextL as="blockquote" ref={bad} />);
+    });
+
+    it('as="div" → ref: Ref<HTMLHeadingElement>', () => {
+        const ok = createRef<HTMLHeadingElement>();
+        expectTypeOf(<TextL as="div" ref={ok} />);
+    });
+});


### PR DESCRIPTION
## Core

### Typography

- Расширены типы для свойства `as` и сужены доступные варианты. Теперь, если выбран любой текстовый тег, то ref будет ожидаться соответствующим (раньше это всегда был HTMLDivElement):


### What/why changed

- На каждый компонент типографики добавлен врапер `typographyComponent`, который сохраняет все свойства из конфига

Поддержка типов и конфигов:
<img width="515" height="198" alt="Screenshot 2026-04-14 at 12 08 13" src="https://github.com/user-attachments/assets/7cf1c8e9-8061-45e3-b290-94d137843c1a" />

Поддержка только доступных тегов:
<img width="574" height="323" alt="Screenshot 2026-04-14 at 11 10 42" src="https://github.com/user-attachments/assets/c128621e-f5a8-4b8a-a9d2-91f062efadc4" />

Правильно:
<img width="574" height="173" alt="Screenshot 2026-04-14 at 11 10 00" src="https://github.com/user-attachments/assets/a838f514-821a-45d9-9014-52468cbca9f5" />

Не правильно:
<img width="574" height="173" alt="Screenshot 2026-04-14 at 11 10 11" src="https://github.com/user-attachments/assets/85a15500-a8ad-4b54-9d6b-24dc8cba1580" />

#### Известные ограничения
Сужение работает не со всеми типами. Например, при указании тега as=`h1`, и ref={HTMLDivElement} ошибки не будет, т.к. структурно HTMLHeadingElement и HTMLDivElement похожи (свойства практически совпадают) и тайпскрипт не увидит разницы. Это валидное поведение, нужно это учитывать.

<img width="515" height="198" alt="image" src="https://github.com/user-attachments/assets/f6959374-d3b9-4893-a00f-79f953e1bf2e" />



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.372.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-b2c@1.614.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-core@1.223.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-giga@0.341.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-homeds@0.341.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-hope@1.369.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-icons@1.235.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-new-hope@0.358.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-tokens@1.135.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-ui@1.345.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-web@1.616.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-bizcom@0.346.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-cs@0.350.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-dfa@0.344.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-finai@0.337.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-insol@0.341.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-netology@0.345.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-os@0.16.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-platform-ai@0.345.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-sbcom@0.345.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-scan@0.344.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-serv@0.345.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-themes@0.47.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-themes@0.62.0-canary.2696.24392788666.0
  npm install @salutejs/sdds-api-tests@0.3.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-cy-utils@0.153.0-canary.2696.24392788666.0
  npm install @salutejs/plasma-sb-utils@0.223.0-canary.2696.24392788666.0
  # or 
  yarn add @salutejs/plasma-asdk@0.372.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-b2c@1.614.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-core@1.223.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-giga@0.341.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-homeds@0.341.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-hope@1.369.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-icons@1.235.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-new-hope@0.358.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-tokens@1.135.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-ui@1.345.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-web@1.616.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-bizcom@0.346.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-cs@0.350.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-dfa@0.344.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-finai@0.337.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-insol@0.341.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-netology@0.345.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-os@0.16.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-platform-ai@0.345.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-sbcom@0.345.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-scan@0.344.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-serv@0.345.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-themes@0.47.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-themes@0.62.0-canary.2696.24392788666.0
  yarn add @salutejs/sdds-api-tests@0.3.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-cy-utils@0.153.0-canary.2696.24392788666.0
  yarn add @salutejs/plasma-sb-utils@0.223.0-canary.2696.24392788666.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
