### PR TITLE
PLASMA-7114: Fix opened order issue

### DIFF
--- a/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/PopupContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, FC, PropsWithChildren, useRef } from 'react';
+import React, { createContext, useState, useContext, useEffect, FC, PropsWithChildren } from 'react';
 import { canUseDOM, safeUseId } from 'src/utils';
 
 import { Portal } from '../Portal';
@@ -9,6 +9,37 @@ import type { PopupContextType, PopupInfo } from './Popup.types';
 import { StyledPortal } from './Popup.styles';
 
 export const POPUP_PORTAL_ID = 'plasma-popup-root';
+
+/**
+ * INFO:
+ * Глобальный координатор overflow для нескольких экземпляров PopupProvider.
+ * Каждый PopupProvider независимо управляет своими items, но overflow на body — общий ресурс.
+ * Используется Set с ID провайдеров вместо счётчика — Set.add/delete идемпотентны,
+ * поэтому повторные вызовы при ремаунте (hydration mismatch, Strict Mode) не ломают состояние.
+ * Overflow сохраняется при ∅→1 и восстанавливается при 1→∅.
+ */
+const globalOverflowState = {
+    activeProviders: new Set<string>(),
+    savedOverflowY: '',
+};
+
+const lockBodyOverflow = (providerId: string) => {
+    if (globalOverflowState.activeProviders.has(providerId)) {
+        return;
+    }
+    if (globalOverflowState.activeProviders.size === 0) {
+        globalOverflowState.savedOverflowY = document.body.style.overflowY;
+    }
+    globalOverflowState.activeProviders.add(providerId);
+    document.body.style.overflowY = 'hidden';
+};
+
+const unlockBodyOverflow = (providerId: string) => {
+    const wasActive = globalOverflowState.activeProviders.delete(providerId);
+    if (wasActive && globalOverflowState.activeProviders.size === 0) {
+        document.body.style.overflowY = globalOverflowState.savedOverflowY;
+    }
+};
 
 const initialItems = new Map<string, PopupInfo>();
 
@@ -40,11 +71,37 @@ export const PopupProvider: FC<
         UNSAFE_SSR_ENABLED?: boolean;
     }
 > = ({ children, providerFrame, UNSAFE_SSR_ENABLED }) => {
-    const prevBodyOverflowY = useRef(canUseDOM ? document.body.style.overflowY : '');
     const [items, setItems] = useState(initialItems);
 
     const uuid = safeUseId();
     const rootId = `${POPUP_PORTAL_ID}-${uuid}`;
+
+    useEffect(() => {
+        if (!canUseDOM) {
+            return;
+        }
+
+        const currentHasModals = hasModals(Array.from(items.values()));
+
+        if (currentHasModals) {
+            lockBodyOverflow(rootId);
+        } else {
+            unlockBodyOverflow(rootId);
+        }
+    }, [items, rootId]);
+
+    /**
+     * INFO:
+     * Cleanup при unmount: если PopupProvider размонтируется с открытой модалкой
+     * (например, при смене роута или hydration mismatch), провайдер удаляется из Set
+     * и overflow восстанавливается, если активных провайдеров не осталось.
+     * Выделен в отдельный эффект, чтобы не срабатывать при каждой смене items.
+     */
+    useEffect(() => {
+        return () => {
+            unlockBodyOverflow(rootId);
+        };
+    }, [rootId]);
 
     const register = (info: PopupInfo) => {
         if (!canUseDOM) {
@@ -53,12 +110,6 @@ export const PopupProvider: FC<
 
         setItems((prevItems) => {
             const newItems = new Map(prevItems);
-
-            if (info.info?.isModal && !hasModals(Array.from(prevItems.values()))) {
-                prevBodyOverflowY.current = document.body.style.overflowY;
-                document.body.style.overflowY = 'hidden';
-            }
-
             newItems.set(info.id, info);
             return newItems;
         });
@@ -75,14 +126,7 @@ export const PopupProvider: FC<
             }
 
             const newItems = new Map(prevItems);
-            const prevHasModals = hasModals(Array.from(newItems.values()));
-
             newItems.delete(id);
-
-            if (prevHasModals && !hasModals(Array.from(newItems.values()))) {
-                document.body.style.overflowY = prevBodyOverflowY.current;
-            }
-
             return newItems;
         });
     };

--- a/packages/plasma-new-hope/src/components/Popup/hooks/usePopup.ts
+++ b/packages/plasma-new-hope/src/components/Popup/hooks/usePopup.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { PopupAnimationInfo, PopupHookArgs } from '../Popup.types';
 import { usePopupContext } from '../PopupContext';
@@ -8,7 +8,10 @@ const usePopupAnimation = (): PopupAnimationInfo => {
     const [endAnimation, setEndAnimation] = useState<boolean>(false);
     const [endTransition, setEndTransition] = useState<boolean>(false);
 
-    return { endAnimation, endTransition, setEndTransition, setEndAnimation };
+    return useMemo(() => ({ endAnimation, endTransition, setEndTransition, setEndAnimation }), [
+        endAnimation,
+        endTransition,
+    ]);
 };
 
 // Хук для внутреннего состояния, необходимого для правильного отображения вложенных окон, а также для анимации


### PR DESCRIPTION
## Core

### What/why changed

https://codesandbox.io/p/sandbox/bag-modaldf-overflow-hidden-na-body-forked-87vw5m?file=%2Fsrc%2FApp.js 

пример на котором нужно тестить

```md
                        ┌─────────────────────────────┐
                        │   register(ModalA)           │
                        │   setItems(updater)          │
                        └──────────────┬──────────────┘
                                       │
                    React вызывает updater 2 раза
                    (StrictMode / concurrent retry)
                                       │
                 ┌─────────────────────┴─────────────────────┐
                 │                                           │
        1-й вызов updater                           2-й вызов updater
                 │                                           │
    save = body.overflowY                       save = body.overflowY
           ▲                                           ▲
           │                                           │
          ""  (оригинал)                           "hidden" ⚠️
                 │                                (от 1-го вызова!)
    body.overflowY = "hidden"                            │
                 │                              save = "hidden" ❌
                 │                                           │
                 └─────────────────────┬─────────────────────┘
                                       │
                                       ▼
                        ┌─────────────────────────────┐
                        │  prevBodyOverflowY = "hidden"│
                        │  (должно быть "")            │
                        └──────────────┬──────────────┘
                                       │
                        Открытие ModalB, ModalC...
                        Закрытие всех трёх модалок
                                       │
                                       ▼
                        ┌─────────────────────────────┐
                        │  unregister последней:       │
                        │                              │
                        │  body.overflowY = save       │
                        │                   ▲          │
                        │                   │          │
                        │               "hidden" ❌    │
                        │                              │
                        │  Скролл сломан навсегда      │
                        └─────────────────────────────┘

```

### Сравнительный анализ: управление overflow в UI-китах

```md
## Общий паттерн

Другие UI-киты решают задачу одинаково: **один глобальный координатор на уровне модуля**, не привязанный к React-дереву. 

Overflow сохраняется при переходе `0 → 1`, восстанавливается при `1 → 0`.

## Ant Design — `ScrollLocker` (rc-util)

- Глобальный массив `locks[]` на уровне модуля
- Каждый Modal создаёт свой экземпляр `ScrollLocker`, но массив — общий
- `lock()` — push в массив; при `length === 1` сохраняет стили, ставит `hidden`
- `unLock()` — splice из массива; при `length === 0` восстанавливает стили
- Дополнительно: компенсация ширины scrollbar через `calc(100% - scrollBarSize)`

## Material UI — `ModalManager` (singleton)

- Класс `ModalManager` с массивом `modals[]`
- Один экземпляр создаётся на уровне модуля (`const defaultManager = new ModalManager()`)
- `add()` / `remove()` — императивные вызовы, без React state
- Overflow управляется только при переходах `0 → 1` и `1 → 0`
- Дополнительно: отдельный tracking контейнеров (поддержка scroll lock не только на body)

## Plasma (до фикса)

- Координатора нет — каждый `PopupProvider` управляет overflow независимо
- Overflow сохраняется/восстанавливается внутри `setItems` state updater (side effect)
- При нескольких `PopupProvider` — каждый сохраняет уже изменённое значение `"hidden"` вместо оригинала

## Ключевые отличия

|                                | Ant Design          | MUI                       | Plasma (до)              |
| ------------------------------ | ------------------- | ------------------------- | ------------------------ |
| Координатор                    | `locks[]` (модуль)  | `ModalManager` (singleton)| нет                      |
| Привязка к React-дереву        | нет                 | нет                       | да (`PopupProvider`)     |
| Side effects в state updater   | нет                 | нет                       | да                       |
| Несколько Provider/Manager     | безопасно           | безопасно                 | ломает overflow          |
| Компенсация scrollbar          | да                  | да                        | нет                      |

## Вывод

Мы единственный из трёх, где управление overflow привязано к React-компоненту (`PopupProvider`) и зависит от того, как пользователь строит дерево компонентов. 

В Ant и MUI координация происходит на уровне JS-модуля, что делает её независимой от количества Provider'ов и структуры React-дерева.

```



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.373.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-b2c@1.615.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-core@1.223.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-giga@0.342.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-homeds@0.342.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-hope@1.369.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-icons@1.235.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-new-hope@0.359.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-tokens@1.135.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-ui@1.345.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-web@1.617.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-bizcom@0.347.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-cs@0.351.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-dfa@0.345.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-finai@0.338.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-insol@0.342.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-netology@0.346.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-os@0.17.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-platform-ai@0.346.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-sbcom@0.346.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-scan@0.345.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-serv@0.346.1-canary.2697.24989223943.0
  npm install @salutejs/core-themes@0.24.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-themes@0.47.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-themes@0.62.1-canary.2697.24989223943.0
  npm install @salutejs/sdds-api-tests@0.4.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-cy-utils@0.153.1-canary.2697.24989223943.0
  npm install @salutejs/plasma-sb-utils@0.223.1-canary.2697.24989223943.0
  # or 
  yarn add @salutejs/plasma-asdk@0.373.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-b2c@1.615.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-core@1.223.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-giga@0.342.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-homeds@0.342.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-hope@1.369.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-icons@1.235.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-new-hope@0.359.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-tokens@1.135.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-ui@1.345.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-web@1.617.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-bizcom@0.347.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-cs@0.351.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-dfa@0.345.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-finai@0.338.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-insol@0.342.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-netology@0.346.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-os@0.17.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-platform-ai@0.346.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-sbcom@0.346.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-scan@0.345.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-serv@0.346.1-canary.2697.24989223943.0
  yarn add @salutejs/core-themes@0.24.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-themes@0.47.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-themes@0.62.1-canary.2697.24989223943.0
  yarn add @salutejs/sdds-api-tests@0.4.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-cy-utils@0.153.1-canary.2697.24989223943.0
  yarn add @salutejs/plasma-sb-utils@0.223.1-canary.2697.24989223943.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
