### PR TITLE
PLASMA-6993: remove data and columns from root div in Table

### DIFF
--- a/packages/plasma-new-hope/src/components/Table/Table.tsx
+++ b/packages/plasma-new-hope/src/components/Table/Table.tsx
@@ -27,7 +27,7 @@ type ColumnSort = {
 };
 type SortingState = ColumnSort[];
 
-export const tableRoot = (Root: RootProps<HTMLDivElement, TableProps>) =>
+export const tableRoot = (Root: RootProps<HTMLDivElement, Omit<TableProps, 'data' | 'columns'>>) =>
     forwardRef<HTMLDivElement, TableProps>(
         (
             {
@@ -207,8 +207,6 @@ export const tableRoot = (Root: RootProps<HTMLDivElement, TableProps>) =>
             return (
                 <Root
                     ref={rootRef}
-                    data={data}
-                    columns={columns}
                     view={view}
                     size={size}
                     className={cls(props.className, classNames?.root, classes.root)}


### PR DESCRIPTION
## Core

### Table
- убраны лишние html-атрибуты из корневого `div`;

Было:
<img width="448" height="225" alt="Снимок экрана 2026-04-21 в 15 24 07" src="https://github.com/user-attachments/assets/c6ef118e-7589-4215-9be1-a1aed1580de2" />

Стало:
<img width="474" height="377" alt="Снимок экрана 2026-04-21 в 15 24 30" src="https://github.com/user-attachments/assets/0650f894-4334-4ae2-81c3-5cacaef531d4" />

### What/why changed
- убраны лишние html-атрибуты из корневого `div`;
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.373.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-b2c@1.615.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-core@1.224.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-giga@0.342.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-homeds@0.342.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-hope@1.370.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-icons@1.236.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-new-hope@0.359.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-tokens@1.136.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-ui@1.346.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-web@1.617.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-bizcom@0.347.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-cs@0.351.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-dfa@0.345.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-finai@0.338.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-insol@0.342.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-netology@0.346.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-os@0.17.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-platform-ai@0.346.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-sbcom@0.346.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-scan@0.345.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-serv@0.346.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-themes@0.48.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-themes@0.63.0-canary.2717.24710516640.0
  npm install @salutejs/sdds-api-tests@0.4.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-cy-utils@0.154.0-canary.2717.24710516640.0
  npm install @salutejs/plasma-sb-utils@0.224.0-canary.2717.24710516640.0
  # or 
  yarn add @salutejs/plasma-asdk@0.373.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-b2c@1.615.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-core@1.224.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-giga@0.342.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-homeds@0.342.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-hope@1.370.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-icons@1.236.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-new-hope@0.359.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-tokens@1.136.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-ui@1.346.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-web@1.617.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-bizcom@0.347.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-cs@0.351.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-dfa@0.345.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-finai@0.338.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-insol@0.342.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-netology@0.346.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-os@0.17.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-platform-ai@0.346.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-sbcom@0.346.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-scan@0.345.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-serv@0.346.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-themes@0.48.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-themes@0.63.0-canary.2717.24710516640.0
  yarn add @salutejs/sdds-api-tests@0.4.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-cy-utils@0.154.0-canary.2717.24710516640.0
  yarn add @salutejs/plasma-sb-utils@0.224.0-canary.2717.24710516640.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
