### PR TITLE
sdds-infra: Fix memory issue for cypress

### DIFF
--- a/cypress/webpack.config.ts
+++ b/cypress/webpack.config.ts
@@ -37,7 +37,14 @@ export const getWebpackConfig = () => {
         cache,
         mode: 'development',
         target: 'web',
-        devtool: browser === 'webkit' ? false : 'eval-source-map',
+        devtool: false,
+        plugins: [
+            {
+                apply(compiler) {
+                    compiler.options.devtool = false;
+                },
+            },
+        ],
         resolve: {
             extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
             modules: ['node_modules'],


### PR DESCRIPTION
### What/why changed

`@cypress/webpack-dev-server` принудительно выставляет `devtool: 'inline-source-map'`
и мержит свой конфиг **после** пользовательского, перетирая любое значение `devtool`.

`inline-source-map` встраивает весь source map как base64-строку в конец каждого JS-чанка.

- При **112 спеках** (без `--components`) — `splitChunks: 'all'` разбивает бандл на десятки
  мелких чанков, каждый с небольшим source map. Chromium загружает их по частям — работает.
- При **1 спеке** (с `--components`) — `splitChunks` нечего разделять, все ~13 500 модулей
  попадают в **один чанк** с гигантским inline source map.
  
Chromium не может распарсить такой файл — OOM crash.

Поэтому отключить source maps через webpack-плагин, который выполняется **после** merge
и перебивает значение Cypress.

**Примечание:**

Проверили решение на рабочей машине Игоря, тесты запускаются.      
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.373.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-b2c@1.615.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-core@1.223.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-giga@0.342.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-homeds@0.342.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-hope@1.369.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-icons@1.235.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-new-hope@0.359.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-tokens@1.135.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-ui@1.345.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-web@1.617.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-bizcom@0.347.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-cs@0.351.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-dfa@0.345.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-finai@0.338.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-insol@0.342.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-netology@0.346.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-os@0.17.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-platform-ai@0.346.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-sbcom@0.346.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-scan@0.345.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-serv@0.346.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-themes@0.47.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-themes@0.62.1-canary.2725.24820545209.0
  npm install @salutejs/sdds-api-tests@0.4.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-cy-utils@0.153.1-canary.2725.24820545209.0
  npm install @salutejs/plasma-sb-utils@0.223.1-canary.2725.24820545209.0
  # or 
  yarn add @salutejs/plasma-asdk@0.373.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-b2c@1.615.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-core@1.223.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-giga@0.342.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-homeds@0.342.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-hope@1.369.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-icons@1.235.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-new-hope@0.359.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-tokens@1.135.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-ui@1.345.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-web@1.617.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-bizcom@0.347.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-cs@0.351.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-dfa@0.345.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-finai@0.338.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-insol@0.342.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-netology@0.346.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-os@0.17.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-platform-ai@0.346.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-sbcom@0.346.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-scan@0.345.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-serv@0.346.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-themes@0.47.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-themes@0.62.1-canary.2725.24820545209.0
  yarn add @salutejs/sdds-api-tests@0.4.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-cy-utils@0.153.1-canary.2725.24820545209.0
  yarn add @salutejs/plasma-sb-utils@0.223.1-canary.2725.24820545209.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
