### PR TITLE
PLASMA: change cypress bundler

### DIFF
--- a/.github/workflows/cypress-common.yml
+++ b/.github/workflows/cypress-common.yml
@@ -80,6 +80,18 @@ jobs:
             else
               npx lerna bootstrap --scope=@salutejs/plasma-${{env.SCOPE}} --scope="@salutejs/core-themes" --scope="@salutejs/${{ inputs.prefix }}-{${{ inputs.scope }},themes}"
             fi
+          
+      - name: Cache Vite deps
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.vite
+          key: vite-deps-${{ inputs.scope }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            vite-deps-${{ inputs.scope }}-
+
+      - name: Fix Vite cache permissions
+        if: always()
+        run: sudo chown -R $(id -u):$(id -g) node_modules/.vite || true
 
       - name: Run Cypress CT for Plasma ${{ inputs.scope }}
         if: ${{ success() }}

--- a/.github/workflows/cypress-common.yml
+++ b/.github/workflows/cypress-common.yml
@@ -89,7 +89,7 @@ jobs:
           restore-keys: |
             vite-deps-${{ inputs.scope }}-
 
-      - name: Fix Vite cache permissions
+      - name: Fix Vite cache permissions (pre-run)
         if: always()
         run: sudo chown -R $(id -u):$(id -g) node_modules/.vite || true
 
@@ -109,6 +109,10 @@ jobs:
           else
               echo "Skipping Cypress: No test files found for specified components"
           fi
+
+      - name: Fix Vite cache permissions (post-run)
+        if: always()
+        run: sudo chown -R $(id -u):$(id -g) node_modules/.vite || true
 
       - name: Reorganize diff artifacts
         if: ${{ failure() || inputs.with-artifacts }}

--- a/.github/workflows/cypress-common.yml
+++ b/.github/workflows/cypress-common.yml
@@ -93,6 +93,16 @@ jobs:
         if: always()
         run: sudo chown -R $(id -u):$(id -g) node_modules/.vite || true
 
+      - name: Check Vite cache state
+        if: always()
+        run: |
+          if [ -d "node_modules/.vite/deps" ]; then
+            FILE_COUNT=$(find node_modules/.vite/deps -name '*.js' | wc -l)
+            echo "Vite cache: ${FILE_COUNT} bundled files (warm start expected)"
+          else
+            echo "No Vite cache (cold start expected)"
+          fi
+
       - name: Run Cypress CT for Plasma ${{ inputs.scope }}
         if: ${{ success() }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ s3_build
 temp
 **/.DS_Store
 **/.swc
+
+# Vite-generated module files (created at dev-server startup)
+cypress/.generated/

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
             bundler: 'vite',
             viteConfig: getViteConfig,
         },
-        justInTimeCompile: false,
+        justInTimeCompile: true,
         setupNodeEvents,
     },
     env: {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { defineConfig } from 'cypress';
 
-import { getWebpackConfig } from './cypress/webpack.config';
+import { getViteConfig } from './cypress/vite.config';
 import { setupNodeEvents } from './cypress/plugins';
 
 const CORE_TESTS_DIR = 'plasma-new-hope';
@@ -52,8 +52,8 @@ export default defineConfig({
         supportFile: supportFilePath,
         devServer: {
             framework: 'react',
-            bundler: 'webpack',
-            webpackConfig: getWebpackConfig(),
+            bundler: 'vite',
+            viteConfig: getViteConfig,
         },
         justInTimeCompile: false,
         setupNodeEvents,

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,0 +1,286 @@
+# HOW TO CYPRESS COMPONENT TEST
+
+Тесты проверяют, что компоненты выглядят правильно: рендерятся, делают скриншот, сравнивают с эталоном. Если пиксели расошлись больше порога (0.5%) — тест падает.
+
+---
+
+## Содержание
+
+-   [Как это работает в двух словах](#как-это-работает-в-двух-словах)
+-   [Структура файлов](#структура-файлов)
+-   [Запуск тестов](#запуск-тестов)
+-   [Два типа тест-файлов](#два-типа-тест-файлов)
+-   [Как добавить тест для нового компонента](#как-добавить-тест-для-нового-компонента)
+-   [Обновление эталонных снимков](#обновление-эталонных-снимков)
+-   [Устройство конфигурации Vite](#устройство-конфигурации-vite)
+-   [Docker и браузеры](#docker-и-браузеры)
+-   [Снимки в git](#снимки-в-git)
+
+---
+
+## Как это работает в двух словах
+
+```
+npm run cy:b2c:run
+        │
+        ▼
+  Docker-контейнер
+        │
+        ▼
+  Cypress запускает Vite dev-сервер
+        │
+        ▼
+  Для каждого *.component-test.tsx:
+    1. Компонент монтируется в браузере
+    2. cy.matchImageSnapshot() делает скриншот viewport'а
+    3. Скриншот сравнивается с эталоном в cypress/snapshots/
+    4. Если diff > 0.5% — тест падает
+```
+
+Тесты — **компонентные** (не e2e): браузер открывает не всё приложение, а отдельный компонент, завёрнутый в тему и SSR-провайдер.
+
+---
+
+## Структура файлов
+
+```
+cypress/
+├── Dockerfile                   # образ с Cypress + Chromium + WebKit
+├── vite.config.ts               # конфигурация Vite dev-сервера
+├── plugins/
+│   ├── index.ts                 # setupNodeEvents: скриншоты, регистрация webkit-браузера
+│   ├── virtualTestPackage.ts    # виртуальный модуль '@plasma-cy/test-package'
+│   ├── virtualTestConfigs.ts    # виртуальный модуль '@plasma-cy/test-configs'
+│   └── virtualTestTheme.ts      # виртуальный модуль '@plasma-cy/test-theme'
+├── support/
+│   ├── index.ts                 # глобальный setup: команды, css, плагины
+│   └── commands.ts              # cy.matchImageSnapshot() + webkit font fix
+├── snapshots/
+│   ├── b2c/chromium/Button/     # эталонные PNG по пакету → браузеру → компоненту
+│   ├── b2c/webkit/Button/
+│   └── ...
+└── fixtures/
+    └── css/plasmaGlobalStyle.css  # базовый CSS (normalize, шрифты)
+```
+
+Тест-файлы живут **внутри пакетов**, не в папке `cypress/`:
+
+```
+packages/
+├── plasma-b2c/src/components/Button/
+│   ├── Button.tsx
+│   ├── Button.config.ts                        # конфигурация вариаций
+│   └── Button.component-test.tsx               # тесты
+├── plasma-new-hope/src/components/Button/
+│   ├── Button.component-test.tsx               # "базовые" тесты для всех пакетов
+│   └── (нет Button.config.ts — он в пакете)
+└── ...
+```
+
+---
+
+## Запуск тестов
+
+Все команды запускают тесты **внутри Docker**.
+
+### Запустить все тесты пакета
+
+```bash
+npm run cy:b2c:run          # plasma-b2c, chromium
+npm run cy:b2c:run:webkit   # plasma-b2c, webkit
+npm run cy:web:run          # plasma-web, chromium
+npm run cy:cs:run           # sdds-cs, chromium
+# ... аналогично для других пакетов: cy:giga, cy:ui, cy:insol, cy:serv, cy:scan, cy:os
+```
+
+### Запустить конкретные компоненты
+
+```bash
+npm run cy:b2c:run --components="Button"
+npm run cy:b2c:run:webkit --components="Button,Chip"
+```
+
+Имена — через запятую, регистр не важен (`button` и `Button` оба работают).
+
+### Посмотреть, какие файлы найдёт команда
+
+Паттерн поиска строится в `cypress.config.ts → getTestMatch()`. Например, для `PACKAGE_NAME=plasma-b2c, COMPONENTS=Button,Chip` Cypress ищет:
+
+```
+**/{plasma-b2c,plasma-new-hope}/**/{Button,Chip}/*.component-test.{ts,tsx}
+```
+
+Таким образом к тестам конкретного пакета всегда добавляются "базовые" тесты из `plasma-new-hope`.
+
+---
+
+## Тест-файлы
+
+### 1. Тесты для новых компонентов — `ComponentName.component-test.tsx`
+
+Пишутся вручную. Используются для специфичных сценариев: интерактивность, редкие состояния, регрессии.
+
+```tsx
+// packages/plasma-b2c/src/components/Chip/Chip.component-test.tsx
+import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
+import { Chip as ChipB2C } from '.';
+
+describe('plasma-b2c: Chip', () => {
+    const Chip = getComponent('Chip') as typeof ChipB2C; // берёт из pre-bundled дистрибутива
+
+    it('size=l, view=default, hasClear', () => {
+        mount(
+            <CypressTestDecorator>
+                <Chip text="Привет" view="default" size="l" hasClear />
+            </CypressTestDecorator>,
+        );
+        cy.matchImageSnapshot();
+    });
+});
+```
+
+> `getComponent('Chip')` — ищет компонент в pre-bundled дистрибутиве текущего пакета
+> (см. виртуальный модуль `@plasma-cy/test-package`). Не импортирует исходник напрямую.
+
+### 2. Базовые тесты из `plasma-new-hope` — используют `getBaseVisualTests`
+
+Живут в `plasma-new-hope/src/components/ComponentName/`. Запускаются для **всех** пакетов (кроме `plasma-ui`), потому что большинство пакетов (`plasma-b2c`, `plasma-web`, `sdds-*`) основаны на `plasma-new-hope`.
+
+Тесты генерируют комбинаторную матрицу из `ComponentName.config.ts` и делают скриншот для каждой комбинации `view × size × ...`:
+
+```tsx
+// packages/plasma-new-hope/src/components/Button/Button.component-test.tsx
+getBaseVisualTests({
+    component: 'Button',
+    componentProps: { text: 'Button' },
+    configPropsForMatrix: ['view', 'size', 'stretching'],
+});
+// → автоматически создаёт it-кейс для каждой комбинации: view=accent, size=m, stretching=fixed и т.д.
+```
+
+Конфиг с вариациями лежит в самом пакете:
+
+```
+packages/plasma-b2c/src/components/Button/Button.config.ts  ← вариации для b2c
+packages/plasma-web/src/components/Button/Button.config.ts  ← вариации для web
+```
+
+---
+
+## Как добавить тест для нового компонента
+
+### Базовые тесты, характерные для всех пакетов
+
+1. Создайте `packages/plasma-new-hope/src/components/MyComponent/MyComponent.component-test.tsx` с `getBaseVisualTests`
+2. Создайте `packages/<package>/src/components/MyComponent/MyComponent.config.ts` с вариациями пропов
+
+---
+
+### Уникальный тест для пакета
+
+Создайте `packages/<package>/src/components/<Component>/<Component>.component-test.tsx`:
+
+```tsx
+import React from 'react';
+import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
+import type { MyComponent as MyComponentType } from '.';
+
+describe('<package>: MyComponent', () => {
+    const MyComponent = getComponent('MyComponent') as typeof MyComponentType;
+
+    it('default state', () => {
+        mount(
+            <CypressTestDecorator>
+                <MyComponent label="Привет" />
+            </CypressTestDecorator>,
+        );
+        cy.matchImageSnapshot();
+    });
+});
+```
+
+## Обновление эталонных снимков
+
+Если компонент изменился намеренно, нужно обновить PNG-эталоны:
+
+```bash
+npm run cy:b2c:update --components="Button"          # chromium
+npm run cy:b2c:update:webkit --components="Button"   # webkit
+```
+
+Команда запишет новые `.snap.png` в `cypress/snapshots/<product>/<browser>/<Component>/`. После этого закоммитьте обновлённые снимки.
+
+---
+
+## Устройство конфигурации Vite
+
+Vite поднимается как dev-сервер внутри Cypress. Конфиг в `cypress/vite.config.ts`.
+
+### Виртуальные модули
+
+Три плагина создают "несуществующие" модули, которые Vite генерирует на лету:
+
+| Модуль                    | Плагин                  | Содержит                                                                                  |
+| ------------------------- | ----------------------- | ----------------------------------------------------------------------------------------- |
+| `@plasma-cy/test-package` | `virtualTestPackage.ts` | Реэкспорт dist тестируемого пакета. `getComponent('Button')` возвращает компонент отсюда  |
+| `@plasma-cy/test-configs` | `virtualTestConfigs.ts` | Namespace-реэкспорт всех `*.config.ts` файлов пакета. Используется в `getBaseVisualTests` |
+| `@plasma-cy/test-theme`   | `virtualTestTheme.ts`   | Тема и типографика для текущего пакета. Используется в `CypressTestDecorator`             |
+
+### Pre-bundling зависимостей
+
+`optimizeDeps.include` в vite.config задаёт, что Vite должен пре-бандлить (CJS → ESM) до старта:
+
+-   `react`, `react-dom`, `styled-components` — стандартные CJS-пакеты
+-   `TEST_PACKAGE_DIST_ALIAS` (`@plasma-cy/test-package-dist`) — весь дистрибутив пакета + plasma-icons собирается в один файл
+
+### Env-переменные
+
+| Переменная                | Пример        | Что делает                                            |
+| ------------------------- | ------------- | ----------------------------------------------------- |
+| `PACKAGE_NAME`            | `plasma-b2c`  | Обязательная. Определяет пакет, тему, dist-барель     |
+| `COMPONENTS`              | `Button,Chip` | Фильтрует тест-файлы. Без неё — все компоненты пакета |
+| `BROWSER`                 | `webkit`      | `chromium` по умолчанию                               |
+| `RETRIES`                 | `5`           | Количество повторов упавшего теста (по умолчанию 5)   |
+| `CYPRESS_updateSnapshots` | `true`        | Режим обновления эталонов                             |
+
+---
+
+## Docker и браузеры
+
+Тесты всегда запускаются в Docker (`cypress/Dockerfile`). Образ содержит:
+
+-   Chromium (системный)
+-   WebKit (через `playwright-webkit`)
+-   Node.js + Cypress
+
+**Почему Docker:** воспроизводимость рендеринга. Шрифты, субпиксельный рендеринг и поведение браузера должны быть одинаковыми на всех машинах и в CI.
+
+**Chromium** — основной браузер.
+
+**WebKit** — для проверки Safari-совместимости. Работает медленнее (нет GPU-акселерации в Docker), скриншоты хранятся отдельно (`snapshots/<product>/webkit/`).
+
+---
+
+## Снимки в git
+
+```
+cypress/snapshots/
+├── b2c/
+│   ├── chromium/
+│   │   ├── Button/
+│   │   │   ├── Button -- view=accent, size=m, stretching=fixed.snap.png
+│   │   │   ├── Button -- disabled.snap.png
+│   │   │   └── ...
+│   │   └── Chip/
+│   └── webkit/
+│       └── Button/
+├── web/
+│   └── chromium/
+└── ...
+```
+
+Путь к снимку: `cypress/snapshots/<productName>/<browser>/<ComponentName>/<TestName>.snap.png`
+
+`productName` — часть имени пакета после `plasma-` или `sdds-`: `b2c`, `web`, `cs`, `giga` и т.д.
+
+Все снимки хранятся в репозитории. При обновлении компонента обновляйте снимки соответствующей командой `cy:<package>:update`.

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -29,6 +29,12 @@ npm run cy:b2c:run
         ▼
   Cypress запускает Vite dev-сервер
         │
+        ├── generateModules() генерирует cypress/.generated/*.ts
+        │   (реальные файлы для @plasma-cy/* алиасов)
+        │
+        ▼
+  Vite запускает optimizeDeps: esbuild пре-бандлит все зависимости
+        │
         ▼
   Для каждого *.component-test.tsx:
     1. Компонент монтируется в браузере
@@ -49,9 +55,13 @@ cypress/
 ├── vite.config.ts               # конфигурация Vite dev-сервера
 ├── plugins/
 │   ├── index.ts                 # setupNodeEvents: скриншоты, регистрация webkit-браузера
-│   ├── virtualTestPackage.ts    # виртуальный модуль '@plasma-cy/test-package'
-│   ├── virtualTestConfigs.ts    # виртуальный модуль '@plasma-cy/test-configs'
-│   └── virtualTestTheme.ts      # виртуальный модуль '@plasma-cy/test-theme'
+│   └── generateModules.ts       # генерирует реальные файлы для @plasma-cy/* модулей
+├── .generated/                  # авто-генерируемые файлы при старте dev-сервера (в .gitignore)
+│   ├── test-package.ts          # реэкспорт dist тестируемого пакета
+│   ├── test-theme.ts            # тема и типографика для текущего пакета
+│   └── test-configs.ts          # namespace-реэкспорт всех *.config.ts файлов пакета
+├── stubs/
+│   └── platform.ts              # заглушка для platform.js (падает при парсинге UA в Cypress)
 ├── support/
 │   ├── index.ts                 # глобальный setup: команды, css, плагины
 │   └── commands.ts              # cy.matchImageSnapshot() + webkit font fix
@@ -112,6 +122,16 @@ npm run cy:b2c:run:webkit --components="Button,Chip"
 
 Таким образом к тестам конкретного пакета всегда добавляются "базовые" тесты из `plasma-new-hope`.
 
+### Подробные логи Vite
+
+Для диагностики производительности (какие файлы загружаются, сколько времени):
+
+```bash
+DEBUG=vite:deps,vite:resolve,vite:cache npm run cy:b2c:run --components="Button"
+# или подробнее:
+DEBUG=vite:* npm run cy:b2c:run --components="Button"
+```
+
 ---
 
 ## Тест-файлы
@@ -126,7 +146,7 @@ import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-u
 import { Chip as ChipB2C } from '.';
 
 describe('plasma-b2c: Chip', () => {
-    const Chip = getComponent('Chip') as typeof ChipB2C; // берёт из pre-bundled дистрибутива
+    const Chip = getComponent('Chip') as typeof ChipB2C; // берёт из пре-бандленного дистрибутива
 
     it('size=l, view=default, hasClear', () => {
         mount(
@@ -139,8 +159,8 @@ describe('plasma-b2c: Chip', () => {
 });
 ```
 
-> `getComponent('Chip')` — ищет компонент в pre-bundled дистрибутиве текущего пакета
-> (см. виртуальный модуль `@plasma-cy/test-package`). Не импортирует исходник напрямую.
+> `getComponent('Chip')` — ищет компонент в пре-бандленном дистрибутиве текущего пакета
+> через модуль `@plasma-cy/test-package`. Не импортирует исходник напрямую.
 
 ### 2. Базовые тесты из `plasma-new-hope` — используют `getBaseVisualTests`
 
@@ -174,8 +194,6 @@ packages/plasma-web/src/components/Button/Button.config.ts  ← вариации
 1. Создайте `packages/plasma-new-hope/src/components/MyComponent/MyComponent.component-test.tsx` с `getBaseVisualTests`
 2. Создайте `packages/<package>/src/components/MyComponent/MyComponent.config.ts` с вариациями пропов
 
----
-
 ### Уникальный тест для пакета
 
 Создайте `packages/<package>/src/components/<Component>/<Component>.component-test.tsx`:
@@ -199,6 +217,8 @@ describe('<package>: MyComponent', () => {
 });
 ```
 
+---
+
 ## Обновление эталонных снимков
 
 Если компонент изменился намеренно, нужно обновить PNG-эталоны:
@@ -216,32 +236,52 @@ npm run cy:b2c:update:webkit --components="Button"   # webkit
 
 Vite поднимается как dev-сервер внутри Cypress. Конфиг в `cypress/vite.config.ts`.
 
-### Виртуальные модули
+### Генерируемые модули
 
-Три плагина создают "несуществующие" модули, которые Vite генерирует на лету:
+При старте dev-сервера `generateModules()` создаёт три реальных `.ts` файла в `cypress/.generated/`:
 
-| Модуль                    | Плагин                  | Содержит                                                                                  |
-| ------------------------- | ----------------------- | ----------------------------------------------------------------------------------------- |
-| `@plasma-cy/test-package` | `virtualTestPackage.ts` | Реэкспорт dist тестируемого пакета. `getComponent('Button')` возвращает компонент отсюда  |
-| `@plasma-cy/test-configs` | `virtualTestConfigs.ts` | Namespace-реэкспорт всех `*.config.ts` файлов пакета. Используется в `getBaseVisualTests` |
-| `@plasma-cy/test-theme`   | `virtualTestTheme.ts`   | Тема и типографика для текущего пакета. Используется в `CypressTestDecorator`             |
+| Алиас                     | Файл                         | Содержит                                                                                  |
+| ------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `@plasma-cy/test-package` | `.generated/test-package.ts` | Реэкспорт dist тестируемого пакета. `getComponent('Button')` возвращает компонент отсюда  |
+| `@plasma-cy/test-configs` | `.generated/test-configs.ts` | Namespace-реэкспорт всех `*.config.ts` файлов пакета. Используется в `getBaseVisualTests` |
+| `@plasma-cy/test-theme`   | `.generated/test-theme.ts`   | Тема и типографика для текущего пакета. Используется в `CypressTestDecorator`             |
+
+**Почему реальные файлы, а не виртуальные модули Vite:** esbuild умеет пре-бандлить только реальные файлы через `optimizeDeps`. Виртуальные модули (Rollup plugin API: `resolveId` + `load`) esbuild не понимает — без реальных файлов `@plasma-cy/*` не попадали бы в пре-бандл и создавали ESM request waterfall при каждом тесте.
 
 ### Pre-bundling зависимостей
 
-`optimizeDeps.include` в vite.config задаёт, что Vite должен пре-бандлить (CJS → ESM) до старта:
+`optimizeDeps.include` в `vite.config.ts` — список пакетов, которые esbuild конвертирует из CJS в ESM и упаковывает в единые чанки до старта тестов. Это устраняет ESM waterfall при загрузке каждого spec-файла:
 
--   `react`, `react-dom`, `styled-components` — стандартные CJS-пакеты
--   `TEST_PACKAGE_DIST_ALIAS` (`@plasma-cy/test-package-dist`) — весь дистрибутив пакета + plasma-icons собирается в один файл
+| Пакет                       | Зачем в include                                                 |
+| --------------------------- | --------------------------------------------------------------- |
+| `react`, `react-dom`        | CJS-пакеты, нужна конвертация в ESM                             |
+| `styled-components`         | CJS-пакет                                                       |
+| `@salutejs/plasma-cy-utils` | Исходники `.tsx`, esbuild бандлит в один файл вместо 9 запросов |
+| `@plasma-cy/test-package`   | Реальный генерируемый файл — dist компонентного пакета          |
+| `@plasma-cy/test-theme`     | Реальный генерируемый файл — тема пакета                        |
+| `@plasma-cy/test-configs`   | Реальный генерируемый файл — config-файлы компонентов           |
+| `cypress-plugin-tab`        | CJS-пакет                                                       |
+
+### Плагины vite.config.ts
+
+**`preload-dep-chunks`** — при каждом HTML-запросе читает `node_modules/.vite/deps/_metadata.json`, находит все `chunk-*.js` файлы и инжектирует `<link rel="modulepreload">` в `<head>`. Браузер начинает загружать shared chunks сразу при получении HTML, не дожидаясь обхода import chain. Это устраняет waterfall из нескольких последовательных round trips на chunk-зависимости.
+
+**`cache-static-assets`** — middleware Vite dev server, добавляет `Cache-Control: public, max-age=31536000, immutable` для шрифтов и изображений. Без этого браузер делает conditional GET при каждом spec-файле (~16 шрифтов × ~500ms round trip в Docker).
+
+### `justInTimeCompile: false`
+
+В `cypress.config.ts` выставлен `justInTimeCompile: false` — Cypress компилирует все spec-файлы заранее, до запуска тестов, что устраняет паузу на холодную компиляцию в начале каждого теста.
 
 ### Env-переменные
 
-| Переменная                | Пример        | Что делает                                            |
-| ------------------------- | ------------- | ----------------------------------------------------- |
-| `PACKAGE_NAME`            | `plasma-b2c`  | Обязательная. Определяет пакет, тему, dist-барель     |
-| `COMPONENTS`              | `Button,Chip` | Фильтрует тест-файлы. Без неё — все компоненты пакета |
-| `BROWSER`                 | `webkit`      | `chromium` по умолчанию                               |
-| `RETRIES`                 | `5`           | Количество повторов упавшего теста (по умолчанию 5)   |
-| `CYPRESS_updateSnapshots` | `true`        | Режим обновления эталонов                             |
+| Переменная                | Пример        | Что делает                                                |
+| ------------------------- | ------------- | --------------------------------------------------------- |
+| `PACKAGE_NAME`            | `plasma-b2c`  | Обязательная. Определяет пакет, тему, dist-барель         |
+| `COMPONENTS`              | `Button,Chip` | Фильтрует тест-файлы. Без неё — все компоненты пакета     |
+| `BROWSER`                 | `webkit`      | `chromium` по умолчанию                                   |
+| `RETRIES`                 | `5`           | Количество повторов упавшего теста (по умолчанию 5)       |
+| `CYPRESS_updateSnapshots` | `true`        | Режим обновления эталонов                                 |
+| `DEBUG`                   | `vite:*`      | Подробные логи Vite (загрузка файлов, кеш, трансформации) |
 
 ---
 
@@ -258,6 +298,10 @@ Vite поднимается как dev-сервер внутри Cypress. Кон
 **Chromium** — основной браузер.
 
 **WebKit** — для проверки Safari-совместимости. Работает медленнее (нет GPU-акселерации в Docker), скриншоты хранятся отдельно (`snapshots/<product>/webkit/`).
+
+### Производительность в Docker
+
+Docker bridge networking добавляет ~500ms на каждый round trip между браузером и Vite dev-сервером. Оптимизации выше (pre-bundling, `modulepreload`, font caching) снижают количество последовательных round trips с ~13 до ~5 на spec-файл. На Linux CI можно дополнительно использовать `--network=host` в Docker run команде — это устраняет накладные расходы сети полностью.
 
 ---
 

--- a/cypress/plugins/generateModules.ts
+++ b/cypress/plugins/generateModules.ts
@@ -1,0 +1,127 @@
+import path from 'path';
+import fs from 'fs';
+
+export const TEST_PACKAGE_DIST_ALIAS = '@plasma-cy/test-package-dist';
+
+const GENERATED_DIR = path.resolve(__dirname, '..', '.generated');
+
+export const getPackageDistPath = (packsPath: string, packageName: string): string => {
+    switch (packageName) {
+        case 'plasma-ui':
+            return path.join(packsPath, 'plasma-ui/es/index.js');
+        case 'sdds-cs':
+            return path.join(packsPath, 'sdds-cs/dist/emotion/es/index.js');
+        default:
+            return path.join(packsPath, packageName, 'dist/styled-components/es/index.js');
+    }
+};
+
+const findConfigFiles = (dir: string): string[] => {
+    if (!fs.existsSync(dir)) return [];
+    const result: string[] = [];
+    const walk = (current: string) => {
+        for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+            if (entry.isDirectory()) {
+                if (entry.name !== '_beta') walk(path.join(current, entry.name));
+            } else if (
+                entry.name.endsWith('.config.ts') &&
+                entry.name.slice(0, -'.config.ts'.length) === path.basename(current)
+            ) {
+                result.push(path.join(current, entry.name));
+            }
+        }
+    };
+    walk(dir);
+    return result;
+};
+
+const buildThemeContent = (packageName: string, packsPath: string): string => {
+    switch (packageName) {
+        case 'plasma-ui': {
+            const theme = path.join(packsPath, 'plasma-tokens', 'es', 'themes', 'salutejs_sber__dark');
+            return [
+                `export { salutejs_sber__dark as themeVars } from '${theme}';`,
+                "export const standardTypo = '';",
+                "export const compatibleTypo = '';",
+            ].join('\n');
+        }
+        case 'plasma-b2c': {
+            const theme = path.join(packsPath, 'plasma-tokens-b2c', 'es', 'themes', 'dark');
+            const stdTypo = path.join(packsPath, 'plasma-typo', 'lib', 'esm', 'standard');
+            const compatTypo = path.join(packsPath, 'plasma-typo', 'lib', 'esm', 'compatible');
+            return [
+                `export { dark as themeVars } from '${theme}';`,
+                `export { standard as standardTypo } from '${stdTypo}';`,
+                `export { compatible as compatibleTypo } from '${compatTypo}';`,
+            ].join('\n');
+        }
+        case 'sdds-os': {
+            const theme = path.join(
+                packsPath,
+                'sdds-os',
+                'node_modules',
+                '@salutejs-ds',
+                'sdds_os',
+                'es',
+                'theme',
+                'themes',
+                'sdds_os__light',
+            );
+            return [
+                `export { sdds_os__light as themeVars } from '${theme}';`,
+                "export const standardTypo = '';",
+                "export const compatibleTypo = '';",
+            ].join('\n');
+        }
+        default: {
+            const themeName = packageName.replace(/-/g, '_');
+            const isSDDS = packageName.startsWith('sdds-');
+            const themeFile = `${themeName}__light`;
+            const themeDir = isSDDS ? 'sdds-themes' : 'plasma-themes';
+            const theme = path.join(packsPath, 'themes', themeDir, 'es', 'themes', themeFile);
+            return [
+                `export { ${themeFile} as themeVars } from '${theme}';`,
+                "export const standardTypo = '';",
+                "export const compatibleTypo = '';",
+            ].join('\n');
+        }
+    }
+};
+
+export interface GeneratedPaths {
+    testPackage: string;
+    testTheme: string;
+    testConfigs: string;
+}
+
+/**
+ * Генерирует реальные файлы вместо виртуальных Vite-модулей.
+ * Реальные файлы позволяют esbuild pre-bundle их через optimizeDeps,
+ * что устраняет ESM request waterfall при загрузке каждого spec-файла.
+ */
+export const generateModules = (packsPath: string): GeneratedPaths => {
+    const packageName = process.env.PACKAGE_NAME;
+    if (!packageName) throw new Error('[generateModules] PACKAGE_NAME env is not set.');
+
+    fs.mkdirSync(GENERATED_DIR, { recursive: true });
+
+    const testPackagePath = path.join(GENERATED_DIR, 'test-package.ts');
+    const distPath = getPackageDistPath(packsPath, packageName);
+    fs.writeFileSync(testPackagePath, `export * from '${distPath}';\n`);
+
+    const testThemePath = path.join(GENERATED_DIR, 'test-theme.ts');
+    fs.writeFileSync(testThemePath, `${buildThemeContent(packageName, packsPath)}\n`);
+
+    const testConfigsPath = path.join(GENERATED_DIR, 'test-configs.ts');
+    const componentsDir = path.join(packsPath, packageName, 'src', 'components');
+    const requested = process.env.COMPONENTS?.split(',')
+        .map((c) => c.trim())
+        .filter(Boolean);
+    const configsContent = findConfigFiles(componentsDir)
+        .filter((f) => !requested?.length || requested.includes(path.basename(f, '.config.ts')))
+        .map((f) => `export * as ${path.basename(f, '.config.ts')} from '${f}';`)
+        .join('\n');
+    fs.writeFileSync(testConfigsPath, `${configsContent}\n`);
+
+    return { testPackage: testPackagePath, testTheme: testThemePath, testConfigs: testConfigsPath };
+};

--- a/cypress/stubs/platform.ts
+++ b/cypress/stubs/platform.ts
@@ -1,0 +1,21 @@
+// Stub for the `platform` package used by ally.js (cypress-plugin-tab).
+// The real platform.js parses navigator.userAgent at module load time which crashes
+// in Cypress/Vite environment. We only need tab-trapping to work, not UA detection.
+const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+
+const platform = {
+    description: ua,
+    layout: null,
+    manufacturer: null,
+    name: 'Chrome',
+    prerelease: null,
+    product: null,
+    ua,
+    version: '120',
+    os: { architecture: 64, family: 'Windows', version: '10' },
+    parse: () => platform,
+    toString: () => 'Chrome 120',
+};
+
+export default platform;
+export const { description, layout, manufacturer, name, prerelease, product, version, os, parse, toString } = platform;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -6,22 +6,6 @@ const { name } = Cypress.spec;
 const componentName = name.split('.').at(0);
 const baseSnapsDir = `${Cypress.env('snapshotsDir')}${Cypress.browser.name}`;
 
-// const getSnapshotPath = () => {
-//     if (Cypress.env('hasSpecGroup')) {
-//         return `${baseSnapsDir}/components`;
-//     }
-
-//     if (Cypress.env('hasComponents')) {
-//         return `${baseSnapsDir}/components/${componentName}`;
-//     }
-
-//     if (['plasma-web', 'plasma-b2c'].includes(Cypress.env('package'))) {
-//         return baseSnapsDir;
-//     }
-
-//     return `${baseSnapsDir}/components`;
-// };
-
 const isUpdateMode =
     Cypress.env('updateSnapshots') || Cypress.env('UPDATE_SNAPSHOTS') || Cypress.env('CYPRESS_updateSnapshots');
 

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -2,5 +2,4 @@ import './commands';
 import '@cypress/code-coverage/support';
 import 'cypress-real-events';
 import '../fixtures/css/plasmaGlobalStyle.css';
-
-require('cypress-plugin-tab');
+import 'cypress-plugin-tab';

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES5",
+        "target": "ESNext",
         "module": "NodeNext",
         "lib": ["esnext", "dom"],
         "types": [
@@ -9,10 +9,11 @@
             "node",
             "cypress-axe",
             "cypress-real-events",
-            "cypress-file-upload"
+            "cypress-file-upload",
+            "vite/client"
         ],
         "allowJs": true,
-        "moduleResolution": "nodenext",
+        "moduleResolution": "NodeNext",
         "esModuleInterop": true,
         "resolveJsonModule": true
     },

--- a/cypress/vite.config.ts
+++ b/cypress/vite.config.ts
@@ -123,6 +123,9 @@ export const getViteConfig = async () => {
             // вызывает "Dynamic require of X is not supported".
             // Все три @plasma-cy/* — реальные сгенерированные файлы с абсолютными путями,
             // esbuild bundle-ит их в отдельные чанки, устраняя ESM waterfall запросов.
+            // holdUntilCrawlEnd: false — не ждём обхода всех spec-файлов перед запуском
+            // esbuild: явный include-список уже содержит все нужные зависимости.
+            holdUntilCrawlEnd: false,
             include: [
                 'cypress-plugin-tab',
                 'react',

--- a/cypress/vite.config.ts
+++ b/cypress/vite.config.ts
@@ -1,0 +1,142 @@
+import path from 'path';
+import fs from 'fs';
+
+import { generateModules } from './plugins/generateModules';
+
+const rootPath = path.resolve(__dirname, '..');
+const packsPath = path.join(rootPath, 'packages');
+const packageName = process.env.PACKAGE_NAME || '';
+const resolveInsidePackage = (...segments: string[]) => path.join(packsPath, packageName, 'node_modules', ...segments);
+
+// Async-функция нужна для динамического импорта @vitejs/plugin-react-swc.
+// Cypress поддерживает viteConfig как функцию и вызывает её через await уже в ESM-контексте
+// дев-сервера — это исключает статический require('vite') при CJS-загрузке cypress.config.ts.
+export const getViteConfig = async () => {
+    const { default: react } = await import('@vitejs/plugin-react-swc');
+
+    // Генерируем реальные файлы вместо виртуальных модулей.
+    // Реальные файлы esbuild умеет pre-bundle через optimizeDeps,
+    // что устраняет ESM waterfall при загрузке каждого spec-файла.
+    const { testPackage, testTheme, testConfigs } = generateModules(packsPath);
+
+    return {
+        plugins: [
+            react({
+                plugins: [['@swc/plugin-emotion', {}]],
+            }),
+            {
+                name: 'preload-dep-chunks',
+                transformIndexHtml() {
+                    const depsDir = path.resolve(rootPath, 'node_modules/.vite/deps');
+                    if (!fs.existsSync(depsDir)) return [];
+
+                    const metaPath = path.join(depsDir, '_metadata.json');
+                    if (!fs.existsSync(metaPath)) return [];
+
+                    let hash: string;
+                    try {
+                        hash = (JSON.parse(fs.readFileSync(metaPath, 'utf-8')) as { hash: string }).hash;
+                    } catch {
+                        return [];
+                    }
+
+                    return fs
+                        .readdirSync(depsDir)
+                        .filter((f) => f.startsWith('chunk-') && f.endsWith('.js'))
+                        .map((chunk) => ({
+                            tag: 'link',
+                            attrs: {
+                                rel: 'modulepreload',
+                                href: `/node_modules/.vite/deps/${chunk}?v=${hash}`,
+                            },
+                            injectTo: 'head' as const,
+                        }));
+                },
+            },
+            {
+                name: 'cache-static-assets',
+                configureServer(server: {
+                    middlewares: {
+                        use(
+                            fn: (
+                                req: { url?: string },
+                                res: { setHeader(k: string, v: string): void },
+                                next: () => void,
+                            ) => void,
+                        ): void;
+                    };
+                }) {
+                    server.middlewares.use((req, res, next) => {
+                        if (/\.(woff2?|ttf|otf|eot|png|jpg|jpeg|svg|gif|webp)$/.test(req.url ?? '')) {
+                            res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+                        }
+                        next();
+                    });
+                },
+            },
+        ],
+        resolve: {
+            preserveSymlinks: true,
+            alias: [
+                // Виртуальные модули заменены реальными сгенерированными файлами
+                { find: '@plasma-cy/test-package', replacement: testPackage },
+                { find: '@plasma-cy/test-theme', replacement: testTheme },
+                { find: '@plasma-cy/test-configs', replacement: testConfigs },
+                // /tokens/* → ESM-сборки: пакеты делают `export * from '@salutejs/plasma-themes/tokens/...'`
+                // и получают CJS без этого алиаса → "exports is not defined" в ESM-контексте.
+                {
+                    find: /^@salutejs\/plasma-themes\/tokens(.*)/,
+                    replacement: path.resolve(rootPath, 'packages/themes/plasma-themes/es/tokens$1'),
+                },
+                {
+                    find: /^@salutejs\/sdds-themes\/tokens(.*)/,
+                    replacement: path.resolve(rootPath, 'packages/themes/sdds-themes/es/tokens$1'),
+                },
+                // Синглтоны: явные алиасы гарантируют один экземпляр react/sc на странице
+                { find: 'styled-components', replacement: resolveInsidePackage('styled-components') },
+                { find: 'react', replacement: resolveInsidePackage('react') },
+                { find: 'react-dom', replacement: resolveInsidePackage('react-dom') },
+                { find: '@salutejs/plasma-icons', replacement: resolveInsidePackage('@salutejs', 'plasma-icons') },
+                {
+                    find: '@salutejs/plasma-tokens-b2c',
+                    replacement: resolveInsidePackage('@salutejs', 'plasma-tokens-b2c'),
+                },
+                { find: '@salutejs/plasma-typo', replacement: resolveInsidePackage('@salutejs', 'plasma-typo') },
+                {
+                    find: '@salutejs/plasma-cy-utils',
+                    replacement: path.resolve(rootPath, 'utils/plasma-cy-utils/src/index.ts'),
+                },
+                {
+                    find: 'src/examples/components',
+                    replacement: path.join(packsPath, packageName, 'src', 'components'),
+                },
+                { find: 'override/_Icon', replacement: resolveInsidePackage('@salutejs', 'plasma-icons') },
+                // Заглушка: оригинальный platform.js падает при парсинге User Agent в Cypress/Vite среде
+                { find: 'platform', replacement: path.resolve(__dirname, 'stubs/platform.ts') },
+            ],
+        },
+        define: {
+            'process.env': '{}',
+        },
+        optimizeDeps: {
+            // CJS-пакеты конвертируются в ESM заранее — иначе `require()` в ESM-контексте
+            // вызывает "Dynamic require of X is not supported".
+            // Все три @plasma-cy/* — реальные сгенерированные файлы с абсолютными путями,
+            // esbuild bundle-ит их в отдельные чанки, устраняя ESM waterfall запросов.
+            include: [
+                'cypress-plugin-tab',
+                'react',
+                'react-dom',
+                'styled-components',
+                '@salutejs/plasma-cy-utils',
+                '@plasma-cy/test-package',
+                '@plasma-cy/test-theme',
+                '@plasma-cy/test-configs',
+            ],
+        },
+
+        esbuild: { sourcemap: false },
+        css: { devSourcemap: false },
+        build: { sourcemap: false },
+    };
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release": "npm run git:diff && auto shipit -v",
     "precy:run": "rm -rf {.nyc_output}",
     "cy:clean": "rm -rf cypress/{results,reports,screenshots,videos}",
-    "cy:run": "CYPRESS_IMAGE=plasmadockerhub/cypress:15.9.0-webkit && docker run --rm -v $PWD:/e2e -w /e2e -e NODE_OPTIONS='--max-old-space-size=16384' --entrypoint=/bin/bash -e CYPRESS_CONFIG_FILE='cypress.config.ts' -e PACKAGE_NAME=$PACKAGE_NAME -e SPEC_GROUP=$SPEC_GROUP -e COMPONENTS=$COMPONENTS -e RETRIES=$RETRIES -e CYPRESS_updateSnapshots=$CYPRESS_updateSnapshots -e WEBPACK_CACHE_ENABLED=$WEBPACK_CACHE_ENABLED -e BROWSER=$BROWSER ${CYPRESS_IMAGE} -c 'cypress run --component --browser ${BROWSER:-chromium}'",
+    "cy:run": "CYPRESS_IMAGE=plasmadockerhub/cypress:15.9.0-webkit && docker run --rm -v $PWD:/e2e -w /e2e --shm-size=1.5gb -e NODE_OPTIONS='--max-old-space-size=16384' --entrypoint=/bin/bash -e CYPRESS_CONFIG_FILE='cypress.config.ts' -e PACKAGE_NAME=$PACKAGE_NAME -e SPEC_GROUP=$SPEC_GROUP -e COMPONENTS=$COMPONENTS -e RETRIES=$RETRIES -e CYPRESS_updateSnapshots=$CYPRESS_updateSnapshots -e WEBPACK_CACHE_ENABLED=$WEBPACK_CACHE_ENABLED -e BROWSER=$BROWSER -e DEBUG=$DEBUG ${CYPRESS_IMAGE} -c 'cypress run --component --browser ${BROWSER:-chromium}'",
     "cy:b2c:run": "PACKAGE_NAME=plasma-b2c COMPONENTS=$npm_config_components WEBPACK_CACHE_ENABLED=$npm_config_webpack_cache_enabled npm run cy:run",
     "cy:giga:run": "PACKAGE_NAME=plasma-giga COMPONENTS=$npm_config_components WEBPACK_CACHE_ENABLED=$npm_config_webpack_cache_enabled npm run cy:run",
     "cy:web:run": "PACKAGE_NAME=plasma-web COMPONENTS=$npm_config_components WEBPACK_CACHE_ENABLED=$npm_config_webpack_cache_enabled npm run cy:run",

--- a/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.component-test.tsx
+++ b/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.component-test.tsx
@@ -1,1 +1,0 @@
-../../../../plasma-hope/src/components/PreviewGallery/PreviewGallery.component-test.tsx

--- a/packages/plasma-b2c/src/components/Upload/types.ts
+++ b/packages/plasma-b2c/src/components/Upload/types.ts
@@ -1,0 +1,7 @@
+export type StatusType = 'error' | 'success';
+
+export interface ValidationResult {
+    message?: string;
+    status?: StatusType;
+    data: File | null;
+}

--- a/packages/plasma-b2c/src/components/Upload/utils.ts
+++ b/packages/plasma-b2c/src/components/Upload/utils.ts
@@ -1,0 +1,42 @@
+import { ValidationResult } from './types';
+
+/**
+ * Метод валидация по-умолчанию, принимающая список поддерживаемых расширений через запятую
+ * и возвращает результат проверки
+ * @param {FileList | null} files выбранный файл
+ * @param {string | undefined} accept поддерживаемые форматы, например, `.mp3,.wav`
+ * @returns {ValidationResult} объект, имеющий необязательные поля `message, status, data`
+ */
+export const defaultValidate = (files: FileList | null, accept?: string): ValidationResult => {
+    if (!files?.length) {
+        return {
+            message: 'Загрузите файл',
+            status: 'error',
+            data: null,
+        };
+    }
+
+    const file = files[0];
+
+    if (!accept) {
+        return {
+            data: file,
+        };
+    }
+
+    const dotRegexp = /\./g;
+    const allowedFormats = accept.replace(/\s/g, '').replace(dotRegexp, '\\.').split(',');
+    const fileTypeRegexp = new RegExp(`${allowedFormats.join('|')}$`, 'i');
+
+    if (!fileTypeRegexp.test(file.name)) {
+        return {
+            message: `Неверный формат файла. Используйте ${accept.replace(dotRegexp, '')}-формат`,
+            status: 'error',
+            data: null,
+        };
+    }
+
+    return {
+        data: file,
+    };
+};

--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.component-test.tsx
@@ -231,7 +231,7 @@ describeFn('Calendar', () => {
         cy.matchImageSnapshot();
     });
 
-    it('default: double calendar', () => {
+    itSkipForWebkit('default: double calendar', () => {
         mount(
             <div style={{ width: '1200px', height: '1134px', overflow: 'hidden' }}>
                 <Demo baseValue={baseDate} type="Days" displayDouble />

--- a/packages/plasma-tokens-b2c/tsconfig.es.json
+++ b/packages/plasma-tokens-b2c/tsconfig.es.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "ESNext",
-        "declaration": false,
+        "declaration": true,
         "declarationMap": false,
         "outDir": "./es",
         "rootDir": "./src"

--- a/packages/plasma-tokens/tsconfig.es.json
+++ b/packages/plasma-tokens/tsconfig.es.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "ESNext",
-        "declaration": false,
+        "declaration": true,
         "declarationMap": false,
         "outDir": "./es",
         "rootDir": "./src"

--- a/packages/plasma-ui/src/components/Fade/Fade.tsx
+++ b/packages/plasma-ui/src/components/Fade/Fade.tsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const gradients = {
+    top: 'radial-gradient(200% 200% at 50% -100%, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%)',
+    bottom: 'radial-gradient(200% 200% at 50% 200%, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%)',
+};
+
+export const Fade = styled.div<{ placement?: 'top' | 'bottom' }>`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 999;
+    background: ${({ placement = 'bottom' }) => gradients[placement]};
+`;

--- a/packages/plasma-ui/src/components/Fade/index.ts
+++ b/packages/plasma-ui/src/components/Fade/index.ts
@@ -1,0 +1,1 @@
+export { Fade } from './Fade';

--- a/packages/plasma-web/src/components/PreviewGallery/PreviewGallery.component-test.tsx
+++ b/packages/plasma-web/src/components/PreviewGallery/PreviewGallery.component-test.tsx
@@ -1,1 +1,0 @@
-../../../../plasma-hope/src/components/PreviewGallery/PreviewGallery.component-test.tsx

--- a/packages/plasma-web/src/components/Upload/types.ts
+++ b/packages/plasma-web/src/components/Upload/types.ts
@@ -1,0 +1,7 @@
+export type StatusType = 'error' | 'success';
+
+export interface ValidationResult {
+    message?: string;
+    status?: StatusType;
+    data: File | null;
+}

--- a/packages/plasma-web/src/components/Upload/utils.ts
+++ b/packages/plasma-web/src/components/Upload/utils.ts
@@ -1,0 +1,42 @@
+import { ValidationResult } from './types';
+
+/**
+ * Метод валидация по-умолчанию, принимающая список поддерживаемых расширений через запятую
+ * и возвращает результат проверки
+ * @param {FileList | null} files выбранный файл
+ * @param {string | undefined} accept поддерживаемые форматы, например, `.mp3,.wav`
+ * @returns {ValidationResult} объект, имеющий необязательные поля `message, status, data`
+ */
+export const defaultValidate = (files: FileList | null, accept?: string): ValidationResult => {
+    if (!files?.length) {
+        return {
+            message: 'Загрузите файл',
+            status: 'error',
+            data: null,
+        };
+    }
+
+    const file = files[0];
+
+    if (!accept) {
+        return {
+            data: file,
+        };
+    }
+
+    const dotRegexp = /\./g;
+    const allowedFormats = accept.replace(/\s/g, '').replace(dotRegexp, '\\.').split(',');
+    const fileTypeRegexp = new RegExp(`${allowedFormats.join('|')}$`, 'i');
+
+    if (!fileTypeRegexp.test(file.name)) {
+        return {
+            message: `Неверный формат файла. Используйте ${accept.replace(dotRegexp, '')}-формат`,
+            status: 'error',
+            data: null,
+        };
+    }
+
+    return {
+        data: file,
+    };
+};

--- a/packages/themes/plasma-themes/tsconfig.es.json
+++ b/packages/themes/plasma-themes/tsconfig.es.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "ESNext",
-        "declaration": false,
+        "declaration": true,
         "declarationMap": false,
         "outDir": "./es",
         "rootDir": "./src"

--- a/packages/themes/sdds-themes/tsconfig.es.json
+++ b/packages/themes/sdds-themes/tsconfig.es.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "ESNext",
-        "declaration": false,
+        "declaration": true,
         "declarationMap": false,
         "outDir": "./es",
         "rootDir": "./src"

--- a/utils/plasma-cy-utils/lib/CypressDecorator.js
+++ b/utils/plasma-cy-utils/lib/CypressDecorator.js
@@ -1,153 +1,63 @@
-"use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.CypressTestDecorator = exports.skipForBrowser = exports.skipForPackages = exports.getDescribeFN = exports.getComponent = exports.hasComponent = void 0;
-var react_1 = __importDefault(require("react"));
-var styled_components_1 = require("styled-components");
-var plasma_themes_1 = require("@salutejs/plasma-themes");
-var sdds_themes_1 = require("@salutejs/sdds-themes");
-var sdds_os_1 = require("@salutejs-ds/sdds_os");
-// plasma-ui
-var themes_1 = require("@salutejs/plasma-tokens/themes");
-// plasma-b2c
-var themes_2 = require("@salutejs/plasma-tokens-b2c/themes");
-var plasma_typo_1 = require("@salutejs/plasma-typo");
-var SSRProvider_1 = require("./SSRProvider");
-var NormalizeCSSDecorator_1 = require("./NormalizeCSSDecorator");
-// NOTE: new theme format
-var ThemeGIGA = (0, styled_components_1.createGlobalStyle)(plasma_themes_1.plasma_giga__light);
-var ThemeCS = (0, styled_components_1.createGlobalStyle)(sdds_themes_1.sdds_cs__light);
-var ThemeINSOL = (0, styled_components_1.createGlobalStyle)(sdds_themes_1.sdds_insol__light);
-var ThemeSERV = (0, styled_components_1.createGlobalStyle)(sdds_themes_1.sdds_serv__light);
-var ThemeSCAN = (0, styled_components_1.createGlobalStyle)(sdds_themes_1.sdds_scan__light);
-var ThemeOS = (0, styled_components_1.createGlobalStyle)(sdds_os_1.sdds_os__light);
-var ThemePLATFORMAI = (0, styled_components_1.createGlobalStyle)(sdds_themes_1.sdds_platform_ai__light);
-var ThemeFINAI = (0, styled_components_1.createGlobalStyle)(sdds_themes_1.sdds_finai__light);
-var ThemeHOMEDS = (0, styled_components_1.createGlobalStyle)(plasma_themes_1.plasma_homeds__light);
-var ThemeWEB = (0, styled_components_1.createGlobalStyle)(plasma_themes_1.plasma_web__light);
-var StandardTypoStyle = (0, styled_components_1.createGlobalStyle)(plasma_typo_1.standard);
-var CompatibleTypoStyle = (0, styled_components_1.createGlobalStyle)(plasma_typo_1.compatible);
-var ColorB2CStyle = (0, styled_components_1.createGlobalStyle)(themes_2.dark);
-var ThemeStyle = (0, styled_components_1.createGlobalStyle)(themes_1.darkSber);
-var testPackagesThemes = {
-    'plasma-giga': react_1.default.createElement(ThemeGIGA, null),
-    'sdds-cs': react_1.default.createElement(ThemeCS, null),
-    'sdds-insol': react_1.default.createElement(ThemeINSOL, null),
-    'plasma-web': react_1.default.createElement(ThemeWEB, null),
-    'sdds-serv': react_1.default.createElement(ThemeSERV, null),
-    'sdds-scan': react_1.default.createElement(ThemeSCAN, null),
-    'sdds-os': react_1.default.createElement(ThemeOS, null),
-    'sdds-platform-ai': react_1.default.createElement(ThemePLATFORMAI, null),
-    'sdds-finai': react_1.default.createElement(ThemeFINAI, null),
-    'plasma-homeds': react_1.default.createElement(ThemeHOMEDS, null),
-};
-var getPackage = function () {
-    var pkgName = Cypress.env('package');
+import React from 'react';
+import { createGlobalStyle } from 'styled-components';
+// Виртуальные модули, резолвятся плагинами в vite.config.ts.
+// eslint-disable-next-line import/no-unresolved
+import { themeVars, standardTypo, compatibleTypo } from '@plasma-cy/test-theme';
+// eslint-disable-next-line import/no-unresolved
+import * as testPackage from '@plasma-cy/test-package';
+import { SSRProvider } from './SSRProvider';
+import { NormalizeCSSDecorator } from './NormalizeCSSDecorator';
+const ThemeStyle = createGlobalStyle(themeVars);
+const StandardTypoStyle = standardTypo ? createGlobalStyle(standardTypo) : null;
+const CompatibleTypoStyle = compatibleTypo ? createGlobalStyle(compatibleTypo) : null;
+const getPackage = function () {
+    const pkgName = Cypress.env('package');
     if (!pkgName) {
         throw new Error('Add package env to your Cypress config');
     }
-    /* eslint-disable */
-    switch (pkgName) {
-        case 'plasma-ui':
-            return require('../../../packages/plasma-ui');
-        case 'plasma-web':
-            return require('../../../packages/plasma-web/dist/styled-components/cjs/index.js');
-        case 'plasma-b2c':
-            return require('../../../packages/plasma-b2c/dist/styled-components/cjs/index.js');
-        case 'plasma-giga':
-            return require('../../../packages/plasma-giga/dist/styled-components/cjs/index.js');
-        case 'sdds-cs':
-            return require('../../../packages/sdds-cs/dist/emotion/cjs/index.js');
-        case 'sdds-insol':
-            return require('../../../packages/sdds-insol/dist/styled-components/cjs/index.js');
-        case 'sdds-serv':
-            return require('../../../packages/sdds-serv/dist/styled-components/cjs/index.js');
-        case 'sdds-scan':
-            return require('../../../packages/sdds-scan/dist/styled-components/cjs/index.js');
-        case 'sdds-os':
-            return require('../../../packages/sdds-os/dist/styled-components/cjs/index.js');
-        case 'sdds-platform-ai':
-            return require('../../../packages/sdds-platform-ai/dist/styled-components/cjs/index.js');
-        case 'sdds-finai':
-            return require('../../../packages/sdds-finai/dist/styled-components/cjs/index.js');
-        case 'plasma-homeds':
-            return require('../../../packages/plasma-homeds/dist/styled-components/cjs/index.js');
-        default:
-            throw new Error("Library ".concat(pkgName, " is not required in plasma-core/CypressHelpers:getComponent"));
-    }
-    /* eslint-enable */
+    return testPackage;
 };
-var hasComponent = function (componentName) {
-    var pkg = getPackage();
+export const hasComponent = (componentName) => {
+    const pkg = getPackage();
     return componentName in pkg && pkg[componentName] !== undefined;
 };
-exports.hasComponent = hasComponent;
-var getComponent = function (componentName) {
-    var pkgName = Cypress.env('package');
-    var pkg = getPackage();
-    var component = pkg[componentName];
+export const getComponent = function (componentName) {
+    const pkgName = Cypress.env('package');
+    const pkg = getPackage();
+    const component = pkg[componentName];
     if (!component) {
-        console.error("Library ".concat(pkgName, " has no ").concat(componentName));
+        console.error(`Library ${pkgName} has no ${componentName}`);
     }
     return component;
 };
-exports.getComponent = getComponent;
-var getDescribeFN = function (component) {
-    var componentExists = (0, exports.hasComponent)(component);
+export const getDescribeFN = (component) => {
+    const componentExists = hasComponent(component);
     return componentExists ? describe : describe.skip;
 };
-exports.getDescribeFN = getDescribeFN;
-var skipForPackages = function (packages) {
-    var pkgName = Cypress.env('package');
+export const skipForPackages = (packages) => {
+    const pkgName = Cypress.env('package');
     return packages.includes(pkgName) ? it.skip : it;
 };
-exports.skipForPackages = skipForPackages;
-var skipForBrowser = function (browsers, customIt) {
-    var browserName = Cypress.browser.family;
+export const skipForBrowser = (browsers, customIt) => {
+    const browserName = Cypress.browser.family;
     return browsers.includes(browserName) ? it.skip : customIt;
 };
-exports.skipForBrowser = skipForBrowser;
-var CypressTestDecorator = function (_a) {
-    var noSSR = _a.noSSR, children = _a.children;
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    var pkgName = Cypress.env('package');
+export const CypressTestDecorator = ({ noSSR, children }) => {
+    const pkgName = Cypress.env('package');
     if (pkgName === 'plasma-ui') {
-        var DeviceThemeProvider = (0, exports.getComponent)('DeviceThemeProvider');
+        const DeviceThemeProvider = getComponent('DeviceThemeProvider');
         if (!DeviceThemeProvider) {
-            return react_1.default.createElement(react_1.default.Fragment, null, children);
+            return React.createElement(React.Fragment, null, children);
         }
-        return (react_1.default.createElement(DeviceThemeProvider, null,
-            react_1.default.createElement(SSRProvider_1.SSRProvider, { noSSR: noSSR },
-                react_1.default.createElement(ThemeStyle, null),
+        return (React.createElement(DeviceThemeProvider, null,
+            React.createElement(SSRProvider, { noSSR: noSSR },
+                React.createElement(ThemeStyle, null),
                 children)));
     }
-    if (pkgName === 'plasma-b2c') {
-        return (react_1.default.createElement(SSRProvider_1.SSRProvider, { noSSR: noSSR },
-            react_1.default.createElement(NormalizeCSSDecorator_1.NormalizeCSSDecorator, null),
-            react_1.default.createElement(StandardTypoStyle, null),
-            react_1.default.createElement(CompatibleTypoStyle, null),
-            react_1.default.createElement(ColorB2CStyle, null),
-            children));
-    }
-    if ([
-        'plasma-giga',
-        'sdds-cs',
-        'sdds-insol',
-        'plasma-web',
-        'sdds-serv',
-        'sdds-scan',
-        'sdds-os',
-        'sdds-platform-ai',
-        'sdds-finai',
-        'plasma-homeds',
-    ].includes(pkgName)) {
-        return (react_1.default.createElement(SSRProvider_1.SSRProvider, { noSSR: noSSR },
-            react_1.default.createElement(NormalizeCSSDecorator_1.NormalizeCSSDecorator, null),
-            testPackagesThemes[pkgName],
-            children));
-    }
-    return react_1.default.createElement(react_1.default.Fragment, null, children);
+    return (React.createElement(SSRProvider, { noSSR: noSSR },
+        React.createElement(NormalizeCSSDecorator, null),
+        React.createElement(ThemeStyle, null),
+        StandardTypoStyle && React.createElement(StandardTypoStyle, null),
+        CompatibleTypoStyle && React.createElement(CompatibleTypoStyle, null),
+        children));
 };
-exports.CypressTestDecorator = CypressTestDecorator;

--- a/utils/plasma-cy-utils/lib/CypressHelpers.js
+++ b/utils/plasma-cy-utils/lib/CypressHelpers.js
@@ -1,33 +1,17 @@
-"use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
+import React from 'react';
+import { mount as cyMount } from '@cypress/react';
+import { CypressTestDecorator } from './CypressDecorator';
+export const mount = (...args) => {
+    const [jsx, opts = {}] = args;
+    return cyMount(React.createElement(CypressTestDecorator, null, jsx), opts);
 };
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.mountLegacyMode = exports.mount = void 0;
-var react_1 = __importDefault(require("react"));
-var react_2 = require("@cypress/react");
-var CypressDecorator_1 = require("./CypressDecorator");
-var mount = function () {
-    var args = [];
-    for (var _i = 0; _i < arguments.length; _i++) {
-        args[_i] = arguments[_i];
-    }
-    var jsx = args[0], _a = args[1], opts = _a === void 0 ? {} : _a;
-    return (0, react_2.mount)(react_1.default.createElement(CypressDecorator_1.CypressTestDecorator, null, jsx), opts);
-};
-exports.mount = mount;
 // INFO: для временного использования в plasma-ui
-var mountLegacyMode = function () {
-    var args = [];
-    for (var _i = 0; _i < arguments.length; _i++) {
-        args[_i] = arguments[_i];
-    }
-    var jsx = args[0], _a = args[1], opts = _a === void 0 ? {} : _a;
+export const mountLegacyMode = (...args) => {
+    const [jsx, opts = {}] = args;
     opts.stylesheets = ((opts === null || opts === void 0 ? void 0 : opts.stylesheets) || []).concat('https://cdn-app.sberdevices.ru/shared-static/0.0.0/styles/SBSansText.0.2.0.css', 'https://cdn-app.sberdevices.ru/shared-static/0.0.0/styles/SBSansDisplay.0.2.0.css');
-    var cm = (0, react_2.mount)(jsx, opts);
+    const cm = cyMount(jsx, opts);
     cy.waitForResources('https://cdn-app.sberdevices.ru/shared-static/0.0.0/styles/SBSansText.0.2.0.css');
     cy.waitForResources('https://cdn-app.sberdevices.ru/shared-static/0.0.0/styles/SBSansDisplay.0.2.0.css');
     cy.waitForResources('SBSansText.0.2.0.css', 'SBSansDisplay.0.2.0.css', { timeout: 1500 });
     return cm;
 };
-exports.mountLegacyMode = mountLegacyMode;

--- a/utils/plasma-cy-utils/lib/NormalizeCSSDecorator.js
+++ b/utils/plasma-cy-utils/lib/NormalizeCSSDecorator.js
@@ -1,12 +1,14 @@
-"use strict";
-var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
-    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
-    return cooked;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.NormalizeCSSDecorator = void 0;
-var styled_components_1 = require("styled-components");
+import { createGlobalStyle } from 'styled-components';
 /* stylelint-disable selector-max-universal */
-exports.NormalizeCSSDecorator = (0, styled_components_1.createGlobalStyle)(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\n    html {\n        box-sizing: border-box;\n    }\n\n    *,\n    ::before,\n    ::after {\n        box-sizing: border-box;\n    }\n"], ["\n    html {\n        box-sizing: border-box;\n    }\n\n    *,\n    ::before,\n    ::after {\n        box-sizing: border-box;\n    }\n"])));
-var templateObject_1;
+export const NormalizeCSSDecorator = createGlobalStyle `
+    html {
+        box-sizing: border-box;
+    }
+
+    *,
+    ::before,
+    ::after {
+        box-sizing: border-box;
+    }
+`;
 /* stylelint-enable selector-max-universal */

--- a/utils/plasma-cy-utils/lib/Portal.js
+++ b/utils/plasma-cy-utils/lib/Portal.js
@@ -1,18 +1,13 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.Portal = void 0;
-var react_1 = require("react");
-var react_dom_1 = require("react-dom");
-var Portal = function (_a) {
-    var id = _a.id, children = _a.children;
-    var el = document.createElement('div');
-    (0, react_1.useEffect)(function () {
-        var portalRoot = document.getElementById(id);
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+export const Portal = ({ id, children }) => {
+    const el = document.createElement('div');
+    useEffect(() => {
+        const portalRoot = document.getElementById(id);
         portalRoot && portalRoot.appendChild(el);
-        return function () {
+        return () => {
             portalRoot && portalRoot.removeChild(el);
         };
     }, [el, id]);
-    return (0, react_dom_1.createPortal)(children, el);
+    return createPortal(children, el);
 };
-exports.Portal = Portal;

--- a/utils/plasma-cy-utils/lib/SSRProvider.js
+++ b/utils/plasma-cy-utils/lib/SSRProvider.js
@@ -1,41 +1,13 @@
-"use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
-    __setModuleDefault(result, mod);
-    return result;
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.SSRProvider = exports.SSRContext = void 0;
-var react_1 = __importStar(require("react"));
-exports.SSRContext = (0, react_1.createContext)({
+import React, { createContext } from 'react';
+export const SSRContext = createContext({
     uniqId: null,
 });
-var SSRProvider = function (_a) {
-    var children = _a.children, _noSSR = _a.noSSR;
-    var value = {
+export const SSRProvider = ({ children, noSSR: _noSSR }) => {
+    const value = {
         uniqId: 0,
     };
     if (_noSSR) {
-        return react_1.default.createElement(react_1.default.Fragment, null, children);
+        return React.createElement(React.Fragment, null, children);
     }
-    return react_1.default.createElement(exports.SSRContext.Provider, { value: value }, children);
+    return React.createElement(SSRContext.Provider, { value: value }, children);
 };
-exports.SSRProvider = SSRProvider;

--- a/utils/plasma-cy-utils/lib/StyleHelpers.js
+++ b/utils/plasma-cy-utils/lib/StyleHelpers.js
@@ -1,18 +1,16 @@
-"use strict";
-var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
-    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
-    return cooked;
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.withNoAnimation = exports.SpaceMe = exports.PadMe = void 0;
-var styled_components_1 = __importDefault(require("styled-components"));
-exports.PadMe = styled_components_1.default.div(templateObject_1 || (templateObject_1 = __makeTemplateObject(["\n    padding: 5px;\n    box-sizing: content-box;\n"], ["\n    padding: 5px;\n    box-sizing: content-box;\n"])));
-exports.SpaceMe = styled_components_1.default.span(templateObject_2 || (templateObject_2 = __makeTemplateObject(["\n    padding: 5px;\n    box-sizing: content-box;\n"], ["\n    padding: 5px;\n    box-sizing: content-box;\n"])));
-var withNoAnimation = function (Comp) {
-    return (0, styled_components_1.default)(Comp)(templateObject_3 || (templateObject_3 = __makeTemplateObject(["\n        animation: none !important;\n        /* stylelint-disable-next-line selector-max-universal */\n        & * {\n            animation: none !important;\n        }\n    "], ["\n        animation: none !important;\n        /* stylelint-disable-next-line selector-max-universal */\n        & * {\n            animation: none !important;\n        }\n    "])));
-};
-exports.withNoAnimation = withNoAnimation;
-var templateObject_1, templateObject_2, templateObject_3;
+import styled from 'styled-components';
+export const PadMe = styled.div `
+    padding: 5px;
+    box-sizing: content-box;
+`;
+export const SpaceMe = styled.span `
+    padding: 5px;
+    box-sizing: content-box;
+`;
+export const withNoAnimation = (Comp) => styled(Comp) `
+        animation: none !important;
+        /* stylelint-disable-next-line selector-max-universal */
+        & * {
+            animation: none !important;
+        }
+    `;

--- a/utils/plasma-cy-utils/lib/getConfigMatrix.js
+++ b/utils/plasma-cy-utils/lib/getConfigMatrix.js
@@ -1,42 +1,36 @@
-"use strict";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.getConfigMatrix = void 0;
-var getConfigMatrix = function (config, options, excludePropsValues) {
+export const getConfigMatrix = (config, options, excludePropsValues) => {
     if (!(config === null || config === void 0 ? void 0 : config.variations)) {
         return [];
     }
-    var variations = config.variations;
+    const { variations } = config;
     // Pre-compute filtered values per prop, respecting options and excludePropsValues
-    var filteredVariations = Object.keys(variations).reduce(function (acc, propName) {
+    const filteredVariations = Object.keys(variations).reduce((acc, propName) => {
         if ((options === null || options === void 0 ? void 0 : options.length) && !options.includes(propName)) {
             return acc;
         }
-        var values = Object.keys(variations[propName]).filter(function (value) { var _a; return !((_a = excludePropsValues === null || excludePropsValues === void 0 ? void 0 : excludePropsValues[propName]) === null || _a === void 0 ? void 0 : _a.includes(value)); });
+        const values = Object.keys(variations[propName]).filter((value) => { var _a; return !((_a = excludePropsValues === null || excludePropsValues === void 0 ? void 0 : excludePropsValues[propName]) === null || _a === void 0 ? void 0 : _a.includes(value)); });
         if (values.length > 0) {
             acc[propName] = values;
         }
         return acc;
     }, {});
     // Find the prop with the most values
-    var maxLength = Object.values(filteredVariations).reduce(function (max, values) { return Math.max(max, values.length); }, 0);
+    const maxLength = Object.values(filteredVariations).reduce((max, values) => Math.max(max, values.length), 0);
     if (maxLength === 0)
         return [];
-    return Array.from({ length: maxLength }, function (_, i) {
-        return Object.keys(filteredVariations).reduce(function (props, propName) {
-            var propValues = filteredVariations[propName];
-            if (propValues.length === 1) {
-                if (i === 0) {
-                    // eslint-disable-next-line prefer-destructuring
-                    props[propName] = propValues[0];
-                }
+    return Array.from({ length: maxLength }, (_, i) => Object.keys(filteredVariations).reduce((props, propName) => {
+        const propValues = filteredVariations[propName];
+        if (propValues.length === 1) {
+            if (i === 0) {
+                // eslint-disable-next-line prefer-destructuring
+                props[propName] = propValues[0];
             }
-            else if (i < propValues.length) {
-                props[propName] = propValues[i];
-            }
-            return props;
-        }, {});
-    });
+        }
+        else if (i < propValues.length) {
+            props[propName] = propValues[i];
+        }
+        return props;
+    }, {}));
 };
-exports.getConfigMatrix = getConfigMatrix;

--- a/utils/plasma-cy-utils/lib/getTests.js
+++ b/utils/plasma-cy-utils/lib/getTests.js
@@ -1,32 +1,16 @@
-"use strict";
-var __assign = (this && this.__assign) || function () {
-    __assign = Object.assign || function(t) {
-        for (var s, i = 1, n = arguments.length; i < n; i++) {
-            s = arguments[i];
-            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-                t[p] = s[p];
-        }
-        return t;
-    };
-    return __assign.apply(this, arguments);
-};
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.getBaseVisualTests = void 0;
-var react_1 = __importDefault(require("react"));
-var CypressHelpers_1 = require("./CypressHelpers");
-var CypressDecorator_1 = require("./CypressDecorator");
-var getConfigMatrix_1 = require("./getConfigMatrix");
-var getConfig = function (component) {
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-dynamic-require
-        return require("src/examples/components/".concat(component, "/").concat(component, ".config.ts")).config;
-    }
-    catch (_a) {
-        return null;
-    }
+import React from 'react';
+// Виртуальный модуль, резолвится плагином virtualTestConfigs в vite.config.ts.
+// Содержит namespace-экспорты вида: export * as Button from '.../Button.config.ts'
+// для всех компонентов текущего пакета.
+// eslint-disable-next-line import/no-unresolved
+import * as testConfigs from '@plasma-cy/test-configs';
+import { mount } from './CypressHelpers';
+import { getComponent, getDescribeFN, hasComponent } from './CypressDecorator';
+import { getConfigMatrix } from './getConfigMatrix';
+const getConfig = (component) => {
+    var _a;
+    const mod = testConfigs[component];
+    return mod ? (_a = mod.config) !== null && _a !== void 0 ? _a : null : null;
 };
 /**
  * Генерирует базовые визуальные тесты для компонента.
@@ -47,28 +31,24 @@ var getConfig = function (component) {
  * @param {string[]} propsForName - пропсы, значения которых включаются в имя теста.
  * @param {string[]} packagesForSkip - список пакетов, для которых тесты будут пропущены через describe.skip.
  */
-var getBaseVisualTests = function (_a) {
-    var component = _a.component, componentProps = _a.componentProps, children = _a.children, actionBeforeSnapshot = _a.actionBeforeSnapshot, configPropsForMatrix = _a.configPropsForMatrix, excludePropsValues = _a.excludePropsValues, propsForName = _a.propsForName, packagesForSkip = _a.packagesForSkip;
-    var componentExists = (0, CypressDecorator_1.hasComponent)(component);
-    var pkgName = Cypress.env('package');
-    var describeFn = (packagesForSkip === null || packagesForSkip === void 0 ? void 0 : packagesForSkip.includes(pkgName)) ? describe.skip : (0, CypressDecorator_1.getDescribeFN)(component);
-    return describeFn("".concat(component), function () {
-        var Component = componentExists ? (0, CypressDecorator_1.getComponent)(component) : null;
+export const getBaseVisualTests = ({ component, componentProps, children, actionBeforeSnapshot, configPropsForMatrix, excludePropsValues, propsForName, packagesForSkip, }) => {
+    const componentExists = hasComponent(component);
+    const pkgName = Cypress.env('package');
+    const describeFn = (packagesForSkip === null || packagesForSkip === void 0 ? void 0 : packagesForSkip.includes(pkgName)) ? describe.skip : getDescribeFN(component);
+    return describeFn(`${component}`, () => {
+        const Component = componentExists ? getComponent(component) : null;
         if (!Component) {
             return;
         }
-        var config = componentExists ? getConfig(component) : null;
-        var configMatrix = (0, getConfigMatrix_1.getConfigMatrix)(config, configPropsForMatrix, excludePropsValues);
-        configMatrix.forEach(function (combination) {
-            var testParams = Object.entries(combination)
-                .map(function (_a) {
-                var propName = _a[0], propValue = _a[1];
-                return "".concat(propName, "=").concat(propValue);
-            })
+        const config = componentExists ? getConfig(component) : null;
+        const configMatrix = getConfigMatrix(config, configPropsForMatrix, excludePropsValues);
+        configMatrix.forEach((combination) => {
+            const testParams = Object.entries(combination)
+                .map(([propName, propValue]) => `${propName}=${propValue}`)
                 .join(', ');
-            var testName = propsForName ? "".concat(testParams, " ").concat(propsForName) : testParams;
-            it("".concat(testName), function () {
-                (0, CypressHelpers_1.mount)(react_1.default.createElement(react_1.default.Fragment, null, children ? (react_1.default.createElement(Component, __assign({}, combination, componentProps), children)) : (react_1.default.createElement(Component, __assign({}, combination, componentProps)))));
+            const testName = propsForName ? `${testParams} ${propsForName}` : testParams;
+            it(`${testName}`, () => {
+                mount(React.createElement(React.Fragment, null, children ? (React.createElement(Component, Object.assign({}, combination, componentProps), children)) : (React.createElement(Component, Object.assign({}, combination, componentProps)))));
                 actionBeforeSnapshot && actionBeforeSnapshot();
                 // @ts-ignore
                 cy.matchImageSnapshot();
@@ -76,4 +56,3 @@ var getBaseVisualTests = function (_a) {
         });
     });
 };
-exports.getBaseVisualTests = getBaseVisualTests;

--- a/utils/plasma-cy-utils/lib/index.js
+++ b/utils/plasma-cy-utils/lib/index.js
@@ -1,23 +1,7 @@
-"use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __exportStar = (this && this.__exportStar) || function(m, exports) {
-    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-__exportStar(require("./Portal"), exports);
-__exportStar(require("./SSRProvider"), exports);
-__exportStar(require("./StyleHelpers"), exports);
-__exportStar(require("./CypressDecorator"), exports);
-__exportStar(require("./CypressHelpers"), exports);
-__exportStar(require("./getConfigMatrix"), exports);
-__exportStar(require("./getTests"), exports);
+export * from './Portal';
+export * from './SSRProvider';
+export * from './StyleHelpers';
+export * from './CypressDecorator';
+export * from './CypressHelpers';
+export * from './getConfigMatrix';
+export * from './getTests';

--- a/utils/plasma-cy-utils/src/CypressDecorator.tsx
+++ b/utils/plasma-cy-utils/src/CypressDecorator.tsx
@@ -1,54 +1,18 @@
 import React from 'react';
 import type { FC, PropsWithChildren } from 'react';
 import { createGlobalStyle } from 'styled-components';
-import { plasma_giga__light, plasma_web__light, plasma_homeds__light } from '@salutejs/plasma-themes';
-import {
-    sdds_cs__light,
-    sdds_insol__light,
-    sdds_serv__light,
-    sdds_scan__light,
-    sdds_platform_ai__light,
-    sdds_finai__light,
-} from '@salutejs/sdds-themes';
-import { sdds_os__light } from '@salutejs-ds/sdds_os';
-// plasma-ui
-import { darkSber } from '@salutejs/plasma-tokens/themes';
-// plasma-b2c
-import { dark } from '@salutejs/plasma-tokens-b2c/themes';
-import { standard as standardTypo, compatible as compatibleTypo } from '@salutejs/plasma-typo';
+// Виртуальные модули, резолвятся плагинами в vite.config.ts.
+// eslint-disable-next-line import/no-unresolved
+import { themeVars, standardTypo, compatibleTypo } from '@plasma-cy/test-theme';
+// eslint-disable-next-line import/no-unresolved
+import * as testPackage from '@plasma-cy/test-package';
 
 import { SSRProvider } from './SSRProvider';
 import { NormalizeCSSDecorator } from './NormalizeCSSDecorator';
 
-// NOTE: new theme format
-const ThemeGIGA = createGlobalStyle(plasma_giga__light);
-const ThemeCS = createGlobalStyle(sdds_cs__light);
-const ThemeINSOL = createGlobalStyle(sdds_insol__light);
-const ThemeSERV = createGlobalStyle(sdds_serv__light);
-const ThemeSCAN = createGlobalStyle(sdds_scan__light);
-const ThemeOS = createGlobalStyle(sdds_os__light);
-const ThemePLATFORMAI = createGlobalStyle(sdds_platform_ai__light);
-const ThemeFINAI = createGlobalStyle(sdds_finai__light);
-const ThemeHOMEDS = createGlobalStyle(plasma_homeds__light);
-const ThemeWEB = createGlobalStyle(plasma_web__light);
-
-const StandardTypoStyle = createGlobalStyle(standardTypo);
-const CompatibleTypoStyle = createGlobalStyle(compatibleTypo);
-const ColorB2CStyle = createGlobalStyle(dark);
-const ThemeStyle = createGlobalStyle(darkSber);
-
-const testPackagesThemes = {
-    'plasma-giga': <ThemeGIGA />,
-    'sdds-cs': <ThemeCS />,
-    'sdds-insol': <ThemeINSOL />,
-    'plasma-web': <ThemeWEB />,
-    'sdds-serv': <ThemeSERV />,
-    'sdds-scan': <ThemeSCAN />,
-    'sdds-os': <ThemeOS />,
-    'sdds-platform-ai': <ThemePLATFORMAI />,
-    'sdds-finai': <ThemeFINAI />,
-    'plasma-homeds': <ThemeHOMEDS />,
-};
+const ThemeStyle = createGlobalStyle(themeVars);
+const StandardTypoStyle = standardTypo ? createGlobalStyle(standardTypo) : null;
+const CompatibleTypoStyle = compatibleTypo ? createGlobalStyle(compatibleTypo) : null;
 
 const getPackage = function <T = PropsWithChildren<{}>>(): Record<string, React.FC<T> | undefined> {
     const pkgName = Cypress.env('package') as string | undefined;
@@ -57,36 +21,7 @@ const getPackage = function <T = PropsWithChildren<{}>>(): Record<string, React.
         throw new Error('Add package env to your Cypress config');
     }
 
-    /* eslint-disable */
-    switch (pkgName) {
-        case 'plasma-ui':
-            return require('../../../packages/plasma-ui');
-        case 'plasma-web':
-            return require('../../../packages/plasma-web/dist/styled-components/cjs/index.js');
-        case 'plasma-b2c':
-            return require('../../../packages/plasma-b2c/dist/styled-components/cjs/index.js');
-        case 'plasma-giga':
-            return require('../../../packages/plasma-giga/dist/styled-components/cjs/index.js');
-        case 'sdds-cs':
-            return require('../../../packages/sdds-cs/dist/emotion/cjs/index.js');
-        case 'sdds-insol':
-            return require('../../../packages/sdds-insol/dist/styled-components/cjs/index.js');
-        case 'sdds-serv':
-            return require('../../../packages/sdds-serv/dist/styled-components/cjs/index.js');
-        case 'sdds-scan':
-            return require('../../../packages/sdds-scan/dist/styled-components/cjs/index.js');
-        case 'sdds-os':
-            return require('../../../packages/sdds-os/dist/styled-components/cjs/index.js');
-        case 'sdds-platform-ai':
-            return require('../../../packages/sdds-platform-ai/dist/styled-components/cjs/index.js');
-        case 'sdds-finai':
-            return require('../../../packages/sdds-finai/dist/styled-components/cjs/index.js');
-        case 'plasma-homeds':
-            return require('../../../packages/plasma-homeds/dist/styled-components/cjs/index.js');
-        default:
-            throw new Error(`Library ${pkgName} is not required in plasma-core/CypressHelpers:getComponent`);
-    }
-    /* eslint-enable */
+    return (testPackage as unknown) as Record<string, React.FC<T> | undefined>;
 };
 
 export const hasComponent = (componentName: string): boolean => {
@@ -123,7 +58,6 @@ export const skipForBrowser = (browsers: string[], customIt: Mocha.TestFunction)
 };
 
 export const CypressTestDecorator: FC<PropsWithChildren<any>> = ({ noSSR, children }) => {
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const pkgName = Cypress.env('package') as string;
 
     if (pkgName === 'plasma-ui') {
@@ -143,40 +77,13 @@ export const CypressTestDecorator: FC<PropsWithChildren<any>> = ({ noSSR, childr
         );
     }
 
-    if (pkgName === 'plasma-b2c') {
-        return (
-            <SSRProvider noSSR={noSSR}>
-                <NormalizeCSSDecorator />
-                <StandardTypoStyle />
-                <CompatibleTypoStyle />
-                <ColorB2CStyle />
-                {children}
-            </SSRProvider>
-        );
-    }
-
-    if (
-        [
-            'plasma-giga',
-            'sdds-cs',
-            'sdds-insol',
-            'plasma-web',
-            'sdds-serv',
-            'sdds-scan',
-            'sdds-os',
-            'sdds-platform-ai',
-            'sdds-finai',
-            'plasma-homeds',
-        ].includes(pkgName)
-    ) {
-        return (
-            <SSRProvider noSSR={noSSR}>
-                <NormalizeCSSDecorator />
-                {testPackagesThemes[pkgName as keyof typeof testPackagesThemes]}
-                {children}
-            </SSRProvider>
-        );
-    }
-
-    return <>{children}</>;
+    return (
+        <SSRProvider noSSR={noSSR}>
+            <NormalizeCSSDecorator />
+            <ThemeStyle />
+            {StandardTypoStyle && <StandardTypoStyle />}
+            {CompatibleTypoStyle && <CompatibleTypoStyle />}
+            {children}
+        </SSRProvider>
+    );
 };

--- a/utils/plasma-cy-utils/src/getTests.tsx
+++ b/utils/plasma-cy-utils/src/getTests.tsx
@@ -1,4 +1,9 @@
 import React, { ReactNode } from 'react';
+// Виртуальный модуль, резолвится плагином virtualTestConfigs в vite.config.ts.
+// Содержит namespace-экспорты вида: export * as Button from '.../Button.config.ts'
+// для всех компонентов текущего пакета.
+// eslint-disable-next-line import/no-unresolved
+import * as testConfigs from '@plasma-cy/test-configs';
 
 import { mount } from './CypressHelpers';
 import { getComponent, getDescribeFN, hasComponent } from './CypressDecorator';
@@ -44,12 +49,8 @@ type GetBaseVisualTestsArgs = {
 };
 
 const getConfig = (component: string): any => {
-    try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-dynamic-require
-        return require(`src/examples/components/${component}/${component}.config.ts`).config;
-    } catch {
-        return null;
-    }
+    const mod = ((testConfigs as unknown) as Record<string, Record<string, unknown>>)[component];
+    return mod ? mod.config ?? null : null;
 };
 
 /**

--- a/utils/plasma-cy-utils/src/vite-virtual-modules.d.ts
+++ b/utils/plasma-cy-utils/src/vite-virtual-modules.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Виртуальный модуль, резолвится плагином virtualTestPackage в cypress/vite.config.ts.
+ * Экспортирует все именованные экспорты пакета, который тестируется (PACKAGE_NAME).
+ */
+declare module '@plasma-cy/test-package';
+
+/**
+ * Виртуальный модуль, резолвится плагином virtualTestConfigs в cypress/vite.config.ts.
+ * Экспортирует конфиги компонентов текущего пакета как namespace-ы:
+ *   import * as testConfigs from '@plasma-cy/test-configs';
+ *   testConfigs.Button.config // → конфиг Button
+ */
+declare module '@plasma-cy/test-configs';
+
+/**
+ * Виртуальный модуль, резолвится плагином virtualTestTheme в cypress/vite.config.ts.
+ * Экспортирует тему только для текущего пакета (PACKAGE_NAME).
+ */
+declare module '@plasma-cy/test-theme';

--- a/utils/plasma-cy-utils/tsconfig.json
+++ b/utils/plasma-cy-utils/tsconfig.json
@@ -1,13 +1,13 @@
 {
     "compilerOptions": {
-        "target": "ES5",
-        "module": "NodeNext",
+        "target": "ES2017",
+        "module": "ESNext",
         "lib": ["dom", "dom.iterable", "esnext"],
         "jsx": "react",
         "declaration": true,
         "importHelpers": false,
-        "typeRoots": ["node_modules/@types"],
-        "types": ["node"],
+        "typeRoots": ["node_modules/@types", "../../node_modules"],
+        "types": ["node", "vite/client"],
 
         /* Strict Type-Checking Options */
         "strict": true,
@@ -27,7 +27,7 @@
         "noFallthroughCasesInSwitch": true,
 
         /* Module Resolution Options */
-        "moduleResolution": "nodenext",
+        "moduleResolution": "bundler",
         "esModuleInterop": true,
 
         /* Advanced Options */


### PR DESCRIPTION
## Infra

### Cypress

- сборка тестов cypress переведена с `webpack` на `vite`

### What/why changed

Описание архитектуры тестирования лежит в `cypress/README.md`

Локальные запуски:

1. vite 
   - `npm run cy:giga:run` - `12m 04s 45ms` 
   - `npm run cy:giga:run:webkit` - `21m 11s 37ms ` 
2. webpack
   - `npm run cy:giga:run` - `22m 12s 54ms` 
   - `npm run cy:giga:run:webkit` - `31m 22s 17ms` 
   - 
CI запуски:

1. vite 
   - `npm run cy:giga:run` - `21m 27s` 
   - `npm run cy:giga:run:webkit` - `30m 10s ` 
2. webpack
   - `npm run cy:giga:run` - `22m 37s` 
   - `npm run cy:giga:run:webkit` - `28m 2s` 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.376.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-b2c@1.618.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-core@1.226.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-giga@0.345.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-homeds@0.345.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-hope@1.372.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-icons@1.238.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-new-hope@0.362.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-tokens-b2c@0.66.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-tokens@1.138.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-ui@1.348.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-web@1.620.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-bizcom@0.350.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-cs@0.354.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-dfa@0.348.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-finai@0.341.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-insol@0.345.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-netology@0.349.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-os@0.20.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-platform-ai@0.349.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-sbcom@0.350.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-scan@0.348.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-serv@0.349.0-canary.2757.25882085866.0
  npm install @salutejs/core-themes@0.30.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-themes@0.50.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-themes@0.65.0-canary.2757.25882085866.0
  npm install @salutejs/sdds-api-tests@0.7.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-cy-utils@0.156.0-canary.2757.25882085866.0
  npm install @salutejs/plasma-sb-utils@0.226.0-canary.2757.25882085866.0
  # or 
  yarn add @salutejs/plasma-asdk@0.376.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-b2c@1.618.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-core@1.226.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-giga@0.345.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-homeds@0.345.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-hope@1.372.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-icons@1.238.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-new-hope@0.362.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-tokens-b2c@0.66.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-tokens@1.138.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-ui@1.348.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-web@1.620.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-bizcom@0.350.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-cs@0.354.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-dfa@0.348.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-finai@0.341.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-insol@0.345.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-netology@0.349.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-os@0.20.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-platform-ai@0.349.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-sbcom@0.350.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-scan@0.348.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-serv@0.349.0-canary.2757.25882085866.0
  yarn add @salutejs/core-themes@0.30.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-themes@0.50.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-themes@0.65.0-canary.2757.25882085866.0
  yarn add @salutejs/sdds-api-tests@0.7.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-cy-utils@0.156.0-canary.2757.25882085866.0
  yarn add @salutejs/plasma-sb-utils@0.226.0-canary.2757.25882085866.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
