### PR TITLE
PLASMA-7172: add custom icon for Checkbox

### DIFF
--- a/packages/plasma-new-hope/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/plasma-new-hope/src/components/Checkbox/Checkbox.styles.ts
@@ -53,6 +53,7 @@ export const StyledTrigger = styled.div`
     flex-shrink: 0;
     flex-grow: 0;
 
+    // TODO: allow controlling animation via tokens [PLASMA-7283]
     input:not(:indeterminate) + label & div {
         transform: scale(0);
         transition: transform 0.15s ease-in-out;

--- a/packages/plasma-new-hope/src/components/Checkbox/Checkbox.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Checkbox/Checkbox.tokens.ts
@@ -16,6 +16,7 @@ export const tokens = {
     triggerBackgroundColor: '--plasma-checkbox-trigger-background-color',
 
     fillColor: '--plasma-checkbox-fill-color',
+    fillColorHover: '--plasma-checkbox-fill-color-hover',
     iconColor: '--plasma-checkbox-icon-color',
     contentTopOffset: '--plasma-checkbox-content-top-offset',
     contentLeftOffset: '--plasma-checkbox-content-left-offset',

--- a/packages/plasma-new-hope/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plasma-new-hope/src/components/Checkbox/Checkbox.tsx
@@ -33,6 +33,8 @@ export const checkboxRoot = (Root: RootProps<HTMLInputElement, CheckboxProps>) =
             description,
             indeterminate,
             appearance,
+            checkIcon,
+            indeterminateIcon,
             style,
             className,
             singleLine = false,
@@ -75,6 +77,10 @@ export const checkboxRoot = (Root: RootProps<HTMLInputElement, CheckboxProps>) =
 
         // Временное решение
         const getIcon = () => {
+            if (checkIcon) {
+                return checkIcon;
+            }
+
             if (appearance === 'outline') {
                 return <DoneThin />;
             }
@@ -83,6 +89,10 @@ export const checkboxRoot = (Root: RootProps<HTMLInputElement, CheckboxProps>) =
         };
 
         const getIndeterminate = () => {
+            if (indeterminateIcon) {
+                return indeterminateIcon;
+            }
+
             if (appearance === 'outline') {
                 return <IndeterminateThin />;
             }

--- a/packages/plasma-new-hope/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/plasma-new-hope/src/components/Checkbox/Checkbox.types.ts
@@ -25,6 +25,14 @@ export interface BaseboxProps {
     size?: string;
     view?: string;
     focused?: boolean;
+    /**
+     * Кастомная иконка галочки.
+     */
+    checkIcon?: React.ReactNode;
+    /**
+     * Кастомная иконка indeterminate-состояния.
+     */
+    indeterminateIcon?: React.ReactNode;
 }
 
 export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>, BaseboxProps {}

--- a/packages/plasma-new-hope/src/components/Checkbox/IconsSvg.tsx
+++ b/packages/plasma-new-hope/src/components/Checkbox/IconsSvg.tsx
@@ -8,6 +8,7 @@ export const Done = () => (
             <path
                 fill={`var(${tokens.iconColor})`}
                 d="m5.70711,8.15582c-0.39053,-0.39052 -1.02369,-0.39052 -1.41422,0c-0.39052,0.39053 -0.39052,1.02369 0,1.41422l3.70666,3.70666l6.71095,-6.70248c0.3908,-0.39027 0.3912,-1.02344 0.0009,-1.41421c-0.3903,-0.39077 -1.02344,-0.39117 -1.41421,-0.00089l-5.29674,5.29004l-2.29334,-2.29334z"
+                pathLength="1"
             />
         </svg>
     </div>
@@ -16,7 +17,7 @@ export const Done = () => (
 export const DoneThin = () => (
     <div style={{ display: 'inline-flex' }}>
         <svg width="10" height="8" viewBox="0 0 10 8" fill="none" style={{ width: `var(${tokens.triggerSize})` }}>
-            <path d="M0.5 4L3.5 7L9.5 1" stroke={`var(${tokens.iconColor})`} />
+            <path d="M0.5 4L3.5 7L9.5 1" stroke={`var(${tokens.iconColor})`} pathLength="1" />
         </svg>
     </div>
 );
@@ -24,7 +25,13 @@ export const DoneThin = () => (
 export const Indeterminate = () => (
     <div style={{ display: 'inline-flex' }}>
         <svg width="100%" viewBox="0 0 18 18" fill="none" style={{ width: `var(${tokens.triggerSize})` }}>
-            <path strokeLinecap="round" strokeWidth="2" stroke={`var(${tokens.iconColor})`} d="m5.09449,9.0315l8,0" />
+            <path
+                strokeLinecap="round"
+                strokeWidth="2"
+                stroke={`var(${tokens.iconColor})`}
+                d="m5.09449,9.0315l8,0"
+                pathLength="1"
+            />
         </svg>
     </div>
 );
@@ -32,7 +39,13 @@ export const Indeterminate = () => (
 export const IndeterminateThin = () => (
     <div style={{ display: 'inline-flex' }}>
         <svg width="100%" viewBox="0 0 18 18" fill="none" style={{ width: `var(${tokens.triggerSize})` }}>
-            <path strokeLinecap="round" strokeWidth="1" stroke={`var(${tokens.iconColor})`} d="m5.09449,9.0315l8,0" />
+            <path
+                strokeLinecap="round"
+                strokeWidth="1"
+                stroke={`var(${tokens.iconColor})`}
+                d="m5.09449,9.0315l8,0"
+                pathLength="1"
+            />
         </svg>
     </div>
 );

--- a/packages/plasma-new-hope/src/components/Checkbox/variations/_view/base.ts
+++ b/packages/plasma-new-hope/src/components/Checkbox/variations/_view/base.ts
@@ -13,4 +13,12 @@ export const base = css`
         background: var(${tokens.fillColor});
         border-color: var(${tokens.triggerBorderCheckedColor});
     }
+
+    input[type='checkbox']:indeterminate:not(:disabled) + ${StyledContentWrapper}:hover ${StyledTrigger} {
+        background: var(${tokens.fillColorHover}, var(${tokens.fillColor}));
+    }
+
+    input:checked:not(:disabled) + ${StyledContentWrapper}:hover ${StyledTrigger} {
+        background: var(${tokens.fillColorHover}, var(${tokens.fillColor}));
+    }
 `;

--- a/packages/plasma-new-hope/src/components/Checkbox/variations/_view/tokens.json
+++ b/packages/plasma-new-hope/src/components/Checkbox/variations/_view/tokens.json
@@ -1,1 +1,1 @@
-["--plasma-checkbox-fill-color"]
+["--plasma-checkbox-fill-color", "plasma-checkbox-fill-color-hover"]

--- a/packages/sdds-sbcom/src/components/Checkbox/Checkbox.config.ts
+++ b/packages/sdds-sbcom/src/components/Checkbox/Checkbox.config.ts
@@ -9,6 +9,7 @@ import {
     textSecondary,
     surfaceTransparentSecondary,
     surfaceAccent,
+    surfaceAccentHover,
 } from '@salutejs-ds/sdds_sbcom/theme/tokens';
 
 /*
@@ -50,6 +51,7 @@ export const config = {
         view: {
             accent: css`
                 ${checkboxTokens.fillColor}: ${surfaceAccent};
+                ${checkboxTokens.fillColorHover}: ${surfaceAccentHover};
                 ${checkboxTokens.iconColor}: ${onDarkTextPrimary};
                 ${checkboxTokens.labelColor}: ${textPrimary};
                 ${checkboxTokens.descriptionColor}: ${textSecondary};

--- a/packages/sdds-sbcom/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/sdds-sbcom/src/components/Checkbox/Checkbox.stories.tsx
@@ -14,8 +14,7 @@ const onChange = action('onChange');
 const onFocus = action('onFocus');
 const onBlur = action('onBlur');
 
-const { sizes } = getConfigVariations(config);
-const views = ['accent', 'negative'];
+const { views, sizes } = getConfigVariations(config);
 
 const propsToDisable = [
     'name',

--- a/packages/sdds-sbcom/src/components/Checkbox/Checkbox.tsx
+++ b/packages/sdds-sbcom/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,6 @@
-import { checkboxConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
-import { ComponentProps } from 'react';
+import { checkboxConfig, component, mergeConfig, checkboxTokens } from '@salutejs/plasma-new-hope/styled-components';
+import React, { forwardRef, ComponentProps } from 'react';
+import styled from 'styled-components';
 
 import { config } from './Checkbox.config';
 
@@ -8,7 +9,59 @@ const CheckboxComponent = component(mergedConfig);
 
 export type CheckboxProps = ComponentProps<typeof CheckboxComponent>;
 
+const CheckboxBase = styled(CheckboxComponent)`
+    & svg path[stroke] {
+        stroke-dasharray: 1;
+        stroke-dashoffset: 1;
+        transition: stroke-dashoffset 0s;
+    }
+
+    & label > div:first-child > div {
+        transition: background 0.1s ease-in-out, border-color 0.1s ease-in-out;
+
+        > div {
+            transform: none;
+            opacity: 0;
+            transition: opacity 0.1s ease-in-out;
+        }
+    }
+
+    & input:is(:checked, :indeterminate) + label {
+        svg path[stroke] {
+            stroke-dashoffset: 0;
+            transition: stroke-dashoffset 0.1s ease-in-out;
+        }
+
+        > div:first-child > div > div {
+            opacity: 1;
+        }
+    }
+`;
+
+const CheckIcon = () => (
+    <div style={{ display: 'inline-flex' }}>
+        <svg
+            width="9.657"
+            height="6.758"
+            viewBox="0 0 9.65723 6.75845"
+            fill="none"
+            style={{ width: `var(${checkboxTokens.triggerSize})`, overflow: 'visible' }}
+        >
+            <path
+                d="M0.22 3.55L3.69 6.76L9.43 1.28"
+                stroke={`var(${checkboxTokens.iconColor})`}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                pathLength="1"
+            />
+        </svg>
+    </div>
+);
+
 /**
  * Флажок или чекбокс. Позволяет пользователю управлять параметром с двумя состояниями — ☑ включено и ☐ отключено.
  */
-export const Checkbox = CheckboxComponent;
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({ checkIcon = <CheckIcon />, ...props }, ref) => (
+    <CheckboxBase ref={ref} checkIcon={checkIcon} {...props} />
+));


### PR DESCRIPTION
## Core

### Checkbox

- добавлена возможность задавать кастомный icon
- добавлена поддержка hover для fillColor

## SDDS-SBCOM

### Checkbox

- компонент изменен в соответствии с макетами

### What/why changed

- добавлена возможность задавать кастомный icon
- добавлена поддержка hover для fillColor
- компонент изменен в соответствии с макетами

<img width="960" height="420" alt="Запись экрана — 2026-05-14 в 15 16 42" src="https://github.com/user-attachments/assets/a670eba9-96dd-474d-8682-ec41eefec2cc" />



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.376.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-b2c@1.618.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-core@1.226.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-giga@0.345.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-homeds@0.345.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-hope@1.372.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-icons@1.238.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-new-hope@0.362.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-tokens@1.138.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-ui@1.348.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-web@1.620.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-bizcom@0.350.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-cs@0.354.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-dfa@0.348.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-finai@0.341.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-insol@0.345.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-netology@0.349.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-os@0.20.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-platform-ai@0.349.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-sbcom@0.350.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-scan@0.348.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-serv@0.349.0-canary.2771.26235229918.0
  npm install @salutejs/core-themes@0.30.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-themes@0.50.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-themes@0.65.0-canary.2771.26235229918.0
  npm install @salutejs/sdds-api-tests@0.7.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-cy-utils@0.156.0-canary.2771.26235229918.0
  npm install @salutejs/plasma-sb-utils@0.226.0-canary.2771.26235229918.0
  # or 
  yarn add @salutejs/plasma-asdk@0.376.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-b2c@1.618.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-core@1.226.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-giga@0.345.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-homeds@0.345.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-hope@1.372.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-icons@1.238.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-new-hope@0.362.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-tokens@1.138.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-ui@1.348.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-web@1.620.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-bizcom@0.350.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-cs@0.354.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-dfa@0.348.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-finai@0.341.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-insol@0.345.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-netology@0.349.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-os@0.20.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-platform-ai@0.349.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-sbcom@0.350.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-scan@0.348.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-serv@0.349.0-canary.2771.26235229918.0
  yarn add @salutejs/core-themes@0.30.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-themes@0.50.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-themes@0.65.0-canary.2771.26235229918.0
  yarn add @salutejs/sdds-api-tests@0.7.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-cy-utils@0.156.0-canary.2771.26235229918.0
  yarn add @salutejs/plasma-sb-utils@0.226.0-canary.2771.26235229918.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
