### PR TITLE
PLASMA-7271: remove portal extra condition for DatePicker

### DIFF
--- a/packages/plasma-b2c/src/components/TimePicker/TimePicker.component-test.tsx
+++ b/packages/plasma-b2c/src/components/TimePicker/TimePicker.component-test.tsx
@@ -21,7 +21,7 @@ describe('TimePicker', () => {
             <PopupProvider>
                 <Modal opened placement="top">
                     <Content>
-                        <TimePicker usePortal dropdownHeight="250px" />
+                        <TimePicker usePortal dropdownHeight="250px" zIndex="9999" />
                     </Content>
                 </Modal>
             </PopupProvider>,
@@ -45,7 +45,7 @@ describe('TimePicker', () => {
                 />
                 <Modal opened placement="bottom">
                     <Content>
-                        <TimePicker usePortal dropdownHeight="250px" />
+                        <TimePicker usePortal dropdownHeight="250px" zIndex="9999" />
                     </Content>
                 </Modal>
             </PopupProvider>,

--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
@@ -320,9 +320,7 @@ export const datePickerRoot = (Root: RootProps<HTMLDivElement, RootDatePickerPro
                         disableFlip={disableFlip}
                         closeOnOverlayClick={closeOnOverlayClick}
                         closeOnEsc={closeOnEsc}
-                        portal={
-                            usePortal && frame !== 'document' ? (frame as string | RefObject<HTMLElement>) : undefined
-                        }
+                        portal={usePortal ? (frame as string | RefObject<HTMLElement>) : undefined}
                         target={(referenceRef) => (
                             <StyledInput
                                 ref={inputRef}

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.component-test.tsx
@@ -166,7 +166,7 @@ describeFn('TimePicker', () => {
             <PopupProvider>
                 <Modal opened placement="top">
                     <Content>
-                        <TimePicker usePortal dropdownHeight="250px" />
+                        <TimePicker usePortal dropdownHeight="250px" zIndex="9999" />
                     </Content>
                 </Modal>
             </PopupProvider>,
@@ -190,7 +190,7 @@ describeFn('TimePicker', () => {
                 />
                 <Modal opened placement="bottom">
                     <Content>
-                        <TimePicker usePortal dropdownHeight="250px" />
+                        <TimePicker usePortal dropdownHeight="250px" zIndex="9999" />
                     </Content>
                 </Modal>
             </PopupProvider>,

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.tsx
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.tsx
@@ -86,6 +86,7 @@ export const timePickerRoot = (
                 closeOnEsc = true,
                 disableFlip,
                 offset,
+                zIndex = 1000,
 
                 // dropdown
                 dropdownAlign = 'left',
@@ -332,9 +333,8 @@ export const timePickerRoot = (
                         offset={offset}
                         placement={placement}
                         disableFlip={disableFlip}
-                        portal={
-                            usePortal && frame !== 'document' ? (frame as string | RefObject<HTMLElement>) : undefined
-                        }
+                        portal={usePortal ? (frame as string | RefObject<HTMLElement>) : undefined}
+                        zIndex={zIndex}
                         target={(referenceRef) => (
                             <StyledInput
                                 ref={inputRef}

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.types.ts
@@ -115,6 +115,11 @@ export type TimePickerPopoverProps = {
      */
     offset?: [number, number];
     /**
+     * CSS-свойство z-index для выпадающего списка времени
+     * @default 1000
+     */
+    zIndex?: CSSProperties['zIndex'];
+    /**
      * Контейнер для позиционирования
      */
     frame?: 'document' | string | RefObject<HTMLElement>;

--- a/packages/plasma-web/src/components/TimePicker/TimePicker.component-test.tsx
+++ b/packages/plasma-web/src/components/TimePicker/TimePicker.component-test.tsx
@@ -21,7 +21,7 @@ describe('TimePicker', () => {
             <PopupProvider>
                 <Modal opened placement="top">
                     <Content>
-                        <TimePicker usePortal dropdownHeight="250px" />
+                        <TimePicker usePortal dropdownHeight="250px" zIndex="9999" />
                     </Content>
                 </Modal>
             </PopupProvider>,
@@ -45,7 +45,7 @@ describe('TimePicker', () => {
                 />
                 <Modal opened placement="bottom">
                     <Content>
-                        <TimePicker usePortal dropdownHeight="250px" />
+                        <TimePicker usePortal dropdownHeight="250px" zIndex="9999" />
                     </Content>
                 </Modal>
             </PopupProvider>,


### PR DESCRIPTION
## Core

### DatePicker

- исправлено условие для `frame`: при указании `document` корректно выносит выпадающий календарь рядом с тегом body

### What/why changed

Ссылка на sandbox: https://codesandbox.io/p/sandbox/plasma-sdds-finai-example-forked-jthgdn

- исправлено условие для `frame`: при указании `document` корректно выносит выпадающий календарь рядом с тегом body

**Before:**
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/a1ea67a8-43d6-42fd-b5b4-c94baf697fbc" />

**After:**
<img width="1000" height="650" alt="image" src="https://github.com/user-attachments/assets/f900a7ab-370c-4405-a90e-1040892ebae9" />


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.376.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-b2c@1.618.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-core@1.226.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-giga@0.345.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-homeds@0.345.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-hope@1.372.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-icons@1.238.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-new-hope@0.362.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-tokens@1.138.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-ui@1.348.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-web@1.620.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-bizcom@0.350.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-cs@0.354.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-dfa@0.348.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-finai@0.341.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-insol@0.345.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-netology@0.349.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-os@0.20.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-platform-ai@0.349.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-sbcom@0.350.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-scan@0.348.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-serv@0.349.0-canary.2784.26149885025.0
  npm install @salutejs/core-themes@0.30.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-themes@0.50.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-themes@0.65.0-canary.2784.26149885025.0
  npm install @salutejs/sdds-api-tests@0.7.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-cy-utils@0.156.0-canary.2784.26149885025.0
  npm install @salutejs/plasma-sb-utils@0.226.0-canary.2784.26149885025.0
  # or 
  yarn add @salutejs/plasma-asdk@0.376.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-b2c@1.618.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-core@1.226.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-giga@0.345.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-homeds@0.345.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-hope@1.372.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-icons@1.238.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-new-hope@0.362.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-tokens@1.138.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-ui@1.348.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-web@1.620.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-bizcom@0.350.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-cs@0.354.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-dfa@0.348.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-finai@0.341.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-insol@0.345.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-netology@0.349.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-os@0.20.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-platform-ai@0.349.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-sbcom@0.350.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-scan@0.348.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-serv@0.349.0-canary.2784.26149885025.0
  yarn add @salutejs/core-themes@0.30.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-themes@0.50.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-themes@0.65.0-canary.2784.26149885025.0
  yarn add @salutejs/sdds-api-tests@0.7.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-cy-utils@0.156.0-canary.2784.26149885025.0
  yarn add @salutejs/plasma-sb-utils@0.226.0-canary.2784.26149885025.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
