### PR TITLE
PLASMA-4366: add gradient support for icons color

### DIFF
--- a/packages/plasma-icons/scripts/utils.ts
+++ b/packages/plasma-icons/scripts/utils.ts
@@ -52,6 +52,7 @@ export const prettify = (source: string) => prettier.format(source, prettierSett
  */
 export const getIconAsset = (source: string, iconName: string) => {
     const viewBox = getViewBox(source);
+
     const svgContent = compose(
         removeLineBreak,
         getSvgContent,

--- a/packages/plasma-icons/src/scalable/IconRoot.tsx
+++ b/packages/plasma-icons/src/scalable/IconRoot.tsx
@@ -1,6 +1,5 @@
 import React, { HTMLAttributes } from 'react';
 import type { CSSProperties } from 'react';
-import styled from 'styled-components';
 
 export const sizeMap = {
     xs: {
@@ -21,6 +20,9 @@ export type IconSize = keyof typeof sizeMap;
 
 export interface IconProps {
     size?: IconSize;
+    /**
+     * Цвет иконки. Можно передавать css-градиент
+     */
     color?: string;
     className?: string;
     style?: CSSProperties;
@@ -31,16 +33,17 @@ interface IconRootProps extends IconProps, HTMLAttributes<HTMLDivElement> {
     icon: React.FC<IconProps>;
 }
 
-const IconsRoot = styled.div`
-    width: var(--icon-size);
-    height: var(--icon-size);
-    flex: none;
+const isGradient = (color: string) => /gradient/.test(color);
 
-    /* Нужно чтобы svg была блочным элементов для отключения baseline */
-    svg {
-        display: block;
+const iconMaskIds = new WeakMap<React.FC<IconProps>, number>();
+let maskCounter = 0;
+
+const getMaskId = (icon: React.FC<IconProps>, size: IconSize): string => {
+    if (!iconMaskIds.has(icon)) {
+        iconMaskIds.set(icon, maskCounter++);
     }
-`;
+    return `plasma-icon-${iconMaskIds.get(icon) ?? maskCounter}-${size}`;
+};
 
 export const getIconComponent = (
     icon16: React.FC<IconProps> | null,
@@ -64,14 +67,46 @@ export const getIconComponent = (
 };
 
 export const IconRoot: React.FC<IconRootProps> = ({ icon: Icon, size, color, className, style, ...rest }) => {
+    const iconSize = `${sizeMap[size].scale}rem`;
+    const resolvedColor = color || 'var(--plasma-colors-primary)';
+    const gradient = isGradient(resolvedColor);
+
     return (
-        <IconsRoot
+        <div
             aria-hidden
-            style={{ '--icon-size': `${sizeMap[size].scale}rem`, ...style } as CSSProperties}
+            style={
+                {
+                    width: iconSize,
+                    height: iconSize,
+                    flex: 'none',
+                    ...style,
+                } as CSSProperties
+            }
             className={`icon-root-container ${className || ''}`}
             {...rest}
         >
-            <Icon color={color || 'var(--plasma-colors-primary)'} size={size} />
-        </IconsRoot>
+            {gradient ? (
+                <svg
+                    width="100%"
+                    height="100%"
+                    viewBox={`0 0 ${sizeMap[size].size} ${sizeMap[size].size}`}
+                    xmlns="http://www.w3.org/2000/svg"
+                    style={{ display: 'block' }}
+                >
+                    <defs>
+                        <mask id={getMaskId(Icon, size)}>
+                            <Icon color="white" size={size} />
+                        </mask>
+                    </defs>
+                    <g mask={`url(#${getMaskId(Icon, size)})`}>
+                        <foreignObject width="100%" height="100%">
+                            <div style={{ width: '100%', height: '100%', background: resolvedColor }} />
+                        </foreignObject>
+                    </g>
+                </svg>
+            ) : (
+                <Icon color={resolvedColor} size={size} style={{ display: 'block' }} />
+            )}
+        </div>
     );
 };


### PR DESCRIPTION
## PLASMA-ICONS

### Icons

- добавлена поддержка градиента

### What/why changed
Пример иконок https://plasma.sberdevices.ru/pr/pr-2786/giga-storybook/?path=/story/data-entry-iconbutton--with-gradient (откачу перед влитием)
- добавлена поддержка градиента
Пример использования
```tsx
<IconBellFill color="linear-gradient(to bottom, #ffffff, #ff002b)" size="s" />
<IconBellFill color="linear-gradient(to bottom right, #11998e, #38ef7d)" size="s" />
<IconBellFill color="radial-gradient(#ffd200, #ff9500, #ff2d55)" size="s" />
```
<img width="621" height="736" alt="image" src="https://github.com/user-attachments/assets/14a30230-c052-4031-a6f2-9857443db9ec" />


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.376.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-b2c@1.618.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-core@1.226.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-giga@0.345.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-homeds@0.345.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-hope@1.372.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-icons@1.238.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-new-hope@0.362.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-tokens@1.138.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-ui@1.348.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-web@1.620.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-bizcom@0.350.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-cs@0.354.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-dfa@0.348.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-finai@0.341.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-insol@0.345.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-netology@0.349.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-os@0.20.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-platform-ai@0.349.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-sbcom@0.350.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-scan@0.348.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-serv@0.349.0-canary.2786.26274748454.0
  npm install @salutejs/core-themes@0.30.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-themes@0.50.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-themes@0.65.0-canary.2786.26274748454.0
  npm install @salutejs/sdds-api-tests@0.7.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-cy-utils@0.156.0-canary.2786.26274748454.0
  npm install @salutejs/plasma-sb-utils@0.226.0-canary.2786.26274748454.0
  # or 
  yarn add @salutejs/plasma-asdk@0.376.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-b2c@1.618.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-core@1.226.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-giga@0.345.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-homeds@0.345.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-hope@1.372.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-icons@1.238.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-new-hope@0.362.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-tokens@1.138.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-ui@1.348.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-web@1.620.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-bizcom@0.350.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-cs@0.354.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-dfa@0.348.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-finai@0.341.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-insol@0.345.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-netology@0.349.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-os@0.20.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-platform-ai@0.349.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-sbcom@0.350.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-scan@0.348.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-serv@0.349.0-canary.2786.26274748454.0
  yarn add @salutejs/core-themes@0.30.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-themes@0.50.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-themes@0.65.0-canary.2786.26274748454.0
  yarn add @salutejs/sdds-api-tests@0.7.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-cy-utils@0.156.0-canary.2786.26274748454.0
  yarn add @salutejs/plasma-sb-utils@0.226.0-canary.2786.26274748454.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
