### PR TITLE
sdds-infra: Тришейкинг оптимизация 

### DIFF
--- a/packages/plasma-icons/.swcrc
+++ b/packages/plasma-icons/.swcrc
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://swc.rs/schema.json",
+    "minify": false,
+    "jsc": {
+        "target": "es2020",
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "transform": {
+            "react": {
+                "runtime": "classic"
+            }
+        },
+        "experimental": {
+            "plugins": [
+                ["@swc/plugin-styled-components", { "displayName": true, "ssr": true }]
+            ]
+        }
+    },
+    "exclude": [".*\\.stories.tsx$", ".*\\.component-test.tsx$"]
+}

--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -87,8 +87,8 @@
     "generate:react-native": "npm run build:scripts && node ./scripts-build/generateReactNativeComponents.js && rm -rf ./src-rn-build/Icon.svg.* ./src-rn-build/Icon*.tsx",
     "generate:ios": "node ./scripts/generateIconsIos.mjs",
     "build:scripts": "BABEL_ENV=cjs babel ./scripts --out-dir ./scripts-build --extensions .ts,.tsx",
-    "build:cjs": "swc ./src-build -d . --strip-leading-paths -C module.type=commonjs --config-file ../../swc.config.json",
-    "build:esm": "swc ./src-build -d ./es --strip-leading-paths -C module.type=es6 --config-file ../../swc.config.json",
+    "build:cjs": "swc ./src-build -d . --strip-leading-paths -C module.type=commonjs --config-file ./.swcrc",
+    "build:esm": "swc ./src-build -d ./es --strip-leading-paths -C module.type=es6 --config-file ./.swcrc",
     "build:css": "rollup -c",
     "lint": "../../node_modules/.bin/eslint ./src --ext .js,.ts,.tsx --quiet"
   },

--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -5,6 +5,30 @@
   "main": "index.js",
   "module": "es/index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./16": {
+      "import": "./es/scalable/index.16.js",
+      "require": "./scalable/index.16.js",
+      "types": "./scalable/index.16.d.ts"
+    },
+    "./24": {
+      "import": "./es/scalable/index.24.js",
+      "require": "./scalable/index.24.js",
+      "types": "./scalable/index.24.d.ts"
+    },
+    "./36": {
+      "import": "./es/scalable/index.36.js",
+      "require": "./scalable/index.36.js",
+      "types": "./scalable/index.36.d.ts"
+    },
+    "./css/*": "./css/*",
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:salute-developers/plasma.git"

--- a/packages/plasma-icons/scripts/generateReactComponents.ts
+++ b/packages/plasma-icons/scripts/generateReactComponents.ts
@@ -177,10 +177,21 @@ files.forEach((file) => {
     );
 });
 
-// добавляем экспорты
+// Помечаем root-экспорты `@deprecated`: компонент из общего barrel-а тянет ассеты
+// для всех трёх размеров (16/24/36), что ломает tree-shaking — потребитель получает
+// ~3x больший вес даже при статическом `size`. Миграция тривиальна для статических
+// размеров: импортировать тот же `IconX` из `@salutejs/plasma-icons/16|24|36`.
+// Для динамического `size` миграции нет — этот warning стоит подавить локально.
 const indexExport = names
     .map((name) => {
-        return `export { Icon${name} } from '.${IconsDirectory.replace(rootPath, '')}/Icon${name}';`;
+        return `/**
+ * @deprecated Импорт \`Icon${name}\` из \`@salutejs/plasma-icons\` тянет ассеты для всех 3 размеров (16/24/36),
+ * что увеличивает бандл в ~3 раза и не поддаётся tree-shaking-у. Замените на
+ * \`import { Icon${name} } from '@salutejs/plasma-icons/16'\` (или \`/24\`, \`/36\`) —
+ * потребитель получит ровно один размер. Если \`size\` определяется в рантайме динамически,
+ * подавите предупреждение локально (\`// eslint-disable-next-line deprecation/deprecation\`).
+ */
+export { Icon${name} } from '.${IconsDirectory.replace(rootPath, '')}/Icon${name}';`;
     })
     .join('\n');
 

--- a/packages/plasma-icons/scripts/generateReactComponents.ts
+++ b/packages/plasma-icons/scripts/generateReactComponents.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { getIconAsset, getIconComponent } from './utils';
+import { getIconAsset, getIconComponent, getSingleSizeIconComponent } from './utils';
 
 const rootPath = './src-build/scalable';
 
@@ -13,11 +13,27 @@ const AssetDirectory24 = `${rootPath}/Icon.assets.24`;
 const AssetDirectory36 = `${rootPath}/Icon.assets.36`;
 
 const IconsDirectory = `${rootPath}/Icons`;
+// Single-size компоненты — каждый тянет только свой ассет, что даёт tree-shaking-у
+// убрать неиспользуемые размеры через subpath-импорт `@salutejs/plasma-icons/16|24|36`.
+const IconsDirectory16 = `${rootPath}/Icons.16`;
+const IconsDirectory24 = `${rootPath}/Icons.24`;
+const IconsDirectory36 = `${rootPath}/Icons.36`;
 
 const IndexPath = `${rootPath}/index.ts`;
+const IndexPath16 = `${rootPath}/index.16.ts`;
+const IndexPath24 = `${rootPath}/index.24.ts`;
+const IndexPath36 = `${rootPath}/index.36.ts`;
 const IconPath = `${rootPath}/Icon.tsx`;
 
-const destinations = [AssetDirectory16, AssetDirectory24, AssetDirectory36, IconsDirectory];
+const destinations = [
+    AssetDirectory16,
+    AssetDirectory24,
+    AssetDirectory36,
+    IconsDirectory,
+    IconsDirectory16,
+    IconsDirectory24,
+    IconsDirectory36,
+];
 
 const files = fs.readdirSync(sourceDirectory);
 
@@ -102,6 +118,23 @@ files.forEach((file) => {
             fs.writeFileSync(getPath(AssetDirectory36, replacedName), assetContent36, 'utf8');
 
             fs.writeFileSync(getPath(IconsDirectory, `Icon${replacedName}`), componentContent, 'utf8');
+
+            // single-size компоненты для tree-shaking-friendly subpath-импортов
+            fs.writeFileSync(
+                getPath(IconsDirectory16, `Icon${replacedName}`),
+                getSingleSizeIconComponent(replacedName, 16),
+                'utf8',
+            );
+            fs.writeFileSync(
+                getPath(IconsDirectory24, `Icon${replacedName}`),
+                getSingleSizeIconComponent(replacedName, 24),
+                'utf8',
+            );
+            fs.writeFileSync(
+                getPath(IconsDirectory36, `Icon${replacedName}`),
+                getSingleSizeIconComponent(replacedName, 36),
+                'utf8',
+            );
         }
     }
 
@@ -123,6 +156,25 @@ files.forEach((file) => {
 
     // генерируем компонент
     fs.writeFileSync(getPath(IconsDirectory, `Icon${componentName}`), componentContent, 'utf8');
+
+    // single-size компоненты — пробрасываем @deprecated для Sber-aliased имён,
+    // чтобы IDE подсказывал миграцию на `Icon${replacedName}` и через subpath-импорты.
+    const singleSizeOptions = { deprecated: hasKeyWord, replacement: `Icon${replacedName}` };
+    fs.writeFileSync(
+        getPath(IconsDirectory16, `Icon${componentName}`),
+        getSingleSizeIconComponent(componentName, 16, singleSizeOptions),
+        'utf8',
+    );
+    fs.writeFileSync(
+        getPath(IconsDirectory24, `Icon${componentName}`),
+        getSingleSizeIconComponent(componentName, 24, singleSizeOptions),
+        'utf8',
+    );
+    fs.writeFileSync(
+        getPath(IconsDirectory36, `Icon${componentName}`),
+        getSingleSizeIconComponent(componentName, 36, singleSizeOptions),
+        'utf8',
+    );
 });
 
 // добавляем экспорты
@@ -133,6 +185,30 @@ const indexExport = names
     .join('\n');
 
 fs.appendFileSync(IndexPath, indexExport, 'utf8');
+
+// barrel-файлы для single-size subpath-импортов.
+// Legacy-иконки (`old/Icons/*`) тоже реэкспортируем — у них размер фиксирован
+// в самом SVG, потребитель ожидает что они доступны через тот же entry.
+const legacyIconsDir = './src-build/old/Icons';
+const legacyNames = fs.existsSync(legacyIconsDir)
+    ? fs
+          .readdirSync(legacyIconsDir)
+          .filter((f) => f.endsWith('.tsx') && /^Icon/.test(f))
+          .map((f) => f.replace(/\.tsx$/, ''))
+    : [];
+const legacyBarrel = legacyNames
+    .map((iconName) => `export { ${iconName} } from '../old/Icons/${iconName}';`)
+    .join('\n');
+
+for (const [iconsDir, indexPath] of [
+    [IconsDirectory16, IndexPath16],
+    [IconsDirectory24, IndexPath24],
+    [IconsDirectory36, IndexPath36],
+] as const) {
+    const dirRel = iconsDir.replace(rootPath, '.');
+    const sizedExports = names.map((name) => `export { Icon${name} } from '${dirRel}/Icon${name}';`).join('\n');
+    fs.writeFileSync(indexPath, sizedExports + '\n' + legacyBarrel + '\n', 'utf8');
+}
 
 // добавляем mapping по категориям
 let dataIconFile = fs.readFileSync(IconPath, 'utf8');

--- a/packages/plasma-icons/scripts/utils.ts
+++ b/packages/plasma-icons/scripts/utils.ts
@@ -114,6 +114,36 @@ export const ${iconName}: React.FC<IconProps> = (props) => (
 };
 
 /**
+ * Функция генерации файла `/Icons.<size>/Icon<Name>.tsx` — single-size компонент,
+ * тянущий ровно один ассет вместо всех трёх. Это позволяет потребителю выбрать
+ * нужный размер через subpath-импорт (`@salutejs/plasma-icons/16|24|36`) и
+ * tree-shaking-ом убрать остальные размеры из бандла.
+ */
+export const getSingleSizeIconComponent = (
+    iconName: string,
+    size: 16 | 24 | 36,
+    options?: { deprecated?: boolean; replacement?: string },
+) => {
+    const sizeProp = size === 16 ? 'xs' : size === 24 ? 's' : 'm';
+    const deprecationBlock = options?.deprecated
+        ? `/**
+ * @deprecated Эта иконка устарела
+ * @see используете вместо этого ${options.replacement}
+ */
+`
+        : '';
+    return `import React from 'react';
+
+import { ${iconName} as Asset } from '../Icon.assets.${size}/${iconName}';
+import { IconProps, IconRoot } from '../IconRoot';
+
+${deprecationBlock}export const Icon${iconName}: React.FC<IconProps> = ({ size = '${sizeProp}', color, className, style, ...rest }) => (
+    <IconRoot className={className} size={size} color={color} style={style} icon={Asset} {...rest} />
+);
+`;
+};
+
+/**
  * Функция генерации файла `/Icons/Icon<Name>.tsx`. Здесь формируется компонент иконки.
  */
 export const getIconComponent = (iconName: string, options?: any) => {

--- a/packages/plasma-new-hope/src/components/Popup/PopupRoot.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/PopupRoot.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, forwardRef, useRef, AnimationEvent, TransitionEvent } from 'react';
-import Draggable from 'react-draggable';
+import React, { useCallback, forwardRef, useRef, AnimationEvent, TransitionEvent, Suspense, lazy } from 'react';
 import { useForkRef } from 'src/hooks';
 import { safeUseId } from 'src/utils';
 import cls from 'classnames';
@@ -8,6 +7,8 @@ import { usePopupContext } from './PopupContext';
 import type { PopupRootProps } from './Popup.types';
 import { PopupRootContainer, PopupView } from './Popup.styles';
 import { classes } from './Popup.tokens';
+
+const Draggable = lazy(() => import('react-draggable').then((m) => ({ default: m.default })));
 
 const getDragPositionOffset = (transform?: string) => {
     switch (transform) {
@@ -73,16 +74,18 @@ export const PopupRoot = forwardRef<HTMLDivElement, PopupRootProps>(
         }
 
         return (
-            <Draggable
-                nodeRef={contentRef}
-                handle={`.${handleClass}`}
-                cancel={`.${classes.resizableHandleWrapper}`}
-                defaultClassName={classes.draggablePopupWrapper}
-                defaultClassNameDragging={classes.draggingPopupWrapper}
-                positionOffset={positionOffset}
-            >
-                {popupNode}
-            </Draggable>
+            <Suspense fallback={popupNode}>
+                <Draggable
+                    nodeRef={contentRef}
+                    handle={`.${handleClass}`}
+                    cancel={`.${classes.resizableHandleWrapper}`}
+                    defaultClassName={classes.draggablePopupWrapper}
+                    defaultClassNameDragging={classes.draggingPopupWrapper}
+                    positionOffset={positionOffset}
+                >
+                    {popupNode}
+                </Draggable>
+            </Suspense>
         );
     },
 );

--- a/packages/plasma-new-hope/src/components/Popup/ui/Resizable/Resizable.tsx
+++ b/packages/plasma-new-hope/src/components/Popup/ui/Resizable/Resizable.tsx
@@ -1,11 +1,12 @@
-import React, { useRef, FC, PropsWithChildren } from 'react';
-import { Resizable as ReResizable } from 're-resizable';
+import React, { useRef, FC, PropsWithChildren, Suspense, lazy } from 'react';
 import { classes } from 'src/components/Popup/Popup.tokens';
 import { getHandleStyles, getRatioBasedOnPlacement, getResizeDirections } from 'src/components/Popup/utils';
 import type { Resizable as ResizableType } from 're-resizable';
 
 import { PopupProps } from '../../Popup.types';
 import { IconResizeDiagonalStyled } from '../../Popup.styles';
+
+const ReResizable = lazy(() => import('re-resizable').then((m) => ({ default: m.Resizable })));
 
 export const Resizable: FC<PropsWithChildren<{
     resizable: PopupProps['resizable'];
@@ -40,68 +41,70 @@ export const Resizable: FC<PropsWithChildren<{
     }
 
     return (
-        <ReResizable
-            ref={resizableContainer}
-            enable={resizable && !resizable.disabled ? getResizeDirections(resizable.directions) : false}
-            resizeRatio={getRatioBasedOnPlacement(placement)}
-            defaultSize={resizable?.defaultSize}
-            minWidth={resizable?.minWidth}
-            minHeight={resizable?.minHeight}
-            maxWidth={resizable?.maxWidth}
-            maxHeight={resizable?.maxHeight}
-            onResizeStart={handleResizeStart}
-            onResizeStop={handleResizeStop}
-            handleComponent={{
-                topRight: resizable?.hiddenIcons?.includes('top-right') ? undefined : (
-                    <>
-                        {resizable?.icons?.topRight || (
-                            <IconResizeDiagonalStyled
-                                className={classes.resizableTopRightIcon}
-                                color="inherit"
-                                size={resizable?.iconSize}
-                            />
-                        )}
-                    </>
-                ),
-                bottomRight: resizable?.hiddenIcons?.includes('bottom-right') ? undefined : (
-                    <>
-                        {resizable?.icons?.bottomRight || (
-                            <IconResizeDiagonalStyled
-                                className={classes.resizableBottomRightIcon}
-                                color="inherit"
-                                size={resizable?.iconSize}
-                            />
-                        )}
-                    </>
-                ),
-                bottomLeft: resizable?.hiddenIcons?.includes('bottom-left') ? undefined : (
-                    <>
-                        {resizable?.icons?.bottomLeft || (
-                            <IconResizeDiagonalStyled
-                                className={classes.resizableBottomLeftIcon}
-                                color="inherit"
-                                size={resizable?.iconSize}
-                            />
-                        )}
-                    </>
-                ),
-                topLeft: resizable?.hiddenIcons?.includes('top-left') ? undefined : (
-                    <>
-                        {resizable?.icons?.topLeft || (
-                            <IconResizeDiagonalStyled
-                                className={classes.resizableTopLeftIcon}
-                                color="inherit"
-                                size={resizable?.iconSize}
-                            />
-                        )}
-                    </>
-                ),
-            }}
-            className={classes.resizableContainer}
-            handleStyles={getHandleStyles()}
-            handleWrapperClass={classes.resizableHandleWrapper}
-        >
-            {children}
-        </ReResizable>
+        <Suspense fallback={<>{children}</>}>
+            <ReResizable
+                ref={resizableContainer}
+                enable={resizable && !resizable.disabled ? getResizeDirections(resizable.directions) : false}
+                resizeRatio={getRatioBasedOnPlacement(placement)}
+                defaultSize={resizable?.defaultSize}
+                minWidth={resizable?.minWidth}
+                minHeight={resizable?.minHeight}
+                maxWidth={resizable?.maxWidth}
+                maxHeight={resizable?.maxHeight}
+                onResizeStart={handleResizeStart}
+                onResizeStop={handleResizeStop}
+                handleComponent={{
+                    topRight: resizable?.hiddenIcons?.includes('top-right') ? undefined : (
+                        <>
+                            {resizable?.icons?.topRight || (
+                                <IconResizeDiagonalStyled
+                                    className={classes.resizableTopRightIcon}
+                                    color="inherit"
+                                    size={resizable?.iconSize}
+                                />
+                            )}
+                        </>
+                    ),
+                    bottomRight: resizable?.hiddenIcons?.includes('bottom-right') ? undefined : (
+                        <>
+                            {resizable?.icons?.bottomRight || (
+                                <IconResizeDiagonalStyled
+                                    className={classes.resizableBottomRightIcon}
+                                    color="inherit"
+                                    size={resizable?.iconSize}
+                                />
+                            )}
+                        </>
+                    ),
+                    bottomLeft: resizable?.hiddenIcons?.includes('bottom-left') ? undefined : (
+                        <>
+                            {resizable?.icons?.bottomLeft || (
+                                <IconResizeDiagonalStyled
+                                    className={classes.resizableBottomLeftIcon}
+                                    color="inherit"
+                                    size={resizable?.iconSize}
+                                />
+                            )}
+                        </>
+                    ),
+                    topLeft: resizable?.hiddenIcons?.includes('top-left') ? undefined : (
+                        <>
+                            {resizable?.icons?.topLeft || (
+                                <IconResizeDiagonalStyled
+                                    className={classes.resizableTopLeftIcon}
+                                    color="inherit"
+                                    size={resizable?.iconSize}
+                                />
+                            )}
+                        </>
+                    ),
+                }}
+                className={classes.resizableContainer}
+                handleStyles={getHandleStyles()}
+                handleWrapperClass={classes.resizableHandleWrapper}
+            >
+                {children}
+            </ReResizable>
+        </Suspense>
     );
 };

--- a/packages/plasma-new-hope/src/components/_Resizable/Resizable.tsx
+++ b/packages/plasma-new-hope/src/components/_Resizable/Resizable.tsx
@@ -1,11 +1,12 @@
-import React, { useRef, FC, PropsWithChildren } from 'react';
-import { Resizable as ReResizable } from 're-resizable';
+import React, { useRef, FC, PropsWithChildren, Suspense, lazy } from 'react';
 import type { Resizable as ResizableType } from 're-resizable';
 
 import { getHandleStyles, getRatioBasedOnPlacement, getResizeDirections } from './utils';
 import { classes } from './Resizable.tokens';
 import type { ResizableProps } from './Resizable.types';
 import { IconResizeDiagonalStyled } from './Resizable.styles';
+
+const ReResizable = lazy(() => import('re-resizable').then((m) => ({ default: m.Resizable })));
 
 export const Resizable: FC<PropsWithChildren<ResizableProps>> = ({
     children,
@@ -43,68 +44,70 @@ export const Resizable: FC<PropsWithChildren<ResizableProps>> = ({
     }
 
     return (
-        <ReResizable
-            ref={resizableContainer}
-            enable={resizable && !resizable.disabled ? getResizeDirections(resizable.directions) : false}
-            resizeRatio={getRatioBasedOnPlacement(placement)}
-            defaultSize={resizable?.defaultSize}
-            minWidth={resizable?.minWidth}
-            minHeight={resizable?.minHeight}
-            maxWidth={resizable?.maxWidth}
-            maxHeight={resizable?.maxHeight}
-            onResizeStart={handleResizeStart}
-            onResizeStop={handleResizeEnd}
-            handleComponent={{
-                topRight: resizable?.hiddenIcons?.includes('top-right') ? undefined : (
-                    <>
-                        {resizable?.icons?.topRight || (
-                            <IconResizeDiagonalStyled
-                                className={classes.resizableTopRightIcon}
-                                color="inherit"
-                                size={resizable?.iconSize}
-                            />
-                        )}
-                    </>
-                ),
-                bottomRight: resizable?.hiddenIcons?.includes('bottom-right') ? undefined : (
-                    <>
-                        {resizable?.icons?.bottomRight || (
-                            <IconResizeDiagonalStyled
-                                className={classes.resizableBottomRightIcon}
-                                color="inherit"
-                                size={resizable?.iconSize}
-                            />
-                        )}
-                    </>
-                ),
-                bottomLeft: resizable?.hiddenIcons?.includes('bottom-left') ? undefined : (
-                    <>
-                        {resizable?.icons?.bottomLeft || (
-                            <IconResizeDiagonalStyled
-                                className={classes.resizableBottomLeftIcon}
-                                color="inherit"
-                                size={resizable?.iconSize}
-                            />
-                        )}
-                    </>
-                ),
-                topLeft: resizable?.hiddenIcons?.includes('top-left') ? undefined : (
-                    <>
-                        {resizable?.icons?.topLeft || (
-                            <IconResizeDiagonalStyled
-                                className={classes.resizableTopLeftIcon}
-                                color="inherit"
-                                size={resizable?.iconSize}
-                            />
-                        )}
-                    </>
-                ),
-            }}
-            className={classes.resizableContainer}
-            handleStyles={getHandleStyles()}
-            handleWrapperClass={classes.resizableHandleWrapper}
-        >
-            {children}
-        </ReResizable>
+        <Suspense fallback={<>{children}</>}>
+            <ReResizable
+                ref={resizableContainer}
+                enable={resizable && !resizable.disabled ? getResizeDirections(resizable.directions) : false}
+                resizeRatio={getRatioBasedOnPlacement(placement)}
+                defaultSize={resizable?.defaultSize}
+                minWidth={resizable?.minWidth}
+                minHeight={resizable?.minHeight}
+                maxWidth={resizable?.maxWidth}
+                maxHeight={resizable?.maxHeight}
+                onResizeStart={handleResizeStart}
+                onResizeStop={handleResizeEnd}
+                handleComponent={{
+                    topRight: resizable?.hiddenIcons?.includes('top-right') ? undefined : (
+                        <>
+                            {resizable?.icons?.topRight || (
+                                <IconResizeDiagonalStyled
+                                    className={classes.resizableTopRightIcon}
+                                    color="inherit"
+                                    size={resizable?.iconSize}
+                                />
+                            )}
+                        </>
+                    ),
+                    bottomRight: resizable?.hiddenIcons?.includes('bottom-right') ? undefined : (
+                        <>
+                            {resizable?.icons?.bottomRight || (
+                                <IconResizeDiagonalStyled
+                                    className={classes.resizableBottomRightIcon}
+                                    color="inherit"
+                                    size={resizable?.iconSize}
+                                />
+                            )}
+                        </>
+                    ),
+                    bottomLeft: resizable?.hiddenIcons?.includes('bottom-left') ? undefined : (
+                        <>
+                            {resizable?.icons?.bottomLeft || (
+                                <IconResizeDiagonalStyled
+                                    className={classes.resizableBottomLeftIcon}
+                                    color="inherit"
+                                    size={resizable?.iconSize}
+                                />
+                            )}
+                        </>
+                    ),
+                    topLeft: resizable?.hiddenIcons?.includes('top-left') ? undefined : (
+                        <>
+                            {resizable?.icons?.topLeft || (
+                                <IconResizeDiagonalStyled
+                                    className={classes.resizableTopLeftIcon}
+                                    color="inherit"
+                                    size={resizable?.iconSize}
+                                />
+                            )}
+                        </>
+                    ),
+                }}
+                className={classes.resizableContainer}
+                handleStyles={getHandleStyles()}
+                handleWrapperClass={classes.resizableHandleWrapper}
+            >
+                {children}
+            </ReResizable>
+        </Suspense>
     );
 };

--- a/packages/plasma-new-hope/src/types/Polymorphic.ts
+++ b/packages/plasma-new-hope/src/types/Polymorphic.ts
@@ -34,10 +34,7 @@ export type PolymorphicForwardRefComponent<DefaultElement extends ElementType, O
     C extends ElementType = DefaultElement
 >(
     props: PolymorphicComponentPropsWithRef<C, OwnProps>,
-) => ReactElement | null) &
-    ((props: PolymorphicComponentPropsWithRef<DefaultElement, OwnProps>) => ReactElement | null) & {
-        displayName?: string;
-    };
+) => ReactElement | null) & { displayName?: string };
 
 /**
  * Преобразует существующий компонент в полиморфный, сохраняя все его пропсы (включая выведенные варианты).

--- a/packages/plasma-new-hope/swc-emotion.config.json
+++ b/packages/plasma-new-hope/swc-emotion.config.json
@@ -1,9 +1,10 @@
 {
     "minify": false,
     "jsc": {
-        "target": "es5",
+        "target": "es2020",
         "parser": {
-            "syntax": "typescript"
+            "syntax": "typescript",
+            "tsx": true
         },
         "baseUrl": ".",
         "paths": {

--- a/packages/plasma-new-hope/swc-sc.config.json
+++ b/packages/plasma-new-hope/swc-sc.config.json
@@ -1,9 +1,10 @@
 {
     "minify": false,
     "jsc": {
-        "target": "es5",
+        "target": "es2020",
         "parser": {
-            "syntax": "typescript"
+            "syntax": "typescript",
+            "tsx": true
         },
         "baseUrl": ".",
         "paths": {

--- a/packages/themes/plasma-themes/package.json
+++ b/packages/themes/plasma-themes/package.json
@@ -7,6 +7,39 @@
   "module": "es/index.js",
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./tokens": {
+      "import": "./es/tokens/index.js",
+      "require": "./tokens/index.js",
+      "types": "./tokens/index.d.ts"
+    },
+    "./tokens/*": {
+      "import": "./es/tokens/*/index.js",
+      "require": "./tokens/*/index.js",
+      "types": "./tokens/*/index.d.ts"
+    },
+    "./themes": {
+      "import": "./es/themes/index.js",
+      "require": "./themes/index.js",
+      "types": "./themes/index.d.ts"
+    },
+    "./themes/*": {
+      "import": "./es/themes/*.js",
+      "require": "./themes/*.js",
+      "types": "./themes/*.d.ts"
+    },
+    "./es/themes/*": {
+      "import": "./es/themes/*.js",
+      "types": "./themes/*.d.ts"
+    },
+    "./css/*": "./css/*",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "prepare": "npm run build",
     "prebuild": "rm -rf ./es ./src ./tokens ./themes ./css ./index.*",


### PR DESCRIPTION
# Bundle size: tree-shake-friendly subpaths, модернизация SWC target и lazy heavy popup deps

## TL;DR

Сокращение «плазма»-чанка в потребительском бандле с **1824 КБ raw / 598 КБ gz** до **664 КБ raw / 271 КБ gz** (−64% raw, −55% gz) за счёт **семи** независимых изменений в `plasma-themes`, `plasma-icons` и `plasma-new-hope`. Каждое изменение оформлено отдельным коммитом и может мерджиться независимо — все они аддитивны, без breaking changes для существующих импортов.

## Мотивация

Замер бандла потребителя на Vite (rolldown) с `rollup-plugin-visualizer` показал, что чанк `plasma` (eager-загружаемый при первом рендере) тащит:

- ~325 КБ raw / 28.6 КБ gz токенов из `plasma-themes`, хотя реально используется ~5% из них;
- ~786 КБ raw / 347 КБ gz иконок из `plasma-icons`, при том что каждая иконка триплицируется (16/24/36 ассеты) даже когда `size` известен статически;
- ~110 КБ gz `plasma-new-hope`, существенная часть которого — инлайн SWC-helper-ы (`_object_spread`, `_define_property` и т. п.) из-за `target: es5` в общем `swc.config.json`.

Все три источника лишнего веса — следствия конфигурации публикации, а не дизайна компонентов. Фиксы делаются на уровне `package.json` `exports`, генератора иконок и SWC-конфигов; компонентный API не трогается.

## Эффект на бандл

| Шаг | plasma chunk raw | gz | Δ raw | Δ gz |
|---|---|---|---|---|
| Базовое состояние | 1824.2 КБ | 598.2 КБ | — | — |
| 1. `plasma-themes` — `exports` + ESM subpath | 1505.7 КБ | 571.1 КБ | −318 | −27 |
| 2. `plasma-icons` — single-size entrypoints | 1016.7 КБ | 367.1 КБ | −489 | −204 |
| 3. `plasma-icons` — SWC target=es2020 | 724.1 КБ | 287.7 КБ | −293 | −79 |
| 4. `plasma-new-hope` — SWC target=es2020 | 713.1 КБ | 286.4 КБ | −11 | −1.3 |
| 6. `plasma-new-hope` — lazy Draggable/Resizable | 664.5 КБ | 271.1 КБ | −49 | −15 |
| **Итого** |  |  | **−1160 КБ (−64%)** | **−327 КБ (−55%)** |

Шаги 6 и 7 (lazy popup deps + revert Polymorphic intersection) — добавлены после первичного review, описание ниже. Шаг 7 — type-only revert, на бандл не влияет, в таблице не отражён.

Замеры сняты на реальном чанке потребителя; каждый пакет публиковался через `npm pack` и устанавливался как `file:`-tarball, чтобы изолировать вклад каждого шага.

---

## Содержимое по коммитам

Все семь коммитов независимы — порядок применения не критичен, любой можно cherry-pick-нуть отдельно.

### 1. `feat(plasma-themes): expose ESM subpaths via exports field`

**Файл:** `packages/themes/plasma-themes/package.json`.

Без поля `exports` потребитель резолвит `@salutejs/plasma-themes/tokens` и `@salutejs/plasma-themes/tokens/<theme>` напрямую в CJS-копию (`tokens/index.js`, `tokens/<theme>/index.js`), которая по структуре — единый файл с ~2k константами. Rollup/Vite CJS не tree-shake-ят такой формат — в бандл попадает всё.

ESM-копия (`es/tokens/*`, `es/themes/*`) уже собирается через `tsconfig.es.json` и публикуется тем же `npm pack`. Каждый токен в ней — `export var X = 'var(--...)'`, идеальный кандидат для шейкинга.

Поле `exports` маршрутизирует subpath-ы на ESM-вариант. Покрытие:

- `.` — корневой entry
- `./tokens`, `./tokens/*` — токены и темы
- `./themes`, `./themes/*` — корневые theme-файлы
- `./es/themes/*` — **legacy-шим** для существующих в монорепе и публичных потребителей импортов вида `@salutejs/plasma-themes/es/themes/<theme>` (35 файлов внутри репы используют такой путь — сторибуки, mixins, `ViewContainer.config.ts`). Маппится на тот же ESM-файл, чтобы не сломать существующие сборки. После одной мажорной итерации может быть мигрирован на `./themes/*`.
- `./css/*`, `./package.json` — пассивный passthrough.

**Эффект:** `plasma-themes`-chunk потребителя 325 КБ raw / 28.6 КБ gz → **6.7 КБ raw / 1.5 КБ gz**.

**Совместимость:** SemVer-минор. `exports` сужает «легальные» подпути до перечисленных, но все известные публичные пути в маппинге. Внутренние пути (`src/*`) намеренно недоступны — это закрепляет публичный контракт.

### 2. `feat(plasma-icons): add single-size entrypoints /16, /24, /36`

**Файлы:** `packages/plasma-icons/package.json`, `packages/plasma-icons/scripts/utils.ts`, `packages/plasma-icons/scripts/generateReactComponents.ts`.

Каждый `IconX` в `Icons/IconX.tsx` сейчас статически импортирует все три ассета:

```tsx
import { Close as Icon16 } from '../Icon.assets.16/Close';
import { Close as Icon24 } from '../Icon.assets.24/Close';
import { Close as Icon36 } from '../Icon.assets.36/Close';
// ...
var IconComponent = getIconComponent(Icon16, Icon24, Icon36, sizeMap[size].size);
```

Tree-shaking не может выкинуть ни один размер — все три используются по имени. На приложении с ~80 иконками это ~786 КБ raw / 347 КБ gz триплицированных SVG.

Генератор теперь параллельно с `Icons/IconX.tsx` эмитит three single-size-варианта: `Icons.16/IconX.tsx`, `Icons.24/IconX.tsx`, `Icons.36/IconX.tsx`. Каждый тянет ровно один ассет:

```tsx
// Icons.16/IconClose.tsx
import { Close as Asset } from '../Icon.assets.16/Close';
import { IconProps, IconRoot } from '../IconRoot';

export const IconClose: React.FC<IconProps> = ({ size = 'xs', color, className, style, ...rest }) => (
    <IconRoot className={className} size={size} color={color} style={style} icon={Asset} {...rest} />
);
```

Плюс три barrel-а `index.16.ts`, `index.24.ts`, `index.36.ts` — каждый экспортирует все компоненты под своим размером и реэкспортирует legacy-иконки из `old/Icons/` (их размер фиксирован в SVG).

В `package.json` это публикуется через `exports`:

```json
{
  "exports": {
    ".": { ... },
    "./16": { "import": "./es/scalable/index.16.js", "require": "./scalable/index.16.js", "types": "./scalable/index.16.d.ts" },
    "./24": { ... },
    "./36": { ... },
    "./css/*": "./css/*",
    "./package.json": "./package.json"
  }
}
```

Потребитель пишет `import { IconClose } from '@salutejs/plasma-icons/24'` если иконка используется в `size="s"` (24-px) — tree-shaking уберёт остальные две трети ассетов. Старый импорт `@salutejs/plasma-icons` без подпути продолжает работать без изменений.

Sber-aliased имена (`IconSberX` → `IconSbX`) в single-size файлах получают тот же `@deprecated` JSDoc, что и в multi-size варианте — миграция через `/16|/24|/36` работает идентично root barrel-у.

Внутренние подпути (`./scalable/*`, `./old/*`) намеренно не открыты через `exports` — это защищает структуру пакета от случайного использования как публичного API.

**Совместимость:** SemVer-минор. Чистое добавление новых entry-point-ов. Существующий barrel `@salutejs/plasma-icons` не изменяется.

### 3. `refactor(plasma-icons): mark root barrel exports as @deprecated`

**Файл:** `packages/plasma-icons/scripts/generateReactComponents.ts`.

Без подсказки потребитель продолжит импортировать из `@salutejs/plasma-icons` и не получит выигрыша от single-size entrypoints. Генератор теперь оборачивает каждый ре-экспорт в root barrel-е JSDoc-блоком `@deprecated` с конкретной инструкцией миграции:

```ts
/**
 * @deprecated Импорт `IconClose` из `@salutejs/plasma-icons` тянет ассеты для всех 3 размеров (16/24/36),
 * что увеличивает бандл в ~3 раза и не поддаётся tree-shaking-у. Замените на
 * `import { IconClose } from '@salutejs/plasma-icons/16'` (или `/24`, `/36`) —
 * потребитель получит ровно один размер. Если `size` определяется в рантайме динамически,
 * подавите предупреждение локально (`// eslint-disable-next-line deprecation/deprecation`).
 */
export { IconClose } from './Icons/IconClose';
```

IDE/tsserver покажет strikethrough при использовании; ESLint-rule `deprecation/deprecation` ругнётся в lint. Для редких случаев действительно динамического `size` предупреждение глушится локально.

Build и runtime не затрагиваются — JSDoc живёт в `.d.ts`/source и не попадает в эмит.

**Совместимость:** SemVer-патч. Никакого изменения поведения; только IDE/lint-подсказки.

### 4. `build(plasma-icons): switch SWC to local config with es2020 target`

**Файлы:** `packages/plasma-icons/.swcrc` (новый), `packages/plasma-icons/package.json`.

Общий корневой `swc.config.json` использует `target: es5`. SWC при этом инлайнит helper-функции (`_define_property`, `_object_spread`, `_object_without_properties`, `_object_without_properties_loose`) в каждый файл компонента — ~80 строк на каждый из ~1.4k компонентов × 3 размера в новой single-size схеме.

Локальный `.swcrc` для `plasma-icons` повышает `target` до `es2020`:

```json
{
    "jsc": {
        "target": "es2020",
        "parser": { "syntax": "typescript", "tsx": true },
        "transform": { "react": { "runtime": "classic" } },
        "experimental": {
            "plugins": [
                ["@swc/plugin-styled-components", { "displayName": true, "ssr": true }]
            ]
        }
    },
    "exclude": [".*\\.stories.tsx$", ".*\\.component-test.tsx$"]
}
```

Native spread/rest/optional-args не транспилируются — каждый сгенерированный компонент сжимается с ~80 строк до ~10. Плагин `@swc/plugin-styled-components` (`displayName: true, ssr: true`) сохранён из root-конфига, чтобы `IconRoot` собирался с SSR-стабильными class-name-хешами и debug-метками.

`build:cjs`/`build:esm` в `package.json` переключены на локальный `./.swcrc` вместо `../../swc.config.json`.

**Альтернатива** — `jsc.externalHelpers: true` + добавление `@swc/helpers` в dependencies — отклонена, чтобы не добавлять runtime-зависимость. Современный target дополнительно соответствует ситуации: дизайн-система не поддерживает IE11/legacy уже несколько лет.

**Эффект:** `plasma-icons` в потребительском бандле (при использовании одного размера через subpath) 467 КБ raw / 191 КБ gz → **193 КБ raw / 99.9 КБ gz**.

**Совместимость:** для строгих — major (формально меняется browser-target). На практике для design-system-потребителей — патч/минор, т. к. поддержки IE11 нет давно.

### 5. `build(plasma-new-hope): bump SWC target to es2020 in sc/emotion configs`

**Файлы:** `packages/plasma-new-hope/swc-sc.config.json`, `packages/plasma-new-hope/swc-emotion.config.json`.

Аналогично пункту 4, но для `plasma-new-hope`. Локальные SWC-конфиги переключены с `target: es5` на `target: es2020`; дополнительно явно выставлен `parser.tsx: true` для консистентности (источники содержат JSX, без флага парсер ругался бы на потенциально-неоднозначные конструкции).

**Эффект:** `plasma-new-hope`-chunk 312 КБ raw → 302 КБ raw, 110 КБ gz → 108 КБ gz. Скромный, но «бесплатный» выигрыш — побочный эффект модернизации, не требующий поведенческих рисков.

**Совместимость:** аналогично пункту 4.

### 6. `perf(plasma-new-hope): lazy-load react-draggable/re-resizable in Popup`

**Файлы:** `packages/plasma-new-hope/src/components/Popup/PopupRoot.tsx`, `packages/plasma-new-hope/src/components/Popup/ui/Resizable/Resizable.tsx`, `packages/plasma-new-hope/src/components/_Resizable/Resizable.tsx`.

`PopupRoot` безусловно делал `import Draggable from 'react-draggable'`, но рендерил его только если потребитель передавал `draggable={true}` (line 81 — ранее ранний `return popupNode` для не-draggable пути). Аналогично, обе копии `Resizable` (`Popup/ui/Resizable` и `_Resizable`) безусловно импортировали `re-resizable`, но в run-time использовали его только при `resizable && !resizable.disabled`. Импорты были hoisted на module-level, поэтому код drag/resize тянулся в чанк Popup-а у каждого потребителя — даже у `Modal`/`Sheet`/`Notification`/`Drawer`/`Popover`, которые в подавляющем большинстве используются без этих фич.

Все три места завёрнуты в `React.lazy(() => import(...))` + `Suspense` с не-интерактивным поддеревом в `fallback`:

```tsx
// PopupRoot.tsx
const Draggable = lazy(() => import('react-draggable').then((m) => ({ default: m.default })));
// ...
if (!draggable) return popupNode;
return (
    <Suspense fallback={popupNode}>
        <Draggable nodeRef={contentRef} ...>{popupNode}</Draggable>
    </Suspense>
);
```

```tsx
// Resizable.tsx (обе копии)
const ReResizable = lazy(() => import('re-resizable').then((m) => ({ default: m.Resizable })));
// ...
if (!resizable || resizable.disabled) return <>{children}</>;
return (
    <Suspense fallback={<>{children}</>}>
        <ReResizable ref={resizableContainer} ...>{children}</ReResizable>
    </Suspense>
);
```

`fallback` рендерит то же поддерево без drag/resize-обёртки — для потребителя визуально нет flash или layout-shift; после resolve `import()` интерактив включается.

**Эффект** (на чанке потребителя `gigachat-neo`):

- plasma chunk: 713.1 КБ raw / 286.4 КБ gz → **664.5 КБ raw / 271.1 КБ gz** (−49 raw / −15 gz).
- Появляются два новых on-demand чанка: `cjs-*` (react-draggable ~33 КБ raw / 10 КБ gz) и `lib-*` (re-resizable ~28 КБ raw / 7 КБ gz). Если потребитель никогда не передаёт `draggable`/`resizable` (типичный кейс для `gigachat-neo`) — чанки не запрашиваются вовсе.

**Совместимость:** SemVer-минор. Внешний API не меняется (`draggable`/`resizable` props работают идентично), но React-tree теперь содержит `Suspense`-границу внутри `PopupRoot`/`Resizable`. Это требует React 18+ (плазма уже на этом требовании). Для SSR `Suspense fallback` рендерится сразу, без visual diff с прежним поведением (т. к. fallback — то же дерево без обёртки).

### 7. `revert(plasma-new-hope): drop strict intersection in PolymorphicForwardRefComponent`

**Файл:** `packages/plasma-new-hope/src/types/Polymorphic.ts`.

Коммит `05833e4abc` («feat(): fix types in Button») добавил вторую сигнатуру в intersection `PolymorphicForwardRefComponent`:

```ts
export type PolymorphicForwardRefComponent<DefaultElement extends ElementType, OwnProps = {}> = (<
    C extends ElementType = DefaultElement
>(
    props: PolymorphicComponentPropsWithRef<C, OwnProps>,
) => ReactElement | null) &
    ((props: PolymorphicComponentPropsWithRef<DefaultElement, OwnProps>) => ReactElement | null) & {
        displayName?: string;
    };
```

Вторая сигнатура сужает тип до конкретного `DefaultElement` (например, `'button'`). В downstream-потребителях это ломает валидные patterns, где плазменные полиморфные компоненты используются как значение пропсов `as=`:

```tsx
<PopupItemControl as={Button} view="clear" stretch>{...}</PopupItemControl>
// → TS2769: 'MakePolymorphic<...>' is not assignable to type '"button"'
```

TypeScript при сравнении с `as: ElementType` коллапсирует полиморфный тип к literal-default-element-у и репортит несоответствие. Та же проблема воспроизводится в `styled(Other)` с `attrs({ as: Button })`.

Коммит откатывает intersection к предыдущему виду:

```ts
export type PolymorphicForwardRefComponent<DefaultElement extends ElementType, OwnProps = {}> = (<
    C extends ElementType = DefaultElement
>(
    props: PolymorphicComponentPropsWithRef<C, OwnProps>,
) => ReactElement | null) & { displayName?: string };
```

Generic call-signature уже поддерживает TypeScript instantiation expressions вида `Button<'a'>` (см. оригинальный комментарий в файле), отдельная default-element-сигнатура не нужна для этого кейса. Если требовался конкретный случай, который покрывала вторая сигнатура, — см. репродукцию в обсуждении PR; сейчас она ломает больше, чем чинит.

**Эффект:** только на типы. Runtime/bundle не затронуты.

**Совместимость:** SemVer-патч (формально downgrade type-strictness, но фактически возвращение к ранее работавшему контракту, по которому собрались downstream-потребители).

---

## Совместимость и migration plan

| Изменение | SemVer | Затрагивает | Действие потребителя |
|---|---|---|---|
| `plasma-themes` exports | minor | публичные subpath-ы | ничего — прозрачно |
| `plasma-icons` `/16/24/36` | minor | новые subpath-ы | опционально — переключиться на single-size для веса |
| `plasma-icons` root `@deprecated` | patch | IDE/lint только | подавить через ESLint или мигрировать |
| `plasma-icons` SWC es2020 | minor (strict: major) | browser-target | убедиться что IE11 не в требованиях |
| `plasma-new-hope` SWC es2020 | то же | то же | то же |
| `plasma-new-hope` lazy Draggable/Resizable | minor | React tree | требуется React 18+ (уже peer) |
| `plasma-new-hope` revert Polymorphic intersection | patch | публичные типы | ничего — возврат к ранее работавшему контракту |

Никаких изменений компонентного API. Никаких изменений в сгенерированных `.d.ts`-сигнатурах публичных компонентов (кроме `PolymorphicForwardRefComponent` — там реверт к более liberal-варианту). Все изменения в `exports` — аддитивные либо сохраняют существующие пути через явный маппинг.