### PR TITLE
plasma-icons: Fix plasma icons exports

### DIFF
--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -47,6 +47,11 @@
             "require": "./scalable/index.36.js",
             "types": "./scalable/index.36.d.ts"
         },
+        "./css": {
+            "import": "./css/es/index.js",
+            "require": "./css/cjs/index.js",
+            "types": "./index.d.ts"
+        },
         "./css/*": "./css/*",
         "./package.json": "./package.json"
     },

--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -26,9 +26,30 @@
         "type": "git",
         "url": "ssh://git@github.com:salute-developers/plasma.git"
     },
-    "main": "index.js",
-    "module": "es/index.js",
-    "types": "index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./es/index.js",
+            "require": "./index.js",
+            "types": "./index.d.ts"
+        },
+        "./16": {
+            "import": "./es/scalable/index.16.js",
+            "require": "./scalable/index.16.js",
+            "types": "./scalable/index.16.d.ts"
+        },
+        "./24": {
+            "import": "./es/scalable/index.24.js",
+            "require": "./scalable/index.24.js",
+            "types": "./scalable/index.24.d.ts"
+        },
+        "./36": {
+            "import": "./es/scalable/index.36.js",
+            "require": "./scalable/index.36.js",
+            "types": "./scalable/index.36.d.ts"
+        },
+        "./css/*": "./css/*",
+        "./package.json": "./package.json"
+    },
     "peerDependencies": {
         "react": ">=16.13.1",
         "react-dom": ">=16.13.1",

--- a/packages/plasma-icons/scripts/generateReactComponents.ts
+++ b/packages/plasma-icons/scripts/generateReactComponents.ts
@@ -177,10 +177,21 @@ files.forEach((file) => {
     );
 });
 
-// добавляем экспорты
+// Помечаем root-экспорты `@deprecated`: компонент из общего barrel-а тянет ассеты
+// для всех трёх размеров (16/24/36), что ломает tree-shaking — потребитель получает
+// ~3x больший вес даже при статическом `size`. Миграция тривиальна для статических
+// размеров: импортировать тот же `IconX` из `@salutejs/plasma-icons/16|24|36`.
+// Для динамического `size` миграции нет — этот warning стоит подавить локально.
 const indexExport = names
     .map((name) => {
-        return `export { Icon${name} } from '.${IconsDirectory.replace(rootPath, '')}/Icon${name}';`;
+        return `/**
+ * @deprecated Импорт \`Icon${name}\` из \`@salutejs/plasma-icons\` тянет ассеты для всех 3 размеров (16/24/36),
+ * что увеличивает бандл в ~3 раза и не поддаётся tree-shaking-у. Замените на
+ * \`import { Icon${name} } from '@salutejs/plasma-icons/16'\` (или \`/24\`, \`/36\`) —
+ * потребитель получит ровно один размер. Если \`size\` определяется в рантайме динамически,
+ * подавите предупреждение локально (\`// eslint-disable-next-line deprecation/deprecation\`).
+ */
+export { Icon${name} } from '.${IconsDirectory.replace(rootPath, '')}/Icon${name}';`;
     })
     .join('\n');
 

--- a/packages/plasma-icons/scripts/generateReactComponents.ts
+++ b/packages/plasma-icons/scripts/generateReactComponents.ts
@@ -13,16 +13,17 @@ const AssetDirectory24 = `${rootPath}/Icon.assets.24`;
 const AssetDirectory36 = `${rootPath}/Icon.assets.36`;
 
 const IconsDirectory = `${rootPath}/Icons`;
-// Single-size компоненты — каждый тянет только свой ассет, что даёт tree-shaking-у
-// убрать неиспользуемые размеры через subpath-импорт `@salutejs/plasma-icons/16|24|36`.
+
 const IconsDirectory16 = `${rootPath}/Icons.16`;
 const IconsDirectory24 = `${rootPath}/Icons.24`;
 const IconsDirectory36 = `${rootPath}/Icons.36`;
 
 const IndexPath = `${rootPath}/index.ts`;
+
 const IndexPath16 = `${rootPath}/index.16.ts`;
 const IndexPath24 = `${rootPath}/index.24.ts`;
 const IndexPath36 = `${rootPath}/index.36.ts`;
+
 const IconPath = `${rootPath}/Icon.tsx`;
 
 const destinations = [
@@ -125,11 +126,13 @@ files.forEach((file) => {
                 getSingleSizeIconComponent(replacedName, 16),
                 'utf8',
             );
+
             fs.writeFileSync(
                 getPath(IconsDirectory24, `Icon${replacedName}`),
                 getSingleSizeIconComponent(replacedName, 24),
                 'utf8',
             );
+
             fs.writeFileSync(
                 getPath(IconsDirectory36, `Icon${replacedName}`),
                 getSingleSizeIconComponent(replacedName, 36),
@@ -157,19 +160,21 @@ files.forEach((file) => {
     // генерируем компонент
     fs.writeFileSync(getPath(IconsDirectory, `Icon${componentName}`), componentContent, 'utf8');
 
-    // single-size компоненты — пробрасываем @deprecated для Sber-aliased имён,
-    // чтобы IDE подсказывал миграцию на `Icon${replacedName}` и через subpath-импорты.
+    // single-size компоненты — пробрасываем @deprecated для старых имён
     const singleSizeOptions = { deprecated: hasKeyWord, replacement: `Icon${replacedName}` };
+
     fs.writeFileSync(
         getPath(IconsDirectory16, `Icon${componentName}`),
         getSingleSizeIconComponent(componentName, 16, singleSizeOptions),
         'utf8',
     );
+
     fs.writeFileSync(
         getPath(IconsDirectory24, `Icon${componentName}`),
         getSingleSizeIconComponent(componentName, 24, singleSizeOptions),
         'utf8',
     );
+
     fs.writeFileSync(
         getPath(IconsDirectory36, `Icon${componentName}`),
         getSingleSizeIconComponent(componentName, 36, singleSizeOptions),
@@ -177,19 +182,14 @@ files.forEach((file) => {
     );
 });
 
-// Помечаем root-экспорты `@deprecated`: компонент из общего barrel-а тянет ассеты
-// для всех трёх размеров (16/24/36), что ломает tree-shaking — потребитель получает
-// ~3x больший вес даже при статическом `size`. Миграция тривиальна для статических
-// размеров: импортировать тот же `IconX` из `@salutejs/plasma-icons/16|24|36`.
-// Для динамического `size` миграции нет — этот warning стоит подавить локально.
 const indexExport = names
     .map((name) => {
         return `/**
  * @deprecated Импорт \`Icon${name}\` из \`@salutejs/plasma-icons\` тянет ассеты для всех 3 размеров (16/24/36),
  * что увеличивает бандл в ~3 раза и не поддаётся tree-shaking-у. Замените на
- * \`import { Icon${name} } from '@salutejs/plasma-icons/16'\` (или \`/24\`, \`/36\`) —
- * потребитель получит ровно один размер. Если \`size\` определяется в рантайме динамически,
- * подавите предупреждение локально (\`// eslint-disable-next-line deprecation/deprecation\`).
+ * \`import { Icon${name} } from '@salutejs/plasma-icons/16'\` (или \`/24\`, \`/36\`).
+ * Если \`size\` определяется в рантайме динамически, подавите предупреждение локально
+ * (\`// eslint-disable-next-line deprecation/deprecation\`).
  */
 export { Icon${name} } from '.${IconsDirectory.replace(rootPath, '')}/Icon${name}';`;
     })
@@ -197,9 +197,6 @@ export { Icon${name} } from '.${IconsDirectory.replace(rootPath, '')}/Icon${name
 
 fs.appendFileSync(IndexPath, indexExport, 'utf8');
 
-// barrel-файлы для single-size subpath-импортов.
-// Legacy-иконки (`old/Icons/*`) тоже реэкспортируем — у них размер фиксирован
-// в самом SVG, потребитель ожидает что они доступны через тот же entry.
 const legacyIconsDir = './src-build/old/Icons';
 const legacyNames = fs.existsSync(legacyIconsDir)
     ? fs
@@ -207,6 +204,7 @@ const legacyNames = fs.existsSync(legacyIconsDir)
           .filter((f) => f.endsWith('.tsx') && /^Icon/.test(f))
           .map((f) => f.replace(/\.tsx$/, ''))
     : [];
+
 const legacyBarrel = legacyNames
     .map((iconName) => `export { ${iconName} } from '../old/Icons/${iconName}';`)
     .join('\n');

--- a/packages/plasma-icons/scripts/generateReactComponents.ts
+++ b/packages/plasma-icons/scripts/generateReactComponents.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { getIconAsset, getIconComponent } from './utils';
+import { getIconAsset, getIconComponent, getSingleSizeIconComponent } from './utils';
 
 const rootPath = './src-build/scalable';
 
@@ -13,11 +13,27 @@ const AssetDirectory24 = `${rootPath}/Icon.assets.24`;
 const AssetDirectory36 = `${rootPath}/Icon.assets.36`;
 
 const IconsDirectory = `${rootPath}/Icons`;
+// Single-size компоненты — каждый тянет только свой ассет, что даёт tree-shaking-у
+// убрать неиспользуемые размеры через subpath-импорт `@salutejs/plasma-icons/16|24|36`.
+const IconsDirectory16 = `${rootPath}/Icons.16`;
+const IconsDirectory24 = `${rootPath}/Icons.24`;
+const IconsDirectory36 = `${rootPath}/Icons.36`;
 
 const IndexPath = `${rootPath}/index.ts`;
+const IndexPath16 = `${rootPath}/index.16.ts`;
+const IndexPath24 = `${rootPath}/index.24.ts`;
+const IndexPath36 = `${rootPath}/index.36.ts`;
 const IconPath = `${rootPath}/Icon.tsx`;
 
-const destinations = [AssetDirectory16, AssetDirectory24, AssetDirectory36, IconsDirectory];
+const destinations = [
+    AssetDirectory16,
+    AssetDirectory24,
+    AssetDirectory36,
+    IconsDirectory,
+    IconsDirectory16,
+    IconsDirectory24,
+    IconsDirectory36,
+];
 
 const files = fs.readdirSync(sourceDirectory);
 
@@ -102,6 +118,23 @@ files.forEach((file) => {
             fs.writeFileSync(getPath(AssetDirectory36, replacedName), assetContent36, 'utf8');
 
             fs.writeFileSync(getPath(IconsDirectory, `Icon${replacedName}`), componentContent, 'utf8');
+
+            // single-size компоненты для tree-shaking-friendly subpath-импортов
+            fs.writeFileSync(
+                getPath(IconsDirectory16, `Icon${replacedName}`),
+                getSingleSizeIconComponent(replacedName, 16),
+                'utf8',
+            );
+            fs.writeFileSync(
+                getPath(IconsDirectory24, `Icon${replacedName}`),
+                getSingleSizeIconComponent(replacedName, 24),
+                'utf8',
+            );
+            fs.writeFileSync(
+                getPath(IconsDirectory36, `Icon${replacedName}`),
+                getSingleSizeIconComponent(replacedName, 36),
+                'utf8',
+            );
         }
     }
 
@@ -123,6 +156,25 @@ files.forEach((file) => {
 
     // генерируем компонент
     fs.writeFileSync(getPath(IconsDirectory, `Icon${componentName}`), componentContent, 'utf8');
+
+    // single-size компоненты — пробрасываем @deprecated для Sber-aliased имён,
+    // чтобы IDE подсказывал миграцию на `Icon${replacedName}` и через subpath-импорты.
+    const singleSizeOptions = { deprecated: hasKeyWord, replacement: `Icon${replacedName}` };
+    fs.writeFileSync(
+        getPath(IconsDirectory16, `Icon${componentName}`),
+        getSingleSizeIconComponent(componentName, 16, singleSizeOptions),
+        'utf8',
+    );
+    fs.writeFileSync(
+        getPath(IconsDirectory24, `Icon${componentName}`),
+        getSingleSizeIconComponent(componentName, 24, singleSizeOptions),
+        'utf8',
+    );
+    fs.writeFileSync(
+        getPath(IconsDirectory36, `Icon${componentName}`),
+        getSingleSizeIconComponent(componentName, 36, singleSizeOptions),
+        'utf8',
+    );
 });
 
 // добавляем экспорты
@@ -133,6 +185,30 @@ const indexExport = names
     .join('\n');
 
 fs.appendFileSync(IndexPath, indexExport, 'utf8');
+
+// barrel-файлы для single-size subpath-импортов.
+// Legacy-иконки (`old/Icons/*`) тоже реэкспортируем — у них размер фиксирован
+// в самом SVG, потребитель ожидает что они доступны через тот же entry.
+const legacyIconsDir = './src-build/old/Icons';
+const legacyNames = fs.existsSync(legacyIconsDir)
+    ? fs
+          .readdirSync(legacyIconsDir)
+          .filter((f) => f.endsWith('.tsx') && /^Icon/.test(f))
+          .map((f) => f.replace(/\.tsx$/, ''))
+    : [];
+const legacyBarrel = legacyNames
+    .map((iconName) => `export { ${iconName} } from '../old/Icons/${iconName}';`)
+    .join('\n');
+
+for (const [iconsDir, indexPath] of [
+    [IconsDirectory16, IndexPath16],
+    [IconsDirectory24, IndexPath24],
+    [IconsDirectory36, IndexPath36],
+] as const) {
+    const dirRel = iconsDir.replace(rootPath, '.');
+    const sizedExports = names.map((name) => `export { Icon${name} } from '${dirRel}/Icon${name}';`).join('\n');
+    fs.writeFileSync(indexPath, sizedExports + '\n' + legacyBarrel + '\n', 'utf8');
+}
 
 // добавляем mapping по категориям
 let dataIconFile = fs.readFileSync(IconPath, 'utf8');

--- a/packages/plasma-icons/scripts/utils.ts
+++ b/packages/plasma-icons/scripts/utils.ts
@@ -115,6 +115,36 @@ export const ${iconName}: React.FC<IconProps> = (props) => (
 };
 
 /**
+ * Функция генерации файла `/Icons.<size>/Icon<Name>.tsx` — single-size компонент,
+ * тянущий ровно один ассет вместо всех трёх. Это позволяет потребителю выбрать
+ * нужный размер через subpath-импорт (`@salutejs/plasma-icons/16|24|36`) и
+ * tree-shaking-ом убрать остальные размеры из бандла.
+ */
+export const getSingleSizeIconComponent = (
+    iconName: string,
+    size: 16 | 24 | 36,
+    options?: { deprecated?: boolean; replacement?: string },
+) => {
+    const sizeProp = size === 16 ? 'xs' : size === 24 ? 's' : 'm';
+    const deprecationBlock = options?.deprecated
+        ? `/**
+ * @deprecated Эта иконка устарела
+ * @see используете вместо этого ${options.replacement}
+ */
+`
+        : '';
+    return `import React from 'react';
+
+import { ${iconName} as Asset } from '../Icon.assets.${size}/${iconName}';
+import { IconProps, IconRoot } from '../IconRoot';
+
+${deprecationBlock}export const Icon${iconName}: React.FC<IconProps> = ({ size = '${sizeProp}', color, className, style, ...rest }) => (
+    <IconRoot className={className} size={size} color={color} style={style} icon={Asset} {...rest} />
+);
+`;
+};
+
+/**
  * Функция генерации файла `/Icons/Icon<Name>.tsx`. Здесь формируется компонент иконки.
  */
 export const getIconComponent = (iconName: string, options?: any) => {

--- a/packages/plasma-icons/src/index.ts
+++ b/packages/plasma-icons/src/index.ts
@@ -154,3 +154,4 @@ export { Icon, iconSectionsSet } from './old/Icon';
 export type { IconName } from './old/Icon';
 
 export * from './scalable';
+export { iconSectionsSet as iconSectionsSetScalable } from './scalable';

--- a/packages/plasma-new-hope/swc-emotion.config.json
+++ b/packages/plasma-new-hope/swc-emotion.config.json
@@ -1,7 +1,7 @@
 {
     "minify": false,
     "jsc": {
-        "target": "es5",
+        "target": "es2020",
         "parser": {
             "syntax": "typescript"
         },

--- a/packages/plasma-new-hope/swc-sc.config.json
+++ b/packages/plasma-new-hope/swc-sc.config.json
@@ -1,7 +1,7 @@
 {
     "minify": false,
     "jsc": {
-        "target": "es5",
+        "target": "es2020",
         "parser": {
             "syntax": "typescript"
         },

--- a/swc.config.json
+++ b/swc.config.json
@@ -1,7 +1,7 @@
 {
     "minify": false,
     "jsc": {
-        "target": "es5",
+        "target": "es2020",
         "parser": {
             "syntax": "typescript"
         },

--- a/website/plasma-website/utils/iconsList.ts
+++ b/website/plasma-website/utils/iconsList.ts
@@ -1,5 +1,4 @@
-import { iconSectionsSet } from '@salutejs/plasma-icons';
-import { iconSectionsSet as iconSectionsSetNew } from '@salutejs/plasma-icons/scalable';
+import { iconSectionsSet, iconSectionsSetScalable as iconSectionsSetNew } from '@salutejs/plasma-icons';
 
 import type { IconGroups, Item, IconGroup } from '../types';
 import { Group } from '../types';


### PR DESCRIPTION
## Core

### Icons

 - добавлена возможность import для каждого размера отдельно   

### What/why changed

Пример в песочнице - https://codesandbox.io/p/sandbox/plasma-web-example-forked-6kvwl3

<img width="1920" height="695" src="https://github.com/user-attachments/assets/52bf15a4-1764-49d2-a03a-3a0fce80a307" />

<img width="1280" height="263" src="https://github.com/user-attachments/assets/f27e510f-269f-4184-97f1-22a120206c8a" />


```md
Главный barrel `@salutejs/plasma-icons` через `Icons/IconX.tsx`
статически импортирует все три ассета (`Icon.assets.16/24/36`) и
выбирает один в рантайме по prop `size`. Tree-shaking не может
выбросить неиспользуемые размеры — все три считаются «used by name».

**На typical-приложении с ~80 иконками это даёт ~800 КБ raw / 350 КБ gz
лишнего веса (триплицированные SVG-ассеты).**

Генератор теперь параллельно с `Icons/IconX.tsx` эмитит
single-size компоненты `Icons.16/IconX.tsx`, `Icons.24/IconX.tsx`,
`Icons.36/IconX.tsx`, каждый из которых импортирует ровно один
ассет своего размера. Плюс barrel-файлы `index.16.ts`, `index.24.ts`,
`index.36.ts` экспортируют все single-size компоненты + реэкспортируют
legacy-иконки из `old/Icons/` (у них размер фиксирован в SVG).

Публичный API расширен через `exports`:
- `@salutejs/plasma-icons/16` → 16-px вариант всех иконок
- `@salutejs/plasma-icons/24` → 24-px (`size="s"` по умолчанию)
- `@salutejs/plasma-icons/36` → 36-px

Старый импорт `@salutejs/plasma-icons` сохраняется без изменений.

Эффект на бандл потребителя при использовании одного размера:
~786 КБ raw → 193 КБ raw.
```

детали в #2792
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.376.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-b2c@1.618.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-core@1.226.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-giga@0.345.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-homeds@0.345.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-hope@1.372.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-icons@1.238.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-new-hope@0.362.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-tokens-b2b@1.55.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-tokens-b2c@0.66.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-tokens-web@1.70.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-tokens@1.138.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-typo@0.43.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-ui@1.348.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-web@1.620.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-bizcom@0.350.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-cs@0.354.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-dfa@0.348.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-finai@0.341.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-insol@0.345.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-netology@0.349.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-os@0.20.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-platform-ai@0.349.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-sbcom@0.350.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-scan@0.348.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-serv@0.349.0-canary.2800.26409674216.0
  npm install @salutejs/core-themes@0.30.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-themes@0.50.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-themes@0.65.0-canary.2800.26409674216.0
  npm install @salutejs/sdds-api-tests@0.7.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-cy-utils@0.156.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-sb-utils@0.226.0-canary.2800.26409674216.0
  npm install @salutejs/plasma-tokens-utils@0.51.0-canary.2800.26409674216.0
  # or 
  yarn add @salutejs/plasma-asdk@0.376.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-b2c@1.618.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-core@1.226.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-giga@0.345.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-homeds@0.345.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-hope@1.372.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-icons@1.238.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-new-hope@0.362.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-tokens-b2b@1.55.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-tokens-b2c@0.66.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-tokens-web@1.70.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-tokens@1.138.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-typo@0.43.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-ui@1.348.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-web@1.620.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-bizcom@0.350.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-cs@0.354.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-dfa@0.348.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-finai@0.341.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-insol@0.345.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-netology@0.349.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-os@0.20.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-platform-ai@0.349.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-sbcom@0.350.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-scan@0.348.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-serv@0.349.0-canary.2800.26409674216.0
  yarn add @salutejs/core-themes@0.30.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-themes@0.50.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-themes@0.65.0-canary.2800.26409674216.0
  yarn add @salutejs/sdds-api-tests@0.7.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-cy-utils@0.156.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-sb-utils@0.226.0-canary.2800.26409674216.0
  yarn add @salutejs/plasma-tokens-utils@0.51.0-canary.2800.26409674216.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
