### PR TITLE
plasma-themes: Expose ESM subpaths via `exports` field

### DIFF
--- a/packages/themes/plasma-themes/package.json
+++ b/packages/themes/plasma-themes/package.json
@@ -7,6 +7,45 @@
   "module": "es/index.js",
   "main": "index.js",
   "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./tokens": {
+      "import": "./es/tokens/index.js",
+      "require": "./tokens/index.js",
+      "types": "./tokens/index.d.ts"
+    },
+    "./tokens/*": {
+      "import": "./es/tokens/*/index.js",
+      "require": "./tokens/*/index.js",
+      "types": "./tokens/*/index.d.ts"
+    },
+    "./themes": {
+      "import": "./es/themes/index.js",
+      "require": "./themes/index.js",
+      "types": "./themes/index.d.ts"
+    },
+    "./themes/*": {
+      "import": "./es/themes/*.js",
+      "require": "./themes/*.js",
+      "types": "./themes/*.d.ts"
+    },
+    "./es/themes": {
+      "import": "./es/themes/index.js",
+      "require": "./themes/index.js",
+      "types": "./themes/index.d.ts"
+    },
+    "./es/themes/*": {
+      "import": "./es/themes/*.js",
+      "require": "./themes/*.js",
+      "types": "./themes/*.d.ts"
+    },
+    "./css/*": "./css/*",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "prepare": "npm run build",
     "prebuild": "rm -rf ./es ./src ./tokens ./themes ./css ./index.*",


### PR DESCRIPTION
## Core

### Plasma-themes

- добавлены явные пути для exports токенов   
 
### What/why changed

```md
Без `exports` потребитель резолвит `@salutejs/plasma-themes/tokens` и
`@salutejs/plasma-themes/tokens/<theme>` напрямую в CJS-копию (`tokens/*.js`),
которую Rollup/Vite не tree-shake-ит — в бандл попадают все ~2k токенов
независимо от того, сколько потребитель реально использует.

Маршрутизирует subpath-ы на уже собираемую ESM-копию (`es/tokens/*`,
`es/themes/*`), где каждый токен — отдельный `export var X = 'var(--...)'`,
который шейкается до фактически использованных.

Маппинг покрывает все известные публичные subpath-ы: `.`, `./tokens`,
`./tokens/*`, `./themes`, `./themes/*`, `./css/*`, `./package.json`.

Legacy-путь `./es/themes/*` (используется в сторибуках и пакетных
mixins по всей монорепе) оставлен в `exports` без `require`-варианта
для обратной совместимости — последующая миграция на `./themes/*`
рекомендуется, но не блокирует релиз.

Эффект на бандл потребителя (Vite): chunk `plasma-themes` 325 KB raw /
28.6 KB gz → 6.7 KB raw / 1.5 KB gz.
```

детали в #2792

Примечание: 

В целом запись в exports

```json
  "./es/themes": {
      "import": "./es/themes/index.js",
      "types": "./themes/index.d.ts"
    },
```

явный рудимент того что мы используем в stories

```tsx
import { plasma_giga__dark, plasma_giga__light } from '@salutejs/plasma-themes/es/themes';
``` 

после исправлений - упростим exports.

Наглядный пример, ошибка сборки во всех пакетах где использовался plasma-themes   

<img width="794" height="223" src="https://github.com/user-attachments/assets/c9497d8d-61ba-4c01-a491-007ca681baf5" />

```console
■  [commonjs--resolver] Missing "./es/themes" specifier in
│  "@salutejs/plasma-themes" package
```
 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.376.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-b2c@1.618.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-core@1.226.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-giga@0.345.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-homeds@0.345.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-hope@1.372.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-icons@1.238.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-new-hope@0.362.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-tokens-b2b@1.55.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-tokens-b2c@0.66.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-tokens-web@1.70.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-tokens@1.138.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-typo@0.43.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-ui@1.348.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-web@1.620.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-bizcom@0.350.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-cs@0.354.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-dfa@0.348.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-finai@0.341.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-insol@0.345.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-netology@0.349.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-os@0.20.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-platform-ai@0.349.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-sbcom@0.350.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-scan@0.348.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-serv@0.349.0-canary.2803.26415962419.0
  npm install @salutejs/core-themes@0.30.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-themes@0.50.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-themes@0.65.0-canary.2803.26415962419.0
  npm install @salutejs/sdds-api-tests@0.7.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-cy-utils@0.156.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-sb-utils@0.226.0-canary.2803.26415962419.0
  npm install @salutejs/plasma-tokens-utils@0.51.0-canary.2803.26415962419.0
  # or 
  yarn add @salutejs/plasma-asdk@0.376.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-b2c@1.618.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-core@1.226.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-giga@0.345.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-homeds@0.345.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-hope@1.372.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-icons@1.238.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-new-hope@0.362.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-tokens-b2b@1.55.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-tokens-b2c@0.66.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-tokens-web@1.70.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-tokens@1.138.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-typo@0.43.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-ui@1.348.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-web@1.620.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-bizcom@0.350.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-cs@0.354.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-dfa@0.348.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-finai@0.341.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-insol@0.345.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-netology@0.349.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-os@0.20.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-platform-ai@0.349.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-sbcom@0.350.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-scan@0.348.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-serv@0.349.0-canary.2803.26415962419.0
  yarn add @salutejs/core-themes@0.30.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-themes@0.50.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-themes@0.65.0-canary.2803.26415962419.0
  yarn add @salutejs/sdds-api-tests@0.7.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-cy-utils@0.156.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-sb-utils@0.226.0-canary.2803.26415962419.0
  yarn add @salutejs/plasma-tokens-utils@0.51.0-canary.2803.26415962419.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
