### PR TITLE
PLASMA-7077: Механизм для адаптива на уровне конфигураций

### DIFF
--- a/packages/plasma-new-hope/src/engines/emotion.tsx
+++ b/packages/plasma-new-hope/src/engines/emotion.tsx
@@ -12,16 +12,18 @@ const Root = styled.div<{
     staticVariants: PolymorphicClassName[];
     dynamicVariants: (props: HTMLAnyAttributes) => any[];
     intersectionStyles: PolymorphicClassName[];
+    responsiveStyles?: PolymorphicClassName;
 }>`
     ${({ base }) => base};
     ${({ staticVariants }) => staticVariants};
     ${({ dynamicVariants }) => dynamicVariants};
     ${({ intersectionStyles }) => intersectionStyles};
+    ${({ responsiveStyles }) => responsiveStyles};
 `;
 
 /* eslint-disable no-underscore-dangle */
 export const _component = (componentConfig: ComponentConfig) => {
-    const { tag, base, intersections } = componentConfig;
+    const { tag, base, intersections, responsive } = componentConfig;
     const staticVariants = getStaticVariants(componentConfig);
     const dynamicVariants = getDynamicVariants(componentConfig);
 
@@ -29,7 +31,9 @@ export const _component = (componentConfig: ComponentConfig) => {
     const R = Root.withComponent(tag as keyof JSX.IntrinsicElements);
 
     return forwardRef<HTMLElement, HTMLAnyAttributes>((props, ref) => {
-        const intersectionStyles = getIntersectionStyles(props, intersections);
+        const { responsive: responsiveProp, ...rest } = props;
+        const intersectionStyles = getIntersectionStyles(rest, intersections);
+        const responsiveStyles = responsiveProp ? responsive : undefined;
 
         return (
             <R
@@ -37,7 +41,8 @@ export const _component = (componentConfig: ComponentConfig) => {
                 staticVariants={staticVariants}
                 dynamicVariants={dynamicVariants}
                 intersectionStyles={intersectionStyles}
-                {...props}
+                responsiveStyles={responsiveStyles}
+                {...rest}
                 ref={ref}
             />
         );

--- a/packages/plasma-new-hope/src/engines/index.ts
+++ b/packages/plasma-new-hope/src/engines/index.ts
@@ -4,10 +4,12 @@ import type { CSS } from './types';
 
 export const css = cssLibrary as CSS;
 export { mergeConfig, component } from './common';
+export { getResponsiveCSS } from './utils';
 
 export type {
     Variant,
     ComponentConfig,
+    MediaQueryRule,
     RootProps,
     CSS,
     RootPropsOmitOnChange,

--- a/packages/plasma-new-hope/src/engines/linaria.tsx
+++ b/packages/plasma-new-hope/src/engines/linaria.tsx
@@ -8,13 +8,13 @@ import { ComponentConfig, HTMLAnyAttributes } from './types';
 
 /* eslint-disable no-underscore-dangle */
 export const _component = (componentConfig: ComponentConfig) => {
-    const { tag, base, name, intersections, invariants } = componentConfig;
+    const { tag, base, name, intersections, invariants, responsive } = componentConfig;
 
     const staticVariants = getStaticVariants(componentConfig);
     const dynamicVariants = getDynamicVariants(componentConfig);
 
     const component = forwardRef<HTMLElement, HTMLAnyAttributes>((props, ref) => {
-        const { className, as, forwardedAs, ...rest } = props;
+        const { className, as, forwardedAs, responsive: responsiveProp, ...rest } = props;
         const variants = dynamicVariants(rest);
         const intersectionStyles = getIntersectionStyles(rest, intersections) as string[];
 
@@ -24,6 +24,7 @@ export const _component = (componentConfig: ComponentConfig) => {
             ...(staticVariants as string[]),
             ...variants,
             ...intersectionStyles,
+            responsiveProp && (responsive as string),
             invariants as string,
         );
 

--- a/packages/plasma-new-hope/src/engines/styled-components.tsx
+++ b/packages/plasma-new-hope/src/engines/styled-components.tsx
@@ -11,21 +11,25 @@ const Root = styled.div<{
     staticVariants: string[];
     dynamicVariants: (props: HTMLAnyAttributes) => any[];
     intersectionStyles: string[];
+    responsiveStyles?: string;
 }>`
     ${({ base }) => base};
     ${({ staticVariants }) => staticVariants};
     ${({ dynamicVariants }) => dynamicVariants};
     ${({ intersectionStyles }) => intersectionStyles};
+    ${({ responsiveStyles }) => responsiveStyles};
 `;
 
 /* eslint-disable no-underscore-dangle */
 export const _component = (componentConfig: ComponentConfig) => {
-    const { tag, base, intersections } = componentConfig;
+    const { tag, base, intersections, responsive } = componentConfig;
     const staticVariants = getStaticVariants(componentConfig);
     const dynamicVariants = getDynamicVariants(componentConfig);
 
     return forwardRef<HTMLElement, HTMLAnyAttributes>((props, ref) => {
-        const intersectionStyles = getIntersectionStyles(props, intersections);
+        const { responsive: responsiveProp, ...rest } = props;
+        const intersectionStyles = getIntersectionStyles(rest, intersections);
+        const responsiveStyles = responsiveProp ? responsive : undefined;
 
         return (
             <Root
@@ -34,7 +38,8 @@ export const _component = (componentConfig: ComponentConfig) => {
                 staticVariants={staticVariants}
                 dynamicVariants={dynamicVariants}
                 intersectionStyles={intersectionStyles}
-                {...props}
+                responsiveStyles={responsiveStyles}
+                {...rest}
                 ref={ref}
             />
         );

--- a/packages/plasma-new-hope/src/engines/types.ts
+++ b/packages/plasma-new-hope/src/engines/types.ts
@@ -79,6 +79,25 @@ export interface Intersection {
     style: PolymorphicClassName;
 }
 
+/**
+ * Конфигурация @media запроса
+ * @experimental
+ */
+export type MediaQueryRule = {
+    /**
+     * Нижняя граница диапазона ширины viewport (min-width) в px.
+     */
+    from?: number;
+    /**
+     * Верхняя граница диапазона ширины viewport (max-width) в px.
+     */
+    to?: number;
+    /**
+     * Декларации size-токенов, применяемые внутри медиа-запроса.
+     */
+    size: string;
+};
+
 export interface ComponentConfig<
     Tag extends HTMLTagList = React.ElementType,
     VariantList extends Variants = Variants,
@@ -96,4 +115,9 @@ export interface ComponentConfig<
     defaults: Partial<Record<string, string>>;
     intersections?: Intersection[];
     invariants?: PolymorphicClassName;
+    /**
+     * Предсобранный CSS-блок для @media запроса
+     * @experimental
+     */
+    responsive?: PolymorphicClassName;
 }

--- a/packages/plasma-new-hope/src/engines/utils.ts
+++ b/packages/plasma-new-hope/src/engines/utils.ts
@@ -1,4 +1,4 @@
-import { ComponentConfig, HTMLAnyAttributes, Intersection, PolymorphicClassName } from './types';
+import { ComponentConfig, HTMLAnyAttributes, Intersection, MediaQueryRule, PolymorphicClassName } from './types';
 
 export const getStaticVariants = (config: ComponentConfig) => {
     if (!config.variations) {
@@ -34,6 +34,57 @@ export const getDynamicVariants = (config: ComponentConfig) => {
         return res;
     };
 };
+
+/**
+ * Собирает строку с @media-блоками для адаптивного режима.
+ * Используется в исходнике конфига вертикали внутри css:
+ *   responsive: css`${getResponsiveCSS([
+ *       { from: 0,    to: 559,       size: sizeL },
+ *       { from: 560,  to: 789,       size: sizeM },
+ *       { from: 1023, to: undefined, size: sizeXL },
+ *   ])}`
+ *
+ * `size` в правиле — это сами декларации (строка с присвоениями токенов),
+ * а не имя вариации; декларации обычно вынесены в общую const, чтобы
+ * переиспользоваться и в `variations.size.*`, и здесь.
+ *
+ * Для css/linaria-сборки linaria статически выполняет вызов на этапе сборки
+ * вертикали и инлайнит готовый @media-CSS в скомпилированный класс; SC/emotion
+ * получают то же в рантайме при первом обращении к модулю.
+ *
+ * Селектор `&&` поднимает специфичность на ×2, чтобы media-правило перебивало
+ * обычную size-вариацию независимо от порядка правил в stylesheet.
+ *
+ * Семантика границ — диапазон ширины viewport в пикселях:
+ *   from → min-width, to → max-width.
+ *
+ * Правила не пересекаются — массив просто конкатенируется.
+ */
+export const getResponsiveCSS = (media: MediaQueryRule[]): string =>
+    media
+        .map(({ from, to, size }) => {
+            if (!size) {
+                return '';
+            }
+
+            const parts: string[] = [];
+
+            if (from !== undefined) {
+                parts.push(`(min-width: ${from}px)`);
+            }
+
+            if (to !== undefined) {
+                parts.push(`(max-width: ${to}px)`);
+            }
+
+            if (!parts.length) {
+                return '';
+            }
+
+            return `@media ${parts.join(' and ')} { && { ${size} } }`;
+        })
+        .filter(Boolean)
+        .join('\n');
 
 export const getIntersectionStyles = (props: Record<string, any>, intersections?: Intersection[]) => {
     if (!intersections) {


### PR DESCRIPTION
### What/why changed



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.380.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-b2c@1.622.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-core@1.229.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-giga@0.349.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-homeds@0.349.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-hope@1.376.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-new-hope@0.366.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-tokens@1.141.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-ui@1.352.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-web@1.624.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-bizcom@0.354.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-cs@0.358.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-dfa@0.352.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-finai@0.345.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-insol@0.349.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-netology@0.353.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-os@0.24.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-platform-ai@0.353.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-sbcom@0.354.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-scan@0.352.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-serv@0.353.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-themes@0.68.1-canary.2804.28012563562.0
  npm install @salutejs/sdds-api-tests@0.11.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-cy-utils@0.159.1-canary.2804.28012563562.0
  npm install @salutejs/plasma-sb-utils@0.230.1-canary.2804.28012563562.0
  # or 
  yarn add @salutejs/plasma-asdk@0.380.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-b2c@1.622.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-core@1.229.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-giga@0.349.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-homeds@0.349.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-hope@1.376.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-new-hope@0.366.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-tokens@1.141.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-ui@1.352.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-web@1.624.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-bizcom@0.354.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-cs@0.358.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-dfa@0.352.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-finai@0.345.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-insol@0.349.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-netology@0.353.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-os@0.24.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-platform-ai@0.353.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-sbcom@0.354.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-scan@0.352.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-serv@0.353.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-themes@0.68.1-canary.2804.28012563562.0
  yarn add @salutejs/sdds-api-tests@0.11.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-cy-utils@0.159.1-canary.2804.28012563562.0
  yarn add @salutejs/plasma-sb-utils@0.230.1-canary.2804.28012563562.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive styles support enabling components to adapt styling dynamically across different viewport sizes through media query configuration across all styling engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->