### PR TITLE
sdds-infra: Avoid poison cache from fork

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -1,41 +1,90 @@
 name: 'Prepare environment'
 
-description: 'Setup node.js env and install all dependencies'
+description: |
+    Setup Node.js and install dependencies. Cache writes are disabled in untrusted contexts
+    (fork PRs via pull_request_target) to prevent poisoning of shared caches.
+
+    IMPORTANT: when invoked from a pull_request_target workflow, this action MUST be referenced
+    by a remote ref (e.g. `salute-developers/plasma/.github/actions/prepare-environment@dev`),
+    NOT by a local path (`./.github/actions/prepare-environment`). A local `uses:` loads the
+    action from the checked-out workspace — if that workspace was checked out from the PR
+    (refs/pull/N/merge), the trust-detection step itself comes from attacker-controlled code
+    and the protection is bypassed.
 
 runs:
-  using: "composite"
-  steps:
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version-file: '.nvmrc'
-        cache: 'npm'
+    using: 'composite'
+    steps:
+        - name: Determine trust context
+          id: trust
+          shell: bash
+          env:
+              EVENT_NAME: ${{ github.event_name }}
+              HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+              BASE_REPO: ${{ github.repository }}
+          run: |
+              if [ "$EVENT_NAME" = "pull_request_target" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+                echo "untrusted=true" >> "$GITHUB_OUTPUT"
+                echo "::notice::Running in UNTRUSTED context (external fork PR). Cache writes are disabled."
+              else
+                echo "untrusted=false" >> "$GITHUB_OUTPUT"
+              fi
 
-    - name: Cache node modules
-      id: node_modules
-      uses: actions/cache@v4
-      with:
-        path: node_modules
-        key: node-modules-${{ hashFiles('package-lock.json') }}
-        restore-keys: |
-          node-modules-${{ hashFiles('package-lock.json') }}
-          node-modules-
+        - name: Setup Node.js
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+          with:
+              node-version-file: '.nvmrc'
 
-    - name: Cache dependencies
-      id: cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache
-        key: cache-${{ hashFiles('package-lock.json') }}
-        restore-keys: |
-          cache-${{ hashFiles('package-lock.json') }}
-          cache-
+        - name: Cache ~/.npm (trusted — restore + save)
+          if: steps.trust.outputs.untrusted == 'false'
+          uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+          with:
+              path: ~/.npm
+              # Только точное совпадение ключа (без restore-keys) — относится и к этому шагу,
+              # и к untrusted-restore ниже. Miss → чистая установка. Partial-match по
+              # мутированному lockfile позволил бы тихо подмешать attacker-controlled tarballs
+              # к проверенным — смысл как раз в том, чтобы такого не допустить.
+              key: npm-trusted-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-    - name: Setup packages
-      shell: bash
-      if: ${{ steps.cache.outputs.cache-hit != 'true' || steps.node_modules.outputs.cache-hit != 'true' }}
-      run: npm ci --no-progress
+        - name: Restore ~/.npm (untrusted — read trusted cache, no save)
+          if: steps.trust.outputs.untrusted == 'true'
+          uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+          with:
+              path: ~/.npm
+              # Тот же ключ, что и у trusted-save шага ↑ — fork PR'ы переиспользуют проверенный кэш.
+              # Защита от записи обеспечивается типом action (actions/cache/restore без post-step
+              # save), а не scoping'ом ключа. Отдельный -untrusted- namespace гарантировал бы
+              # вечный miss — никто в этом action никогда не пишет в такой ключ.
+              key: npm-trusted-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-    - name: Apply patches for fix maxBuffer issue
-      shell: bash
-      run: npx patch-package
+        - name: Cache Cypress binary (trusted — restore + save)
+          if: steps.trust.outputs.untrusted == 'false'
+          uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+          with:
+              path: ~/.cache/Cypress
+              # Версия Cypress зафиксирована в package-lock.json, поэтому хэш lockfile —
+              # достаточный и детерминированный ключ.
+              key: cypress-trusted-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+        - name: Restore Cypress binary (untrusted — read trusted cache, no save)
+          if: steps.trust.outputs.untrusted == 'true'
+          uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+          with:
+              path: ~/.cache/Cypress
+              # Тот же ключ, что и у trusted-save ↑. Обоснование — см. npm restore шаг.
+              key: cypress-trusted-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+        - name: Install dependencies
+          shell: bash
+          run: npm ci --no-progress
+
+        - name: Verify Cypress install
+          # Доп. проверка целостности: сверяет SHA256 кэшированного бинаря с тем,
+          # что прописан в установленном cypress-пакете. Основная защита от подмены —
+          # запрет записи в кэш в untrusted-контексте (шаги Cache/Restore выше);
+          # verify ловит рассинхрон версия/бинарь и любые повреждения кэша.
+          shell: bash
+          run: npx cypress verify
+
+        - name: Apply patches
+          shell: bash
+          run: node_modules/.bin/patch-package

--- a/.github/workflows/change-detection.yml
+++ b/.github/workflows/change-detection.yml
@@ -29,7 +29,10 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Prepare environment
-        uses: ./.github/actions/prepare-environment
+        # Remote ref (а не локальный ./...) — обязательно, т.к. workflow вызывается
+        # из pull_request_target цепочек (documentation-deploy-pr, publish-canary).
+        # Иначе action.yml возьмется из PR-checkout и весь защитный механизм обходится.
+        uses: salute-developers/plasma/.github/actions/prepare-environment@dev
 
       - name: Set exclude-dependents env
         if: ${{ inputs.exclude-dependents }}

--- a/.github/workflows/documentation-deploy-common.yml
+++ b/.github/workflows/documentation-deploy-common.yml
@@ -54,7 +54,9 @@ jobs:
                     show-progress: false
 
             -   name: Prepare environment
-                uses: ./.github/actions/prepare-environment
+                # Remote ref (а не локальный ./...) — единый стиль с pull_request_target
+                # цепочками: action.yml всегда берётся из dev, не из workspace.
+                uses: salute-developers/plasma/.github/actions/prepare-environment@dev
 
             -   name: Lerna bootstrap
                 run: npx lerna bootstrap --scope="@salutejs/{plasma-b2c,plasma-web,plasma-website,plasma-tokens-b2c,plasma-typo,plasma-icons,plasma-new-hope,plasma-themes,core-themes}"
@@ -104,7 +106,9 @@ jobs:
                     show-progress: false
 
             -   name: Prepare environment
-                uses: ./.github/actions/prepare-environment
+                # Remote ref (а не локальный ./...) — единый стиль с pull_request_target
+                # цепочками: action.yml всегда берётся из dev, не из workspace.
+                uses: salute-developers/plasma/.github/actions/prepare-environment@dev
 
             -   name: Set job environment variables
                 run: |

--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -50,7 +50,9 @@ jobs:
                     show-progress: false
 
             -   name: Prepare environment
-                uses: ./.github/actions/prepare-environment
+                # Remote ref (а не локальный ./...) — обязательно для pull_request_target.
+                # Иначе action.yml берётся из PR-checkout и его trust-логика обходится.
+                uses: salute-developers/plasma/.github/actions/prepare-environment@dev
 
             -   name: Lerna bootstrap
                 run: npx lerna bootstrap --scope="@salutejs/core-themes" --scope="@salutejs/plasma-{b2c,web,website,tokens-b2c,typo,icons,new-hope,themes}"
@@ -105,7 +107,9 @@ jobs:
                     ref: refs/pull/${{github.event.pull_request.number}}/merge
 
             -   name: Prepare environment
-                uses: ./.github/actions/prepare-environment
+                # Remote ref (а не локальный ./...) — обязательно для pull_request_target.
+                # Иначе action.yml берётся из PR-checkout и его trust-логика обходится.
+                uses: salute-developers/plasma/.github/actions/prepare-environment@dev
 
             -   name: Set job environment variables
                 run: |

--- a/.github/workflows/publish-common.yml
+++ b/.github/workflows/publish-common.yml
@@ -59,7 +59,10 @@ jobs:
         run: git config --local --unset http.https://github.com/.extraheader
 
       - name: Prepare environment
-        uses: ./.github/actions/prepare-environment
+          # Remote ref (а не локальный ./...) — обязательно, т.к. workflow вызывается
+          # из pull_request_target цепочек (documentation-deploy-pr, publish-canary).
+          # Иначе action.yml возьмется из PR-checkout и весь защитный механизм обходится.
+        uses: salute-developers/plasma/.github/actions/prepare-environment@dev
 
       - name: Lerna bootstrap
         run: npm run ${{ inputs.cmd }} -- --ignore="@salutejs/{*-docs,plasma-website}"

--- a/.github/workflows/theme-builder-pr.yml
+++ b/.github/workflows/theme-builder-pr.yml
@@ -3,10 +3,8 @@ name: PR theme-builder
 on:
   pull_request:
     branches:
-      - master
-  pull_request_target:
-    branches:
       - dev
+      - master
 
 concurrency:
   # New commit on branch cancels running workflows of the same branch


### PR DESCRIPTION
### What/why changed

**Postmortem**: https://tanstack.com/blog/npm-supply-chain-compromise-postmortem.

> В мае 2026 в TanStack произошёл supply chain attack: атакующий через fork PR с `pull_request_target` отравил GitHub Actions cache, который позже подтянул `release.yml`, выгрузил из памяти OIDC-токен раннера и опубликовал 84 малварных версии 42 пакетов в npm. 

### А что у нас?
   
У нас тот же паттерн, на пример в `documentation-deploy-pr.yml` ходит на `pull_request_target` и через цепочку `change-detection` / `publish-common` использует один и тот же `prepare-environment`, который писал в общий cache. 

Fork PR мог положить туда подменённые tarball'ы под ключом `hashFiles(package-lock.json)`, а следующий доверенный запуск (publish-canary, deploy с dev) подтянул бы их к себе. Этот PR закрывает вектор.

### Что меняется?

**`prepare-environment/action.yml`** — основной фикс:

- **Trust-detection шаг.** Если `event_name == pull_request_target` и `head.repo != base.repo` (fork) — контекст помечается `untrusted=true`.
- **Cache раздвоен по trust-контексту.** В trusted — `actions/cache` (restore + post-save). В untrusted — `actions/cache/restore` (только чтение, без post-step save). Запись отрублена на уровне типа action'а, а не permissions: cache использует runner-internal token, `permissions:` его не ограничивает (как раз грабли TanStack).
- **Один namespace ключа для обоих режимов** (`npm-trusted-…`). Fork PR'ы переиспользуют доверенный кэш.
- **Только exact-match ключ, без `restore-keys`.** Partial-match по мутированному lockfile позволил бы подмешать чужие tarball'ы к проверенному кешу.
- **Убран `node_modules` cache.** Это уже распакованные/исполнимые артефакты — отравленный `node_modules` исполняется на первой же команде. Кэшируем только `~/.npm` (tarball'ы, валидируются по integrity из lockfile) и `~/.cache/Cypress` (бинарь, дополнительно проверяется `cypress verify`).
- **Pin третьих action'ов на SHA** (`actions/setup-node`, `actions/cache`) — рекомендация из postmortem, исключает скрытую подмену тэга.
- **`npx cypress verify`** — доп. интегрити-проверка бинаря против установленного пакета (ловит рассинхрон/повреждение кэша).