### PR TITLE
PLASMA-7032: fix onToggle in Dropdown

### DIFF
--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.component-test.tsx
@@ -726,6 +726,16 @@ describeFn('Dropdown', () => {
         cy.pressKey('Escape');
         cy.get('@onToggle').its('callCount').should('equal', 8);
         cy.get('@onToggle').should('have.been.calledWith', false);
+
+        cy.pressKey('Enter');
+        cy.get('[id$="tree_level_1"]').should('be.visible');
+        cy.get('@onToggle').its('callCount').should('equal', 9);
+        cy.get('@onToggle').should('have.been.calledWith', true);
+
+        cy.pressKey('Escape');
+        cy.get('[id$="tree_level_1"]').should('not.exist');
+        cy.get('@onToggle').its('callCount').should('equal', 10);
+        cy.get('@onToggle').should('have.been.calledWith', false);
     });
 
     it('behavior: nesting lists within scroll', { scrollBehavior: false }, () => {

--- a/packages/plasma-new-hope/src/components/Dropdown/hooks/useKeyboardNavigation.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/hooks/useKeyboardNavigation.ts
@@ -149,6 +149,7 @@ export const useKeyNavigation = ({
                 if (!path[0]) {
                     dispatchPath({ type: 'opened_first_level' });
                     dispatchFocusedPath({ type: 'set_initial_focus' });
+                    handleGlobalToggle(true, event);
                     break;
                 }
 


### PR DESCRIPTION
## Core

### Dropdown
- исправлен баг с `onToggle`, при котором коллбэк не всегда срабатывал при работе через клавиатурную навигацию;

### What/why changed
- исправлен баг с `onToggle`, при котором коллбэк не всегда срабатывал при работе через клавиатурную навигацию;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown keyboard navigation to properly handle opening the menu when no item is currently selected

* **Tests**
  * Enhanced dropdown keyboard interaction test coverage for open/close scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.378.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-b2c@1.620.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-core@1.228.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-giga@0.347.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-homeds@0.347.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-hope@1.374.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-icons@1.239.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-new-hope@0.364.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-tokens-b2b@1.56.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-tokens-b2c@0.67.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-tokens-web@1.71.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-tokens@1.140.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-typo@0.44.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-ui@1.350.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-web@1.622.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-bizcom@0.352.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-cs@0.356.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-dfa@0.350.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-finai@0.343.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-insol@0.347.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-netology@0.351.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-os@0.22.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-platform-ai@0.351.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-sbcom@0.352.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-scan@0.350.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-serv@0.351.0-canary.2825.26824986432.0
  npm install @salutejs/core-themes@0.31.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-themes@0.52.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-themes@0.67.0-canary.2825.26824986432.0
  npm install @salutejs/sdds-api-tests@0.9.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-cy-utils@0.158.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-sb-utils@0.228.0-canary.2825.26824986432.0
  npm install @salutejs/plasma-tokens-utils@0.52.0-canary.2825.26824986432.0
  # or 
  yarn add @salutejs/plasma-asdk@0.378.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-b2c@1.620.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-core@1.228.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-giga@0.347.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-homeds@0.347.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-hope@1.374.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-icons@1.239.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-new-hope@0.364.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-tokens-b2b@1.56.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-tokens-b2c@0.67.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-tokens-web@1.71.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-tokens@1.140.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-typo@0.44.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-ui@1.350.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-web@1.622.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-bizcom@0.352.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-cs@0.356.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-dfa@0.350.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-finai@0.343.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-insol@0.347.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-netology@0.351.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-os@0.22.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-platform-ai@0.351.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-sbcom@0.352.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-scan@0.350.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-serv@0.351.0-canary.2825.26824986432.0
  yarn add @salutejs/core-themes@0.31.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-themes@0.52.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-themes@0.67.0-canary.2825.26824986432.0
  yarn add @salutejs/sdds-api-tests@0.9.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-cy-utils@0.158.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-sb-utils@0.228.0-canary.2825.26824986432.0
  yarn add @salutejs/plasma-tokens-utils@0.52.0-canary.2825.26824986432.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
