### PR TITLE
sdds-sbcom: Fixing some configs Switch

### DIFF
--- a/packages/sdds-sbcom/src/components/Switch/Switch.config.ts
+++ b/packages/sdds-sbcom/src/components/Switch/Switch.config.ts
@@ -4,12 +4,10 @@ import {
     bodyM,
     bodyS,
     surfaceAccent,
-    surfaceAccentHover,
-    surfaceTransparentTertiary,
-    surfaceTransparentTertiaryHover,
     textPrimary,
     textSecondary,
     onDarkTextPrimary,
+    onLightSurfaceSolidDeep,
 } from '@salutejs-ds/sdds_sbcom/theme/tokens';
 
 /*
@@ -110,17 +108,15 @@ export const config = {
                 ${switchTokens.descriptionMaxLines}: initial;
 
                 ${switchTokens.trackBackgroundColorOn}: ${surfaceAccent};
-                ${switchTokens.trackBackgroundColorOnHover}: ${surfaceAccentHover};
-                ${switchTokens.trackBackgroundColorOff}: ${surfaceTransparentTertiary};
-                ${switchTokens.trackBackgroundColorOffHover}: ${surfaceTransparentTertiaryHover};
+                ${switchTokens.trackBackgroundColorOff}: ${onLightSurfaceSolidDeep};
 
                 ${switchTokens.trackBorderWidthOn}: 0;
                 ${switchTokens.trackBorderWidthOff}: 0;
 
                 ${switchTokens.thumbBackgroundColorOn}: ${onDarkTextPrimary};
                 ${switchTokens.thumbBackgroundColorOff}: ${onDarkTextPrimary};
-
-                ${switchTokens.thumbBorderColorOff}: ${surfaceTransparentTertiary};
+                ${switchTokens.thumbBorderColorOn}: ${surfaceAccent};
+                ${switchTokens.thumbBorderColorOff}: ${onLightSurfaceSolidDeep};
             `,
         },
         disabled: {


### PR DESCRIPTION
Поправил конфиги согласно дс
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.379.0-canary.2840.27009418496.0
  npm install @salutejs/plasma-b2c@1.621.0-canary.2840.27009418496.0
  npm install @salutejs/plasma-giga@0.348.0-canary.2840.27009418496.0
  npm install @salutejs/plasma-homeds@0.348.0-canary.2840.27009418496.0
  npm install @salutejs/plasma-hope@1.375.0-canary.2840.27009418496.0
  npm install @salutejs/plasma-new-hope@0.365.0-canary.2840.27009418496.0
  npm install @salutejs/plasma-ui@1.351.0-canary.2840.27009418496.0
  npm install @salutejs/plasma-web@1.623.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-bizcom@0.353.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-cs@0.357.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-dfa@0.351.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-finai@0.344.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-insol@0.348.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-netology@0.352.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-os@0.23.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-platform-ai@0.352.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-sbcom@0.353.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-scan@0.351.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-serv@0.352.0-canary.2840.27009418496.0
  npm install @salutejs/sdds-api-tests@0.10.0-canary.2840.27009418496.0
  npm install @salutejs/plasma-sb-utils@0.229.0-canary.2840.27009418496.0
  # or 
  yarn add @salutejs/plasma-asdk@0.379.0-canary.2840.27009418496.0
  yarn add @salutejs/plasma-b2c@1.621.0-canary.2840.27009418496.0
  yarn add @salutejs/plasma-giga@0.348.0-canary.2840.27009418496.0
  yarn add @salutejs/plasma-homeds@0.348.0-canary.2840.27009418496.0
  yarn add @salutejs/plasma-hope@1.375.0-canary.2840.27009418496.0
  yarn add @salutejs/plasma-new-hope@0.365.0-canary.2840.27009418496.0
  yarn add @salutejs/plasma-ui@1.351.0-canary.2840.27009418496.0
  yarn add @salutejs/plasma-web@1.623.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-bizcom@0.353.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-cs@0.357.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-dfa@0.351.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-finai@0.344.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-insol@0.348.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-netology@0.352.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-os@0.23.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-platform-ai@0.352.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-sbcom@0.353.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-scan@0.351.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-serv@0.352.0-canary.2840.27009418496.0
  yarn add @salutejs/sdds-api-tests@0.10.0-canary.2840.27009418496.0
  yarn add @salutejs/plasma-sb-utils@0.229.0-canary.2840.27009418496.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
