### PR TITLE
PLASMA-7380: update TimePicker callback event type

### DIFF
--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.template-doc.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/{{ package }}';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.tsx
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.tsx
@@ -200,28 +200,32 @@ export const timePickerRoot = (
                 onToggle?.(false);
             }, [floatingPopoverRef, timeGridRootRef]);
 
-            const handleOnChange = (event: TimePickerGridChangeEvent) => {
-                if (!event) {
+            const handleOnChange = (formattedValues: TimePickerGridChangeEvent) => {
+                if (!formattedValues) {
                     return;
                 }
 
-                let timeString = event.value;
+                let timeString = formattedValues.value;
                 if (format === 'HH:mm' && viewValue.length > 5) {
                     timeString = viewValue.substring(0, 5);
                 }
                 setInnerTime(timeString ?? '');
 
                 setActiveTime({
-                    hours: !Number.isNaN(event.timeValues.hour) ? event.timeValues.hour : null,
-                    minutes: !Number.isNaN(event.timeValues.minute) ? event.timeValues.minute : null,
+                    hours: !Number.isNaN(formattedValues.timeValues.hour) ? formattedValues.timeValues.hour : null,
+                    minutes: !Number.isNaN(formattedValues.timeValues.minute)
+                        ? formattedValues.timeValues.minute
+                        : null,
                     seconds:
-                        format === 'HH:mm:ss' && !Number.isNaN(event.timeValues.second)
-                            ? event.timeValues.second
+                        format === 'HH:mm:ss' && !Number.isNaN(formattedValues.timeValues.second)
+                            ? formattedValues.timeValues.second
                             : null,
                     currentColumn: null,
                 });
 
-                onChange?.(event);
+                if (onChange) {
+                    onChange(formattedValues, formattedValues);
+                }
             };
 
             const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -230,23 +234,35 @@ export const timePickerRoot = (
 
                 const { innerString, values, newCursorPosition } = processTimeInput(input, format, cursorPos);
 
+                const { hh: hours, mm: minutes, ss: seconds } = values;
                 setInnerTime(innerString);
                 setActiveTime((prev) => ({
                     ...prev,
-                    hours: values.hh,
-                    minutes: values.mm,
-                    seconds: values.ss,
+                    hours,
+                    minutes,
+                    seconds,
                 }));
 
+                const formattedValues = {
+                    value: innerString,
+                    timeValues: {
+                        hour: hours,
+                        minute: minutes,
+                        second: seconds,
+                    },
+                };
+
                 if (onChange) {
-                    onChange(({
-                        ...event,
-                        target: {
-                            ...event.target,
-                            value: innerString,
-                            timeValues: values,
+                    onChange(
+                        {
+                            ...event,
+                            target: {
+                                ...event.target,
+                                ...formattedValues,
+                            },
                         },
-                    } as unknown) as ChangeEvent<HTMLInputElement>);
+                        formattedValues,
+                    );
                 }
 
                 requestAnimationFrame(() => {

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.types.ts
@@ -96,7 +96,7 @@ export type TextFieldProps = {
     autoComplete?: string;
     /**
      * Обработчик изменения значения
-     * @secription тип `TimePickerChangeEvent` для event - *deprecated*
+     * @description тип `TimePickerChangeEvent` для event - *deprecated*
      */
     onChange?: (
         event: TimePickerChangeEvent | ChangeEvent<HTMLInputElement> | null,

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.types.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, HTMLAttributes, RefObject, SyntheticEvent } from 'react';
+import type { ChangeEvent, CSSProperties, HTMLAttributes, RefObject, SyntheticEvent } from 'react';
 
 import type { HintProps, LabelProps } from '../TextField/TextField.types';
 
@@ -31,9 +31,9 @@ export type TimePickerFloatingPopoverProps = {
 export type TimePickerChangeEvent = {
     value?: string;
     timeValues: {
-        hour?: number;
-        minute?: number;
-        second?: number;
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
     };
 };
 
@@ -96,8 +96,12 @@ export type TextFieldProps = {
     autoComplete?: string;
     /**
      * Обработчик изменения значения
+     * @secription тип `TimePickerChangeEvent` для event - *deprecated*
      */
-    onChange?: (event: TimePickerChangeEvent) => void;
+    onChange?: (
+        event: TimePickerChangeEvent | ChangeEvent<HTMLInputElement> | null,
+        formattedValues: TimePickerChangeEvent,
+    ) => void;
 } & LabelProps;
 
 export type TimePickerPopoverProps = {

--- a/packages/plasma-new-hope/src/components/TimePicker/utils/index.ts
+++ b/packages/plasma-new-hope/src/components/TimePicker/utils/index.ts
@@ -113,8 +113,10 @@ export const processTimeInput = (
         innerString += `:${segments[2]}`;
     }
 
-    if (innerString.length - 2 <= newCursorPosition) {
-        newCursorPosition += innerString.length - newCursorPosition;
+    if (input.length > innerString.length) {
+        newCursorPosition = Math.min(newCursorPosition, innerString.length);
+    } else if (innerString.length - 2 <= newCursorPosition) {
+        newCursorPosition = innerString.length;
     }
 
     return { innerString, values, newCursorPosition };

--- a/website/plasma-b2c-docs/docs/components/TimePicker.mdx
+++ b/website/plasma-b2c-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/plasma-b2c';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/plasma-giga-docs/docs/components/TimePicker.mdx
+++ b/website/plasma-giga-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/plasma-giga';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/plasma-homeds-docs/docs/components/TimePicker.mdx
+++ b/website/plasma-homeds-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/plasma-homeds';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/plasma-web-docs/docs/components/TimePicker.mdx
+++ b/website/plasma-web-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/plasma-web';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-bizcom-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-bizcom-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/sdds-bizcom';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-cs-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-cs-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/plasma-b2c';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-dfa-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-dfa-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/sdds-dfa';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-finai-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-finai-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/sdds-finai';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-insol-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-insol-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/sdds-insol';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-netology-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-netology-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/sdds-netology';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-platform-ai-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/sdds-platform-ai';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-scan-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-scan-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/sdds-scan';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 

--- a/website/sdds-serv-docs/docs/components/TimePicker.mdx
+++ b/website/sdds-serv-docs/docs/components/TimePicker.mdx
@@ -17,8 +17,8 @@ import React from 'react';
 import { TimePicker } from '@salutejs/sdds-serv';
 
 export function App() {
-    const handleTimeChange = (event) => {
-        console.log('Выбрано время:', event.target.value);
+    const handleTimeChange = (event, formattedValues) => {
+        console.log('Выбрано время:', formattedValues.value);
     };
 
     return (
@@ -33,6 +33,23 @@ export function App() {
     );
 }
 ```
+
+:::note Изменение сигнатуры `onChange`
+Колбэк `onChange` теперь принимает **второй аргумент** `formattedValues: TimePickerChangeEvent` — нормализованный объект с текущим значением времени, который всегда имеет одинаковую структуру вне зависимости от способа ввода (ручной ввод или выбор из выпадающего списка).
+
+```ts
+type TimePickerChangeEvent = {
+    value?: string;
+    timeValues: {
+        hour?: number | null;
+        minute?: number | null;
+        second?: number | null;
+    };
+};
+```
+
+Рекомендуется использовать `formattedValues` вместо первого аргумента `event`, тип которого в качестве `TimePickerChangeEvent` является **устаревшим (deprecated)**.
+:::
 
 ### Управление внешним видом
 


### PR DESCRIPTION
## Core

### TimePicker

- исправлена типизация onChange: event - `ChangeEvent<HTMLInputElement> | null`, formattedValues - `TimePickerChangeEvent`
- исправлен скачек каретки при изменении значения

### What/why changed

- исправлена типизация onChange: event - `ChangeEvent<HTMLInputElement> | null`, formattedValues - `TimePickerChangeEvent`
- исправлен скачек каретки при изменении значения

<img width="522" height="426" alt="timepicker carret behavior" src="https://github.com/user-attachments/assets/5cef0a9b-dba3-4ab4-94bf-f6402e26d67c" />


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.378.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-b2c@1.620.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-core@1.228.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-giga@0.347.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-homeds@0.347.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-hope@1.374.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-icons@1.239.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-new-hope@0.364.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-tokens-b2b@1.56.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-tokens-b2c@0.67.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-tokens-web@1.71.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-tokens@1.140.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-typo@0.44.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-ui@1.350.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-web@1.622.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-bizcom@0.352.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-cs@0.356.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-dfa@0.350.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-finai@0.343.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-insol@0.347.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-netology@0.351.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-os@0.22.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-platform-ai@0.351.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-sbcom@0.352.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-scan@0.350.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-serv@0.351.0-canary.2847.27196956598.0
  npm install @salutejs/core-themes@0.31.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-themes@0.52.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-themes@0.67.0-canary.2847.27196956598.0
  npm install @salutejs/sdds-api-tests@0.9.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-cy-utils@0.158.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-sb-utils@0.228.0-canary.2847.27196956598.0
  npm install @salutejs/plasma-tokens-utils@0.52.0-canary.2847.27196956598.0
  # or 
  yarn add @salutejs/plasma-asdk@0.378.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-b2c@1.620.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-core@1.228.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-giga@0.347.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-homeds@0.347.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-hope@1.374.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-icons@1.239.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-new-hope@0.364.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-tokens-b2b@1.56.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-tokens-b2c@0.67.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-tokens-web@1.71.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-tokens@1.140.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-typo@0.44.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-ui@1.350.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-web@1.622.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-bizcom@0.352.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-cs@0.356.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-dfa@0.350.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-finai@0.343.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-insol@0.347.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-netology@0.351.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-os@0.22.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-platform-ai@0.351.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-sbcom@0.352.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-scan@0.350.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-serv@0.351.0-canary.2847.27196956598.0
  yarn add @salutejs/core-themes@0.31.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-themes@0.52.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-themes@0.67.0-canary.2847.27196956598.0
  yarn add @salutejs/sdds-api-tests@0.9.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-cy-utils@0.158.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-sb-utils@0.228.0-canary.2847.27196956598.0
  yarn add @salutejs/plasma-tokens-utils@0.52.0-canary.2847.27196956598.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TimePicker `onChange` now provides a second `formattedValues` argument — a normalized object with consistent structure; first `event` argument is marked deprecated.
  * `timeValues` fields (hour/minute/second) are now optional and may be null for clearer/consistent semantics.

* **Documentation**
  * Updated quick-start examples and API notes across docs to show the new `onChange(event, formattedValues)` usage and recommend `formattedValues`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->