### PR TITLE
PLASMA-7377: add tabIndex for Safari

### DIFF
--- a/packages/plasma-new-hope/src/components/Button/Button.tsx
+++ b/packages/plasma-new-hope/src/components/Button/Button.tsx
@@ -83,6 +83,7 @@ export const buttonRoot = (Root: RootProps<HTMLButtonElement, ButtonProps>) =>
                 value={value}
                 disabled={disabled}
                 focused={focused || outlined}
+                tabIndex={disabled ? -1 : 0}
                 className={cx(squareClass, stretchingClass, classes.buttonItem, isLoadingClass, className)}
                 style={
                     {


### PR DESCRIPTION
## Core

### Button

- добавлен `tabIndex` для корректного отображения фокусного состояния в `Safari`

### What/why changed

- добавлен `tabIndex` для корректного отображения фокусного состояния в `Safari`
В Safari по умолчанию кнопки и ссылки пропускаются при навигации табом.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation behavior for buttons by ensuring disabled buttons are not keyboard-focusable while enabled buttons remain accessible through keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.0-canary.2854.27329867964.0
  npm install @salutejs/plasma-b2c@1.623.0-canary.2854.27329867964.0
  npm install @salutejs/plasma-giga@0.350.0-canary.2854.27329867964.0
  npm install @salutejs/plasma-homeds@0.350.0-canary.2854.27329867964.0
  npm install @salutejs/plasma-new-hope@0.367.0-canary.2854.27329867964.0
  npm install @salutejs/plasma-web@1.625.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-bizcom@0.355.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-cs@0.359.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-dfa@0.353.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-finai@0.346.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-insol@0.350.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-netology@0.354.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-os@0.25.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-platform-ai@0.354.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-sbcom@0.355.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-scan@0.353.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-serv@0.354.0-canary.2854.27329867964.0
  npm install @salutejs/sdds-api-tests@0.12.0-canary.2854.27329867964.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.0-canary.2854.27329867964.0
  yarn add @salutejs/plasma-b2c@1.623.0-canary.2854.27329867964.0
  yarn add @salutejs/plasma-giga@0.350.0-canary.2854.27329867964.0
  yarn add @salutejs/plasma-homeds@0.350.0-canary.2854.27329867964.0
  yarn add @salutejs/plasma-new-hope@0.367.0-canary.2854.27329867964.0
  yarn add @salutejs/plasma-web@1.625.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-bizcom@0.355.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-cs@0.359.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-dfa@0.353.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-finai@0.346.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-insol@0.350.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-netology@0.354.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-os@0.25.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-platform-ai@0.354.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-sbcom@0.355.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-scan@0.353.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-serv@0.354.0-canary.2854.27329867964.0
  yarn add @salutejs/sdds-api-tests@0.12.0-canary.2854.27329867964.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
