### PR TITLE
PLASMA-7398: add hover and active colors for scrollbar thumb

### DIFF
--- a/packages/plasma-b2c/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/plasma-b2c/src/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {

--- a/packages/plasma-giga/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/plasma-giga/src/components/Scrollbar/Scrollbar.config.ts
@@ -1,10 +1,17 @@
-import { surfaceTransparentPrimary, surfaceTransparentTertiary } from '@salutejs/plasma-themes/tokens/plasma_giga';
+import {
+    surfaceTransparentPrimary,
+    surfaceTransparentTertiary,
+    surfaceTransparentTertiaryHover,
+    surfaceTransparentTertiaryActive,
+} from '@salutejs/plasma-themes/tokens/plasma_giga';
 
 export const config = {
     view: {
         default: {
             trackColor: `${surfaceTransparentPrimary}`,
             thumbColor: `${surfaceTransparentTertiary}`,
+            thumbHoverColor: `${surfaceTransparentTertiaryHover}`,
+            thumbActiveColor: `${surfaceTransparentTertiaryActive}`,
         },
     },
     size: {

--- a/packages/plasma-homeds/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/plasma-homeds/src/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {

--- a/packages/plasma-new-hope/src/examples/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/plasma-new-hope/src/examples/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {

--- a/packages/plasma-new-hope/src/mixins/addScrollbar.ts
+++ b/packages/plasma-new-hope/src/mixins/addScrollbar.ts
@@ -14,13 +14,21 @@ export type ScrollbarProps = {
      */
     thumbColor?: string;
     /**
+     * Цвет тумблера прокрутки при наведении
+     */
+    thumbHoverColor?: string;
+    /**
+     * Цвет тумблера прокрутки при нажатии
+     */
+    thumbActiveColor?: string;
+    /**
      * Смещение по высоте
      */
     scrollHeightOffset?: string;
 };
 
 export const addScrollbar = (args: ScrollbarProps) => {
-    const { scrollWidth, trackColor, thumbColor, scrollHeightOffset = 0 } = args;
+    const { scrollWidth, trackColor, thumbColor, thumbHoverColor, thumbActiveColor, scrollHeightOffset = 0 } = args;
 
     return `
         &::-webkit-scrollbar {
@@ -44,11 +52,11 @@ export const addScrollbar = (args: ScrollbarProps) => {
             transition: background-color 0.2s ease;
 
             &:hover {
-                background-color: ${thumbColor};
+                background-color: ${thumbHoverColor ?? thumbColor};
             }
 
             &:active {
-                background-color: ${thumbColor};
+                background-color: ${thumbActiveColor ?? thumbColor};
             }
         }
     `;

--- a/packages/plasma-web/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/plasma-web/src/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {

--- a/packages/sdds-dfa/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/sdds-dfa/src/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {

--- a/packages/sdds-netology/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/sdds-netology/src/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {

--- a/packages/sdds-os/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/sdds-os/src/components/Scrollbar/Scrollbar.config.ts
@@ -7,6 +7,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-solid-primary)',
             thumbColor: 'var(--surface-solid-tertiary)',
+            thumbHoverColor: 'var(--surface-solid-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-solid-tertiary-active)',
         },
     },
     size: {

--- a/packages/sdds-platform-ai/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/sdds-platform-ai/src/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {

--- a/packages/sdds-sbcom/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/sdds-sbcom/src/components/Scrollbar/Scrollbar.config.ts
@@ -1,10 +1,17 @@
-import { surfaceTransparentPrimary, surfaceTransparentTertiary } from '@salutejs-ds/sdds_sbcom/theme/tokens';
+import {
+    surfaceTransparentPrimary,
+    surfaceTransparentTertiary,
+    surfaceTransparentTertiaryHover,
+    surfaceTransparentTertiaryActive,
+} from '@salutejs-ds/sdds_sbcom/theme/tokens';
 
 export const config = {
     view: {
         default: {
             trackColor: `${surfaceTransparentPrimary}`,
             thumbColor: `${surfaceTransparentTertiary}`,
+            thumbHoverColor: `${surfaceTransparentTertiaryHover}`,
+            thumbActiveColor: `${surfaceTransparentTertiaryActive}`,
         },
     },
     size: {

--- a/packages/sdds-scan/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/sdds-scan/src/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {

--- a/packages/sdds-serv/src/components/Scrollbar/Scrollbar.config.ts
+++ b/packages/sdds-serv/src/components/Scrollbar/Scrollbar.config.ts
@@ -3,6 +3,8 @@ export const config = {
         default: {
             trackColor: 'var(--surface-transparent-primary)',
             thumbColor: 'var(--surface-transparent-tertiary)',
+            thumbHoverColor: 'var(--surface-transparent-tertiary-hover)',
+            thumbActiveColor: 'var(--surface-transparent-tertiary-active)',
         },
     },
     size: {


### PR DESCRIPTION
## Core

### Scrollbar

- добавлены токены цвета для `hover` и `active` состояний thumb

### What/why changed

- добавлены токены цвета для `hover` и `active` состояний thumb
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.0-canary.2859.27346355786.0
  npm install @salutejs/plasma-b2c@1.623.0-canary.2859.27346355786.0
  npm install @salutejs/plasma-giga@0.350.0-canary.2859.27346355786.0
  npm install @salutejs/plasma-homeds@0.350.0-canary.2859.27346355786.0
  npm install @salutejs/plasma-new-hope@0.367.0-canary.2859.27346355786.0
  npm install @salutejs/plasma-web@1.625.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-bizcom@0.355.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-cs@0.359.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-dfa@0.353.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-finai@0.346.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-insol@0.350.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-netology@0.354.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-os@0.25.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-platform-ai@0.354.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-sbcom@0.355.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-scan@0.353.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-serv@0.354.0-canary.2859.27346355786.0
  npm install @salutejs/sdds-api-tests@0.12.0-canary.2859.27346355786.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.0-canary.2859.27346355786.0
  yarn add @salutejs/plasma-b2c@1.623.0-canary.2859.27346355786.0
  yarn add @salutejs/plasma-giga@0.350.0-canary.2859.27346355786.0
  yarn add @salutejs/plasma-homeds@0.350.0-canary.2859.27346355786.0
  yarn add @salutejs/plasma-new-hope@0.367.0-canary.2859.27346355786.0
  yarn add @salutejs/plasma-web@1.625.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-bizcom@0.355.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-cs@0.359.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-dfa@0.353.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-finai@0.346.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-insol@0.350.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-netology@0.354.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-os@0.25.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-platform-ai@0.354.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-sbcom@0.355.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-scan@0.353.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-serv@0.354.0-canary.2859.27346355786.0
  yarn add @salutejs/sdds-api-tests@0.12.0-canary.2859.27346355786.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scrollbar components now support customizable thumb colors for both hover and active interaction states across all design system packages.
  * Enhanced interactive state styling provides improved visual feedback and gives designers greater control over scrollbar appearance.
  * Extended styling configuration enables creation of more refined and consistent scrollbar experiences in applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->