### PR TITLE
PLASMA-7447: Remove unused storeon dependency

### DIFF
--- a/packages/plasma-hope/package-lock.json
+++ b/packages/plasma-hope/package-lock.json
@@ -12,8 +12,7 @@
         "@popperjs/core": "2.9.2",
         "react-file-drop": "3.1.6",
         "react-popper": "2.3.0",
-        "react-sortable-hoc": "2.0.0",
-        "storeon": "3.1.4"
+        "react-sortable-hoc": "2.0.0"
       },
       "devDependencies": {
         "@babel/cli": "7.24.1",
@@ -8385,26 +8384,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/storeon": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/storeon/-/storeon-3.1.4.tgz",
-      "integrity": "sha512-GUSyCevVP00T5b5/Z05ZGkrJFh4IbXjCAl+R27pBslamFLS/qSxJoSwYIGbIZOjujRAgUiWIzPDZP6Ma3vSR9Q==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "preact": ">=10.0.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "preact": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -15467,11 +15446,6 @@
           "dev": true
         }
       }
-    },
-    "storeon": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/storeon/-/storeon-3.1.4.tgz",
-      "integrity": "sha512-GUSyCevVP00T5b5/Z05ZGkrJFh4IbXjCAl+R27pBslamFLS/qSxJoSwYIGbIZOjujRAgUiWIzPDZP6Ma3vSR9Q=="
     },
     "strip-final-newline": {
       "version": "2.0.0",

--- a/packages/plasma-hope/package.json
+++ b/packages/plasma-hope/package.json
@@ -47,8 +47,7 @@
     "@salutejs/plasma-typo": "0.45.0-dev.0",
     "react-file-drop": "3.1.6",
     "react-popper": "2.3.0",
-    "react-sortable-hoc": "2.0.0",
-    "storeon": "3.1.4"
+    "react-sortable-hoc": "2.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.24.1",


### PR DESCRIPTION
## PLASMA-HOPE

### Dependencies

- removed unused `storeon` dependency from `@salutejs/plasma-hope`

### What/why changed

Part of the plasma-hope → plasma-new-hope migration ([#2870](https://github.com/salute-developers/plasma/issues/2870)).

**Stream T — Trim plasma-hope**, step **T1**. The `storeon` package has no imports in `packages/plasma-hope/src`. Removing it reduces dependency surface with no runtime or consumer API impact.

Stream T PRs: #2861 (T1), #2862 (T2), #2863 (T3), #2864 (T4), #2865 (T5), #2866 (T6), #2867 (T7), #2868 (T8). **Merge strictly in order T1→T8** into `dev`; rebase the next PR onto `dev` after each merge.

Issue: #2870
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.380.1-canary.2861.27425256521.0
  npm install @salutejs/plasma-b2c@1.622.1-canary.2861.27425256521.0
  npm install @salutejs/plasma-giga@0.349.1-canary.2861.27425256521.0
  npm install @salutejs/plasma-homeds@0.349.1-canary.2861.27425256521.0
  npm install @salutejs/plasma-hope@1.376.1-canary.2861.27425256521.0
  npm install @salutejs/plasma-new-hope@0.366.1-canary.2861.27425256521.0
  npm install @salutejs/plasma-web@1.624.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-bizcom@0.354.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-cs@0.358.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-dfa@0.352.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-finai@0.345.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-insol@0.349.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-netology@0.353.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-os@0.24.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-platform-ai@0.353.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-sbcom@0.354.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-scan@0.352.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-serv@0.353.1-canary.2861.27425256521.0
  npm install @salutejs/sdds-api-tests@0.11.1-canary.2861.27425256521.0
  # or 
  yarn add @salutejs/plasma-asdk@0.380.1-canary.2861.27425256521.0
  yarn add @salutejs/plasma-b2c@1.622.1-canary.2861.27425256521.0
  yarn add @salutejs/plasma-giga@0.349.1-canary.2861.27425256521.0
  yarn add @salutejs/plasma-homeds@0.349.1-canary.2861.27425256521.0
  yarn add @salutejs/plasma-hope@1.376.1-canary.2861.27425256521.0
  yarn add @salutejs/plasma-new-hope@0.366.1-canary.2861.27425256521.0
  yarn add @salutejs/plasma-web@1.624.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-bizcom@0.354.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-cs@0.358.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-dfa@0.352.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-finai@0.345.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-insol@0.349.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-netology@0.353.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-os@0.24.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-platform-ai@0.353.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-sbcom@0.354.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-scan@0.352.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-serv@0.353.1-canary.2861.27425256521.0
  yarn add @salutejs/sdds-api-tests@0.11.1-canary.2861.27425256521.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
