### PR TITLE
PLASMA-7445: Remove `!important` from accordionItemBorderRadius config

### DIFF
--- a/packages/plasma-b2c/src/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-b2c/src/components/Accordion/Accordion.config.ts
@@ -59,7 +59,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorder}: none;
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);

--- a/packages/plasma-b2c/src/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-b2c/src/components/Accordion/Accordion.config.ts
@@ -59,7 +59,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorder}: none;
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);

--- a/packages/plasma-giga/src/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-giga/src/components/Accordion/Accordion.config.ts
@@ -54,7 +54,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: ${textPrimary};
                 ${accordionTokens.accordionItemIconColor}: ${textPrimary};
                 ${accordionTokens.accordionItemFocus}: ${surfaceAccent};
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: ${surfaceClear};
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid ${surfaceSolidTertiary};
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/plasma-giga/src/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-giga/src/components/Accordion/Accordion.config.ts
@@ -54,7 +54,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: ${textPrimary};
                 ${accordionTokens.accordionItemIconColor}: ${textPrimary};
                 ${accordionTokens.accordionItemFocus}: ${surfaceAccent};
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: ${surfaceClear};
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid ${surfaceSolidTertiary};
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/plasma-giga/src/components/Accordion/Accordion.update-test.component-test.tsx
+++ b/packages/plasma-giga/src/components/Accordion/Accordion.update-test.component-test.tsx
@@ -83,6 +83,7 @@ describe('plasma-giga: Accordion', () => {
         );
 
         cy.get('.accordion-root').last().trigger('click', { waitForAnimations: true });
+        cy.get('.accordion-item').should('have.css', 'border-radius', '0px');
 
         cy.matchImageSnapshot();
     });

--- a/packages/plasma-homeds/src/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-homeds/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/plasma-homeds/src/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-homeds/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/plasma-new-hope/src/components/Accordion/Accordion.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Accordion/Accordion.tokens.ts
@@ -21,6 +21,7 @@ export const tokens = {
     accordionItemOpenedBackground: '--plasma-accordion-item-opened-background',
     accordionItemShadow: '--plasma-accordion-item-shadow',
     accordionItemBorderRadius: '--plasma-accordion-item-border-radius',
+    accordionItemViewBorderRadius: '--plasma-accordion-item-view-border-radius',
     accordionItemPadding: '--plasma-accordion-item-padding',
     accordionItemPaddingVertical: '--plasma-accordion-item-padding-vertical',
     accordionItemPaddingHorizontal: '--plasma-accordion-item-padding-horizontal',

--- a/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
+++ b/packages/plasma-new-hope/src/components/Accordion/ui/AccordionItem/AccordionItem.tsx
@@ -86,7 +86,11 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
             </StyledPlus>
         );
 
-        const accordionBorderRadius = convertRoundnessMatrix(pin, `var(${tokens.accordionItemBorderRadius})`, '1.5rem');
+        const accordionBorderRadius = convertRoundnessMatrix(
+            pin,
+            `var(${tokens.accordionItemViewBorderRadius}, var(${tokens.accordionItemBorderRadius}))`,
+            '1.5rem',
+        );
         const openedClass = opened ?? value ? classes.accordionItemOpened : '';
         const disabledClass = disabled ? classes.accordionDisabled : '';
 

--- a/packages/plasma-new-hope/src/examples/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-new-hope/src/examples/components/Accordion/Accordion.config.ts
@@ -32,7 +32,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorder}: none;
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);

--- a/packages/plasma-new-hope/src/examples/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-new-hope/src/examples/components/Accordion/Accordion.config.ts
@@ -32,7 +32,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorder}: none;
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);

--- a/packages/plasma-web/src/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-web/src/components/Accordion/Accordion.config.ts
@@ -58,7 +58,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorder}: none;
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);

--- a/packages/plasma-web/src/components/Accordion/Accordion.config.ts
+++ b/packages/plasma-web/src/components/Accordion/Accordion.config.ts
@@ -58,7 +58,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorder}: none;
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);

--- a/packages/sdds-bizcom/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-bizcom/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-bizcom/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-bizcom/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-cs/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-cs/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-accent);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.125rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-cs/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-cs/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-accent);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.125rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-dfa/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-dfa/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-dfa/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-dfa/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-finai/src/components/Accordion/Accordion.config.draft.ts
+++ b/packages/sdds-finai/src/components/Accordion/Accordion.config.draft.ts
@@ -31,7 +31,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-finai/src/components/Accordion/Accordion.config.draft.ts
+++ b/packages/sdds-finai/src/components/Accordion/Accordion.config.draft.ts
@@ -31,7 +31,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-finai/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-finai/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-finai/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-finai/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-insol/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-insol/src/components/Accordion/Accordion.config.ts
@@ -31,7 +31,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-insol/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-insol/src/components/Accordion/Accordion.config.ts
@@ -31,7 +31,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-netology/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-netology/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-netology/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-netology/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-os/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-os/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-os/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-os/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-platform-ai/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-platform-ai/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-platform-ai/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-platform-ai/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-sbcom/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-sbcom/src/components/Accordion/Accordion.config.ts
@@ -52,7 +52,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: ${textPrimary};
                 ${accordionTokens.accordionItemIconColor}: ${textPrimary};
                 ${accordionTokens.accordionItemFocus}: ${surfaceAccent};
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: ${surfaceClear};
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid ${surfaceSolidTertiary};
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-sbcom/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-sbcom/src/components/Accordion/Accordion.config.ts
@@ -52,7 +52,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: ${textPrimary};
                 ${accordionTokens.accordionItemIconColor}: ${textPrimary};
                 ${accordionTokens.accordionItemFocus}: ${surfaceAccent};
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: ${surfaceClear};
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid ${surfaceSolidTertiary};
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-scan/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-scan/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-scan/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-scan/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-serv/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-serv/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem !important;
+                ${accordionTokens.accordionItemBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;

--- a/packages/sdds-serv/src/components/Accordion/Accordion.config.ts
+++ b/packages/sdds-serv/src/components/Accordion/Accordion.config.ts
@@ -29,7 +29,7 @@ export const config = {
                 ${accordionTokens.accordionItemTextColor}: var(--text-primary);
                 ${accordionTokens.accordionItemIconColor}: var(--text-primary);
                 ${accordionTokens.accordionItemFocus}: var(--surface-accent);
-                ${accordionTokens.accordionItemBorderRadius}: 0rem;
+                ${accordionTokens.accordionItemViewBorderRadius}: 0rem;
                 ${accordionTokens.accordionBackground}: var(--surface-clear);
                 ${accordionTokens.accordionItemBorderBottom}: 0.063rem solid var(--surface-solid-tertiary);
                 ${accordionTokens.accordionItemPaddingHorizontalLeft}: 0;


### PR DESCRIPTION
## Core

### Accordion

- убран `!important` из токена `accordionItemBorderRadius` для размера `xs` в конфигурации

### What/why changed

В конфигурации Accordion для размера `xs` значение `accordionItemBorderRadius: 0rem` задавалось с `!important`. Использование `!important` в конфигурационных файлах компонентов не допускается — оно усложняет кастомизацию и переопределение стилей. Исправление затрагивает 17 конфигов во всех тематических пакетах.

Closes #2869

### Прежде чем перевести в статус "requested a review" убедитесь

- [x] Добавлен номер issue (если есть);
- [x] Добавлены/обновлены **cypress тесты** если PR касается визуальной составляющей;

Made with [Cursor](https://cursor.com)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.380.1-canary.2871.27431281125.0
  npm install @salutejs/plasma-b2c@1.622.1-canary.2871.27431281125.0
  npm install @salutejs/plasma-giga@0.349.1-canary.2871.27431281125.0
  npm install @salutejs/plasma-homeds@0.349.1-canary.2871.27431281125.0
  npm install @salutejs/plasma-new-hope@0.366.1-canary.2871.27431281125.0
  npm install @salutejs/plasma-web@1.624.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-bizcom@0.354.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-cs@0.358.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-dfa@0.352.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-finai@0.345.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-insol@0.349.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-netology@0.353.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-os@0.24.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-platform-ai@0.353.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-sbcom@0.354.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-scan@0.352.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-serv@0.353.1-canary.2871.27431281125.0
  npm install @salutejs/sdds-api-tests@0.11.1-canary.2871.27431281125.0
  # or 
  yarn add @salutejs/plasma-asdk@0.380.1-canary.2871.27431281125.0
  yarn add @salutejs/plasma-b2c@1.622.1-canary.2871.27431281125.0
  yarn add @salutejs/plasma-giga@0.349.1-canary.2871.27431281125.0
  yarn add @salutejs/plasma-homeds@0.349.1-canary.2871.27431281125.0
  yarn add @salutejs/plasma-new-hope@0.366.1-canary.2871.27431281125.0
  yarn add @salutejs/plasma-web@1.624.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-bizcom@0.354.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-cs@0.358.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-dfa@0.352.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-finai@0.345.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-insol@0.349.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-netology@0.353.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-os@0.24.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-platform-ai@0.353.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-sbcom@0.354.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-scan@0.352.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-serv@0.353.1-canary.2871.27431281125.0
  yarn add @salutejs/sdds-api-tests@0.11.1-canary.2871.27431281125.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Accordion component border-radius styling by refactoring how the "clear" view applies border-radius values, ensuring consistent visual behavior across all themes.

* **Tests**
  * Added test coverage to verify correct border-radius rendering in Accordion components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->