### PR TITLE
PLASMA-7421: add vertical pilled segment border-radius

### DIFF
--- a/packages/plasma-new-hope/src/components/Segment/tokens.ts
+++ b/packages/plasma-new-hope/src/components/Segment/tokens.ts
@@ -26,6 +26,7 @@ export const tokens = {
 
     groupBorderRadius: '--plasma-segment-group-border-radius',
     groupPilledBorderRadius: '--plasma-segment-group-pilled-border-radius',
+    verticalGroupPilledBorderRadius: '--plasma-segment-vertical-group-pilled-border-radius',
     groupWidth: '--plasma-segment-group-width',
     groupHeight: '--plasma-segment-group-height',
     groupArrowPadding: '--plasma-segment-group-arrow-padding',

--- a/packages/plasma-new-hope/src/components/Segment/ui/SegmentGroup/variations/_pilled/base.ts
+++ b/packages/plasma-new-hope/src/components/Segment/ui/SegmentGroup/variations/_pilled/base.ts
@@ -5,5 +5,9 @@ import { classes, tokens } from '../../../../tokens';
 export const base = css`
     &.${classes.segmentPilled} {
         border-radius: var(${tokens.groupPilledBorderRadius});
+
+        &.${classes.segmentVertical} {
+            border-radius: var(${tokens.verticalGroupPilledBorderRadius}, var(${tokens.groupPilledBorderRadius}));
+        }
     }
 `;


### PR DESCRIPTION
## Core

### Segment

- добавлен токен скругления для вертикальных скругленных сегментов

### What/why changed

- добавлен токен скругления для вертикальных скругленных сегментов


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added new CSS variable and styling configuration for vertical pilled segment groups, enabling enhanced visual customization with fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.0-canary.2874.27532082852.0
  npm install @salutejs/plasma-b2c@1.623.0-canary.2874.27532082852.0
  npm install @salutejs/plasma-giga@0.350.0-canary.2874.27532082852.0
  npm install @salutejs/plasma-homeds@0.350.0-canary.2874.27532082852.0
  npm install @salutejs/plasma-new-hope@0.367.0-canary.2874.27532082852.0
  npm install @salutejs/plasma-web@1.625.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-bizcom@0.355.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-cs@0.359.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-dfa@0.353.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-finai@0.346.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-insol@0.350.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-netology@0.354.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-os@0.25.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-platform-ai@0.354.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-sbcom@0.355.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-scan@0.353.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-serv@0.354.0-canary.2874.27532082852.0
  npm install @salutejs/sdds-api-tests@0.12.0-canary.2874.27532082852.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.0-canary.2874.27532082852.0
  yarn add @salutejs/plasma-b2c@1.623.0-canary.2874.27532082852.0
  yarn add @salutejs/plasma-giga@0.350.0-canary.2874.27532082852.0
  yarn add @salutejs/plasma-homeds@0.350.0-canary.2874.27532082852.0
  yarn add @salutejs/plasma-new-hope@0.367.0-canary.2874.27532082852.0
  yarn add @salutejs/plasma-web@1.625.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-bizcom@0.355.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-cs@0.359.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-dfa@0.353.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-finai@0.346.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-insol@0.350.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-netology@0.354.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-os@0.25.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-platform-ai@0.354.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-sbcom@0.355.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-scan@0.353.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-serv@0.354.0-canary.2874.27532082852.0
  yarn add @salutejs/sdds-api-tests@0.12.0-canary.2874.27532082852.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
