### PR TITLE
PLASMA-7438: add Notification coundown example

### DIFF
--- a/packages/plasma-new-hope/src/components/ProgressBarCircular/ProgressBarCircular.styles.ts
+++ b/packages/plasma-new-hope/src/components/ProgressBarCircular/ProgressBarCircular.styles.ts
@@ -27,12 +27,15 @@ export const StyledBackgroundCircle = styled.circle<{ customStrokeWidth?: number
         `calc(calc(50px / var(${tokens.size})) * calc(${customStrokeWidth}) * 2)`};
 `;
 
-export const StyledProgressCircle = styled.circle<{ customStrokeWidth?: number; percent?: number }>`
+export const StyledProgressCircle = styled.circle<{ customStrokeWidth?: number; percent?: number; reverse?: boolean }>`
     --percentage: ${({ percent }) => percent ?? 0};
     --radius: ${({ customStrokeWidth = `var(${tokens.strokeSize})` }) =>
         `calc(50px - calc(calc(50px / var(${tokens.size})) * ${customStrokeWidth}))`};
     --circumference: calc(calc(2 * 3.1415926535) * var(--radius));
-    --dashoffset: calc(var(--circumference) - (var(--percentage, 0) * var(--circumference) / 100));
+    --dashoffset: ${({ reverse }) =>
+        reverse
+            ? 'calc((var(--percentage, 0) * var(--circumference) / 100) - var(--circumference))'
+            : 'calc(var(--circumference) - (var(--percentage, 0) * var(--circumference) / 100))'};
 
     fill: none;
     stroke: var(${tokens.progressStroke});

--- a/packages/plasma-new-hope/src/components/ProgressBarCircular/ProgressBarCircular.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/ProgressBarCircular/ProgressBarCircular.template-doc.mdx
@@ -14,11 +14,11 @@ import TabItem from '@theme/TabItem';
 
 ```tsx live
 import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-scan';
+import { ProgressBarCircular } from '@salutejs/{{ package }}';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
             <ProgressBarCircular value={75} />
@@ -35,11 +35,11 @@ export function App() {
     <TabItem value="view" label="View" default>
         ```tsx live
         import React from 'react';
-        import { ProgressBarCircular } from '@salutejs/sdds-scan';
+        import { ProgressBarCircular } from '@salutejs/{{ package }}';
 
         export function App() {
             return (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
                     <ProgressBarCircular value={50} view="default" />
                     <ProgressBarCircular value={50} view="secondary" />
                     <ProgressBarCircular value={50} view="accent" />
@@ -55,11 +55,11 @@ export function App() {
     <TabItem value="size" label="Size">
         ```tsx live
         import React from 'react';
-        import { ProgressBarCircular } from '@salutejs/sdds-scan';
+        import { ProgressBarCircular } from '@salutejs/{{ package }}';
 
         export function App() {
             return (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
                     <ProgressBarCircular value={50} size="xxl" />
                     <ProgressBarCircular value={50} size="xl" />
                     <ProgressBarCircular value={50} size="l" />
@@ -80,11 +80,11 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-scan';
+import { ProgressBarCircular } from '@salutejs/{{ package }}';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} hasTrack={false} />
             <ProgressBarCircular value={50} />
         </div>
@@ -98,11 +98,11 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-scan';
+import { ProgressBarCircular } from '@salutejs/{{ package }}';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -118,11 +118,11 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-scan';
+import { ProgressBarCircular } from '@salutejs/{{ package }}';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
@@ -136,11 +136,11 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-scan';
+import { ProgressBarCircular } from '@salutejs/{{ package }}';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+        <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
             <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
         </div>
@@ -156,11 +156,11 @@ export function App() {
     <TabItem value="text" label="Текст" default>
         ```tsx live
         import React from 'react';
-        import { ProgressBarCircular } from '@salutejs/sdds-scan';
+        import { ProgressBarCircular } from '@salutejs/{{ package }}';
 
         export function App() {
             return (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
                     <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
                     <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
                     <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
@@ -172,12 +172,12 @@ export function App() {
     <TabItem value="icon" label="Иконка">
         ```tsx live
         import React from 'react';
-        import { ProgressBarCircular } from '@salutejs/sdds-scan';
+        import { ProgressBarCircular } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         export function App() {
             return (
-                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                <div style=\{{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
                     <ProgressBarCircular value={100} size="xl">
                         <IconDone color="var(--text-primary)" size="s" />
                     </ProgressBarCircular>

--- a/packages/plasma-new-hope/src/components/ProgressBarCircular/ProgressBarCircular.tsx
+++ b/packages/plasma-new-hope/src/components/ProgressBarCircular/ProgressBarCircular.tsx
@@ -25,6 +25,7 @@ export const progressBarCircularRoot = (Root: RootProps<HTMLDivElement, Progress
             className,
             strokeSize,
             hasTrack = true,
+            reverse,
             ...rest
         } = props;
 
@@ -50,6 +51,7 @@ export const progressBarCircularRoot = (Root: RootProps<HTMLDivElement, Progress
                         customStrokeWidth={strokeSize}
                         className={classes.progressCircle}
                         percent={percentage}
+                        reverse={reverse}
                         transform="rotate(-90 50 50)"
                     />
                 </StyledSVG>

--- a/packages/plasma-new-hope/src/components/ProgressBarCircular/ProgressBarCircular.types.ts
+++ b/packages/plasma-new-hope/src/components/ProgressBarCircular/ProgressBarCircular.types.ts
@@ -29,6 +29,10 @@ export type CustomProgressBarCircularProps = {
      */
     hasTrack?: boolean;
     /**
+     * Обратное направление дуги (уменьшение по часовой стрелке)
+     */
+    reverse?: boolean;
+    /**
      * Контент в центре компонента
      */
     children?: ReactNode;

--- a/packages/plasma-new-hope/src/examples/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/components/Notification/Notification.stories.tsx
@@ -17,7 +17,6 @@ import { WithTheme } from '../../_helpers';
 import { PopupProvider } from '../Popup/Popup';
 import type { NotificationProps } from '../../../components/Notification';
 import { IconDisclosureRight, IconTrash } from '../../../components/_Icon';
-import { ProgressBarCircular } from '../ProgressBarCircular/ProgressBarCircular';
 import {
     titles,
     size,
@@ -288,82 +287,4 @@ export const WithModal: StoryObj<StoryLiveDemoProps> = {
         },
     },
     render: (args) => <StoryWithModal {...args} />,
-};
-
-const CountdownProgressBar = ({ duration }: { duration: number }) => {
-    const [progress, setProgress] = useState(100);
-    const [secondsLeft, setSecondsLeft] = useState(Math.ceil(duration / 1000));
-
-    useEffect(() => {
-        const startTime = Date.now();
-
-        const timer = setInterval(() => {
-            const elapsed = Date.now() - startTime;
-            const remaining = Math.max(0, duration - elapsed);
-            setProgress((remaining / duration) * 100);
-            setSecondsLeft(Math.ceil(remaining / 1000));
-            if (remaining === 0) clearInterval(timer);
-        }, 100);
-
-        return () => clearInterval(timer);
-    }, [duration]);
-
-    return (
-        <ProgressBarCircular value={progress} size="s" view="default" reverse>
-            {secondsLeft}
-        </ProgressBarCircular>
-    );
-};
-
-type StoryWithCountdownProps = {
-    timeout: number;
-    placement?: NotificationPlacement;
-};
-
-const StoryWithCountdown = ({ timeout, placement }: StoryWithCountdownProps) => {
-    const count = useRef(0);
-
-    const handleClick = useCallback(() => {
-        addNotification(
-            {
-                ...getNotificationProps(count.current),
-                title: undefined,
-                closeIconType: 'thin',
-                children: (
-                    <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: '1fr auto' }}>
-                        <CountdownProgressBar duration={timeout} />
-                        <span>{texts[1].slice(0, 57)}</span>
-                    </div>
-                ),
-                iconPlacement: 'left',
-                layout: 'horizontal',
-            },
-            timeout,
-        );
-        count.current++;
-    }, [timeout]);
-
-    return (
-        <NotificationsProvider placement={placement}>
-            <StyledWrapper>
-                <Button text="Показать уведомление" onClick={handleClick} />
-            </StyledWrapper>
-        </NotificationsProvider>
-    );
-};
-
-export const WithCountdown: StoryObj<StoryWithCountdownProps> = {
-    argTypes: {
-        placement: {
-            options: notificationsPlacements,
-            control: {
-                type: 'select',
-            },
-        },
-    },
-    args: {
-        timeout: 5000,
-        placement: 'bottom-right',
-    },
-    render: (args) => <StoryWithCountdown {...args} />,
 };

--- a/packages/plasma-new-hope/src/examples/components/Notification/Notification.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/components/Notification/Notification.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react-vite';
@@ -17,6 +17,7 @@ import { WithTheme } from '../../_helpers';
 import { PopupProvider } from '../Popup/Popup';
 import type { NotificationProps } from '../../../components/Notification';
 import { IconDisclosureRight, IconTrash } from '../../../components/_Icon';
+import { ProgressBarCircular } from '../ProgressBarCircular/ProgressBarCircular';
 import {
     titles,
     size,
@@ -287,4 +288,82 @@ export const WithModal: StoryObj<StoryLiveDemoProps> = {
         },
     },
     render: (args) => <StoryWithModal {...args} />,
+};
+
+const CountdownProgressBar = ({ duration }: { duration: number }) => {
+    const [progress, setProgress] = useState(100);
+    const [secondsLeft, setSecondsLeft] = useState(Math.ceil(duration / 1000));
+
+    useEffect(() => {
+        const startTime = Date.now();
+
+        const timer = setInterval(() => {
+            const elapsed = Date.now() - startTime;
+            const remaining = Math.max(0, duration - elapsed);
+            setProgress((remaining / duration) * 100);
+            setSecondsLeft(Math.ceil(remaining / 1000));
+            if (remaining === 0) clearInterval(timer);
+        }, 100);
+
+        return () => clearInterval(timer);
+    }, [duration]);
+
+    return (
+        <ProgressBarCircular value={progress} size="s" view="default" reverse>
+            {secondsLeft}
+        </ProgressBarCircular>
+    );
+};
+
+type StoryWithCountdownProps = {
+    timeout: number;
+    placement?: NotificationPlacement;
+};
+
+const StoryWithCountdown = ({ timeout, placement }: StoryWithCountdownProps) => {
+    const count = useRef(0);
+
+    const handleClick = useCallback(() => {
+        addNotification(
+            {
+                ...getNotificationProps(count.current),
+                title: undefined,
+                closeIconType: 'thin',
+                children: (
+                    <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: '1fr auto' }}>
+                        <CountdownProgressBar duration={timeout} />
+                        <span>{texts[1].slice(0, 57)}</span>
+                    </div>
+                ),
+                iconPlacement: 'left',
+                layout: 'horizontal',
+            },
+            timeout,
+        );
+        count.current++;
+    }, [timeout]);
+
+    return (
+        <NotificationsProvider placement={placement}>
+            <StyledWrapper>
+                <Button text="Показать уведомление" onClick={handleClick} />
+            </StyledWrapper>
+        </NotificationsProvider>
+    );
+};
+
+export const WithCountdown: StoryObj<StoryWithCountdownProps> = {
+    argTypes: {
+        placement: {
+            options: notificationsPlacements,
+            control: {
+                type: 'select',
+            },
+        },
+    },
+    args: {
+        timeout: 5000,
+        placement: 'bottom-right',
+    },
+    render: (args) => <StoryWithCountdown {...args} />,
 };

--- a/packages/sdds-sbcom/src/components/Notification/Notification.stories.tsx
+++ b/packages/sdds-sbcom/src/components/Notification/Notification.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
 import type { StoryObj, Meta } from '@storybook/react-vite';
 import { IconDisclosureRight, IconTrash } from '@salutejs/plasma-icons';
@@ -7,6 +7,7 @@ import { action } from 'storybook/actions';
 import { addNotification } from '@salutejs/plasma-new-hope';
 import type { NotificationIconPlacement } from '@salutejs/plasma-new-hope';
 
+import { ProgressBarCircular } from '../ProgressBarCircular/ProgressBarCircular';
 import { Button } from '../Button/Button';
 import { Modal } from '../Modal/Modal';
 import { PopupProvider } from '../Popup';
@@ -258,4 +259,82 @@ export const WithModal: StoryObj<StoryLiveDemoProps> = {
         },
     },
     render: (args) => <StoryWithModal {...args} />,
+};
+
+type StoryWithCountdownProps = {
+    timeout: number;
+    placement?: NotificationPlacement;
+};
+
+const CountdownProgressBar = ({ duration }: { duration: number }) => {
+    const [progress, setProgress] = useState(100);
+    const [secondsLeft, setSecondsLeft] = useState(Math.ceil(duration / 1000));
+
+    useEffect(() => {
+        const startTime = Date.now();
+
+        const timer = setInterval(() => {
+            const elapsed = Date.now() - startTime;
+            const remaining = Math.max(0, duration - elapsed);
+            setProgress((remaining / duration) * 100);
+            setSecondsLeft(Math.ceil(remaining / 1000));
+            if (remaining === 0) clearInterval(timer);
+        }, 100);
+
+        return () => clearInterval(timer);
+    }, [duration]);
+
+    return (
+        <ProgressBarCircular value={progress} size="s" view="default" reverse>
+            {secondsLeft}
+        </ProgressBarCircular>
+    );
+};
+
+const StoryWithCountdown = ({ timeout, placement }: StoryWithCountdownProps) => {
+    const count = useRef(0);
+
+    const handleClick = useCallback(() => {
+        addNotification(
+            {
+                ...getNotificationProps(count.current),
+                title: undefined,
+                closeIconType: 'thin',
+                children: (
+                    <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: '1fr auto' }}>
+                        <CountdownProgressBar duration={timeout} />
+                        <span>{texts[1].slice(0, 57)}</span>
+                    </div>
+                ),
+                iconPlacement: 'left',
+                layout: 'horizontal',
+            },
+            timeout,
+        );
+        count.current++;
+    }, [timeout]);
+
+    return (
+        <NotificationsProvider placement={placement}>
+            <div style={{ height: '100vh' }}>
+                <Button text="Показать уведомление" onClick={handleClick} />
+            </div>
+        </NotificationsProvider>
+    );
+};
+
+export const WithCountdown: StoryObj<StoryWithCountdownProps> = {
+    argTypes: {
+        placement: {
+            options: notificationsPlacements,
+            control: {
+                type: 'select',
+            },
+        },
+    },
+    args: {
+        timeout: 5000,
+        placement: 'bottom-right',
+    },
+    render: (args) => <StoryWithCountdown {...args} />,
 };

--- a/website/plasma-b2c-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/plasma-b2c-docs/docs/components/ProgressBarCircular.mdx
@@ -1,27 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы. 
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -29,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/plasma-b2c';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-            
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-            
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-b2c';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-b2c';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-b2c';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-b2c';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-b2c';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-b2c';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -142,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/plasma-b2c';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/plasma-b2c';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -152,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -161,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/plasma-b2c';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/plasma-b2c';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-b2c';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-b2c';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/plasma-giga-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/plasma-giga-docs/docs/components/ProgressBarCircular.mdx
@@ -1,27 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы. 
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -29,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/plasma-giga';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-            
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-            
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-giga';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-giga';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-giga';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-giga';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-giga';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-giga';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -142,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/plasma-giga';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/plasma-giga';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -152,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -161,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/plasma-giga';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/plasma-giga';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-giga';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-giga';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/plasma-homeds-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/plasma-homeds-docs/docs/components/ProgressBarCircular.mdx
@@ -1,28 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы.
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -30,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/plasma-homeds';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-homeds';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-homeds';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-homeds';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-homeds';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-homeds';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-homeds';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -143,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/plasma-homeds';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/plasma-homeds';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -153,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -162,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/plasma-homeds';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/plasma-homeds';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-homeds';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-homeds';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/plasma-web-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/plasma-web-docs/docs/components/ProgressBarCircular.mdx
@@ -1,27 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы. 
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -29,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/plasma-web';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-            
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-            
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-web';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-web';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-web';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/plasma-web';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-web';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-web';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -142,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/plasma-web';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/plasma-web';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -152,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -161,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/plasma-web';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/plasma-web';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-web';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/plasma-web';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/sdds-dfa-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/sdds-dfa-docs/docs/components/ProgressBarCircular.mdx
@@ -1,27 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы. 
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -29,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/sdds-dfa';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-            
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-            
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-dfa';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-dfa';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-dfa';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-dfa';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-dfa';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-dfa';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -142,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/sdds-dfa';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-dfa';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -152,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -161,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/sdds-dfa';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-dfa';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-dfa';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-dfa';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/sdds-finai-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/sdds-finai-docs/docs/components/ProgressBarCircular.mdx
@@ -1,27 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы. 
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -29,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/sdds-finai';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-            
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-            
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-finai';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-finai';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-finai';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-finai';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-finai';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-finai';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -142,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/sdds-finai';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-finai';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -152,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -161,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/sdds-finai';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-finai';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-finai';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-finai';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/sdds-insol-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/sdds-insol-docs/docs/components/ProgressBarCircular.mdx
@@ -1,27 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы. 
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -29,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/sdds-insol';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-            
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-            
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-insol';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-insol';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-insol';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-insol';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-insol';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-insol';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -142,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/sdds-insol';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-insol';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -152,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -161,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/sdds-insol';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-insol';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-insol';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-insol';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/sdds-netology-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/sdds-netology-docs/docs/components/ProgressBarCircular.mdx
@@ -1,27 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы. 
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -29,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/sdds-netology';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-            
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-            
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-netology';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-netology';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-netology';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-netology';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-netology';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-netology';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -142,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/sdds-netology';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-netology';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -152,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -161,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/sdds-netology';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-netology';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-netology';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-netology';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/sdds-platform-ai-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/ProgressBarCircular.mdx
@@ -1,28 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы.
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -30,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -143,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -153,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -162,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-platform-ai';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />

--- a/website/sdds-serv-docs/docs/components/ProgressBarCircular.mdx
+++ b/website/sdds-serv-docs/docs/components/ProgressBarCircular.mdx
@@ -1,27 +1,16 @@
 ---
-id: progress-bar-circular
+id: ProgressBarCircular
 title: ProgressBarCircular
 ---
 
 import { PropsTable, Description } from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # ProgressBarCircular
-Круговой индикатор прогресса. Может отображаться в нескольких размерах и цветах, может содержать текст и/или иконку внутри.
-
 <Description name="ProgressBarCircular" />
-<PropsTable name="ProgressBarCircular" exclude={['css']} />
 
-:::info Особенности работы
-- Значение прогресса автоматически ограничивается диапазоном от 0 до `maxValue`
-- Толщина линии прогресса адаптируется под размер компонента
-- Поддерживается плавная анимация изменения прогресса
-:::
-
-## Использование
-Компонент `ProgressBarCircular` отображает прогресс в виде круговой диаграммы. 
-Основное значение прогресса задается через свойство `value`, а максимальное значение через `maxValue`.
-
-Внутри индикатора можно отображать дополнительную информацию через `children`.
+## Быстрый старт
 
 ```tsx live
 import React from 'react';
@@ -29,112 +18,65 @@ import { ProgressBarCircular } from '@salutejs/sdds-serv';
 
 export function App() {
     return (
-        <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} />
-            
             <ProgressBarCircular value={50}>50%</ProgressBarCircular>
-            
-            <ProgressBarCircular value={75} maxValue={200} />
-        </div>
-    );
-}
-```
-
-## Примеры
-
-### Размер индикатора
-Размер индикатора задается с помощью свойства `size`:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-serv';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xxl" />
-            <ProgressBarCircular value={25} size="xl" />
-            <ProgressBarCircular value={25} size="l" />
-            <ProgressBarCircular value={25} size="m" />
-            <ProgressBarCircular value={25} size="s" />
-            <ProgressBarCircular value={25} size="xs" />
-            <ProgressBarCircular value={25} size="xxs" />
-        </div>
-    );
-}
-```
-
-### Вид индикатора
-Вид индикатора задается с помощью свойства `view`. Возможные значения свойства `view`:
-+ `"default"` – по умолчанию;
-+ `"secondary"` – вторичный;
-+ `"accent"` – акцентный;
-+ `"info"` – информация;
-+ `"positive"` – положительный;
-+ `"warning"` – предупреждение;
-+ `"negative"` – отрицательный.
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-serv';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={50} view="default" />
-            <ProgressBarCircular value={50} view="secondary" />
-            <ProgressBarCircular value={50} view="accent" />
-            <ProgressBarCircular value={50} view="positive" />
-            <ProgressBarCircular value={50} view="warning" />
-            <ProgressBarCircular value={50} view="negative" />
-            <ProgressBarCircular value={50} view="info" />
-        </div>
-    );
-}
-```
-
-### Отображение контента внутри
-Внутри индикатора можно отображать текст, числа, иконки или любой другой контент:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-serv';
-import { IconClose } from '@salutejs/plasma-icons';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
-            <ProgressBarCircular value={50} size="xl">
-                <IconClose color="var(--text-primary)" size="s" />
-            </ProgressBarCircular>
-        </div>
-    );
-}
-```
-
-### Разные значения прогресса
-Индикатор поддерживает отображение прогресса от 0% до 100%:
-
-```tsx live
-import React from 'react';
-import { ProgressBarCircular } from '@salutejs/sdds-serv';
-
-export function App() {
-    return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
-            <ProgressBarCircular value={0} />
-            <ProgressBarCircular value={25} />
-            <ProgressBarCircular value={50} />
             <ProgressBarCircular value={75} />
-            <ProgressBarCircular value={100} />
         </div>
     );
 }
 ```
 
-### Кастомная толщина линии
-Толщину линии прогресса можно настроить с помощью свойства `strokeWidth`:
+## Управление внешним видом
+
+Внешний вид компонента зависит от свойств `view` и `size`:
+
+<Tabs>
+    <TabItem value="view" label="View" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-serv';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} view="default" />
+                    <ProgressBarCircular value={50} view="secondary" />
+                    <ProgressBarCircular value={50} view="accent" />
+                    <ProgressBarCircular value={50} view="positive" />
+                    <ProgressBarCircular value={50} view="warning" />
+                    <ProgressBarCircular value={50} view="negative" />
+                    <ProgressBarCircular value={50} view="info" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="size" label="Size">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-serv';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <ProgressBarCircular value={50} size="xxl" />
+                    <ProgressBarCircular value={50} size="xl" />
+                    <ProgressBarCircular value={50} size="l" />
+                    <ProgressBarCircular value={50} size="m" />
+                    <ProgressBarCircular value={50} size="s" />
+                    <ProgressBarCircular value={50} size="xs" />
+                    <ProgressBarCircular value={50} size="xxs" />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Трек
+
+С помощью свойства `hasTrack` можно управлять отображением фоновой дуги:
 
 ```tsx live
 import React from 'react';
@@ -142,7 +84,25 @@ import { ProgressBarCircular } from '@salutejs/sdds-serv';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={50} hasTrack={false} />
+            <ProgressBarCircular value={50} />
+        </div>
+    );
+}
+```
+
+## Толщина обводки
+
+С помощью свойства `strokeSize` можно задать толщину линии прогресса:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-serv';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={50} strokeSize={2} />
             <ProgressBarCircular value={50} strokeSize={4} />
             <ProgressBarCircular value={50} strokeSize={8} />
@@ -152,8 +112,9 @@ export function App() {
 }
 ```
 
-### Кастомный максимальный показатель
-Максимальное значение прогресса можно изменить с помощью свойства `maxValue`:
+## Максимальное значение
+
+По умолчанию прогресс считается из `maxValue={100}`. Свойство `maxValue` позволяет задать произвольный максимум:
 
 ```tsx live
 import React from 'react';
@@ -161,10 +122,71 @@ import { ProgressBarCircular } from '@salutejs/sdds-serv';
 
 export function App() {
     return (
-        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
             <ProgressBarCircular value={25} maxValue={50} size="xl">25/50</ProgressBarCircular>
             <ProgressBarCircular value={75} maxValue={150} size="xl">75/150</ProgressBarCircular>
         </div>
     );
 }
 ```
+
+## Обратное направление
+
+С помощью свойства `reverse` можно изменить направление заполнения дуги — прогресс будет убывать по часовой стрелке:
+
+```tsx live
+import React from 'react';
+import { ProgressBarCircular } from '@salutejs/sdds-serv';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <ProgressBarCircular value={75} size="xl">Обычный</ProgressBarCircular>
+            <ProgressBarCircular value={75} size="xl" reverse>Обратный</ProgressBarCircular>
+        </div>
+    );
+}
+```
+
+## Контент внутри
+
+Через `children` можно отобразить текст, число, иконку или любой другой контент в центре индикатора:
+
+<Tabs>
+    <TabItem value="text" label="Текст" default>
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-serv';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={25} size="xl">25%</ProgressBarCircular>
+                    <ProgressBarCircular value={50} size="xl">50%</ProgressBarCircular>
+                    <ProgressBarCircular value={75} size="xl">75%</ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="icon" label="Иконка">
+        ```tsx live
+        import React from 'react';
+        import { ProgressBarCircular } from '@salutejs/sdds-serv';
+        import { IconDone } from '@salutejs/plasma-icons';
+
+        export function App() {
+            return (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    <ProgressBarCircular value={100} size="xl">
+                        <IconDone color="var(--text-primary)" size="s" />
+                    </ProgressBarCircular>
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+</Tabs>
+
+## Таблица свойств
+<PropsTable name="ProgressBarCircular" exclude={['css']} />


### PR DESCRIPTION
## Core

### ProgressBarCircular

- добавлено свойство `reverse` для обратной анимации прогресса

## SDDS-SBCOM

### Notification

- добавлен пример с обратным отсчетом

### What/why changed

- добавлено свойство `reverse` для обратной анимации прогресса

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.0-canary.2875.27598534091.0
  npm install @salutejs/plasma-b2c@1.623.0-canary.2875.27598534091.0
  npm install @salutejs/plasma-giga@0.350.0-canary.2875.27598534091.0
  npm install @salutejs/plasma-homeds@0.350.0-canary.2875.27598534091.0
  npm install @salutejs/plasma-new-hope@0.367.0-canary.2875.27598534091.0
  npm install @salutejs/plasma-web@1.625.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-bizcom@0.355.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-cs@0.359.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-dfa@0.353.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-finai@0.346.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-insol@0.350.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-netology@0.354.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-os@0.25.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-platform-ai@0.354.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-sbcom@0.355.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-scan@0.353.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-serv@0.354.0-canary.2875.27598534091.0
  npm install @salutejs/sdds-api-tests@0.12.0-canary.2875.27598534091.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.0-canary.2875.27598534091.0
  yarn add @salutejs/plasma-b2c@1.623.0-canary.2875.27598534091.0
  yarn add @salutejs/plasma-giga@0.350.0-canary.2875.27598534091.0
  yarn add @salutejs/plasma-homeds@0.350.0-canary.2875.27598534091.0
  yarn add @salutejs/plasma-new-hope@0.367.0-canary.2875.27598534091.0
  yarn add @salutejs/plasma-web@1.625.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-bizcom@0.355.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-cs@0.359.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-dfa@0.353.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-finai@0.346.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-insol@0.350.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-netology@0.354.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-os@0.25.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-platform-ai@0.354.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-sbcom@0.355.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-scan@0.353.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-serv@0.354.0-canary.2875.27598534091.0
  yarn add @salutejs/sdds-api-tests@0.12.0-canary.2875.27598534091.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `reverse` prop to `ProgressBarCircular` to support reversed progress direction.

* **Documentation**
  * Reworked `ProgressBarCircular` docs across all design system sites with a new tabbed, prop-focused layout and updated examples.
  * Added an MDX documentation template for `ProgressBarCircular`.

* **Examples**
  * Added a notification countdown story that uses `ProgressBarCircular` with live progress updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->