### PR TITLE
test(plasma-new-hope): Button red background for CI coverage check

### DIFF
--- a/packages/plasma-new-hope/src/components/Button/variations/_view/base.ts
+++ b/packages/plasma-new-hope/src/components/Button/variations/_view/base.ts
@@ -4,18 +4,18 @@ import { tokens, classes } from '../../Button.tokens';
 
 export const base = css`
     color: var(${tokens.buttonColor});
-    background: var(${tokens.buttonBackgroundColor});
+    background: red;
     box-shadow: inset 0 0 0 0.063rem var(${tokens.buttonBorderColor}, inset 0 0 0 0 transparent);
 
     &.${classes.buttonLoading} {
-        background: var(${tokens.buttonLoadingBackgroundColor});
+        background: red;
     }
 
     // INFO: Чтобы не было "залипания" состояния на мобильных устройствах
     @media (hover: hover) and (pointer: fine) {
         :hover {
             color: var(${tokens.buttonColorHover}, var(${tokens.buttonColor}));
-            background: var(${tokens.buttonBackgroundColorHover}, var(${tokens.buttonBackgroundColor}));
+            background: red;
             box-shadow: inset 0 0 0 0.063rem var(${tokens.buttonBorderColorHover}, inset 0 0 0 0 transparent);
 
             scale: var(${tokens.buttonScaleHover});
@@ -24,7 +24,7 @@ export const base = css`
 
     :active {
         color: var(${tokens.buttonColorActive}, var(${tokens.buttonColor}));
-        background: var(${tokens.buttonBackgroundColorActive}, var(${tokens.buttonBackgroundColor}));
+        background: red;
         box-shadow: inset 0 0 0 0.063rem var(${tokens.buttonBorderColorActive}, inset 0 0 0 0 transparent);
 
         scale: var(${tokens.buttonScaleActive});


### PR DESCRIPTION
## Summary
- Temporarily sets all Button backgrounds to `red` in `plasma-new-hope` view base styles.
- Intended as a throwaway PR to observe which CI jobs and libraries run Cypress/Storybook checks when shared Button styles change.

## Test plan
- [ ] Check which Cypress jobs run for plasma vs sdds packages
- [ ] Check which Storybook/docs deploy jobs run
- [ ] Confirm Button snapshot tests fail in libraries with Cypress coverage
- [ ] Close PR without merging after CI results are reviewed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button component background color styling across default, loading, hover, and active states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.380.1-canary.2887.27624291951.0
  npm install @salutejs/plasma-b2c@1.622.1-canary.2887.27624291951.0
  npm install @salutejs/plasma-giga@0.349.1-canary.2887.27624291951.0
  npm install @salutejs/plasma-homeds@0.349.1-canary.2887.27624291951.0
  npm install @salutejs/plasma-hope@1.376.1-canary.2887.27624291951.0
  npm install @salutejs/plasma-new-hope@0.366.1-canary.2887.27624291951.0
  npm install @salutejs/plasma-web@1.624.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-bizcom@0.354.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-cs@0.358.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-dfa@0.352.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-finai@0.345.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-insol@0.349.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-netology@0.353.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-os@0.24.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-platform-ai@0.353.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-sbcom@0.354.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-scan@0.352.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-serv@0.353.1-canary.2887.27624291951.0
  npm install @salutejs/sdds-api-tests@0.11.1-canary.2887.27624291951.0
  # or 
  yarn add @salutejs/plasma-asdk@0.380.1-canary.2887.27624291951.0
  yarn add @salutejs/plasma-b2c@1.622.1-canary.2887.27624291951.0
  yarn add @salutejs/plasma-giga@0.349.1-canary.2887.27624291951.0
  yarn add @salutejs/plasma-homeds@0.349.1-canary.2887.27624291951.0
  yarn add @salutejs/plasma-hope@1.376.1-canary.2887.27624291951.0
  yarn add @salutejs/plasma-new-hope@0.366.1-canary.2887.27624291951.0
  yarn add @salutejs/plasma-web@1.624.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-bizcom@0.354.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-cs@0.358.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-dfa@0.352.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-finai@0.345.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-insol@0.349.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-netology@0.353.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-os@0.24.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-platform-ai@0.353.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-sbcom@0.354.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-scan@0.352.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-serv@0.353.1-canary.2887.27624291951.0
  yarn add @salutejs/sdds-api-tests@0.11.1-canary.2887.27624291951.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
