### PR TITLE
chore: add Cursor rules for draft PRs targeting dev

### DIFF
--- a/.cursor/rules/pull-requests.mdc
+++ b/.cursor/rules/pull-requests.mdc
@@ -7,10 +7,12 @@ alwaysApply: true
 
 Always create pull requests in **Draft** mode until they are ready for review.
 
-When using `gh pr create`, include the `--draft` flag:
+**Base branch:** target `dev`, not `master`. See `CONTRIBUTING.md#pull-request`.
+
+When using `gh pr create`, include `--draft` and `--base dev`:
 
 ```bash
-gh pr create --draft --title "..." --body "$(cat <<'EOF'
+gh pr create --draft --base dev --title "..." --body "$(cat <<'EOF'
 ## Core
 
 ### ComponentName
@@ -31,6 +33,8 @@ Follow the structure in `.github/PULL_REQUEST_TEMPLATE.md`:
 - `###` heading — component, function, theme, etc.
 - Bullet list of changes
 - `### What/why changed` — **required**
+
+Exception: [HotFix](CONTRIBUTING.md#hotfix) PRs need a separate PR into `master` as well.
 
 Before marking ready for review (`gh pr ready`), verify the checklist from the template:
 

--- a/.cursor/rules/pull-requests.mdc
+++ b/.cursor/rules/pull-requests.mdc
@@ -1,0 +1,44 @@
+---
+description: Create pull requests as drafts until ready for review
+alwaysApply: true
+---
+
+# Pull Requests
+
+Always create pull requests in **Draft** mode until they are ready for review.
+
+When using `gh pr create`, include the `--draft` flag:
+
+```bash
+gh pr create --draft --title "..." --body "$(cat <<'EOF'
+## Core
+
+### ComponentName
+
+- change description
+
+### What/why changed
+
+Problem description and rationale.
+
+EOF
+)"
+```
+
+Follow the structure in `.github/PULL_REQUEST_TEMPLATE.md`:
+
+- `##` heading — scope: `Core`, or a specific library (`SDDS-CS`, `PLASMA-WEB`, `PLASMA-ICONS`)
+- `###` heading — component, function, theme, etc.
+- Bullet list of changes
+- `### What/why changed` — **required**
+
+Before marking ready for review (`gh pr ready`), verify the checklist from the template:
+
+- Issue number added (if applicable)
+- Cypress tests added/updated for visual changes
+
+Mark a PR as ready for review only when the user explicitly asks (e.g. "mark PR ready for review", "take out of draft"):
+
+```bash
+gh pr ready
+```


### PR DESCRIPTION
## Chore

### Cursor rules, GitHub workflow

- добавлено правило `.cursor/rules/pull-requests.mdc` для создания PR в draft-режиме;
- зафиксирована целевая ветка `dev` (не `master`) и формат описания по `.github/PULL_REQUEST_TEMPLATE.md`;
- описан чеклист перед `gh pr ready` и исключение для HotFix.

### What/why changed

Унифицируем работу с GitHub для агентов и разработчиков: PR открываются как draft до готовности к ревью, базовая ветка всегда `dev`, тело PR следует шаблону репозитория. Это снижает риск случайных PR в `master` и неполных описаний.

Made with [Cursor](https://cursor.com)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.380.1-canary.2890.27636785383.0
  npm install @salutejs/plasma-b2c@1.622.1-canary.2890.27636785383.0
  npm install @salutejs/plasma-giga@0.349.1-canary.2890.27636785383.0
  npm install @salutejs/plasma-homeds@0.349.1-canary.2890.27636785383.0
  npm install @salutejs/plasma-hope@1.376.1-canary.2890.27636785383.0
  npm install @salutejs/plasma-new-hope@0.366.1-canary.2890.27636785383.0
  npm install @salutejs/plasma-web@1.624.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-bizcom@0.354.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-cs@0.358.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-dfa@0.352.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-finai@0.345.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-insol@0.349.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-netology@0.353.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-os@0.24.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-platform-ai@0.353.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-sbcom@0.354.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-scan@0.352.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-serv@0.353.1-canary.2890.27636785383.0
  npm install @salutejs/sdds-api-tests@0.11.1-canary.2890.27636785383.0
  # or 
  yarn add @salutejs/plasma-asdk@0.380.1-canary.2890.27636785383.0
  yarn add @salutejs/plasma-b2c@1.622.1-canary.2890.27636785383.0
  yarn add @salutejs/plasma-giga@0.349.1-canary.2890.27636785383.0
  yarn add @salutejs/plasma-homeds@0.349.1-canary.2890.27636785383.0
  yarn add @salutejs/plasma-hope@1.376.1-canary.2890.27636785383.0
  yarn add @salutejs/plasma-new-hope@0.366.1-canary.2890.27636785383.0
  yarn add @salutejs/plasma-web@1.624.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-bizcom@0.354.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-cs@0.358.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-dfa@0.352.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-finai@0.345.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-insol@0.349.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-netology@0.353.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-os@0.24.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-platform-ai@0.353.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-sbcom@0.354.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-scan@0.352.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-serv@0.353.1-canary.2890.27636785383.0
  yarn add @salutejs/sdds-api-tests@0.11.1-canary.2890.27636785383.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No end-user visible changes in this release. This update addresses internal development workflow and pull request management processes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->