### PR TITLE
sdds-infra: Fix documentation deploy preview comment links

### DIFF
--- a/.github/create-links.js
+++ b/.github/create-links.js
@@ -1,13 +1,35 @@
-module.exports = () => {
-    const { PACKAGES_DS, BASE_URL } = process.env;
+const getStorybookShortName = (packageName) => packageName.replace(/^plasma-/, '');
 
-    const links = JSON.parse(PACKAGES_DS)
-        .map((item) => {
-            const name = item.replace('plasma-', '');
+module.exports = () => {
+    const { DEPLOYED_PACKAGES, BASE_URL, INCLUDE_WEBSITE } = process.env;
+    const deployedPackages = JSON.parse(DEPLOYED_PACKAGES || '[]');
+    const includeWebsite = INCLUDE_WEBSITE === 'true';
+
+    const storybookLinks = deployedPackages
+        .map((packageName) => {
+            const name = getStorybookShortName(packageName);
 
             return `${name} storybook: ${BASE_URL}/${name}-storybook/`;
         })
         .join('\n');
 
-    return 'Documentation preview deployed!' + '\n\n' + `website: ${BASE_URL}/` + '\n' + `${links}`;
+    const parts = ['Documentation preview deployed!', ''];
+
+    if (includeWebsite) {
+        parts.push(`website: ${BASE_URL}/`);
+    }
+
+    if (storybookLinks) {
+        if (includeWebsite) {
+            parts.push('');
+        }
+
+        parts.push(storybookLinks);
+    }
+
+    if (!includeWebsite && !storybookLinks) {
+        return 'Documentation preview deploy finished with no published links.';
+    }
+
+    return parts.join('\n');
 };

--- a/.github/get-deployed-packages.js
+++ b/.github/get-deployed-packages.js
@@ -1,0 +1,39 @@
+const DEPLOY_ARTIFACTS_JOB_PATTERN = /^Deploy artifacts \((.+)\)$/;
+
+/**
+ * Returns package names from successful deploy-artifacts matrix jobs in the current workflow run.
+ */
+module.exports = async (github, context) => {
+    const deployedPackages = [];
+    let page = 1;
+
+    while (true) {
+        const { data } = await github.rest.actions.listJobsForWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: context.runId,
+            per_page: 100,
+            page,
+        });
+
+        for (const job of data.jobs) {
+            if (job.conclusion !== 'success') {
+                continue;
+            }
+
+            const match = job.name.match(DEPLOY_ARTIFACTS_JOB_PATTERN);
+
+            if (match) {
+                deployedPackages.push(match[1]);
+            }
+        }
+
+        if (data.jobs.length < 100) {
+            break;
+        }
+
+        page += 1;
+    }
+
+    return deployedPackages.sort();
+};

--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -212,7 +212,7 @@ jobs:
     attache-comment:
         name: Attached comment
         needs: [ state, deploy-website, deploy-artifacts ]
-        if: ${{ always() && (contains(needs.deploy-website.result, 'success') || contains(needs.deploy-artifacts.result, 'success')) }}
+        if: ${{ always() && (needs.deploy-website.result == 'success' || needs.deploy-artifacts.result == 'success' || needs.deploy-artifacts.result == 'failure') }}
         runs-on: ubuntu-22.04
         steps:
             -   uses: actions/checkout@v4
@@ -224,12 +224,17 @@ jobs:
                 id: comment-link
                 uses: actions/github-script@v7
                 env:
-                    PACKAGES_DS: ${{ toJSON(fromJSON(needs.state.outputs.STATE).PACKAGES_DOCUMENTATIONS_RUN) }}
                     BASE_URL: ${{ vars.STAGE_STABLE_URL }}/pr/pr-${{ github.event.number }}
+                    INCLUDE_WEBSITE: ${{ needs.deploy-website.result == 'success' }}
                 with:
                     result-encoding: string
                     script: |
+                        const getDeployedPackages = require('./.github/get-deployed-packages.js');
                         const createLinks = require('./.github/create-links.js');
+
+                        const deployedPackages = await getDeployedPackages(github, context);
+
+                        process.env.DEPLOYED_PACKAGES = JSON.stringify(deployedPackages);
 
                         return createLinks();
 

--- a/.github/workflows/documentation-deploy-release-branch.yml
+++ b/.github/workflows/documentation-deploy-release-branch.yml
@@ -178,7 +178,7 @@ jobs:
   attache-comment:
     name: Attached comment
     needs: [ prepare-config-deploy, deploy-website, deploy-artifacts ]
-    if: ${{ always() && (contains(needs.deploy-website.result, 'success') || contains(needs.deploy-artifacts.result, 'success')) }}
+    if: ${{ always() && (needs.deploy-website.result == 'success' || needs.deploy-artifacts.result == 'success' || needs.deploy-artifacts.result == 'failure') }}
     runs-on: ubuntu-22.04
     steps:
       -   uses: actions/checkout@v4
@@ -190,12 +190,17 @@ jobs:
           id: comment-link
           uses: actions/github-script@v7
           env:
-            PACKAGES_DS: ${{ toJSON(fromJSON(needs.prepare-config-deploy.outputs.MATRIX)) }}
             BASE_URL: ${{ vars.STAGE_STABLE_URL }}/pr/pr-${{ github.event.number }}
+            INCLUDE_WEBSITE: ${{ needs.deploy-website.result == 'success' }}
           with:
             result-encoding: string
             script: |
+              const getDeployedPackages = require('./.github/get-deployed-packages.js');
               const createLinks = require('./.github/create-links.js');
+
+              const deployedPackages = await getDeployedPackages(github, context);
+
+              process.env.DEPLOYED_PACKAGES = JSON.stringify(deployedPackages);
 
               return createLinks();
 


### PR DESCRIPTION
## Core

### Documentation deploy workflows

- added `get-deployed-packages.js` to resolve storybook links from successfully deployed artifact jobs in the current workflow run
- updated `create-links.js` to build the PR comment from actually deployed packages and optional website deploy status
- adjusted `attache-comment` job conditions in PR and release-branch documentation deploy workflows to post a comment when artifact deploy fails
- removed reliance on the planned deploy matrix (`PACKAGES_DS` / `MATRIX`) when generating preview links

### What/why changed

Documentation preview comments could list storybook links for packages that were planned in the deploy matrix but did not actually deploy, or skip posting a comment when artifact deployment partially failed. The comment is now generated from successful `Deploy artifacts (<package>)` jobs and includes only links that were really published; website link is shown only when website deploy succeeded.

Made with [Cursor](https://cursor.com)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.380.1-canary.2893.27701294838.0
  npm install @salutejs/plasma-b2c@1.622.1-canary.2893.27701294838.0
  npm install @salutejs/plasma-giga@0.349.1-canary.2893.27701294838.0
  npm install @salutejs/plasma-homeds@0.349.1-canary.2893.27701294838.0
  npm install @salutejs/plasma-hope@1.376.1-canary.2893.27701294838.0
  npm install @salutejs/plasma-new-hope@0.366.1-canary.2893.27701294838.0
  npm install @salutejs/plasma-ui@1.352.1-canary.2893.27701294838.0
  npm install @salutejs/plasma-web@1.624.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-bizcom@0.354.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-cs@0.358.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-dfa@0.352.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-finai@0.345.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-insol@0.349.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-netology@0.353.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-os@0.24.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-platform-ai@0.353.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-sbcom@0.354.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-scan@0.352.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-serv@0.353.1-canary.2893.27701294838.0
  npm install @salutejs/sdds-api-tests@0.11.1-canary.2893.27701294838.0
  npm install @salutejs/plasma-sb-utils@0.230.1-canary.2893.27701294838.0
  # or 
  yarn add @salutejs/plasma-asdk@0.380.1-canary.2893.27701294838.0
  yarn add @salutejs/plasma-b2c@1.622.1-canary.2893.27701294838.0
  yarn add @salutejs/plasma-giga@0.349.1-canary.2893.27701294838.0
  yarn add @salutejs/plasma-homeds@0.349.1-canary.2893.27701294838.0
  yarn add @salutejs/plasma-hope@1.376.1-canary.2893.27701294838.0
  yarn add @salutejs/plasma-new-hope@0.366.1-canary.2893.27701294838.0
  yarn add @salutejs/plasma-ui@1.352.1-canary.2893.27701294838.0
  yarn add @salutejs/plasma-web@1.624.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-bizcom@0.354.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-cs@0.358.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-dfa@0.352.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-finai@0.345.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-insol@0.349.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-netology@0.353.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-os@0.24.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-platform-ai@0.353.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-sbcom@0.354.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-scan@0.352.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-serv@0.353.1-canary.2893.27701294838.0
  yarn add @salutejs/sdds-api-tests@0.11.1-canary.2893.27701294838.0
  yarn add @salutejs/plasma-sb-utils@0.230.1-canary.2893.27701294838.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
