### PR TITLE
PLASMA-5873: Свойство readOnly помечено как `deprecated`

### DIFF
--- a/packages/plasma-new-hope/src/components/Checkbox/Checkbox.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Checkbox/Checkbox.template-doc.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/packages/plasma-new-hope/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/plasma-new-hope/src/components/Checkbox/Checkbox.types.ts
@@ -1,18 +1,33 @@
-import type { InputHTMLAttributes } from '../../types';
+import type { InputHTMLAttributes } from 'src/types';
+import type { ReactNode } from 'react';
 
 export interface BaseboxProps {
     /**
-     * Уникальный идентификатор control
+     * Стиль для UI конфигурации
+     * Влияет на выбор предустановленного набора токенов
+     * @default default
+     */
+    appearance?: string;
+    /**
+     * Размер компонента
+     */
+    size?: string;
+    /**
+     * Вид компонента
+     */
+    view?: string;
+    /**
+     * Уникальный идентификатор компонента
      */
     id?: string;
     /**
      * Метка-подпись к элементу
      */
-    label?: React.ReactNode;
+    label?: ReactNode;
     /**
      * Описание элемента
      */
-    description?: React.ReactNode;
+    description?: ReactNode;
     /**
      * Title и description в одну строку или с переносом строк
      */
@@ -21,18 +36,18 @@ export interface BaseboxProps {
      * Неопределенное состояние компонента - когда часть потомков не выбрана.
      */
     indeterminate?: boolean;
-    appearance?: string;
-    size?: string;
-    view?: string;
+    /**
+     * Компонента находиться в фокусе
+     */
     focused?: boolean;
     /**
      * Кастомная иконка галочки.
      */
-    checkIcon?: React.ReactNode;
+    checkIcon?: ReactNode;
     /**
      * Кастомная иконка indeterminate-состояния.
      */
-    indeterminateIcon?: React.ReactNode;
+    indeterminateIcon?: ReactNode;
 }
 
 export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>, BaseboxProps {}

--- a/packages/plasma-new-hope/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/plasma-new-hope/src/components/Checkbox/Checkbox.types.ts
@@ -48,6 +48,12 @@ export interface BaseboxProps {
      * Кастомная иконка indeterminate-состояния.
      */
     indeterminateIcon?: ReactNode;
+    /**
+     * Состояние readOnly применяется исключительно к текстовым полям.
+     * @deprecated
+     * @see https://html.spec.whatwg.org/multipage/input.html#do-not-apply
+     */
+    readOnly?: boolean;
 }
 
-export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>, BaseboxProps {}
+export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'readOnly'>, BaseboxProps {}

--- a/packages/plasma-new-hope/src/components/Radiobox/Radiobox.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Radiobox/Radiobox.template-doc.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/plasma-b2c-docs/docs/components/Checkbox.mdx
+++ b/website/plasma-b2c-docs/docs/components/Checkbox.mdx
@@ -7,12 +7,12 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
-Актуальным значением для свойства `view` - является `accent`. 
+Актуальным значением для свойства `view` - является `accent`.
 
-Все остальные значения `deprecated` и будут удалены в ближайшее время! 
+Все остальные значения `deprecated` и будут удалены в ближайшее время!
 :::
 
 ## Использование
@@ -41,9 +41,9 @@ import { Checkbox } from '@salutejs/plasma-b2c';
 
 export function App() {
     return (
-        <Checkbox 
-            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>} 
-            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}  
+        <Checkbox
+            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>}
+            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}
         />
     );
 }

--- a/website/plasma-b2c-docs/docs/components/Radiobox.mdx
+++ b/website/plasma-b2c-docs/docs/components/Radiobox.mdx
@@ -7,12 +7,12 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
-Актуальным значением для свойства `view` - является `accent`. 
+Актуальным значением для свойства `view` - является `accent`.
 
-Все остальные значения `deprecated` и будут удалены в ближайшее время! 
+Все остальные значения `deprecated` и будут удалены в ближайшее время!
 :::
 <StorybookLink name="Radiobox" />
 

--- a/website/plasma-giga-docs/docs/components/Checkbox.mdx
+++ b/website/plasma-giga-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/plasma-giga-docs/docs/components/Radiobox.mdx
+++ b/website/plasma-giga-docs/docs/components/Radiobox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/plasma-homeds-docs/docs/components/Checkbox.mdx
+++ b/website/plasma-homeds-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 ## Использование
 Компонент `Checkbox` может содержать лейбл и описание.

--- a/website/plasma-homeds-docs/docs/components/Radiobox.mdx
+++ b/website/plasma-homeds-docs/docs/components/Radiobox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 ## Использование
 Компонент `Radiobox` может содержать лейбл и описание.

--- a/website/plasma-web-docs/docs/components/Checkbox.mdx
+++ b/website/plasma-web-docs/docs/components/Checkbox.mdx
@@ -7,12 +7,12 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
-Актуальным значением для свойства `view` - является `accent`. 
+Актуальным значением для свойства `view` - является `accent`.
 
-Все остальные значения `deprecated` и будут удалены в ближайшее время! 
+Все остальные значения `deprecated` и будут удалены в ближайшее время!
 :::
 
 ## Использование
@@ -30,7 +30,7 @@ export function App() {
 ```
 
 Свойства `description` и `label` могут принимать JSX элементы.
-По умолчанию, контент внутри лейбла и описания многострочный. Для того, чтобы стал однострочным, необходимо использовать свойство `singleLine`(по умолчанию `false`).
+По умолчанию, контент внутри лейбла и описания многострочный. Для того чтобы стал однострочным, необходимо использовать свойство `singleLine`(по умолчанию `false`).
 
 ```tsx live
 import React from 'react';
@@ -38,9 +38,9 @@ import { Checkbox } from '@salutejs/plasma-web';
 
 export function App() {
     return (
-        <Checkbox 
-            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>} 
-            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}  
+        <Checkbox
+            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>}
+            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}
         />
     );
 }

--- a/website/plasma-web-docs/docs/components/Radiobox.mdx
+++ b/website/plasma-web-docs/docs/components/Radiobox.mdx
@@ -7,12 +7,12 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
-Актуальным значением для свойства `view` - является `accent`. 
+Актуальным значением для свойства `view` - является `accent`.
 
-Все остальные значения `deprecated` и будут удалены в ближайшее время! 
+Все остальные значения `deprecated` и будут удалены в ближайшее время!
 :::
 <StorybookLink name="Radiobox" />
 

--- a/website/sdds-bizcom-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-bizcom-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-bizcom-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-bizcom-docs/docs/components/Radiobox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-cs-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-cs-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 ## Использование
 Компонент `Checkbox` может содержать лейбл и описание.
@@ -25,7 +25,7 @@ export function App() {
 
 Свойства `description` и `label` могут принимать JSX элементы.
 
-По умолчанию, контент внутри лейбла и описания многострочный. 
+По умолчанию, контент внутри лейбла и описания многострочный.
 
 Для того чтобы стал однострочным, необходимо использовать свойство `singleLine`(по умолчанию `false`).
 
@@ -35,9 +35,9 @@ import { Checkbox } from '@salutejs/sdds-cs';
 
 export function App() {
     return (
-        <Checkbox 
-            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>} 
-            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}  
+        <Checkbox
+            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>}
+            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}
         />
     );
 }

--- a/website/sdds-cs-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-cs-docs/docs/components/Radiobox.mdx
@@ -7,12 +7,12 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 ## Использование
 Компонент `Radiobox` может содержать лейбл и описание.
 
-По умолчанию, контент внутри лейбла и описания многострочный. 
+По умолчанию, контент внутри лейбла и описания многострочный.
 
 Для того чтобы стал однострочным, необходимо использовать свойство `singleLine`(по умолчанию `false`).
 

--- a/website/sdds-finai-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-finai-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-finai-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-finai-docs/docs/components/Radiobox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-insol-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-insol-docs/docs/components/Checkbox.mdx
@@ -7,12 +7,12 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
-Актуальным значением для свойства `view` - является `accent`. 
+Актуальным значением для свойства `view` - является `accent`.
 
-Все остальные значения `deprecated` и будут удалены в ближайшее время! 
+Все остальные значения `deprecated` и будут удалены в ближайшее время!
 :::
 
 ## Использование
@@ -31,7 +31,7 @@ export function App() {
 
 Свойства `description` и `label` могут принимать JSX элементы.
 
-По умолчанию, контент внутри лейбла и описания многострочный. 
+По умолчанию, контент внутри лейбла и описания многострочный.
 
 Для того чтобы стал однострочным, необходимо использовать свойство `singleLine`(по умолчанию `false`).
 
@@ -41,9 +41,9 @@ import { Checkbox } from '@salutejs/sdds-insol';
 
 export function App() {
     return (
-        <Checkbox 
-            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>} 
-            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}  
+        <Checkbox
+            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>}
+            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}
         />
     );
 }

--- a/website/sdds-insol-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-insol-docs/docs/components/Radiobox.mdx
@@ -7,18 +7,18 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
-Актуальным значением для свойства `view` - является `accent`. 
+Актуальным значением для свойства `view` - является `accent`.
 
-Все остальные значения `deprecated` и будут удалены в ближайшее время! 
+Все остальные значения `deprecated` и будут удалены в ближайшее время!
 :::
 
 ## Использование
 Компонент `Radiobox` может содержать лейбл и описание.
 
-По умолчанию, контент внутри лейбла и описания многострочный. 
+По умолчанию, контент внутри лейбла и описания многострочный.
 
 Для того чтобы стал однострочным, необходимо использовать свойство `singleLine`(по умолчанию `false`).
 

--- a/website/sdds-netology-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-netology-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-netology-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-netology-docs/docs/components/Radiobox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-platform-ai-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 ## Использование
 Компонент `Checkbox` может содержать лейбл и описание.

--- a/website/sdds-platform-ai-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/Radiobox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 ## Использование
 Компонент `Radiobox` может содержать лейбл и описание.

--- a/website/sdds-sbcom-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-sbcom-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-sbcom-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-sbcom-docs/docs/components/Radiobox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-scan-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-scan-docs/docs/components/Checkbox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-scan-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-scan-docs/docs/components/Radiobox.mdx
@@ -7,7 +7,7 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
 Актуальным значением для свойства `view` - является `accent`.

--- a/website/sdds-serv-docs/docs/components/Checkbox.mdx
+++ b/website/sdds-serv-docs/docs/components/Checkbox.mdx
@@ -7,12 +7,12 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Checkbox
 <Description name="Checkbox" />
-<PropsTable name="Checkbox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Checkbox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
-Актуальным значением для свойства `view` - является `accent`. 
+Актуальным значением для свойства `view` - является `accent`.
 
-Все остальные значения `deprecated` и будут удалены в ближайшее время! 
+Все остальные значения `deprecated` и будут удалены в ближайшее время!
 :::
 
 ## Использование
@@ -31,7 +31,7 @@ export function App() {
 
 Свойства `description` и `label` могут принимать JSX элементы.
 
-По умолчанию, контент внутри лейбла и описания многострочный. 
+По умолчанию, контент внутри лейбла и описания многострочный.
 
 Для того чтобы стал однострочным, необходимо использовать свойство `singleLine`(по умолчанию `false`).
 
@@ -41,9 +41,9 @@ import { Checkbox } from '@salutejs/sdds-serv';
 
 export function App() {
     return (
-        <Checkbox 
-            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>} 
-            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}  
+        <Checkbox
+            label={<div>Чекбокс со <a href="/#">ссылкой</a></div>}
+            description={<div>Описание чекбокса со <a href="/#">ссылкой</a></div>}
         />
     );
 }

--- a/website/sdds-serv-docs/docs/components/Radiobox.mdx
+++ b/website/sdds-serv-docs/docs/components/Radiobox.mdx
@@ -7,18 +7,18 @@ import { PropsTable, Description } from '@site/src/components';
 
 # Radiobox
 <Description name="Radiobox" />
-<PropsTable name="Radiobox" exclude={['css', 'focused']} include={['defaultChecked']} />
+<PropsTable name="Radiobox" exclude={['css', 'focused', 'readOnly']} include={['defaultChecked']} />
 
 :::caution Устаревшие значения для свойства view
-Актуальным значением для свойства `view` - является `accent`. 
+Актуальным значением для свойства `view` - является `accent`.
 
-Все остальные значения `deprecated` и будут удалены в ближайшее время! 
+Все остальные значения `deprecated` и будут удалены в ближайшее время!
 :::
 
 ## Использование
 Компонент `Radiobox` может содержать лейбл и описание.
 
-По умолчанию, контент внутри лейбла и описания многострочный. 
+По умолчанию, контент внутри лейбла и описания многострочный.
 
 Для того чтобы стал однострочным, необходимо использовать свойство `singleLine`(по умолчанию `false`).
 


### PR DESCRIPTION
## Core

### Checkbox, Radiobox 

-  cвойство `readOnly` помечено как `deprecated`

### What/why changed

Прямая ссылка на спецификацию WHATWG HTML Standard, где определён список типов, к которым применяется readonly:

https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly

Там для каждого типа <input> указано в таблице «Content attributes», применяется ли к нему readonly. 

Для checkbox, radio, color, range, file и кнопок - **не применяется**.

Более явная формулировка - в разделе про список применимости атрибутов: 

https://html.spec.whatwg.org/multipage/input.html#do-not-apply

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.380.1-canary.2895.27739720201.0
  npm install @salutejs/plasma-b2c@1.622.1-canary.2895.27739720201.0
  npm install @salutejs/plasma-giga@0.349.1-canary.2895.27739720201.0
  npm install @salutejs/plasma-homeds@0.349.1-canary.2895.27739720201.0
  npm install @salutejs/plasma-hope@1.376.1-canary.2895.27739720201.0
  npm install @salutejs/plasma-new-hope@0.366.1-canary.2895.27739720201.0
  npm install @salutejs/plasma-ui@1.352.1-canary.2895.27739720201.0
  npm install @salutejs/plasma-web@1.624.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-bizcom@0.354.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-cs@0.358.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-dfa@0.352.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-finai@0.345.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-insol@0.349.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-netology@0.353.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-os@0.24.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-platform-ai@0.353.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-sbcom@0.354.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-scan@0.352.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-serv@0.353.1-canary.2895.27739720201.0
  npm install @salutejs/sdds-api-tests@0.11.1-canary.2895.27739720201.0
  npm install @salutejs/plasma-sb-utils@0.230.1-canary.2895.27739720201.0
  # or 
  yarn add @salutejs/plasma-asdk@0.380.1-canary.2895.27739720201.0
  yarn add @salutejs/plasma-b2c@1.622.1-canary.2895.27739720201.0
  yarn add @salutejs/plasma-giga@0.349.1-canary.2895.27739720201.0
  yarn add @salutejs/plasma-homeds@0.349.1-canary.2895.27739720201.0
  yarn add @salutejs/plasma-hope@1.376.1-canary.2895.27739720201.0
  yarn add @salutejs/plasma-new-hope@0.366.1-canary.2895.27739720201.0
  yarn add @salutejs/plasma-ui@1.352.1-canary.2895.27739720201.0
  yarn add @salutejs/plasma-web@1.624.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-bizcom@0.354.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-cs@0.358.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-dfa@0.352.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-finai@0.345.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-insol@0.349.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-netology@0.353.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-os@0.24.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-platform-ai@0.353.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-sbcom@0.354.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-scan@0.352.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-serv@0.353.1-canary.2895.27739720201.0
  yarn add @salutejs/sdds-api-tests@0.11.1-canary.2895.27739720201.0
  yarn add @salutejs/plasma-sb-utils@0.230.1-canary.2895.27739720201.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deprecated `readOnly` property to Checkbox component with HTML spec reference.

* **Documentation**
  * Updated Checkbox and Radiobox documentation across all platforms to exclude `readOnly` from displayed properties table.
  * Improved component documentation formatting and layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->