### PR TITLE
PLASMA-7392: improve types in portal props

### DIFF
--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
@@ -35,7 +35,7 @@ export type AutocompleteProps<T extends SuggestionItemType = SuggestionItemType>
     /**
      * Портал для выпадающего списка. Принимает id контейнера или ref.
      */
-    portal?: string | React.RefObject<HTMLElement>;
+    portal?: string | React.RefObject<HTMLElement | null>;
     /**
      * CSS-свойство z-index для выпадающего списка.
      */

--- a/packages/plasma-new-hope/src/components/Autocomplete/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Autocomplete/FloatingPopover.tsx
@@ -70,7 +70,7 @@ const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
 );
 
 type FloatingPortalReturnedProps = {
-    root?: React.RefObject<HTMLElement>;
+    root?: React.RefObject<HTMLElement | null>;
     id?: string;
 };
 

--- a/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/plasma-new-hope/src/components/Dropdown/Dropdown.types.ts
@@ -107,7 +107,7 @@ export type DropdownProps<T extends ItemOption = ItemOption> = {
     /**
      * Портал для выпадающего списка. Принимает id контейнера или ref.
      */
-    portal?: string | RefObject<HTMLElement>;
+    portal?: string | RefObject<HTMLElement | null>;
     /**
      * Callback для кастомной настройки айтема в выпадающем списке.
      */

--- a/packages/plasma-new-hope/src/components/Dropdown/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Dropdown/FloatingPopover.tsx
@@ -93,7 +93,7 @@ const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
 );
 
 type FloatingPortalReturnedProps = {
-    root?: React.RefObject<HTMLElement>;
+    root?: React.RefObject<HTMLElement | null>;
     id?: string;
 };
 

--- a/packages/plasma-new-hope/src/components/Popover/Popover.types.ts
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.types.ts
@@ -36,7 +36,7 @@ export type CustomPopoverProps = {
     /**
      * В каком контейнере позиционируется(по умолчанию document), можно также указать id элемента или ref для него.
      */
-    frame?: 'document' | string | RefObject<HTMLElement>;
+    frame?: 'document' | string | RefObject<HTMLElement | null>;
     /**
      * Элемент или ref на элемент, рядом с которым произойдет вызов всплывающего окна.
      */

--- a/packages/plasma-new-hope/src/components/Popup/Popup.types.ts
+++ b/packages/plasma-new-hope/src/components/Popup/Popup.types.ts
@@ -40,7 +40,7 @@ export interface PopupProps extends React.HTMLAttributes<HTMLDivElement> {
     /**
      * В каком контейнере позиционируется (по умолчанию document), можно также указать id элемента или ref для него.
      */
-    frame?: 'document' | string | React.RefObject<HTMLElement>;
+    frame?: 'document' | string | React.RefObject<HTMLElement | null>;
     /**
      * Если `frame` отличается от `document` применяет `position='fixed'`
      *  @description Может быть полезно, когда во frame происходит дополнительная стилизация содержимого компонента,

--- a/utils/api-tests/src/components/Popover/Popover.api.test.tsx
+++ b/utils/api-tests/src/components/Popover/Popover.api.test.tsx
@@ -14,7 +14,7 @@ describe('Basics', () => {
         expectTypeOf<PopoverProps>().toHaveProperty('offset').toEqualTypeOf<[number, number] | undefined>();
         expectTypeOf<PopoverProps>()
             .toHaveProperty('frame')
-            .toEqualTypeOf<string | RefObject<HTMLElement> | undefined>();
+            .toEqualTypeOf<string | RefObject<HTMLElement | null> | undefined>();
         expectTypeOf<PopoverProps>().toHaveProperty('hasArrow').toEqualTypeOf<boolean | undefined>();
         expectTypeOf<PopoverProps>().toHaveProperty('zIndex').toEqualTypeOf<string | undefined>();
         expectTypeOf<PopoverProps>().toHaveProperty('preventOverflow').toEqualTypeOf<boolean | undefined>();


### PR DESCRIPTION
## Core

### Autocomplete, Dropdown, Popover, Popup
- улучшена типизация свойств `portal`;

### What/why changed
- улучшена типизация свойств `portal`;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type compatibility for portal/frame/root refs across Autocomplete, Dropdown, Popover, and Popup, now supporting refs whose referenced element may be `null` at runtime.
* **Tests**
  * Updated Popover API typing checks to match the new `frame` ref nullability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-b2c@1.623.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-core@1.230.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-giga@0.350.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-homeds@0.350.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-hope@1.377.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-new-hope@0.367.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-ui@1.353.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-web@1.625.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-bizcom@0.355.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-cs@0.359.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-dfa@0.353.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-finai@0.346.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-insol@0.350.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-netology@0.354.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-os@0.25.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-platform-ai@0.354.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-sbcom@0.355.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-scan@0.353.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-serv@0.354.0-canary.2896.27808886164.0
  npm install @salutejs/sdds-api-tests@0.12.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-cy-utils@0.160.0-canary.2896.27808886164.0
  npm install @salutejs/plasma-sb-utils@0.231.0-canary.2896.27808886164.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-b2c@1.623.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-core@1.230.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-giga@0.350.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-homeds@0.350.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-hope@1.377.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-new-hope@0.367.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-ui@1.353.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-web@1.625.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-bizcom@0.355.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-cs@0.359.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-dfa@0.353.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-finai@0.346.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-insol@0.350.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-netology@0.354.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-os@0.25.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-platform-ai@0.354.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-sbcom@0.355.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-scan@0.353.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-serv@0.354.0-canary.2896.27808886164.0
  yarn add @salutejs/sdds-api-tests@0.12.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-cy-utils@0.160.0-canary.2896.27808886164.0
  yarn add @salutejs/plasma-sb-utils@0.231.0-canary.2896.27808886164.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
