### PR TITLE
PLASMA-7543: storybook in sdds-serv based on css

### DIFF
--- a/packages/sdds-serv/.storybook/main.ts
+++ b/packages/sdds-serv/.storybook/main.ts
@@ -1,23 +1,151 @@
 import { mergeConfig } from 'vite';
+import type { Plugin } from 'vite';
 import type { StorybookConfig } from '@storybook/react-vite';
 import linaria from '@linaria/vite';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const USE_EMOTION_COMPONENTS = process.env.USE_EMOTION_COMPONENTS || false;
+// @ts-ignore
+const require = createRequire(import.meta.url);
+// @ts-ignore
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const storyMap = {
-    linaria: ['../src/**/*.stories.tsx'],
-    emotion: ['../src-emotion/**/*.stories.tsx'],
+const PLASMA_NEW_HOPE_SC = '@salutejs/plasma-new-hope/styled-components';
+const PLASMA_NEW_HOPE_CSS = '@salutejs/plasma-new-hope/css';
+const PLASMA_NEW_HOPE_SRC = path.resolve(__dirname, '../../plasma-new-hope/src/index.ts');
+const SDDS_SERV_TOKENS = '@salutejs/sdds-themes/tokens/sdds_serv';
+const nodeModulesRegExp = /[\\/]node_modules[\\/]/;
+const storybookViteDepsRegExp = /[\\/]node_modules[\\/]\.cache[\\/]storybook[\\/].*[\\/]sb-vite[\\/]deps[\\/]/;
+const hasImportOrExport = (code: string) => /(?:^|\*\/|;|})\s*(?:export|import)\s/m.test(code);
+const linariaResolveStorage = new AsyncLocalStorage<boolean>();
+
+const replaceAllImports = (code: string) => code.split(PLASMA_NEW_HOPE_SC).join(PLASMA_NEW_HOPE_CSS);
+
+const transformToCssComponents = (): Plugin => ({
+    name: 'sdds-serv-css-components',
+    enforce: 'pre' as const,
+    transform(code: string, id: string) {
+        const [filename] = id.split('?', 1);
+
+        if (!filename.includes(`${path.sep}src${path.sep}`)) {
+            return null;
+        }
+
+        let nextCode = replaceAllImports(code);
+
+        if (filename.endsWith(`${path.sep}components${path.sep}Spinner${path.sep}Spinner.tsx`)) {
+            nextCode = nextCode
+                .replace("import styled from 'styled-components';\n", '')
+                .replace(
+                    'export const Spinner = styled(SpinnerComponent)``;',
+                    'export const Spinner = SpinnerComponent;',
+                );
+        }
+
+        if (nextCode === code) {
+            return null;
+        }
+
+        return {
+            code: nextCode,
+            map: null,
+        };
+    },
+});
+
+const resolveForLinariaEvaluation = (): Plugin => ({
+    name: 'sdds-serv-linaria-cjs-resolver',
+    enforce: 'pre' as const,
+    resolveId(source: string, importer?: string) {
+        if (!linariaResolveStorage.getStore()) {
+            return null;
+        }
+
+        if (source === PLASMA_NEW_HOPE_CSS) {
+            return PLASMA_NEW_HOPE_SRC;
+        }
+
+        if (source === SDDS_SERV_TOKENS) {
+            return require.resolve(source, {
+                paths: [__dirname],
+            });
+        }
+
+        if (
+            importer?.includes(
+                `${path.sep}packages${path.sep}plasma-new-hope${path.sep}dist${path.sep}css${path.sep}cjs${path.sep}`,
+            )
+        ) {
+            return require.resolve(source, {
+                paths: [path.dirname(importer)],
+            });
+        }
+
+        return null;
+    },
+});
+
+const useCjsResolverInsideLinaria = (plugin: Plugin): Plugin => {
+    const originalTransform = plugin.transform;
+
+    if (!originalTransform || typeof originalTransform !== 'function') {
+        return plugin;
+    }
+
+    return {
+        ...plugin,
+        transform(...args) {
+            return linariaResolveStorage.run(true, () => originalTransform.apply(this, args));
+        },
+    };
 };
 
-const stories = ['../README.mdx'];
+const linariaPlugin = useCjsResolverInsideLinaria(
+    linaria({
+        exclude: ['../../../'],
+        rules: [
+            {
+                action: require.resolve('@linaria/shaker'),
+            },
+            {
+                test: nodeModulesRegExp,
+                action: 'ignore',
+            },
+            {
+                test: (filename, code) =>
+                    nodeModulesRegExp.test(filename) &&
+                    !storybookViteDepsRegExp.test(filename) &&
+                    hasImportOrExport(code),
+                action: require.resolve('@linaria/shaker'),
+            },
+            {
+                test: storybookViteDepsRegExp,
+                action: 'ignore',
+            },
+        ],
+        tagResolver: (source, tag) => {
+            if (source === PLASMA_NEW_HOPE_CSS) {
+                if (tag === 'css') {
+                    return require.resolve('@linaria/core/processors/css');
+                }
 
-if (USE_EMOTION_COMPONENTS) {
-    stories.push(...storyMap['emotion']);
-} else {
-    // default
-    stories.push(...storyMap['linaria']);
-}
+                if (tag === 'styled') {
+                    return require.resolve('@linaria/react/processors/styled');
+                }
+            }
+
+            return null;
+        },
+        displayName: true,
+        babelOptions: {
+            presets: ['@babel/preset-typescript', '@babel/preset-react'],
+        },
+    }),
+);
+
+const stories = ['../README.mdx', '../src/**/*.stories.tsx'];
 
 const config: StorybookConfig = {
     staticDirs: ['public'],
@@ -42,14 +170,22 @@ const config: StorybookConfig = {
             resolve: {
                 dedupe: ['react', 'react-dom', 'styled-components'],
                 preserveSymlinks: true,
-                alias: {
-                    '@salutejs/plasma-sb-utils': path.resolve('../../utils/plasma-sb-utils/src'),
-                },
+                alias: [
+                    {
+                        find: '@salutejs/plasma-sb-utils',
+                        replacement: path.resolve('../../utils/plasma-sb-utils/src'),
+                    },
+                ],
             },
             build: {
                 sourcemap: false,
             },
+            optimizeDeps: {
+                include: ['@salutejs/plasma-new-hope/css'],
+            },
             plugins: [
+                transformToCssComponents(),
+                resolveForLinariaEvaluation(),
                 /* Plugin that fixes a bug in Storybook@10 - https://github.com/storybookjs/storybook/issues/21716 */
                 {
                     name: 'fix-mdx-react-shim',
@@ -62,13 +198,7 @@ const config: StorybookConfig = {
                         return null;
                     },
                 },
-                linaria({
-                    exclude: ['../../../'],
-                    displayName: true,
-                    babelOptions: {
-                        presets: ['@babel/preset-typescript', '@babel/preset-react'],
-                    },
-                }),
+                linariaPlugin,
             ],
         });
     },

--- a/packages/sdds-serv/package.json
+++ b/packages/sdds-serv/package.json
@@ -7,16 +7,8 @@
     "access": "public"
   },
   "license": "MIT",
-  "files": [
-    "dist",
-    "types"
-  ],
-  "keywords": [
-    "design-system",
-    "react-components",
-    "ui-kit",
-    "react"
-  ],
+  "files": ["dist", "types"],
+  "keywords": ["design-system", "react-components", "ui-kit", "react"],
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:salute-developers/plasma.git",
@@ -103,26 +95,15 @@
     "build:emotion:esm": "swc ./src-emotion -d ./dist/emotion/es --strip-leading-paths --config-file ../../swc.config.json -C module.type=es6",
     "postbuild:emotion": "rm -rf src-emotion",
     "generate:typings": "rm -rf types && tsc",
-    "storybook": "npm run storybook:sc",
-    "prestorybook:emotion": "npm run prebuild:emotion",
-    "storybook:emotion": "USE_EMOTION_COMPONENTS=true storybook dev -p ${PORT:-7002} -c .storybook",
-    "storybook:sc": "USE_STYLED_COMPONENTS=true storybook dev -p ${PORT:-7002} -c .storybook",
+    "storybook": "storybook dev -p ${PORT:-7002} -c .storybook",
     "storybook:build": "storybook build -c .storybook -o build-sb",
     "typescript-coverage": "npx typescript-coverage-report > /dev/null",
     "lint": "../../node_modules/.bin/eslint ./src --ext .js,.ts,.tsx --quiet"
   },
   "typeCoverage": {
-    "ignoreFiles": [
-      "src/**/*.component-test.tsx",
-      "src/**/*.stories.tsx",
-      "src/**/*.styles.ts"
-    ],
+    "ignoreFiles": ["src/**/*.component-test.tsx", "src/**/*.stories.tsx", "src/**/*.styles.ts"],
     "atLeast": 99.9
   },
-  "contributors": [
-    "salute.developers@gmail.com"
-  ],
-  "sideEffects": [
-    "*.css"
-  ]
+  "contributors": ["salute.developers@gmail.com"],
+  "sideEffects": ["*.css"]
 }


### PR DESCRIPTION
### What/why changed
Сторибук в `sdds-serv` полностью переведен на css;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified Storybook development setup by removing emotion and styled-components variant scripts, reducing command complexity.
  * Updated and consolidated Storybook configuration for consistent component rendering and styling handling.
  * Reformatted package manifest configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-b2c@1.623.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-core@1.230.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-giga@0.350.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-homeds@0.350.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-hope@1.377.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-new-hope@0.367.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-ui@1.353.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-web@1.625.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-bizcom@0.355.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-cs@0.359.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-dfa@0.353.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-finai@0.346.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-insol@0.350.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-netology@0.354.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-os@0.25.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-platform-ai@0.354.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-sbcom@0.355.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-scan@0.353.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-serv@0.354.0-canary.2898.27761161065.0
  npm install @salutejs/sdds-api-tests@0.12.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-cy-utils@0.160.0-canary.2898.27761161065.0
  npm install @salutejs/plasma-sb-utils@0.231.0-canary.2898.27761161065.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-b2c@1.623.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-core@1.230.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-giga@0.350.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-homeds@0.350.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-hope@1.377.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-new-hope@0.367.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-ui@1.353.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-web@1.625.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-bizcom@0.355.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-cs@0.359.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-dfa@0.353.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-finai@0.346.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-insol@0.350.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-netology@0.354.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-os@0.25.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-platform-ai@0.354.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-sbcom@0.355.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-scan@0.353.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-serv@0.354.0-canary.2898.27761161065.0
  yarn add @salutejs/sdds-api-tests@0.12.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-cy-utils@0.160.0-canary.2898.27761161065.0
  yarn add @salutejs/plasma-sb-utils@0.231.0-canary.2898.27761161065.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
