### PR TITLE
PLASMA: fix Button state color tokens overwrite

### DIFF
--- a/packages/plasma-new-hope/src/components/Button/Button.styles.ts
+++ b/packages/plasma-new-hope/src/components/Button/Button.styles.ts
@@ -18,8 +18,6 @@ export const ButtonText = styled.span`
         text-align: start;
     }
 
-    color: var(${tokens.buttonTextColor});
-
     ${applyEllipsis()}
 `;
 


### PR DESCRIPTION
### What/why changed
color перебивал токены сверху для состояний hover/active. Поэтому при наведении и нажатии цвет текста у кнопки не менялся

Копия изменений из next-insol
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-b2c@1.623.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-core@1.230.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-giga@0.350.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-homeds@0.350.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-hope@1.377.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-new-hope@0.367.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-ui@1.353.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-web@1.625.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-bizcom@0.355.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-cs@0.359.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-dfa@0.353.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-finai@0.346.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-insol@0.350.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-netology@0.354.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-os@0.25.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-platform-ai@0.354.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-sbcom@0.355.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-scan@0.353.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-serv@0.354.0-canary.2900.27814340692.0
  npm install @salutejs/sdds-api-tests@0.12.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-cy-utils@0.160.0-canary.2900.27814340692.0
  npm install @salutejs/plasma-sb-utils@0.231.0-canary.2900.27814340692.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-b2c@1.623.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-core@1.230.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-giga@0.350.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-homeds@0.350.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-hope@1.377.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-new-hope@0.367.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-ui@1.353.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-web@1.625.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-bizcom@0.355.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-cs@0.359.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-dfa@0.353.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-finai@0.346.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-insol@0.350.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-netology@0.354.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-os@0.25.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-platform-ai@0.354.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-sbcom@0.355.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-scan@0.353.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-serv@0.354.0-canary.2900.27814340692.0
  yarn add @salutejs/sdds-api-tests@0.12.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-cy-utils@0.160.0-canary.2900.27814340692.0
  yarn add @salutejs/plasma-sb-utils@0.231.0-canary.2900.27814340692.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
