### PR TITLE
PLASMA-7402: update Popover close on nested Popover click

### DIFF
--- a/packages/plasma-new-hope/src/components/Popover/Popover.tsx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.tsx
@@ -317,6 +317,7 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, PopoverProps>) =>
                                     <StyledPopover
                                         {...attributes.popper}
                                         onTransitionEnd={handleTransitionEnd}
+                                        onClick={(e) => e.nativeEvent.stopPropagation()}
                                         className={cx(classes.root, openClass, animatedClass)}
                                         ref={popoverForkRef}
                                         style={{


### PR DESCRIPTION
## Core

### Popover

- исправлено закрытие при клике на вложенные выпадающие окна с порталом

### What/why changed
<img width="2344" height="1706" alt="Запись-экрана-2026-06-24-в-12 08 31" src="https://github.com/user-attachments/assets/9c9ef53e-580b-4ebc-badd-8922bf464d21" />

- исправлено закрытие при клике на вложенные выпадающие окна с порталом

Когда внутри Popover открывается Dropdown, Select DatePicker, и тд., при выборе элемента из списка элемент детачится до проверки contains:
```
1. Клик на item
2. React синхронно обрабатывает обработчики (handleGlobalToggle -> opened = false)
3. React делает flush состояния -> FloatingPortal анмаунтится -> item удаляется из DOM
4. Нативное событие продолжает всплывать -> достигает document
5. onDocumentClick: popoverRef.current?.contains(event.target) -> event.target уже detached -> contains() возвращает false
6. Popover закрывается
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.382.0-canary.2904.28082272968.0
  npm install @salutejs/plasma-b2c@1.624.0-canary.2904.28082272968.0
  npm install @salutejs/plasma-giga@0.351.0-canary.2904.28082272968.0
  npm install @salutejs/plasma-homeds@0.351.0-canary.2904.28082272968.0
  npm install @salutejs/plasma-new-hope@0.368.0-canary.2904.28082272968.0
  npm install @salutejs/plasma-web@1.626.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-bizcom@0.356.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-cs@0.360.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-dfa@0.354.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-finai@0.347.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-insol@0.351.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-netology@0.355.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-os@0.26.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-platform-ai@0.355.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-sbcom@0.356.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-scan@0.354.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-serv@0.355.0-canary.2904.28082272968.0
  npm install @salutejs/sdds-api-tests@0.13.0-canary.2904.28082272968.0
  # or 
  yarn add @salutejs/plasma-asdk@0.382.0-canary.2904.28082272968.0
  yarn add @salutejs/plasma-b2c@1.624.0-canary.2904.28082272968.0
  yarn add @salutejs/plasma-giga@0.351.0-canary.2904.28082272968.0
  yarn add @salutejs/plasma-homeds@0.351.0-canary.2904.28082272968.0
  yarn add @salutejs/plasma-new-hope@0.368.0-canary.2904.28082272968.0
  yarn add @salutejs/plasma-web@1.626.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-bizcom@0.356.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-cs@0.360.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-dfa@0.354.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-finai@0.347.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-insol@0.351.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-netology@0.355.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-os@0.26.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-platform-ai@0.355.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-sbcom@0.356.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-scan@0.354.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-serv@0.355.0-canary.2904.28082272968.0
  yarn add @salutejs/sdds-api-tests@0.13.0-canary.2904.28082272968.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Popover no longer unintentionally closes when clicking inside the component or nested portal content while `closeOnOverlayClick` is enabled.

* **Tests**
  * Added test coverage to verify Popover behavior when clicking inside normal and nested portal content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->