### PR TITLE
PLASMA-7553: add test for onToggle, onClick, onChange, onItemSelect callbacks

### DIFF
--- a/packages/plasma-new-hope/src/components/Carousel/CarouselNew/Carousel.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Carousel/CarouselNew/Carousel.component-test.tsx
@@ -224,13 +224,11 @@ describeFn('Carousel', () => {
     it('prop: onChangeIndex', () => {
         cy.viewport(700, 500);
 
+        const onChangeIndex = cy.stub().as('onChangeIndex');
+
         mount(
             <div style={{ width: '600px' }}>
-                <Carousel
-                    onChangeIndex={(index) => {
-                        expect(index).to.eq(1);
-                    }}
-                >
+                <Carousel onChangeIndex={onChangeIndex}>
                     {items.map((item, i) => (
                         <StyledCard key={i}>{item.title}</StyledCard>
                     ))}
@@ -239,5 +237,7 @@ describeFn('Carousel', () => {
         );
 
         cy.get('.carousel-right-control-button').click();
+        cy.get('@onChangeIndex').should('have.been.calledOnce');
+        cy.get('@onChangeIndex').should('have.been.calledWith', 1);
     });
 });

--- a/packages/plasma-new-hope/src/components/Carousel/CarouselNew/Carousel.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Carousel/CarouselNew/Carousel.component-test.tsx
@@ -220,4 +220,24 @@ describeFn('Carousel', () => {
         cy.get('[data-carousel-index="17"]').should('not.exist');
         cy.get('[data-carousel-index="3"]').should('not.exist');
     });
+
+    it('prop: onChangeIndex', () => {
+        cy.viewport(700, 500);
+
+        mount(
+            <div style={{ width: '600px' }}>
+                <Carousel
+                    onChangeIndex={(index) => {
+                        expect(index).to.eq(1);
+                    }}
+                >
+                    {items.map((item, i) => (
+                        <StyledCard key={i}>{item.title}</StyledCard>
+                    ))}
+                </Carousel>
+            </div>,
+        );
+
+        cy.get('.carousel-right-control-button').click();
+    });
 });

--- a/packages/plasma-new-hope/src/components/CodeField/CodeField.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/CodeField/CodeField.component-test.tsx
@@ -152,4 +152,19 @@ describeFn('CodeField', () => {
 
         cy.matchImageSnapshot();
     });
+
+    it('prop: onChange', () => {
+        mount(
+            <CodeField
+                codeLength={4}
+                autoFocus
+                autoComplete="off"
+                onChange={(value) => {
+                    expect(value).to.eq('1');
+                }}
+            />,
+        );
+
+        cy.focused().type('1');
+    });
 });

--- a/packages/plasma-new-hope/src/components/CodeField/CodeField.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/CodeField/CodeField.component-test.tsx
@@ -154,17 +154,13 @@ describeFn('CodeField', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <CodeField
-                codeLength={4}
-                autoFocus
-                autoComplete="off"
-                onChange={(value) => {
-                    expect(value).to.eq('1');
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<CodeField codeLength={4} autoFocus autoComplete="off" onChange={onChange} />);
 
         cy.focused().type('1');
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').should('have.been.calledWith', '1');
     });
 });

--- a/packages/plasma-new-hope/src/components/CodeInput/CodeInput.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/CodeInput/CodeInput.component-test.tsx
@@ -133,16 +133,13 @@ describeFn('CodeInput', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <CodeInput
-                codeLength={4}
-                autoFocus
-                onChange={(value) => {
-                    expect(value).to.eq('1');
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<CodeInput codeLength={4} autoFocus onChange={onChange} />);
 
         cy.focused().type('1');
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').should('have.been.calledWith', '1');
     });
 });

--- a/packages/plasma-new-hope/src/components/CodeInput/CodeInput.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/CodeInput/CodeInput.component-test.tsx
@@ -131,4 +131,18 @@ describeFn('CodeInput', () => {
 
         cy.matchImageSnapshot();
     });
+
+    it('prop: onChange', () => {
+        mount(
+            <CodeInput
+                codeLength={4}
+                autoFocus
+                onChange={(value) => {
+                    expect(value).to.eq('1');
+                }}
+            />,
+        );
+
+        cy.focused().type('1');
+    });
 });

--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.component-test.tsx
@@ -1133,6 +1133,79 @@ describeFn('Combobox', () => {
         cy.get('@onToggle').should('have.been.calledWith', false);
     });
 
+    it('prop: onToggle', () => {
+        cy.viewport(400, 300);
+
+        mount(
+            <div style={{ width: '300px' }}>
+                <Combobox
+                    id="combobox"
+                    items={items}
+                    label="Label"
+                    placeholder="Placeholder"
+                    onToggle={(isOpen) => {
+                        expect(isOpen).to.be.oneOf([true, false]);
+                    }}
+                />
+            </div>,
+        );
+
+        cy.get('#combobox').click();
+        cy.get('body').click('bottomRight');
+    });
+
+    it('prop: onChange', () => {
+        cy.viewport(400, 300);
+
+        mount(
+            <div style={{ width: '300px' }}>
+                <Combobox
+                    id="combobox"
+                    items={items}
+                    label="Label"
+                    placeholder="Placeholder"
+                    onChange={(value, item) => {
+                        expect(value).to.eq('north_america');
+                        expect(item?.value).to.eq('north_america');
+                    }}
+                />
+            </div>,
+        );
+
+        cy.get('#combobox').click();
+        cy.get('[id$="north_america"]').click();
+    });
+
+    it('prop: onClick', () => {
+        cy.viewport(400, 300);
+
+        const simpleItems = [
+            { value: 'item1', label: 'Item 1' },
+            { value: 'item2', label: 'Item 2' },
+        ];
+
+        mount(
+            <div style={{ width: '300px' }}>
+                <Combobox
+                    id="combobox"
+                    items={simpleItems}
+                    label="Label"
+                    placeholder="Placeholder"
+                    multiple
+                    selectAllOptions={{
+                        label: 'Выбрать всё',
+                        onClick: () => {
+                            expect(true).to.eq(true);
+                        },
+                    }}
+                />
+            </div>,
+        );
+
+        cy.get('#combobox').click();
+        cy.contains('Выбрать всё').click();
+    });
+
     it('treeView, single mode', () => {
         cy.viewport(400, 599);
 

--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.component-test.tsx
@@ -1133,47 +1133,23 @@ describeFn('Combobox', () => {
         cy.get('@onToggle').should('have.been.calledWith', false);
     });
 
-    it('prop: onToggle', () => {
-        cy.viewport(400, 300);
-
-        mount(
-            <div style={{ width: '300px' }}>
-                <Combobox
-                    id="combobox"
-                    items={items}
-                    label="Label"
-                    placeholder="Placeholder"
-                    onToggle={(isOpen) => {
-                        expect(isOpen).to.be.oneOf([true, false]);
-                    }}
-                />
-            </div>,
-        );
-
-        cy.get('#combobox').click();
-        cy.get('body').click('bottomRight');
-    });
-
     it('prop: onChange', () => {
         cy.viewport(400, 300);
 
+        const onChange = cy.stub().as('onChange');
+
         mount(
             <div style={{ width: '300px' }}>
-                <Combobox
-                    id="combobox"
-                    items={items}
-                    label="Label"
-                    placeholder="Placeholder"
-                    onChange={(value, item) => {
-                        expect(value).to.eq('north_america');
-                        expect(item?.value).to.eq('north_america');
-                    }}
-                />
+                <Combobox id="combobox" items={items} label="Label" placeholder="Placeholder" onChange={onChange} />
             </div>,
         );
 
         cy.get('#combobox').click();
         cy.get('[id$="north_america"]').click();
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').should('have.been.calledWith', 'north_america');
+        cy.get('@onChange').its('firstCall.args.1.value').should('eq', 'north_america');
     });
 
     it('prop: onClick', () => {
@@ -1183,6 +1159,8 @@ describeFn('Combobox', () => {
             { value: 'item1', label: 'Item 1' },
             { value: 'item2', label: 'Item 2' },
         ];
+
+        const onClick = cy.spy().as('selectAllOnClick');
 
         mount(
             <div style={{ width: '300px' }}>
@@ -1194,9 +1172,7 @@ describeFn('Combobox', () => {
                     multiple
                     selectAllOptions={{
                         label: 'Выбрать всё',
-                        onClick: () => {
-                            expect(true).to.eq(true);
-                        },
+                        onClick,
                     }}
                 />
             </div>,
@@ -1204,6 +1180,8 @@ describeFn('Combobox', () => {
 
         cy.get('#combobox').click();
         cy.contains('Выбрать всё').click();
+
+        cy.get('@selectAllOnClick').should('have.been.calledOnce');
     });
 
     it('treeView, single mode', () => {

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePicker.component-test.tsx
@@ -500,6 +500,37 @@ describeFn('DatePicker', () => {
         cy.get('body').click(0, 0);
         cy.get('input').first().should('have.value', '');
     });
+
+    it('prop: onToggle', () => {
+        cy.viewport(500, 544);
+
+        mount(
+            <Demo
+                defaultDate={new Date(2023, 5, 14)}
+                onToggle={(isOpen, event) => {
+                    expect(isOpen).to.be.oneOf([true, false]);
+                    expect(event?.type).to.be.oneOf(['click', 'pointerdown', undefined]);
+                }}
+            />,
+        );
+
+        cy.get('input').first().click();
+        cy.get('body').click(0, 0);
+    });
+
+    it('prop: onChange', () => {
+        cy.viewport(500, 544);
+
+        mount(
+            <Demo
+                onChange={(event) => {
+                    expect(event.target).to.have.property('value');
+                }}
+            />,
+        );
+
+        cy.get('input').first().click().type('14062023');
+    });
 });
 
 describeFnRange('DatePickerRange', () => {

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePicker.component-test.tsx
@@ -504,32 +504,33 @@ describeFn('DatePicker', () => {
     it('prop: onToggle', () => {
         cy.viewport(500, 544);
 
+        const onToggle = cy.stub().as('onToggle');
+
         mount(
-            <Demo
-                defaultDate={new Date(2023, 5, 14)}
-                onToggle={(isOpen, event) => {
-                    expect(isOpen).to.be.oneOf([true, false]);
-                    expect(event?.type).to.be.oneOf(['click', 'pointerdown', undefined]);
-                }}
-            />,
+            <>
+                <span id="outer">outer text</span>
+                <Demo defaultDate={new Date(2023, 5, 14)} onToggle={onToggle} />
+            </>,
         );
 
         cy.get('input').first().click();
-        cy.get('body').click(0, 0);
+        cy.get('@onToggle').should('have.been.calledOnce');
+        cy.get('@onToggle').should('have.been.calledWith', true);
+
+        cy.get('#outer').click();
+        cy.get('@onToggle').should('have.been.calledTwice');
+        cy.get('@onToggle').should('have.been.calledWith', false);
     });
 
     it('prop: onChange', () => {
         cy.viewport(500, 544);
 
-        mount(
-            <Demo
-                onChange={(event) => {
-                    expect(event.target).to.have.property('value');
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<Demo onChange={onChange} />);
 
         cy.get('input').first().click().type('14062023');
+        cy.get('@onChange').should('have.been.called');
     });
 });
 

--- a/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.component-test.tsx
@@ -642,4 +642,35 @@ describeFn('DateTimePicker', () => {
 
         cy.matchImageSnapshot();
     });
+
+    it('prop: onToggle', () => {
+        cy.viewport(750, 700);
+
+        mount(
+            <Demo
+                defaultDate={new Date(2023, 5, 14, 0, 0, 0)}
+                onToggle={(isOpen, event) => {
+                    expect(isOpen).to.be.oneOf([true, false]);
+                    expect(event?.type).to.eq('click');
+                }}
+            />,
+        );
+
+        cy.get('input').first().click();
+        cy.get('body').click(0, 0);
+    });
+
+    it('prop: onChange', () => {
+        cy.viewport(750, 700);
+
+        mount(
+            <Demo
+                onChange={(event) => {
+                    expect(event.target).to.have.property('value');
+                }}
+            />,
+        );
+
+        cy.get('input').first().click().type('14062023');
+    });
 });

--- a/packages/plasma-new-hope/src/components/NumberFormat/NumberFormat.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/NumberFormat/NumberFormat.component-test.tsx
@@ -146,16 +146,12 @@ describeFn('NumberFormat', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <NumberFormat
-                label="Числовой формат"
-                textAfter="₽"
-                onChange={() => {
-                    expect(true).to.eq(true);
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<NumberFormat label="Числовой формат" textAfter="₽" onChange={onChange} />);
 
         cy.get('input').type('123');
+
+        cy.get('@onChange').should('have.been.called');
     });
 });

--- a/packages/plasma-new-hope/src/components/NumberFormat/NumberFormat.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/NumberFormat/NumberFormat.component-test.tsx
@@ -144,4 +144,18 @@ describeFn('NumberFormat', () => {
 
         cy.matchImageSnapshot();
     });
+
+    it('prop: onChange', () => {
+        mount(
+            <NumberFormat
+                label="Числовой формат"
+                textAfter="₽"
+                onChange={() => {
+                    expect(true).to.eq(true);
+                }}
+            />,
+        );
+
+        cy.get('input').type('123');
+    });
 });

--- a/packages/plasma-new-hope/src/components/NumberInput/NumberInput.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/NumberInput/NumberInput.component-test.tsx
@@ -356,4 +356,19 @@ describeFn('NumberInput', () => {
         mount(<InteractiveNumberInput min={0} max={10} displayWithoutValue="decrement" />);
         cy.get('button').first().should('have.attr', 'tabindex', '0');
     });
+
+    it('prop: onChange', () => {
+        mount(
+            <NumberInput
+                value={5}
+                min={0}
+                max={10}
+                onChange={(_event, value) => {
+                    expect(value).to.eq(6);
+                }}
+            />,
+        );
+
+        cy.get('button').last().click();
+    });
 });

--- a/packages/plasma-new-hope/src/components/NumberInput/NumberInput.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/NumberInput/NumberInput.component-test.tsx
@@ -358,17 +358,13 @@ describeFn('NumberInput', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <NumberInput
-                value={5}
-                min={0}
-                max={10}
-                onChange={(_event, value) => {
-                    expect(value).to.eq(6);
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<NumberInput value={5} min={0} max={10} onChange={onChange} />);
 
         cy.get('button').last().click();
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').its('firstCall.args.1').should('eq', 6);
     });
 });

--- a/packages/plasma-new-hope/src/components/Pagination/Pagination.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Pagination/Pagination.component-test.tsx
@@ -395,17 +395,13 @@ describeFn('Pagination', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <Pagination
-                value={10}
-                count={count}
-                slots={slots[1]}
-                onChange={(page) => {
-                    expect(page).to.eq(11);
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<Pagination value={10} count={count} slots={slots[1]} onChange={onChange} />);
 
         cy.contains('button', '11').click();
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').should('have.been.calledWith', 11);
     });
 });

--- a/packages/plasma-new-hope/src/components/Pagination/Pagination.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Pagination/Pagination.component-test.tsx
@@ -393,4 +393,19 @@ describeFn('Pagination', () => {
         cy.get('button.pagination-page-button-active').should('contain.text', '3');
         cy.matchImageSnapshot();
     });
+
+    it('prop: onChange', () => {
+        mount(
+            <Pagination
+                value={10}
+                count={count}
+                slots={slots[1]}
+                onChange={(page) => {
+                    expect(page).to.eq(11);
+                }}
+            />,
+        );
+
+        cy.contains('button', '11').click();
+    });
 });

--- a/packages/plasma-new-hope/src/components/Popover/Popover.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Popover/Popover.component-test.tsx
@@ -276,4 +276,31 @@ describeFn('Popover', () => {
         cy.get('button').contains('Open').click();
         cy.matchImageSnapshot();
     });
+
+    it('prop: onToggle', () => {
+        const ControlledPopover = () => {
+            const [isOpen, setIsOpen] = React.useState(false);
+
+            return (
+                <Popover
+                    opened={isOpen}
+                    onToggle={(opened) => {
+                        expect(opened).to.be.oneOf([true, false]);
+                        setIsOpen(opened);
+                    }}
+                    trigger="click"
+                    target={<Button>Target</Button>}
+                >
+                    <p>{text}</p>
+                </Popover>
+            );
+        };
+
+        mount(<ControlledPopover />);
+
+        cy.get('button').first().click();
+        cy.get('p').contains(text).should('be.visible');
+        cy.get('button').first().click();
+        cy.get('p').contains(text).should('not.be.visible');
+    });
 });

--- a/packages/plasma-new-hope/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.component-test.tsx
@@ -672,6 +672,79 @@ describeFn('Select', () => {
         cy.get('@onToggle').should('have.been.calledWith', false);
     });
 
+    it('prop: onToggle', () => {
+        cy.viewport(400, 300);
+
+        mount(
+            <div style={{ width: '300px' }}>
+                <Select
+                    id="select"
+                    items={items}
+                    label="Label"
+                    placeholder="Placeholder"
+                    onToggle={(isOpen) => {
+                        expect(isOpen).to.be.oneOf([true, false]);
+                    }}
+                />
+            </div>,
+        );
+
+        cy.get('#select').click();
+        cy.get('body').click('topRight');
+    });
+
+    it('prop: onChange', () => {
+        cy.viewport(400, 300);
+
+        mount(
+            <div style={{ width: '300px' }}>
+                <Select
+                    id="select"
+                    items={items}
+                    label="Label"
+                    placeholder="Placeholder"
+                    onChange={(value, item) => {
+                        expect(value).to.eq('north_america');
+                        expect(item?.value).to.eq('north_america');
+                    }}
+                />
+            </div>,
+        );
+
+        cy.get('#select').click();
+        cy.get('[id$="north_america"]').click();
+    });
+
+    it('prop: onClick', () => {
+        cy.viewport(400, 300);
+
+        const simpleItems = [
+            { value: 'item1', label: 'Item 1' },
+            { value: 'item2', label: 'Item 2' },
+        ];
+
+        mount(
+            <div style={{ width: '300px' }}>
+                <Select
+                    id="select"
+                    multiselect
+                    items={simpleItems}
+                    label="Label"
+                    placeholder="Placeholder"
+                    selectAllOptions={{
+                        label: 'Выбрать всё',
+                        onClick: () => {
+                            expect(true).to.eq(true);
+                        },
+                    }}
+                />
+            </div>,
+        );
+
+        cy.get('#select').click();
+        cy.contains('Выбрать всё').click();
+    });
+
     it('item disabled', () => {
         cy.viewport(400, 100);
 

--- a/packages/plasma-new-hope/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.component-test.tsx
@@ -672,47 +672,23 @@ describeFn('Select', () => {
         cy.get('@onToggle').should('have.been.calledWith', false);
     });
 
-    it('prop: onToggle', () => {
-        cy.viewport(400, 300);
-
-        mount(
-            <div style={{ width: '300px' }}>
-                <Select
-                    id="select"
-                    items={items}
-                    label="Label"
-                    placeholder="Placeholder"
-                    onToggle={(isOpen) => {
-                        expect(isOpen).to.be.oneOf([true, false]);
-                    }}
-                />
-            </div>,
-        );
-
-        cy.get('#select').click();
-        cy.get('body').click('topRight');
-    });
-
     it('prop: onChange', () => {
         cy.viewport(400, 300);
 
+        const onChange = cy.stub().as('onChange');
+
         mount(
             <div style={{ width: '300px' }}>
-                <Select
-                    id="select"
-                    items={items}
-                    label="Label"
-                    placeholder="Placeholder"
-                    onChange={(value, item) => {
-                        expect(value).to.eq('north_america');
-                        expect(item?.value).to.eq('north_america');
-                    }}
-                />
+                <Select id="select" items={items} label="Label" placeholder="Placeholder" onChange={onChange} />
             </div>,
         );
 
         cy.get('#select').click();
         cy.get('[id$="north_america"]').click();
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').should('have.been.calledWith', 'north_america');
+        cy.get('@onChange').its('firstCall.args.1.value').should('eq', 'north_america');
     });
 
     it('prop: onClick', () => {
@@ -722,6 +698,8 @@ describeFn('Select', () => {
             { value: 'item1', label: 'Item 1' },
             { value: 'item2', label: 'Item 2' },
         ];
+
+        const onClick = cy.spy().as('selectAllOnClick');
 
         mount(
             <div style={{ width: '300px' }}>
@@ -733,9 +711,7 @@ describeFn('Select', () => {
                     placeholder="Placeholder"
                     selectAllOptions={{
                         label: 'Выбрать всё',
-                        onClick: () => {
-                            expect(true).to.eq(true);
-                        },
+                        onClick,
                     }}
                 />
             </div>,
@@ -743,6 +719,8 @@ describeFn('Select', () => {
 
         cy.get('#select').click();
         cy.contains('Выбрать всё').click();
+
+        cy.get('@selectAllOnClick').should('have.been.calledOnce');
     });
 
     it('item disabled', () => {

--- a/packages/plasma-new-hope/src/components/Slider/Slider.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Slider/Slider.component-test.tsx
@@ -20,6 +20,16 @@ getBaseVisualTests({
     configPropsForMatrix: ['view', 'size'],
 });
 
+const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+const changeRangeInputValue = (rangeElement: HTMLInputElement) => (value: number) => {
+    if (!nativeInputValueSetter) {
+        return;
+    }
+
+    nativeInputValueSetter.call(rangeElement, value);
+    rangeElement.dispatchEvent(new CustomEvent('change', { detail: { value }, bubbles: true }));
+};
+
 describeFn('Slider', () => {
     const Slider = componentExists ? getComponent<SliderProps>('Slider') : () => null;
     const sliderThumbSelector = '[type="range"]';
@@ -354,17 +364,15 @@ describeFn('Slider', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <Slider
-                min={0}
-                max={100}
-                value={50}
-                onChange={(value) => {
-                    expect(value).to.eq(75);
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
 
-        cy.get(sliderThumbSelector).invoke('val', 75).trigger('input', { force: true });
+        mount(<Slider min={0} max={100} value={50} onChange={onChange} />);
+
+        cy.get(sliderThumbSelector).then((range) => {
+            changeRangeInputValue(range[0] as HTMLInputElement)(75);
+        });
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').should('have.been.calledWith', 75);
     });
 });

--- a/packages/plasma-new-hope/src/components/Slider/Slider.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Slider/Slider.component-test.tsx
@@ -352,4 +352,19 @@ describeFn('Slider', () => {
         );
         cy.matchImageSnapshot();
     });
+
+    it('prop: onChange', () => {
+        mount(
+            <Slider
+                min={0}
+                max={100}
+                value={50}
+                onChange={(value) => {
+                    expect(value).to.eq(75);
+                }}
+            />,
+        );
+
+        cy.get(sliderThumbSelector).invoke('val', 75).trigger('input', { force: true });
+    });
 });

--- a/packages/plasma-new-hope/src/components/Steps/Steps.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Steps/Steps.component-test.tsx
@@ -338,4 +338,24 @@ describeFn('Steps', () => {
 
         cy.matchImageSnapshot();
     });
+
+    it('prop: onChange', () => {
+        const clickableItems: StepItemProps[] = [
+            { title: 'Step 1', indicator: 1, status: 'active' },
+            { title: 'Step 2', indicator: 2, status: 'inactive' },
+        ];
+
+        mount(
+            <Steps
+                items={clickableItems}
+                onChange={(item, index, prevIndex) => {
+                    expect(index).to.eq(1);
+                    expect(prevIndex).to.eq(0);
+                    expect(item.title).to.eq('Step 2');
+                }}
+            />,
+        );
+
+        cy.contains('Step 2').click();
+    });
 });

--- a/packages/plasma-new-hope/src/components/Steps/Steps.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Steps/Steps.component-test.tsx
@@ -345,17 +345,15 @@ describeFn('Steps', () => {
             { title: 'Step 2', indicator: 2, status: 'inactive' },
         ];
 
-        mount(
-            <Steps
-                items={clickableItems}
-                onChange={(item, index, prevIndex) => {
-                    expect(index).to.eq(1);
-                    expect(prevIndex).to.eq(0);
-                    expect(item.title).to.eq('Step 2');
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<Steps items={clickableItems} onChange={onChange} />);
 
         cy.contains('Step 2').click();
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').its('firstCall.args.0.title').should('eq', 'Step 2');
+        cy.get('@onChange').its('firstCall.args.1').should('eq', 1);
+        cy.get('@onChange').its('firstCall.args.2').should('eq', 0);
     });
 });

--- a/packages/plasma-new-hope/src/components/TextField/TextField.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.component-test.tsx
@@ -311,6 +311,32 @@ describeFn('TextField', () => {
         cy.matchImageSnapshot();
     });
 
+    it('prop: onChange', () => {
+        mount(
+            <TextField
+                placeholder="Placeholder"
+                onChange={(event) => {
+                    expect(event.target.value).to.eq('t');
+                }}
+            />,
+        );
+
+        cy.get('input').type('t');
+    });
+
+    it('prop: onClick', () => {
+        mount(
+            <TextField
+                placeholder="Placeholder"
+                onClick={(event) => {
+                    expect(event.type).to.eq('click');
+                }}
+            />,
+        );
+
+        cy.get('input').click();
+    });
+
     it('truncate placeholder', () => {
         mount(
             <div style={{ width: '6rem' }}>

--- a/packages/plasma-new-hope/src/components/TextField/TextField.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.component-test.tsx
@@ -312,29 +312,25 @@ describeFn('TextField', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <TextField
-                placeholder="Placeholder"
-                onChange={(event) => {
-                    expect(event.target.value).to.eq('t');
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<TextField placeholder="Placeholder" onChange={onChange} />);
 
         cy.get('input').type('t');
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').its('firstCall.args.0.target.value').should('eq', 't');
     });
 
     it('prop: onClick', () => {
-        mount(
-            <TextField
-                placeholder="Placeholder"
-                onClick={(event) => {
-                    expect(event.type).to.eq('click');
-                }}
-            />,
-        );
+        const onClick = cy.stub().as('onClick');
+
+        mount(<TextField placeholder="Placeholder" onClick={onClick} />);
 
         cy.get('input').click();
+
+        cy.get('@onClick').should('have.been.calledOnce');
+        cy.get('@onClick').its('firstCall.args.0.type').should('eq', 'click');
     });
 
     it('truncate placeholder', () => {

--- a/packages/plasma-new-hope/src/components/TextFieldSlider/TextFieldSlider.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TextFieldSlider/TextFieldSlider.component-test.tsx
@@ -341,4 +341,17 @@ describeFn('plasma-new-hope: TextFieldSlider', () => {
         cy.contains('span', '75').click();
         cy.get('input').first().should('have.value', '0');
     });
+
+    it('prop: onChange', () => {
+        mount(
+            <TextFieldSlider
+                {...textFieldSliderProps}
+                onChange={() => {
+                    expect(true).to.eq(true);
+                }}
+            />,
+        );
+
+        cy.get('input[type="range"]').invoke('val', 75).trigger('input', { force: true });
+    });
 });

--- a/packages/plasma-new-hope/src/components/TextFieldSlider/TextFieldSlider.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TextFieldSlider/TextFieldSlider.component-test.tsx
@@ -343,15 +343,15 @@ describeFn('plasma-new-hope: TextFieldSlider', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <TextFieldSlider
-                {...textFieldSliderProps}
-                onChange={() => {
-                    expect(true).to.eq(true);
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
 
-        cy.get('input[type="range"]').invoke('val', 75).trigger('input', { force: true });
+        mount(<TextFieldSlider {...textFieldSliderProps} onChange={onChange} />);
+
+        cy.get('input[type="range"]').then((range) => {
+            changeRangeInputValue(range[0] as HTMLInputElement)(75);
+        });
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').its('firstCall.args.1').should('deep.equal', { raw: 75, formatted: '75' });
     });
 });

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.component-test.tsx
@@ -502,31 +502,30 @@ describeFn('TimePicker', () => {
     it('prop: onToggle', () => {
         cy.viewport(580, 800);
 
-        mount(
-            <TimePicker
-                value="00:00"
-                onToggle={(isOpen) => {
-                    expect(isOpen).to.be.oneOf([true, false]);
-                }}
-            />,
-        );
+        const onToggle = cy.stub().as('onToggle');
+
+        mount(<TimePicker value="00:00" onToggle={onToggle} />);
 
         cy.get('input').first().click();
+        cy.get('@onToggle').should('have.been.calledOnce');
+        cy.get('@onToggle').should('have.been.calledWith', true);
+
         cy.get('body').click(0, 0);
+        cy.get('@onToggle').should('have.been.calledTwice');
+        cy.get('@onToggle').should('have.been.calledWith', false);
     });
 
     it('prop: onChange', () => {
         cy.viewport(580, 800);
 
-        mount(
-            <TimePicker
-                value="00:00"
-                onChange={(_event, formattedValues) => {
-                    expect(formattedValues).to.have.property('value');
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<TimePicker value="00:00" onChange={onChange} />);
 
         cy.get('input').first().clear().type('1230');
+
+        cy.get('@onChange').should('have.been.called');
+        cy.get('@onChange').its('lastCall.args.1').should('have.property', 'value');
+        cy.get('@onChange').its('lastCall.args.1').should('have.property', 'timeValues');
     });
 });

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.component-test.tsx
@@ -498,4 +498,35 @@ describeFn('TimePicker', () => {
 
         cy.get('input').first().should('have.value', '12:05');
     });
+
+    it('prop: onToggle', () => {
+        cy.viewport(580, 800);
+
+        mount(
+            <TimePicker
+                value="00:00"
+                onToggle={(isOpen) => {
+                    expect(isOpen).to.be.oneOf([true, false]);
+                }}
+            />,
+        );
+
+        cy.get('input').first().click();
+        cy.get('body').click(0, 0);
+    });
+
+    it('prop: onChange', () => {
+        cy.viewport(580, 800);
+
+        mount(
+            <TimePicker
+                value="00:00"
+                onChange={(_event, formattedValues) => {
+                    expect(formattedValues).to.have.property('value');
+                }}
+            />,
+        );
+
+        cy.get('input').first().clear().type('1230');
+    });
 });

--- a/packages/plasma-new-hope/src/components/TimePickerGrid/TimePickerGrid.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TimePickerGrid/TimePickerGrid.component-test.tsx
@@ -38,4 +38,17 @@ describeFn('TimePickerGrid', () => {
         mount(<TimePickerGrid value="00:14" multiplicityMinutes={5} />);
         cy.matchImageSnapshot();
     });
+
+    it('prop: onChange', () => {
+        mount(
+            <TimePickerGrid
+                value="00:00"
+                onChange={(event) => {
+                    expect(event.value).to.eq('01:00');
+                }}
+            />,
+        );
+
+        cy.contains('01').click();
+    });
 });

--- a/packages/plasma-new-hope/src/components/TimePickerGrid/TimePickerGrid.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/TimePickerGrid/TimePickerGrid.component-test.tsx
@@ -40,15 +40,13 @@ describeFn('TimePickerGrid', () => {
     });
 
     it('prop: onChange', () => {
-        mount(
-            <TimePickerGrid
-                value="00:00"
-                onChange={(event) => {
-                    expect(event.value).to.eq('01:00');
-                }}
-            />,
-        );
+        const onChange = cy.stub().as('onChange');
+
+        mount(<TimePickerGrid value="00:00" onChange={onChange} />);
 
         cy.contains('01').click();
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').its('firstCall.args.0.value').should('eq', '01:00');
     });
 });

--- a/packages/plasma-new-hope/src/components/Tour/Tour.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Tour/Tour.component-test.tsx
@@ -423,4 +423,49 @@ describeFn('Tour', () => {
         cy.get('#close').click();
         cy.get('small').should('not.exist');
     });
+
+    it('prop: onChange', () => {
+        const ref1 = React.createRef<HTMLButtonElement>();
+        const ref2 = React.createRef<HTMLButtonElement>();
+
+        const steps = [
+            { target: ref1, title: 'Title 1', description: 'Description 1' },
+            { target: ref2, title: 'Title 2', description: 'Description 2' },
+        ];
+
+        const renderStep = (
+            current: number,
+            _length: number,
+            _last: boolean,
+            step: unknown,
+            setCurrent: (index: number) => void,
+        ) => (
+            <Card>
+                <Title>{(step as { title?: string })?.title}</Title>
+                <Footer>
+                    <Button id="next-step" size="s" type="button" onClick={() => setCurrent(current + 1)}>
+                        Далее
+                    </Button>
+                </Footer>
+            </Card>
+        );
+
+        mount(
+            <div style={{ width: '100%', height: '300px' }}>
+                <Button ref={ref1}>Блок 1</Button>
+                <Button ref={ref2}>Блок 2</Button>
+                <Tour
+                    open
+                    current={0}
+                    onChange={(current) => {
+                        expect(current).to.eq(1);
+                    }}
+                    steps={steps}
+                    renderStep={renderStep}
+                />
+            </div>,
+        );
+
+        cy.get('#next-step').click();
+    });
 });

--- a/packages/plasma-new-hope/src/components/Tour/Tour.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Tour/Tour.component-test.tsx
@@ -450,22 +450,19 @@ describeFn('Tour', () => {
             </Card>
         );
 
+        const onChange = cy.stub().as('onChange');
+
         mount(
             <div style={{ width: '100%', height: '300px' }}>
                 <Button ref={ref1}>Блок 1</Button>
                 <Button ref={ref2}>Блок 2</Button>
-                <Tour
-                    open
-                    current={0}
-                    onChange={(current) => {
-                        expect(current).to.eq(1);
-                    }}
-                    steps={steps}
-                    renderStep={renderStep}
-                />
+                <Tour open current={0} onChange={onChange} steps={steps} renderStep={renderStep} />
             </div>,
         );
 
         cy.get('#next-step').click();
+
+        cy.get('@onChange').should('have.been.calledOnce');
+        cy.get('@onChange').should('have.been.calledWith', 1);
     });
 });


### PR DESCRIPTION
## Core
### Test
- добавлены тесты событий onToggle, onClick, onChange, onItemSelect
### What/why changed
- добавлены тесты событий onToggle, onClick, onChange, onItemSelect
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-b2c@1.623.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-core@1.230.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-giga@0.350.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-homeds@0.350.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-hope@1.377.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-icons@1.241.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-new-hope@0.367.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-tokens-b2b@1.57.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-tokens-b2c@0.68.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-tokens-web@1.72.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-tokens@1.142.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-typo@0.45.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-ui@1.353.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-web@1.625.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-bizcom@0.355.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-cs@0.359.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-dfa@0.353.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-finai@0.346.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-insol@0.350.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-netology@0.354.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-os@0.25.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-platform-ai@0.354.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-sbcom@0.355.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-scan@0.353.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-serv@0.354.1-canary.2908.28502446091.0
  npm install @salutejs/core-themes@0.32.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-themes@0.53.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-themes@0.69.1-canary.2908.28502446091.0
  npm install @salutejs/sdds-api-tests@0.12.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-cy-utils@0.160.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-sb-utils@0.231.1-canary.2908.28502446091.0
  npm install @salutejs/plasma-tokens-utils@0.53.1-canary.2908.28502446091.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-b2c@1.623.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-core@1.230.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-giga@0.350.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-homeds@0.350.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-hope@1.377.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-icons@1.241.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-new-hope@0.367.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-tokens-b2b@1.57.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-tokens-b2c@0.68.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-tokens-web@1.72.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-tokens@1.142.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-typo@0.45.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-ui@1.353.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-web@1.625.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-bizcom@0.355.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-cs@0.359.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-dfa@0.353.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-finai@0.346.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-insol@0.350.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-netology@0.354.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-os@0.25.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-platform-ai@0.354.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-sbcom@0.355.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-scan@0.353.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-serv@0.354.1-canary.2908.28502446091.0
  yarn add @salutejs/core-themes@0.32.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-themes@0.53.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-themes@0.69.1-canary.2908.28502446091.0
  yarn add @salutejs/sdds-api-tests@0.12.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-cy-utils@0.160.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-sb-utils@0.231.1-canary.2908.28502446091.0
  yarn add @salutejs/plasma-tokens-utils@0.53.1-canary.2908.28502446091.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Cypress component test coverage for: Carousel, CodeField, CodeInput, Combobox, DatePicker, DateTimePicker, NumberFormat, NumberInput, Pagination, Popover, Select, Slider, Steps, TextField, TextFieldSlider, TimePicker, TimePickerGrid, and Tour.
  * Tests validate that user interactions (clicking controls, selecting options, typing values, and toggling panels) correctly trigger the relevant callbacks with the expected arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->