### PR TITLE
PLASMA-7599: fix renderTarget in Select

### DIFF
--- a/packages/plasma-new-hope/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.component-test.tsx
@@ -909,6 +909,104 @@ describeFn('Select', () => {
         cy.matchImageSnapshot();
     });
 
+    it('renderTarget single', () => {
+        cy.viewport(1000, 400);
+
+        const renderTarget = cy.stub().as('renderTarget');
+
+        renderTarget.callsFake((item, opened) => (
+            <button type="button" id="custom-target">
+                {item?.label || 'Placeholder'} {opened ? 'opened' : 'closed'}
+            </button>
+        ));
+
+        const Component = () => {
+            const [value, setValue] = useState('');
+
+            return <Select id="select" value={value} onChange={setValue} items={items} renderTarget={renderTarget} />;
+        };
+
+        mount(<Component />);
+
+        cy.get('#custom-target').should('contain.text', 'Placeholder closed');
+        cy.get('@renderTarget').then((stub) => {
+            expect(stub.lastCall.args[0]).to.equal(null);
+        });
+        cy.get('@renderTarget').its('lastCall.args.1').should('equal', false);
+
+        cy.get('#custom-target').click();
+
+        cy.get('#custom-target').should('contain.text', 'Placeholder opened');
+        cy.get('@renderTarget').then((stub) => {
+            expect(stub.lastCall.args[0]).to.equal(null);
+        });
+        cy.get('@renderTarget').its('lastCall.args.1').should('equal', true);
+
+        cy.contains('Южная Америка').click();
+        cy.contains('Колумбия').click();
+        cy.contains('Богота').click();
+
+        cy.get('#custom-target').should('contain.text', 'Богота closed');
+        cy.get('@renderTarget').its('lastCall.args.0').should('include', { value: 'bogota', label: 'Богота' });
+        cy.get('@renderTarget').its('lastCall.args.1').should('equal', false);
+    });
+
+    it('renderTarget multiple', () => {
+        cy.viewport(1000, 400);
+
+        const renderTarget = cy.stub().as('renderTarget');
+
+        renderTarget.callsFake((selectedItems, opened) => (
+            <button type="button" id="custom-target">
+                {selectedItems.length ? selectedItems.map((item) => item.label).join(', ') : 'Empty'}{' '}
+                {opened ? 'opened' : 'closed'}
+            </button>
+        ));
+
+        const Component = () => {
+            const [value, setValue] = useState<string[]>([]);
+
+            return (
+                <Select
+                    id="select"
+                    multiselect
+                    value={value}
+                    onChange={setValue}
+                    items={items}
+                    renderTarget={renderTarget}
+                />
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#custom-target').should('contain.text', 'Empty closed');
+        cy.get('@renderTarget').its('lastCall.args.0').should('deep.equal', []);
+        cy.get('@renderTarget').its('lastCall.args.1').should('equal', false);
+
+        cy.get('#custom-target').click();
+
+        cy.get('#custom-target').should('contain.text', 'Empty opened');
+        cy.get('@renderTarget').its('lastCall.args.0').should('deep.equal', []);
+        cy.get('@renderTarget').its('lastCall.args.1').should('equal', true);
+
+        cy.contains('Южная Америка').click();
+        cy.contains('Колумбия').click();
+        cy.get('[id$="bogota"] .checkbox-trigger').click();
+        cy.get('[id$="medellin"] .checkbox-trigger').click();
+
+        cy.get('#custom-target').should('contain.text', 'Богота, Медельин opened');
+        cy.get('@renderTarget')
+            .its('lastCall.args.0')
+            .then((selectedItems) => {
+                expect(selectedItems.map(({ value, label }) => ({ value, label }))).to.deep.equal([
+                    { value: 'bogota', label: 'Богота' },
+                    { value: 'medellin', label: 'Медельин' },
+                ]);
+            });
+        cy.get('@renderTarget').its('lastCall.args.1').should('equal', true);
+    });
+
     it('shift', () => {
         cy.viewport(400, 400);
 

--- a/packages/plasma-new-hope/src/components/Select/Select.types.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.types.ts
@@ -143,7 +143,7 @@ type SelectSingleProps<K extends ItemOption> = {
     /**
      * Callback для кастомной настройки значения в селекте.
      */
-    renderTarget?: (value: K, opened?: boolean) => ReactNode;
+    renderTarget?: (value: K | null, opened?: boolean) => ReactNode;
     selectAllOptions?: never;
 };
 

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/Target.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/Target.tsx
@@ -48,6 +48,7 @@ export const Target = forwardRef<HTMLButtonElement, TargetProps>(
                     inputWrapperRef={inputWrapperRef}
                     multiselect={multiselect}
                     value={value}
+                    opened={opened}
                     renderTarget={renderTarget}
                     valueToItemMap={valueToItemMap}
                 />

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/ui/RenderTarget/RenderTarget.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/ui/RenderTarget/RenderTarget.tsx
@@ -2,13 +2,14 @@ import React, { ReactNode, Ref } from 'react';
 
 import { TargetProps } from '../../Target.types';
 
-type Props = Pick<TargetProps, 'multiselect' | 'value' | 'renderTarget' | 'valueToItemMap'> & {
+type Props = Pick<TargetProps, 'multiselect' | 'value' | 'opened' | 'renderTarget' | 'valueToItemMap'> & {
     inputWrapperRef?: Ref<HTMLElement>;
 };
 
 export const RenderTarget: React.FC<Props> = ({
     multiselect,
     value,
+    opened,
     renderTarget,
     valueToItemMap,
     inputWrapperRef,
@@ -20,11 +21,11 @@ export const RenderTarget: React.FC<Props> = ({
             .map((itemValue) => valueToItemMap.get(itemValue))
             .filter((item): item is NonNullable<typeof item> => Boolean(item));
 
-        content = (renderTarget as any)(selectedItems);
+        content = (renderTarget as any)(selectedItems, opened);
     } else {
-        const selectedItem = valueToItemMap.get(value as string);
+        const selectedItem = valueToItemMap.get(value as string) ?? null;
 
-        content = selectedItem ? (renderTarget as any)(selectedItem) : null;
+        content = (renderTarget as any)(selectedItem, opened);
     }
 
     return <div ref={inputWrapperRef as Ref<HTMLDivElement>}>{content}</div>;

--- a/utils/api-tests/src/components/Select/Select.api.test.tsx
+++ b/utils/api-tests/src/components/Select/Select.api.test.tsx
@@ -101,7 +101,7 @@ describe('Basics', () => {
         expectTypeOf<SelectProps>()
             .toHaveProperty('renderTarget')
             .toEqualTypeOf<
-                | ((value: ItemOption, opened?: boolean) => ReactNode)
+                | ((value: ItemOption | null, opened?: boolean) => ReactNode)
                 | ((value: ItemOption[], opened?: boolean) => ReactNode)
                 | undefined
             >();


### PR DESCRIPTION
## Core

### Select
- исправлено поведение свойства `renderTarget` в single-режиме;

### What/why changed
- исправлено поведение свойства `renderTarget` в single-режиме;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom select targets now receive the current open/closed state, including during single-select empty selection.
  * The single-select `renderTarget` callback now consistently receives `null` when no item is selected (instead of being conditionally skipped).

* **Tests**
  * Added Cypress coverage for `renderTarget` behavior in both single-select and multiselect modes, including correct `opened` values and selected item payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.382.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-b2c@1.624.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-core@1.231.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-giga@0.351.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-homeds@0.351.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-hope@1.378.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-icons@1.242.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-new-hope@0.368.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-tokens-b2b@1.58.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-tokens-b2c@0.69.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-tokens-web@1.73.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-tokens@1.143.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-typo@0.46.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-ui@1.354.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-web@1.626.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-bizcom@0.356.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-cs@0.360.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-dfa@0.354.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-finai@0.347.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-insol@0.351.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-netology@0.355.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-os@0.26.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-platform-ai@0.355.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-sbcom@0.356.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-scan@0.354.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-serv@0.355.0-canary.2919.28372949774.0
  npm install @salutejs/core-themes@0.33.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-themes@0.54.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-themes@0.70.0-canary.2919.28372949774.0
  npm install @salutejs/sdds-api-tests@0.13.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-cy-utils@0.161.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-sb-utils@0.232.0-canary.2919.28372949774.0
  npm install @salutejs/plasma-tokens-utils@0.54.0-canary.2919.28372949774.0
  # or 
  yarn add @salutejs/plasma-asdk@0.382.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-b2c@1.624.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-core@1.231.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-giga@0.351.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-homeds@0.351.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-hope@1.378.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-icons@1.242.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-new-hope@0.368.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-tokens-b2b@1.58.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-tokens-b2c@0.69.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-tokens-web@1.73.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-tokens@1.143.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-typo@0.46.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-ui@1.354.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-web@1.626.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-bizcom@0.356.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-cs@0.360.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-dfa@0.354.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-finai@0.347.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-insol@0.351.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-netology@0.355.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-os@0.26.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-platform-ai@0.355.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-sbcom@0.356.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-scan@0.354.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-serv@0.355.0-canary.2919.28372949774.0
  yarn add @salutejs/core-themes@0.33.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-themes@0.54.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-themes@0.70.0-canary.2919.28372949774.0
  yarn add @salutejs/sdds-api-tests@0.13.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-cy-utils@0.161.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-sb-utils@0.232.0-canary.2919.28372949774.0
  yarn add @salutejs/plasma-tokens-utils@0.54.0-canary.2919.28372949774.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
