### PR TITLE
PLASMA-7551: fix range date chose in Calendar

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.Range.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.Range.component-test.tsx
@@ -41,7 +41,7 @@ describeFn('CalendarRange', () => {
     const CalendarDoubleRange = componentExists ? getComponent('CalendarDoubleRange') : () => null;
 
     const Demo = (args) => {
-        const { min, max, displayDouble, baseValue, size = 's', type = 'Days', locale = 'ru' } = args;
+        const { min, max, displayDouble, baseValue, size = 's', type = 'Days', locale = 'ru', renderFromDate } = args;
         const [values, setValue] = useState<[Date, Date?]>(baseValue);
 
         const handleOnChange = useCallback((newValue: [Date, Date?]) => {
@@ -75,7 +75,7 @@ describeFn('CalendarRange', () => {
         };
 
         const calendarMap = {
-            Days: getCalendarComponent({ type: 'Days', eventList: events, disabledList: disabledDays }),
+            Days: getCalendarComponent({ type: 'Days', eventList: events, disabledList: disabledDays, renderFromDate }),
             Months: getCalendarComponent({ type: 'Months' }),
             Quarters: getCalendarComponent({ type: 'Quarters' }),
             Years: getCalendarComponent({ type: 'Years' }),
@@ -126,6 +126,16 @@ describeFn('CalendarRange', () => {
         mount(<Demo baseValue={[undefined, undefined]} />);
 
         cy.get('body').find('[aria-selected="true"]').should('not.be.exist');
+    });
+
+    it('range: completes selection in 2 clicks from empty state', () => {
+        mount(<Demo baseValue={[undefined, undefined]} renderFromDate={new Date(1999, 6, 1)} />);
+
+        cy.get('[data-day="7"][data-month-index="6"]').first().click();
+        cy.get('[aria-selected="true"]').should('have.length', 1);
+
+        cy.get('[data-day="19"][data-month-index="6"]').first().click();
+        cy.get('[aria-selected="true"]').should('have.length', 2);
     });
 
     it('range in progress', () => {

--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.component-test.tsx
@@ -167,12 +167,19 @@ describeFn('Calendar', () => {
             type = 'Days',
             locale = 'ru',
             stretched = false,
+            uncontrolled = false,
+            renderFromDate,
         } = args;
         const [value, setValue] = useState(baseValue);
 
-        const handleOnChange = useCallback((newValue: Date) => {
-            setValue(newValue);
-        }, []);
+        const handleOnChange = useCallback(
+            (newValue: Date) => {
+                if (!uncontrolled) {
+                    setValue(newValue);
+                }
+            },
+            [uncontrolled],
+        );
 
         const getCalendarComponent = (rest) => {
             return displayDouble ? (
@@ -205,7 +212,13 @@ describeFn('Calendar', () => {
         };
 
         const calendarMap = {
-            Days: getCalendarComponent({ type: 'Days', eventList: events, disabledList: disabledDays, stretched }),
+            Days: getCalendarComponent({
+                type: 'Days',
+                eventList: events,
+                disabledList: disabledDays,
+                stretched,
+                renderFromDate,
+            }),
             Months: getCalendarComponent({ type: 'Months', eventMonthList: monthEvents, stretched }),
             Quarters: getCalendarComponent({ type: 'Quarters', eventQuarterList: quarterEvents, stretched }),
             Years: getCalendarComponent({ type: 'Years', eventYearList: yearEvents, stretched }),
@@ -275,6 +288,25 @@ describeFn('Calendar', () => {
         mount(<Demo />);
 
         cy.get('body').find('[aria-selected="true"]').should('not.be.exist');
+    });
+
+    it('uncontrolled: click selects a day without external value update', () => {
+        mount(<Demo uncontrolled renderFromDate={new Date(1999, 6, 1)} />);
+
+        cy.get('[data-day="7"][data-month-index="6"]').first().click();
+
+        cy.get('[aria-selected="true"]').should('have.length', 1);
+        cy.get('[data-day="7"][data-month-index="6"]').first().should('have.attr', 'aria-selected', 'true');
+    });
+
+    it('uncontrolled: clicking another day replaces the selection', () => {
+        mount(<Demo uncontrolled renderFromDate={new Date(1999, 6, 1)} />);
+
+        cy.get('[data-day="7"][data-month-index="6"]').first().click();
+        cy.get('[data-day="15"][data-month-index="6"]').first().click();
+
+        cy.get('[aria-selected="true"]').should('have.length', 1);
+        cy.get('[data-day="15"][data-month-index="6"]').first().should('have.attr', 'aria-selected', 'true');
     });
 
     it('days: prev month', () => {

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
@@ -15,7 +15,7 @@ import cls from 'classnames';
 import { useForkRef } from 'src/hooks';
 import { RootProps } from 'src/engines';
 
-import type { Calendar, CalendarConfigProps, DateObject } from '../Calendar.types';
+import type { Calendar, CalendarConfigProps, CalendarValueType, DateInfo, DateObject } from '../Calendar.types';
 import { getInitialState, reducer, sizeMap } from '../store/reducer';
 import { ActionType, CalendarState } from '../store/types';
 import { I18N, isValueUpdate } from '../utils';
@@ -69,6 +69,15 @@ export const calendarBaseRoot = (
             );
             const value = focusedDate || secondValue || firstValue;
 
+            const isSingleMode = !Array.isArray(externalValue);
+            const [internalValue, setInternalValue] = useState<CalendarValueType>(externalValue);
+            const [prevExternalForSelection, setPrevExternalForSelection] = useState<CalendarValueType>(externalValue);
+
+            if (isValueUpdate(externalValue, prevExternalForSelection)) {
+                setInternalValue(externalValue);
+                setPrevExternalForSelection(externalValue);
+            }
+
             const [hoveredItem, setHoveredItem] = useState<DateObject | undefined>();
             const [prevType, setPrevType] = useState(type);
             const [prevValue, setPrevValue] = useState(value);
@@ -108,13 +117,23 @@ export const calendarBaseRoot = (
                 onPrev: handlePrev,
             });
 
+            const handleOnChangeValue = useCallback(
+                (newDay: Date, dateInfo?: DateInfo) => {
+                    if (isSingleMode && externalValue == null) {
+                        setInternalValue(newDay);
+                    }
+                    onChangeValue?.(newDay, dateInfo);
+                },
+                [onChangeValue, isSingleMode, externalValue],
+            );
+
             const {
                 handleOnChangeDay,
                 handleOnChangeMonth,
                 handleOnChangeQuarter,
                 handleOnChangeYear,
                 handleUpdateCalendarState,
-            } = useCalendarDateChange({ type, onChangeValue, onSelectIndexes, dispatch });
+            } = useCalendarDateChange({ type, onChangeValue: handleOnChangeValue, onSelectIndexes, dispatch });
 
             // Изменяем ключ каждый раз как пытаемся перейти на даты которые находятся за пределами min/max ограничений.
             // Это необходимо для того чтобы screen-reader корректно озвучивал уведомление aria-live="assertive"
@@ -223,7 +242,7 @@ export const calendarBaseRoot = (
                     />
                     {calendarState === CalendarState.Days && (
                         <CalendarDays
-                            value={externalValue}
+                            value={internalValue}
                             date={date}
                             min={min}
                             max={max}
@@ -243,7 +262,7 @@ export const calendarBaseRoot = (
                     )}
                     {calendarState === CalendarState.Months && (
                         <CalendarMonths
-                            value={externalValue}
+                            value={internalValue}
                             date={date}
                             min={min}
                             max={max}
@@ -262,7 +281,7 @@ export const calendarBaseRoot = (
                     )}
                     {calendarState === CalendarState.Quarters && (
                         <CalendarQuarters
-                            value={externalValue}
+                            value={internalValue}
                             date={date}
                             min={min}
                             max={max}
@@ -280,7 +299,7 @@ export const calendarBaseRoot = (
                     )}
                     {calendarState === CalendarState.Years && (
                         <CalendarYears
-                            value={externalValue}
+                            value={internalValue}
                             date={date}
                             startYear={startYear}
                             selectIndexes={selectIndexes}

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
@@ -15,7 +15,7 @@ import cls from 'classnames';
 import type { RootProps } from 'src/engines';
 
 import { useForkRef } from '../../../hooks';
-import type { Calendar, CalendarConfigProps, DateObject } from '../Calendar.types';
+import type { Calendar, CalendarConfigProps, CalendarValueType, DateInfo, DateObject } from '../Calendar.types';
 import { YEAR_RENDER_COUNT, getNextDate, isValueUpdate, I18N } from '../utils';
 import { useKeyNavigation, useCalendarNavigation, useCalendarDateChange } from '../hooks';
 import { CalendarDays, CalendarHeader, CalendarMonths, CalendarQuarters, CalendarYears, EventTooltip } from '../ui';
@@ -70,6 +70,15 @@ export const calendarDoubleRoot = (
             );
             const value = focusedDate || secondValue || firstValue;
 
+            const isSingleMode = !Array.isArray(externalValue);
+            const [internalValue, setInternalValue] = useState<CalendarValueType>(externalValue);
+            const [prevExternalForSelection, setPrevExternalForSelection] = useState<CalendarValueType>(externalValue);
+
+            if (isValueUpdate(externalValue, prevExternalForSelection)) {
+                setInternalValue(externalValue);
+                setPrevExternalForSelection(externalValue);
+            }
+
             const [hoveredItem, setHoveredItem] = useState<DateObject | undefined>();
             const [prevType, setPrevType] = useState(type);
             const [prevValue, setPrevValue] = useState(value);
@@ -110,13 +119,23 @@ export const calendarDoubleRoot = (
                 onPrev: handlePrev,
             });
 
+            const handleOnChangeValue = useCallback(
+                (newDay: Date, dateInfo?: DateInfo) => {
+                    if (isSingleMode && externalValue == null) {
+                        setInternalValue(newDay);
+                    }
+                    onChangeValue?.(newDay, dateInfo);
+                },
+                [onChangeValue, isSingleMode, externalValue],
+            );
+
             const {
                 handleOnChangeDay,
                 handleOnChangeMonth,
                 handleOnChangeQuarter,
                 handleOnChangeYear,
                 handleUpdateCalendarState,
-            } = useCalendarDateChange({ type, onChangeValue, onSelectIndexes, dispatch });
+            } = useCalendarDateChange({ type, onChangeValue: handleOnChangeValue, onSelectIndexes, dispatch });
 
             const updateSecondDate = () => {
                 if (calendarState === CalendarState.Days) {
@@ -272,7 +291,7 @@ export const calendarDoubleRoot = (
                         {calendarState === CalendarState.Days && (
                             <>
                                 <CalendarDays
-                                    value={externalValue}
+                                    value={internalValue}
                                     date={firstDate}
                                     min={min}
                                     max={max}
@@ -292,7 +311,7 @@ export const calendarDoubleRoot = (
                                 />
                                 <StyledSeparator />
                                 <CalendarDays
-                                    value={externalValue}
+                                    value={internalValue}
                                     date={secondDate}
                                     min={min}
                                     max={max}
@@ -316,7 +335,7 @@ export const calendarDoubleRoot = (
                         {calendarState === CalendarState.Months && (
                             <>
                                 <CalendarMonths
-                                    value={externalValue}
+                                    value={internalValue}
                                     date={firstDate}
                                     min={min}
                                     max={max}
@@ -335,7 +354,7 @@ export const calendarDoubleRoot = (
                                 />
                                 <StyledSeparator />
                                 <CalendarMonths
-                                    value={externalValue}
+                                    value={internalValue}
                                     date={secondDate}
                                     min={min}
                                     max={max}
@@ -358,7 +377,7 @@ export const calendarDoubleRoot = (
                         {calendarState === CalendarState.Quarters && (
                             <>
                                 <CalendarQuarters
-                                    value={externalValue}
+                                    value={internalValue}
                                     date={firstDate}
                                     min={min}
                                     max={max}
@@ -376,7 +395,7 @@ export const calendarDoubleRoot = (
                                 />
                                 <StyledSeparator />
                                 <CalendarQuarters
-                                    value={externalValue}
+                                    value={internalValue}
                                     date={secondDate}
                                     min={min}
                                     max={max}
@@ -398,7 +417,7 @@ export const calendarDoubleRoot = (
                         {calendarState === CalendarState.Years && (
                             <>
                                 <CalendarYears
-                                    value={externalValue}
+                                    value={internalValue}
                                     date={firstDate}
                                     startYear={startYear}
                                     selectIndexes={selectIndexes}
@@ -417,7 +436,7 @@ export const calendarDoubleRoot = (
                                 />
                                 <StyledSeparator />
                                 <CalendarYears
-                                    value={externalValue}
+                                    value={internalValue}
                                     date={secondDate}
                                     startYear={startYear + YEAR_RENDER_COUNT}
                                     selectIndexes={selectIndexes}

--- a/packages/plasma-new-hope/src/components/Calendar/hoc/withRange.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/hoc/withRange.tsx
@@ -42,13 +42,15 @@ export const withRange = <T extends Calendar>(Component: FC<Calendar>) => ({
                 return;
             }
 
-            setValues([startValue, newDay]);
-
-            const [first, second] = getSortedValues([startValue, newDay]);
-
             if (startValue) {
+                setValues([startValue, newDay]);
+
+                const [first, second] = getSortedValues([startValue, newDay]);
+
                 onChangeValue([first, second], dateInfo);
             } else {
+                setValues([newDay, undefined]);
+
                 onChangeSingleValue?.(newDay, dateInfo);
             }
         },


### PR DESCRIPTION
## Core

### Calendar

- исправлен выбор даты в range-календаре при начальных `[undefined, undefined]`
- добавлен неконтролируемый режим

### What/why changed

- исправлен выбор даты в range-календаре при начальных `[undefined, undefined]`
- добавлен неконтролируемый режим


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar selection handling across single and double-date modes, keeping the visible selection synchronized with the current value.
  * Fixed range picking logic so an empty range can be completed in two clicks.
  * Improved uncontrolled calendar behavior so day selection updates correctly after user clicks.
  * Enhanced range demo rendering support via `renderFromDate`, improving day cell selection initialization.
* **Tests**
  * Added Cypress coverage for completing an empty range in two clicks and for uncontrolled day selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.382.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-b2c@1.624.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-core@1.231.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-giga@0.351.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-homeds@0.351.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-hope@1.378.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-icons@1.242.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-new-hope@0.368.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-tokens-b2b@1.58.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-tokens-b2c@0.69.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-tokens-web@1.73.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-tokens@1.143.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-typo@0.46.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-ui@1.354.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-web@1.626.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-bizcom@0.356.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-cs@0.360.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-dfa@0.354.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-finai@0.347.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-insol@0.351.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-netology@0.355.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-os@0.26.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-platform-ai@0.355.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-sbcom@0.356.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-scan@0.354.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-serv@0.355.0-canary.2921.28425642279.0
  npm install @salutejs/core-themes@0.33.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-themes@0.54.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-themes@0.70.0-canary.2921.28425642279.0
  npm install @salutejs/sdds-api-tests@0.13.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-cy-utils@0.161.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-sb-utils@0.232.0-canary.2921.28425642279.0
  npm install @salutejs/plasma-tokens-utils@0.54.0-canary.2921.28425642279.0
  # or 
  yarn add @salutejs/plasma-asdk@0.382.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-b2c@1.624.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-core@1.231.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-giga@0.351.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-homeds@0.351.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-hope@1.378.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-icons@1.242.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-new-hope@0.368.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-tokens-b2b@1.58.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-tokens-b2c@0.69.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-tokens-web@1.73.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-tokens@1.143.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-typo@0.46.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-ui@1.354.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-web@1.626.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-bizcom@0.356.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-cs@0.360.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-dfa@0.354.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-finai@0.347.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-insol@0.351.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-netology@0.355.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-os@0.26.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-platform-ai@0.355.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-sbcom@0.356.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-scan@0.354.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-serv@0.355.0-canary.2921.28425642279.0
  yarn add @salutejs/core-themes@0.33.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-themes@0.54.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-themes@0.70.0-canary.2921.28425642279.0
  yarn add @salutejs/sdds-api-tests@0.13.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-cy-utils@0.161.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-sb-utils@0.232.0-canary.2921.28425642279.0
  yarn add @salutejs/plasma-tokens-utils@0.54.0-canary.2921.28425642279.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
