### PR TITLE
PLASMA-7619: add width calculation to HiddenTextArea

### DIFF
--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.styles.ts
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.styles.ts
@@ -257,6 +257,11 @@ export const StyledHiddenTextArea = styled.textarea<{
     resize?: string;
     cols?: number;
 }>`
+    ${privateTokens.scrollbarCompensationPadding}: calc(var(${tokens.borderSize}, 0.0625rem) + var(${
+    tokens.scrollbarMarginRight
+}, 0rem));
+
+    width: ${({ cols }) => (cols ? 'unset' : '100%')};
     max-height: none !important;
     min-height: var(${tokens.inputMinHeight}) !important;
     visibility: hidden !important;
@@ -269,8 +274,8 @@ export const StyledHiddenTextArea = styled.textarea<{
     border-width: 0;
     padding-right: ${({ hasContentRight }) =>
         hasContentRight
-            ? `var(${tokens.inputPaddingRightWithRightContent}, 0)`
-            : `var(${tokens.inputPaddingRight}, 0)`};
+            ? `calc(var(${privateTokens.scrollbarCompensationPadding}, 0) + var(${tokens.inputPaddingRightWithRightContent}, 0))`
+            : `calc(var(${privateTokens.scrollbarCompensationPadding}, 0) + var(${tokens.inputPaddingRight}, 0))`};
     padding-left: var(${tokens.inputPaddingLeft}, 0);
     padding-top: 0;
     padding-bottom: 0;

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tokens.ts
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tokens.ts
@@ -2,6 +2,7 @@ export const privateTokens = {
     inputActualHeight: '--plasma_private-textarea-input-actual-height',
     wrapperPaddingBottomInnerLabel: '--plasma_private-textarea-inner-label-padding-bottom',
     dividerColor: '--plasma_private-textarea-divider-color',
+    scrollbarCompensationPadding: '--plasma_private-textarea-scrollbar-compensation-padding',
 };
 
 export const classes = {


### PR DESCRIPTION
## Core

### TextArea

- добавлен расчет ширины `HiddenTextArea` для корректного создания новой строки

### What/why changed

**Before:**
<img width="482" height="168" alt="textarea autores before" src="https://github.com/user-attachments/assets/f0323b05-1b18-408e-9fdb-afb7a74c7733" />

**After:**
<img width="482" height="168" alt="autoresize after" src="https://github.com/user-attachments/assets/51173fb7-7c8c-47ca-9de1-e21a31028da0" />

- добавлен расчет ширины `HiddenTextArea` для корректного создания новой строки


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TextArea spacing when scrollbars are present, helping text and content align more consistently.
  * Adjusted hidden input padding to better account for right-side content and scrollbar-related spacing.
  * Reduced layout shifts caused by scrollbar geometry in TextArea components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.382.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-b2c@1.624.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-core@1.231.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-giga@0.351.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-homeds@0.351.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-hope@1.378.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-icons@1.242.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-new-hope@0.368.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-tokens-b2b@1.58.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-tokens-b2c@0.69.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-tokens-web@1.73.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-tokens@1.143.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-typo@0.46.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-ui@1.354.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-web@1.626.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-bizcom@0.356.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-cs@0.360.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-dfa@0.354.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-finai@0.347.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-insol@0.351.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-netology@0.355.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-os@0.26.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-platform-ai@0.355.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-sbcom@0.356.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-scan@0.354.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-serv@0.355.0-canary.2930.28520884969.0
  npm install @salutejs/core-themes@0.33.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-themes@0.54.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-themes@0.70.0-canary.2930.28520884969.0
  npm install @salutejs/sdds-api-tests@0.13.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-cy-utils@0.161.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-sb-utils@0.232.0-canary.2930.28520884969.0
  npm install @salutejs/plasma-tokens-utils@0.54.0-canary.2930.28520884969.0
  # or 
  yarn add @salutejs/plasma-asdk@0.382.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-b2c@1.624.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-core@1.231.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-giga@0.351.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-homeds@0.351.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-hope@1.378.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-icons@1.242.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-new-hope@0.368.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-tokens-b2b@1.58.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-tokens-b2c@0.69.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-tokens-web@1.73.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-tokens@1.143.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-typo@0.46.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-ui@1.354.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-web@1.626.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-bizcom@0.356.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-cs@0.360.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-dfa@0.354.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-finai@0.347.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-insol@0.351.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-netology@0.355.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-os@0.26.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-platform-ai@0.355.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-sbcom@0.356.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-scan@0.354.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-serv@0.355.0-canary.2930.28520884969.0
  yarn add @salutejs/core-themes@0.33.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-themes@0.54.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-themes@0.70.0-canary.2930.28520884969.0
  yarn add @salutejs/sdds-api-tests@0.13.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-cy-utils@0.161.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-sb-utils@0.232.0-canary.2930.28520884969.0
  yarn add @salutejs/plasma-tokens-utils@0.54.0-canary.2930.28520884969.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
