### PR TITLE
PLASMA-7623: add onBlur in Autocomplete

### DIFF
--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.component-test.tsx
@@ -285,6 +285,40 @@ describeFn('Autocomplete', () => {
         cy.get('ul[role="listbox"]').should('be.visible');
     });
 
+    it('closes list on blur', () => {
+        const onBlur = cy.stub().as('onBlur');
+
+        cy.viewport(1000, 500);
+
+        mount(
+            <Autocomplete
+                label="Label"
+                leftHelper="Helper Text"
+                suggestions={suggestions}
+                threshold={0}
+                onBlur={onBlur}
+            />,
+        );
+
+        cy.get('input').click();
+        cy.get('ul[role="listbox"]').should('be.visible');
+        cy.get('input').blur();
+        cy.get('ul[role="listbox"]').should('not.exist');
+        cy.get('@onBlur').should('have.been.calledOnce');
+    });
+
+    it('selects item by mouse click', () => {
+        cy.viewport(1000, 500);
+
+        mount(<Autocomplete label="Label" leftHelper="Helper Text" suggestions={suggestions} />);
+
+        cy.get('input').click();
+        cy.focused().type('ал');
+        cy.get('ul li').first().click();
+        cy.get('ul').should('not.exist');
+        cy.get('input').should('have.value', 'Алексей Смирнов');
+    });
+
     it('portal', () => {
         mount(<DemoWithPortal />);
 

--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.tsx
@@ -34,6 +34,8 @@ export const autocompleteRoot = (Root: RootProps<HTMLInputElement, Omit<Autocomp
                 textBefore,
                 textAfter,
                 onScroll,
+                onBlur,
+                onFocus,
                 listMaxHeight = '25rem',
                 listWidth,
                 portal,
@@ -69,17 +71,43 @@ export const autocompleteRoot = (Root: RootProps<HTMLInputElement, Omit<Autocomp
 
             const helperTextId = safeUseId();
             const floatingPopoverRef = useRef<HTMLDivElement>(null);
+            const floatingListRef = useRef<HTMLDivElement>(null);
             const listWrapperRef = useRef<HTMLDivElement>(null);
+            const isListMouseDownRef = useRef<boolean>(false);
 
             /* Логика работы при клике за пределами выпадающего списка */
             useOutsideClick(() => {
                 setIsOpen(false);
             }, [floatingPopoverRef, listWrapperRef]);
 
-            const handleFocus = () => {
+            const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+                if (onFocus) {
+                    onFocus(event);
+                }
+
                 if (!readOnly && value.toString().length >= threshold) {
                     setIsOpen(true);
                 }
+            };
+
+            const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+                if (onBlur) {
+                    onBlur(event);
+                }
+
+                if (isListMouseDownRef.current) {
+                    return;
+                }
+
+                setIsOpen(false);
+            };
+
+            const handleListMouseDown = () => {
+                isListMouseDownRef.current = true;
+
+                window.setTimeout(() => {
+                    isListMouseDownRef.current = false;
+                }, 0);
             };
 
             const handleItemClick = (e: SuggestionItemType) => {
@@ -151,6 +179,8 @@ export const autocompleteRoot = (Root: RootProps<HTMLInputElement, Omit<Autocomp
                         listWidth={listWidth}
                         offset={_offset}
                         flip={flip}
+                        floatingRef={floatingListRef}
+                        onFloatingMouseDown={handleListMouseDown}
                         target={(referenceRef) => (
                             <StyledTextField
                                 ref={ref}
@@ -168,6 +198,7 @@ export const autocompleteRoot = (Root: RootProps<HTMLInputElement, Omit<Autocomp
                                 textBefore={textBefore}
                                 textAfter={textAfter}
                                 onFocus={handleFocus}
+                                onBlur={handleBlur}
                                 onKeyDown={onKeyDown}
                                 role="combobox"
                                 aria-autocomplete="list"

--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.types.ts
@@ -138,6 +138,8 @@ export type FloatingPopoverProps = {
     target: React.ReactNode | ((ref: React.MutableRefObject<HTMLElement | null>) => React.ReactNode);
     children: React.ReactNode;
     opened: boolean;
+    floatingRef?: React.MutableRefObject<HTMLDivElement | null>;
+    onFloatingMouseDown?: React.MouseEventHandler<HTMLDivElement>;
     portal?: AutocompleteProps['portal'];
     zIndex?: AutocompleteProps['zIndex'];
     listWidth?: AutocompleteProps['listWidth'];

--- a/packages/plasma-new-hope/src/components/Autocomplete/FloatingPopover.tsx
+++ b/packages/plasma-new-hope/src/components/Autocomplete/FloatingPopover.tsx
@@ -13,7 +13,21 @@ import { safeUseId } from 'src/utils';
 import type { FloatingPopoverProps } from './Autocomplete.types';
 
 const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
-    ({ target, children, opened, portal, zIndex, listWidth, offset, flip: flipFlag }, ref) => {
+    (
+        {
+            target,
+            children,
+            opened,
+            floatingRef,
+            onFloatingMouseDown,
+            portal,
+            zIndex,
+            listWidth,
+            offset,
+            flip: flipFlag,
+        },
+        ref,
+    ) => {
         const { refs, floatingStyles } = useFloating({
             whileElementsMounted(referenceEl, floatingEl, update) {
                 return autoUpdate(referenceEl, floatingEl, update, {
@@ -42,6 +56,13 @@ const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
         });
 
         const wrappedId = safeUseId();
+        const setFloatingRef = (node: HTMLDivElement | null) => {
+            refs.setFloating(node);
+
+            if (floatingRef) {
+                floatingRef.current = node;
+            }
+        };
 
         // Проверка на target. Это может быть как ReactNode, так и функция, в которую пробрасывается ref.
         // Это нужно для более тонкой настройки reference-элемента, вокруг которого и будет позиционироваться выпадашка.
@@ -59,7 +80,11 @@ const FloatingPopover = forwardRef<HTMLDivElement, FloatingPopoverProps>(
                     // root - принимает ref контейнера портала.
                     // id - если есть портал - не используется, если портала нет - подставляется 'wrappedId'.
                     <FloatingPortal {...getFloatingPortalProps(portal, wrappedId)}>
-                        <div ref={refs.setFloating} style={{ ...floatingStyles, zIndex: zIndex || 1000 }}>
+                        <div
+                            ref={setFloatingRef}
+                            style={{ ...floatingStyles, zIndex: zIndex || 1000 }}
+                            onMouseDown={onFloatingMouseDown}
+                        >
                             {children}
                         </div>
                     </FloatingPortal>


### PR DESCRIPTION
## Core

### Autocomplete
- исправлено баг, при котором выпадающий список подсказок мог не закрываться при смене фокуса у поля ввода;

### What/why changed


Было:
<img width="320" height="449" alt="after" src="https://github.com/user-attachments/assets/a0b25a29-8887-49c6-b96f-8dc71f8194dc" />

Стало:
<img width="320" height="449" alt="before" src="https://github.com/user-attachments/assets/42f64d94-9e73-4d15-82a5-6469b2d19c49" />
- исправлено баг, при котором выпадающий список подсказок мог не закрываться при смене фокуса у поля ввода;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Autocomplete now supports an `onBlur` callback and improves focus/blur handling behavior.

* **Bug Fixes**
  * Suggestions now close reliably on input blur.
  * Clicking a suggestion updates the input value and closes the dropdown as expected.

* **Tests**
  * Added Cypress coverage for “closes list on blur” and “selects item by mouse click.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.382.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-b2c@1.624.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-core@1.231.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-giga@0.351.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-homeds@0.351.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-hope@1.378.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-icons@1.242.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-new-hope@0.368.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-tokens-b2b@1.58.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-tokens-b2c@0.69.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-tokens-web@1.73.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-tokens@1.143.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-typo@0.46.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-ui@1.354.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-web@1.626.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-bizcom@0.356.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-cs@0.360.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-dfa@0.354.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-finai@0.347.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-insol@0.351.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-netology@0.355.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-os@0.26.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-platform-ai@0.355.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-sbcom@0.356.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-scan@0.354.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-serv@0.355.0-canary.2939.28848057806.0
  npm install @salutejs/core-themes@0.33.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-themes@0.54.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-themes@0.70.0-canary.2939.28848057806.0
  npm install @salutejs/sdds-api-tests@0.13.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-cy-utils@0.161.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-sb-utils@0.232.0-canary.2939.28848057806.0
  npm install @salutejs/plasma-tokens-utils@0.54.0-canary.2939.28848057806.0
  # or 
  yarn add @salutejs/plasma-asdk@0.382.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-b2c@1.624.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-core@1.231.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-giga@0.351.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-homeds@0.351.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-hope@1.378.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-icons@1.242.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-new-hope@0.368.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-tokens-b2b@1.58.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-tokens-b2c@0.69.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-tokens-web@1.73.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-tokens@1.143.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-typo@0.46.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-ui@1.354.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-web@1.626.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-bizcom@0.356.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-cs@0.360.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-dfa@0.354.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-finai@0.347.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-insol@0.351.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-netology@0.355.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-os@0.26.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-platform-ai@0.355.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-sbcom@0.356.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-scan@0.354.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-serv@0.355.0-canary.2939.28848057806.0
  yarn add @salutejs/core-themes@0.33.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-themes@0.54.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-themes@0.70.0-canary.2939.28848057806.0
  yarn add @salutejs/sdds-api-tests@0.13.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-cy-utils@0.161.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-sb-utils@0.232.0-canary.2939.28848057806.0
  yarn add @salutejs/plasma-tokens-utils@0.54.0-canary.2939.28848057806.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
