### PR TITLE
PLASMA-7625: Исправлено двойная вставка при фокусе через Tab

### DIFF
--- a/packages/plasma-new-hope/src/components/CodeInput/CodeInput.tsx
+++ b/packages/plasma-new-hope/src/components/CodeInput/CodeInput.tsx
@@ -2,11 +2,9 @@ import React, { forwardRef, Fragment, useCallback, useRef, useState } from 'reac
 import cls from 'classnames';
 import type { ChangeEvent, KeyboardEvent, ClipboardEvent } from 'react';
 import type { RootProps } from 'src/engines';
-import { useDidMountEffect } from 'src/hooks';
+import { useDidMountEffect, useCodeHook } from 'src/hooks';
 import { getSizeValueFromProp } from 'src/utils';
-
-import { BACKSPACE_KEY, FORBIDDEN_KEYS, ONLY_DIGITS_PATTERN } from '../../utils/constants';
-import { useCodeHook } from '../../hooks';
+import { BACKSPACE_KEY, FORBIDDEN_KEYS, ONLY_DIGITS_PATTERN } from 'src/utils/constants';
 
 import type { CodeInputProps } from './CodeInput.types';
 import { getCodeValue, getFieldPattern, getPlaceholderValue, handleCodeError, handleItemError } from './utils';
@@ -109,6 +107,7 @@ export const codeInputRoot = (Root: RootProps<HTMLDivElement, CodeInputProps>) =
                 }
 
                 if (type === 'circle') {
+                    event.preventDefault();
                     handleAddSymbol(key, index);
                     inputRefs.current[index]?.focus();
                 }


### PR DESCRIPTION
## Core

### CodeInput

- исправлена ошибка двойной вставки\ввода в состояние фокуса через `Tab`  

### What/why changed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling for circle-style code inputs so default key behavior is blocked before custom input handling runs, resulting in more consistent entry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.381.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-b2c@1.623.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-core@1.230.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-giga@0.350.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-homeds@0.350.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-hope@1.377.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-icons@1.241.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-new-hope@0.367.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-tokens-b2b@1.57.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-tokens-b2c@0.68.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-tokens-web@1.72.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-tokens@1.142.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-typo@0.45.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-ui@1.353.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-web@1.625.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-bizcom@0.355.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-cs@0.359.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-dfa@0.353.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-finai@0.346.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-insol@0.350.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-netology@0.354.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-os@0.25.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-platform-ai@0.354.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-sbcom@0.355.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-scan@0.353.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-serv@0.354.1-canary.2941.28840343487.0
  npm install @salutejs/core-themes@0.32.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-themes@0.53.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-themes@0.69.1-canary.2941.28840343487.0
  npm install @salutejs/sdds-api-tests@0.12.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-cy-utils@0.160.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-sb-utils@0.231.1-canary.2941.28840343487.0
  npm install @salutejs/plasma-tokens-utils@0.53.1-canary.2941.28840343487.0
  # or 
  yarn add @salutejs/plasma-asdk@0.381.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-b2c@1.623.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-core@1.230.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-giga@0.350.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-homeds@0.350.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-hope@1.377.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-icons@1.241.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-new-hope@0.367.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-tokens-b2b@1.57.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-tokens-b2c@0.68.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-tokens-web@1.72.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-tokens@1.142.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-typo@0.45.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-ui@1.353.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-web@1.625.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-bizcom@0.355.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-cs@0.359.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-dfa@0.353.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-finai@0.346.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-insol@0.350.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-netology@0.354.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-os@0.25.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-platform-ai@0.354.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-sbcom@0.355.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-scan@0.353.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-serv@0.354.1-canary.2941.28840343487.0
  yarn add @salutejs/core-themes@0.32.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-themes@0.53.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-themes@0.69.1-canary.2941.28840343487.0
  yarn add @salutejs/sdds-api-tests@0.12.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-cy-utils@0.160.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-sb-utils@0.231.1-canary.2941.28840343487.0
  yarn add @salutejs/plasma-tokens-utils@0.53.1-canary.2941.28840343487.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
