### PR TITLE
PLASMA-7763: fix keyboard logic in readOnly mode

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.component-test.tsx
@@ -381,6 +381,31 @@ describeFn('Combobox', () => {
         cy.matchImageSnapshot();
     });
 
+    it('readOnly: does not handle keyboard navigation or remove chips', () => {
+        const onChange = cy.stub().as('onChange');
+
+        mount(
+            <Combobox
+                id="read-only"
+                multiple
+                readOnly
+                defaultValue={['north_america']}
+                items={items}
+                onChange={onChange}
+            />,
+        );
+
+        cy.get('#read-only').click();
+        cy.pressKey('ArrowDown');
+        cy.get('[id$="tree_level_1"]').should('not.exist');
+        cy.pressKey('Enter');
+        cy.get('[id$="tree_level_1"]').should('not.exist');
+
+        cy.get('.has-chips button').click().focus().pressKey('Backspace');
+        cy.get('.has-chips button').should('have.length', 1);
+        cy.get('@onChange').should('not.have.been.called');
+    });
+
     it('variant', () => {
         cy.viewport(1280, 732);
 
@@ -2278,11 +2303,9 @@ describeFn('Combobox', () => {
         cy.pressKey('Enter');
         cy.pressKey('ArrowLeft');
         cy.get('[id$="tree_level_1"]').should('not.exist');
-        cy.get('#multiple').should('be.focused');
+        cy.get('.has-chips .chips-wrapper button:last-child').should('have.attr', 'data-focus-visible-added');
         cy.get('.has-chips').should('exist');
         cy.get('.has-chips button').should('have.length', 6);
-        cy.pressKey('ArrowLeft');
-        cy.get('.has-chips .chips-wrapper button:last-child').should('have.attr', 'data-focus-visible-added');
         cy.pressKey('Backspace');
         cy.get('.has-chips button').should('have.length', 5);
         cy.get('.has-chips .chips-wrapper button:last-child').should('have.attr', 'data-focus-visible-added');

--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.tsx
@@ -206,6 +206,8 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             treeView,
             valueToPathMap: filteredValueToPathMap,
             items: filteredItems,
+            disabled,
+            readOnly,
         });
 
         /**
@@ -267,7 +269,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
 
         /* Обработчик чипов */
         const handleChipClick = (chip: { value: string; label: string; disabled: boolean }) => {
-            if (!Array.isArray(value)) return;
+            if (readOnly || !Array.isArray(value)) return;
 
             if (isTargetAmount) {
                 // При закрытии чипа в режиме isTargetAmount в value оставляем только disabled-элементы

--- a/packages/plasma-new-hope/src/components/Combobox/hooks/useKeyboardNavigation.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/hooks/useKeyboardNavigation.ts
@@ -58,6 +58,8 @@ type Props = {
     treeView: boolean;
     valueToPathMap: Map<string, string[]>;
     items: ItemOptionTransformed[];
+    disabled: boolean;
+    readOnly: boolean;
 };
 
 type ReturnedProps = {
@@ -84,9 +86,19 @@ export const useKeyNavigation = ({
     treeView,
     valueToPathMap,
     items,
+    disabled,
+    readOnly,
 }: Props): ReturnedProps => {
+    const getGuardedKeyDown = (onKeyDown: ReturnedProps['onKeyDown']) => (event: React.KeyboardEvent<HTMLElement>) => {
+        if (disabled || readOnly) {
+            return;
+        }
+
+        onKeyDown(event);
+    };
+
     if (treeView) {
-        return keyboardNavigationTree({
+        const { onKeyDown } = keyboardNavigationTree({
             focusedPath,
             dispatchFocusedPath,
             path,
@@ -105,10 +117,14 @@ export const useKeyNavigation = ({
             treeView,
             valueToPathMap,
             items,
+            disabled,
+            readOnly,
         });
+
+        return { onKeyDown: getGuardedKeyDown(onKeyDown) };
     }
 
-    return keyboardNavigationDefault({
+    const { onKeyDown } = keyboardNavigationDefault({
         focusedPath,
         dispatchFocusedPath,
         path,
@@ -127,7 +143,11 @@ export const useKeyNavigation = ({
         treeView,
         valueToPathMap,
         items,
+        disabled,
+        readOnly,
     });
+
+    return { onKeyDown: getGuardedKeyDown(onKeyDown) };
 };
 
 const keyboardNavigationDefault = ({
@@ -198,7 +218,6 @@ const keyboardNavigationDefault = ({
 
             case keys.ArrowLeft: {
                 if (path[0]) {
-                    event.stopPropagation();
                     event.preventDefault();
 
                     if (focusedPath.length) {
@@ -211,7 +230,15 @@ const keyboardNavigationDefault = ({
 
                     if (path.length === 1) {
                         handleListToggle(false);
+
+                        // Передаем событие в TextField, чтобы его навигация сразу
+                        // установила фокус на последний выбранный чип.
+                        if (multiple && Array.isArray(value) && value.length) {
+                            break;
+                        }
                     }
+
+                    event.stopPropagation();
                 }
 
                 break;

--- a/packages/plasma-new-hope/src/components/Select/Select.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.component-test.tsx
@@ -2382,6 +2382,32 @@ describeFn('Select', () => {
         );
         cy.matchImageSnapshot();
     });
+
+    it('readOnly: does not handle keyboard navigation or remove chips', () => {
+        const onChange = cy.stub().as('onChange');
+
+        mount(
+            <Select
+                id="read-only"
+                target="textfield-like"
+                multiselect
+                readOnly
+                defaultValue={['north_america']}
+                items={items}
+                onChange={onChange}
+            />,
+        );
+
+        cy.get('#read-only input').click();
+        cy.pressKey('ArrowDown');
+        cy.get('[id$="tree_level_1"]').should('not.exist');
+        cy.pressKey('Enter');
+        cy.get('[id$="tree_level_1"]').should('not.exist');
+
+        cy.get('#read-only .has-chips button').focus().pressKey('Backspace');
+        cy.get('#read-only .has-chips button').should('have.length', 1);
+        cy.get('@onChange').should('not.have.been.called');
+    });
 });
 
 describeFn('Select react-hook-form', () => {

--- a/packages/plasma-new-hope/src/components/Select/Select.tsx
+++ b/packages/plasma-new-hope/src/components/Select/Select.tsx
@@ -200,6 +200,7 @@ export const selectRoot = (Root: RootProps<HTMLDivElement, Omit<SelectProps, 'it
             treeView,
             valueToPathMap,
             items: transformedItems,
+            disabled,
             readOnly,
         });
 

--- a/packages/plasma-new-hope/src/components/Select/hooks/useKeyboardNavigation.ts
+++ b/packages/plasma-new-hope/src/components/Select/hooks/useKeyboardNavigation.ts
@@ -40,6 +40,7 @@ type Props = {
     treeView: boolean;
     valueToPathMap: Map<string, string[]>;
     items: ItemOption[];
+    disabled: boolean;
     readOnly: boolean;
 };
 
@@ -78,6 +79,7 @@ export const useKeyNavigation = ({
     treeView,
     valueToPathMap,
     items,
+    disabled,
     readOnly,
 }: Props): ReturnedProps => {
     if (treeView) {
@@ -95,6 +97,7 @@ export const useKeyNavigation = ({
             treeView,
             valueToPathMap,
             items,
+            disabled,
             readOnly,
         });
     }
@@ -113,6 +116,7 @@ export const useKeyNavigation = ({
         treeView,
         valueToPathMap,
         items,
+        disabled,
         readOnly,
     });
 };
@@ -126,13 +130,14 @@ const keyboardNavigationDefault = ({
     focusedToValueMap,
     handleListToggle,
     handlePressDown,
+    disabled,
     readOnly,
 }: Props): ReturnedProps => {
     const currentIndex: number = focusedPath?.[focusedPath.length - 1] || 0;
     const currentLength: number = pathMap.get(path?.[focusedPath.length - 1]) || 0;
 
     const onKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-        if (readOnly) {
+        if (disabled || readOnly) {
             return;
         }
 
@@ -341,6 +346,7 @@ const keyboardNavigationTree = ({
     dispatchTreePath,
     valueToPathMap,
     items,
+    disabled,
     readOnly,
 }: Props): ReturnedProps => {
     const currentItem = getItemByFocused(focusedPath, focusedToValueMap);
@@ -366,7 +372,7 @@ const keyboardNavigationTree = ({
     };
 
     const onKeyDown = (event: KeyboardEvent<HTMLElement>) => {
-        if (readOnly) {
+        if (disabled || readOnly) {
             return;
         }
 

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.tsx
@@ -85,7 +85,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
 
         // Обработчик чипов
         const handleChipClick = (chip: { value: string; label: string; disabled: boolean }) => {
-            if (!Array.isArray(value)) return;
+            if (readOnly || !Array.isArray(value)) return;
 
             if (isTargetAmount) {
                 // При закрытии чипа в режиме isTargetAmount в value оставляем только disabled-элементы

--- a/packages/plasma-new-hope/src/components/TextField/hooks/useKeyNavigation.ts
+++ b/packages/plasma-new-hope/src/components/TextField/hooks/useKeyNavigation.ts
@@ -80,7 +80,7 @@ export const useKeyNavigation = ({
     };
 
     const onChipClear = (clearId: string, index: number) => {
-        if (!chips.length && !newCustomChips?.length) {
+        if (disabled || readOnly || (!chips.length && !newCustomChips?.length)) {
             return;
         }
 
@@ -92,6 +92,10 @@ export const useKeyNavigation = ({
     };
 
     const handleChipKeyDown = (event: KeyboardEvent<HTMLButtonElement>, chipId: string, chipIndex: number) => {
+        if (disabled || readOnly) {
+            return;
+        }
+
         if (event.key === Keys.Tab) {
             event.preventDefault();
         }


### PR DESCRIPTION
## Core

### Combobox
- исправлено поведение клавиатурной навигации при удалении чипов в режиме `readOnly` + `multiple`;

### What/why changed
- исправлено поведение клавиатурной навигации при удалении чипов в режиме `readOnly` + `multiple`;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only Combobox, Select, and TextField controls now prevent keyboard actions from opening lists, navigating options, removing chips, or triggering changes.
  * Read-only chip controls no longer respond to clicks, Backspace, or other removal interactions.
  * Improved keyboard focus behavior for multiselect controls while preserving expected navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.383.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-b2c@1.625.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-core@1.232.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-giga@0.352.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-homeds@0.352.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-hope@1.379.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-icons@1.243.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-new-hope@0.369.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-tokens-b2b@1.59.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-tokens-b2c@0.70.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-tokens-web@1.74.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-tokens@1.144.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-typo@0.47.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-ui@1.355.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-web@1.627.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-bizcom@0.357.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-cs@0.361.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-dfa@0.355.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-finai@0.348.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-insol@0.352.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-netology@0.356.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-os@0.27.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-platform-ai@0.356.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-sbcom@0.357.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-scan@0.355.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-serv@0.356.0-canary.2963.29581187217.0
  npm install @salutejs/core-themes@0.35.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-themes@0.56.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-themes@0.71.0-canary.2963.29581187217.0
  npm install @salutejs/sdds-api-tests@0.14.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-cy-utils@0.162.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-sb-utils@0.233.0-canary.2963.29581187217.0
  npm install @salutejs/plasma-tokens-utils@0.55.0-canary.2963.29581187217.0
  # or 
  yarn add @salutejs/plasma-asdk@0.383.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-b2c@1.625.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-core@1.232.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-giga@0.352.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-homeds@0.352.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-hope@1.379.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-icons@1.243.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-new-hope@0.369.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-tokens-b2b@1.59.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-tokens-b2c@0.70.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-tokens-web@1.74.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-tokens@1.144.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-typo@0.47.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-ui@1.355.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-web@1.627.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-bizcom@0.357.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-cs@0.361.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-dfa@0.355.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-finai@0.348.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-insol@0.352.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-netology@0.356.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-os@0.27.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-platform-ai@0.356.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-sbcom@0.357.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-scan@0.355.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-serv@0.356.0-canary.2963.29581187217.0
  yarn add @salutejs/core-themes@0.35.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-themes@0.56.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-themes@0.71.0-canary.2963.29581187217.0
  yarn add @salutejs/sdds-api-tests@0.14.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-cy-utils@0.162.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-sb-utils@0.233.0-canary.2963.29581187217.0
  yarn add @salutejs/plasma-tokens-utils@0.55.0-canary.2963.29581187217.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
