### PR TITLE
PLASMA-7744: fix conditional render in Note

### DIFF
--- a/packages/plasma-new-hope/src/components/Note/Note.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Note/Note.component-test.tsx
@@ -89,6 +89,27 @@ describeFn('Note', () => {
         cy.matchImageSnapshot();
     });
 
+    it('renders conditional text after it becomes visible', () => {
+        const ConditionalText = () => {
+            const [isTextVisible, setIsTextVisible] = React.useState(false);
+
+            return (
+                <>
+                    <button type="button" onClick={() => setIsTextVisible(true)}>
+                        Show text
+                    </button>
+                    <Note text={isTextVisible && <span data-testid="conditional-note-text">Text</span>} />
+                </>
+            );
+        };
+
+        mount(<ConditionalText />);
+
+        cy.get('[data-testid="conditional-note-text"]').should('not.exist');
+        cy.contains('button', 'Show text').click();
+        cy.get('[data-testid="conditional-note-text"]').should('have.text', 'Text');
+    });
+
     it('long title', () => {
         mount(
             <Note

--- a/packages/plasma-new-hope/src/components/Note/Note.tsx
+++ b/packages/plasma-new-hope/src/components/Note/Note.tsx
@@ -66,17 +66,17 @@ export const noteRoot = (Root: RootProps<HTMLDivElement, NoteProps>) =>
                 : '0';
 
             const setTruncatedText = () => {
+                if (!text || typeof text !== 'string' || !height) {
+                    setInnerText(text);
+                    return;
+                }
+
                 if (
                     !canUseDOM ||
                     !contentWrapperRef?.current ||
                     !textBoxRef?.current ||
                     !textRenderHelperRef?.current
                 ) {
-                    return;
-                }
-
-                if (!text || typeof text !== 'string' || !height) {
-                    setInnerText(text);
                     return;
                 }
 


### PR DESCRIPTION
## Core

### Note
- исправлен баг, при котором не показывался `text` при условном рендеринге;

### What/why changed
- исправлен баг, при котором не показывался `text` при условном рендеринге;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Note` text handling when truncation-related inputs aren’t available, preserving the original text reliably.
  * Ensured truncation calculations only run when the required display elements are present.

* **Tests**
  * Added a visual/component test to verify that `Note` text is conditionally rendered after a user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.383.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-b2c@1.625.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-core@1.232.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-giga@0.352.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-homeds@0.352.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-hope@1.379.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-icons@1.243.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-new-hope@0.369.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-tokens-b2b@1.59.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-tokens-b2c@0.70.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-tokens-web@1.74.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-tokens@1.144.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-typo@0.47.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-web@1.627.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-bizcom@0.357.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-cs@0.361.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-dfa@0.355.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-finai@0.348.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-insol@0.352.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-netology@0.356.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-os@0.27.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-platform-ai@0.356.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-sbcom@0.357.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-scan@0.355.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-serv@0.356.0-canary.2965.29807625966.0
  npm install @salutejs/core-themes@0.35.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-themes@0.56.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-themes@0.71.0-canary.2965.29807625966.0
  npm install @salutejs/sdds-api-tests@0.14.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-cy-utils@0.162.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-sb-utils@0.233.0-canary.2965.29807625966.0
  npm install @salutejs/plasma-tokens-utils@0.55.0-canary.2965.29807625966.0
  # or 
  yarn add @salutejs/plasma-asdk@0.383.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-b2c@1.625.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-core@1.232.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-giga@0.352.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-homeds@0.352.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-hope@1.379.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-icons@1.243.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-new-hope@0.369.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-tokens-b2b@1.59.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-tokens-b2c@0.70.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-tokens-web@1.74.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-tokens@1.144.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-typo@0.47.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-web@1.627.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-bizcom@0.357.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-cs@0.361.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-dfa@0.355.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-finai@0.348.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-insol@0.352.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-netology@0.356.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-os@0.27.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-platform-ai@0.356.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-sbcom@0.357.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-scan@0.355.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-serv@0.356.0-canary.2965.29807625966.0
  yarn add @salutejs/core-themes@0.35.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-themes@0.56.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-themes@0.71.0-canary.2965.29807625966.0
  yarn add @salutejs/sdds-api-tests@0.14.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-cy-utils@0.162.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-sb-utils@0.233.0-canary.2965.29807625966.0
  yarn add @salutejs/plasma-tokens-utils@0.55.0-canary.2965.29807625966.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
