### PR TITLE
PLASMA-7617: add TextField disabled text opacity

### DIFF
--- a/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/Autocomplete.tokens.ts
@@ -101,6 +101,8 @@ export const tokens = {
     textFieldTextAfterMargin: '--plasma-autocomplete-textfield-after-text-margin',
 
     textFieldDisabledOpacity: '--plasma-autocomplete-textfield-disabled-opacity',
+    textFieldDisabledBackgroundOpacity: '--plasma-autocomplete-textfield-disabled-background-opacity',
+    textFieldDisabledInnerContentOpacity: '--plasma-autocomplete-textfield-disabled-inner-content-opacity',
     textFieldReadOnlyOpacity: '--plasma-autocomplete-textfield-readonly-opacity',
 
     /** Токены для tooltip */

--- a/packages/plasma-new-hope/src/components/Autocomplete/ui/TextField/TextField.styles.ts
+++ b/packages/plasma-new-hope/src/components/Autocomplete/ui/TextField/TextField.styles.ts
@@ -76,6 +76,8 @@ export const StyledTextField = styled(TextField)`
     ${textFieldTokens.textBeforeMargin}: var(${autocompleteTokens.textFieldTextBeforeMargin});
     ${textFieldTokens.textAfterMargin}: var(${autocompleteTokens.textFieldTextAfterMargin});
     ${textFieldTokens.disabledOpacity}: var(${autocompleteTokens.textFieldDisabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${autocompleteTokens.textFieldDisabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${autocompleteTokens.textFieldDisabledInnerContentOpacity});
     ${textFieldTokens.focusColor}: var(${autocompleteTokens.textFieldFocusColor});
     ${textFieldTokens.contentSlotColor}: var(${autocompleteTokens.textFieldContentSlotColor});
     ${textFieldTokens.contentSlotColorHover}: var(${autocompleteTokens.textFieldContentSlotColorHover});

--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.tokens.ts
@@ -172,6 +172,8 @@ export const tokens = {
     textFieldTextAfterMargin: '--plasma-combobox-new-textfield-after-text-margin',
 
     textFieldDisabledOpacity: '--plasma-combobox-new-textfield-disabled-opacity',
+    textFieldDisabledBackgroundOpacity: '--plasma-combobox-new-textfield-disabled-background-opacity',
+    textFieldDisabledInnerContentOpacity: '--plasma-combobox-new-textfield-disabled-inner-content-opacity',
     textFieldReadOnlyOpacity: '--plasma-combobox-new-textfield-readonly-opacity',
 
     /** Токены для tooltip */

--- a/packages/plasma-new-hope/src/components/Combobox/ui/Target/Target.styles.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ui/Target/Target.styles.ts
@@ -121,6 +121,8 @@ export const StyledTextField = styled(TextField)<{ opened: boolean }>`
     ${textFieldTokens.textAfterMargin}: var(${comboboxTokens.textFieldTextAfterMargin});
 
     ${textFieldTokens.disabledOpacity}: var(${comboboxTokens.textFieldDisabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${comboboxTokens.textFieldDisabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${comboboxTokens.textFieldDisabledInnerContentOpacity});
 
     ${textFieldTokens.hintCustomIconTargetSize}: var(${comboboxTokens.textFieldHintCustomIconTargetSize});
     ${textFieldTokens.hintMargin}: var(${comboboxTokens.textFieldHintMargin});

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePicker.tokens.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePicker.tokens.ts
@@ -149,6 +149,8 @@ export const tokens = {
 
     /** Прозрачность для всего компонента в состоянии disabled */
     disabledOpacity: '--plasma-date-picker-disabled-opacity',
+    disabledBackgroundOpacity: '--plasma-date-picker-disabled-background-opacity',
+    disabledInnerContentOpacity: '--plasma-date-picker-disabled-inner-content-opacity',
 
     rangeReadOnlyOpacity: '--plasma-date-picker-readonly-opacity',
 
@@ -418,4 +420,6 @@ export const tokens = {
     shortcutBorderRadius: '--plasma-date-picker-shortcut-item-border-radius',
 
     outlineFocusColor: '--plasma-date-picker-outline-focus',
+    textFieldDisabledBackgroundOpacity: '--plasma-date-picker-disabled-textfield-background-opacity',
+    textFieldDisabledInnerContentOpacity: '--plasma-date-picker-disabled-textfield-inner-content-opacity',
 };

--- a/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.styles.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.styles.ts
@@ -208,6 +208,9 @@ export const StyledRange = styled(Range)`
     ${rangeTokens.textFieldColorReadOnly}: var(${tokens.textFieldColorReadOnly});
     ${rangeTokens.textFieldBackgroundColorReadOnly}: var(${tokens.textFieldBackgroundColorReadOnly});
     ${rangeTokens.textFieldPlaceholderColorReadOnly}: var(${tokens.textFieldPlaceholderColorReadOnly});
+
+    ${rangeTokens.disabledBackgroundOpacity}: var(${tokens.textFieldDisabledBackgroundOpacity});
+    ${rangeTokens.disabledInnerContentOpacity}: var(${tokens.textFieldDisabledInnerContentOpacity});
 `;
 
 export const base = css`

--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.styles.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.styles.ts
@@ -99,6 +99,8 @@ export const StyledInput = styled(TextField)`
     ${textFieldTokens.lineHeight}: var(${tokens.textFieldLineHeight});
 
     ${textFieldTokens.disabledOpacity}: var(${tokens.disabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${tokens.disabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${tokens.disabledInnerContentOpacity});
     
     ${textFieldTokens.textBeforeColor}: var(${tokens.textFieldTextBeforeColor});
     ${textFieldTokens.textAfterColor}: var(${tokens.textFieldTextAfterColor});

--- a/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.tokens.ts
+++ b/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.tokens.ts
@@ -347,5 +347,7 @@ export const tokens = {
     /** Прозрачность для всего компонента в состоянии disabled */
     timeGridDisabledOpacity: '--plasma-date-time-picker-grid-disabled-opacity',
     disabledOpacity: '--plasma-date-time-picker-disabled-opacity',
+    disabledBackgroundOpacity: '--plasma-date-time-picker-disabled-background-opacity',
+    disabledInnerContentOpacity: '--plasma-date-time-picker-disabled-inner-content-opacity',
     outlineFocusColor: '--plasma-date-time-picker-outline-focus',
 };

--- a/packages/plasma-new-hope/src/components/DateTimePicker/ui/Input/Input.styles.ts
+++ b/packages/plasma-new-hope/src/components/DateTimePicker/ui/Input/Input.styles.ts
@@ -117,6 +117,8 @@ export const StyledInput = styled(TextField)`
     ${textFieldTokens.lineHeight}: var(${tokens.textFieldLineHeight});
 
     ${textFieldTokens.disabledOpacity}: var(${tokens.disabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${tokens.disabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${tokens.disabledInnerContentOpacity});
     
     ${textFieldTokens.textBeforeColor}: var(${tokens.textFieldTextBeforeColor});
     ${textFieldTokens.textAfterColor}: var(${tokens.textFieldTextAfterColor});

--- a/packages/plasma-new-hope/src/components/Range/Range.styles.ts
+++ b/packages/plasma-new-hope/src/components/Range/Range.styles.ts
@@ -68,6 +68,8 @@ export const StyledInput = styled(TextField)`
     ${textFieldTokens.lineHeight}: var(${tokens.textFieldLineHeight});
 
     ${textFieldTokens.disabledOpacity}: var(${tokens.disabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${tokens.disabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${tokens.disabledInnerContentOpacity});
 
     ${textFieldTokens.textBeforeColor}: var(${tokens.textFieldTextBeforeColor});
     ${textFieldTokens.textAfterColor}: var(${tokens.textFieldTextAfterColor});

--- a/packages/plasma-new-hope/src/components/Range/Range.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Range/Range.tokens.ts
@@ -168,6 +168,8 @@ export const tokens = {
 
     /** Прозрачность для всего компонента в состоянии disabled */
     disabledOpacity: '--plasma-range-disabled-opacity',
+    disabledBackgroundOpacity: '--plasma-range-disabled-background-opacity',
+    disabledInnerContentOpacity: '--plasma-range-disabled-inner-content-opacity',
     readOnlyOpacity: '--plasma-range-readonly-opacity',
     labelColorReadOnly: '--plasma-range-info-wrapper-label-color-readonly',
     titleCaptionColorReadOnly: '--plasma-range-info-wrapper-title-caption-color-readonly',

--- a/packages/plasma-new-hope/src/components/Select/Select.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Select/Select.tokens.ts
@@ -181,6 +181,8 @@ export const tokens = {
     textFieldTextAfterMargin: '--plasma-select-textfield-after-text-margin',
 
     textFieldDisabledOpacity: '--plasma-select-textfield-disabled-opacity',
+    textFieldDisabledBackgroundOpacity: '--plasma-select-textfield-disabled-background-opacity',
+    textFieldDisabledInnerContentOpacity: '--plasma-select-textfield-disabled-inner-content-opacity',
     textFieldReadOnlyOpacity: '--plasma-select-textfield-readonly-opacity',
 
     /** Токены для tooltip */

--- a/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.styles.tsx
+++ b/packages/plasma-new-hope/src/components/Select/ui/Target/ui/Textfield/Textfield.styles.tsx
@@ -111,6 +111,8 @@ export const StyledTextField = styled(TextField)<{ opened: boolean }>`
     ${textFieldTokens.textAfterMargin}: var(${tokens.textFieldTextAfterMargin});
 
     ${textFieldTokens.disabledOpacity}: var(${tokens.textFieldDisabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${tokens.textFieldDisabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${tokens.textFieldDisabledInnerContentOpacity});
 
     ${textFieldTokens.hintCustomIconTargetSize}: var(${tokens.textFieldHintCustomIconTargetSize});
     ${textFieldTokens.hintMargin}: var(${tokens.textFieldHintMargin});

--- a/packages/plasma-new-hope/src/components/Slider/Slider.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Slider/Slider.tokens.ts
@@ -115,4 +115,6 @@ export const tokens = {
     textFieldBorderColorFocus: '--plasma-slider-text-field-border-color-focus',
 
     disabledOpacity: '--plasma-slider-disabled-opacity',
+    disabledBackgroundOpacity: '--plasma-slider-disabled-background-opacity',
+    disabledInnerContentOpacity: '--plasma-slider-disabled-inner-content-opacity',
 };

--- a/packages/plasma-new-hope/src/components/Slider/components/Double/Double.styles.ts
+++ b/packages/plasma-new-hope/src/components/Slider/components/Double/Double.styles.ts
@@ -45,6 +45,8 @@ export const StyledInput = styled(TextField)`
     ${textFieldTokens.caretColor}: var(${tokens.textFieldCaretColor});
     ${textFieldTokens.placeholderColor}: var(${tokens.textFieldPlaceholderColor});
     ${textFieldTokens.disabledOpacity}: var(${tokens.disabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${tokens.disabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${tokens.disabledInnerContentOpacity});
 
     ${textFieldTokens.height}: var(${tokens.textFieldHeight});
     ${textFieldTokens.padding}: var(${tokens.textFieldPadding});

--- a/packages/plasma-new-hope/src/components/TextArea/TextArea.tokens.ts
+++ b/packages/plasma-new-hope/src/components/TextArea/TextArea.tokens.ts
@@ -185,6 +185,8 @@ export const tokens = {
 
     /** Прозрачность для всего компонента в состоянии disabled */
     disabledOpacity: '--plasma-textarea-disabled-opacity',
+    disabledBackgroundOpacity: '--plasma-textarea-disabled-background-opacity',
+    disabledInnerContentOpacity: '--plasma-textarea-disabled-inner-content-opacity',
     inputColorDisabled: '--plasma-textarea-input-color-disabled',
 
     /** Токены для tooltip */

--- a/packages/plasma-new-hope/src/components/TextArea/variations/_disabled/base.ts
+++ b/packages/plasma-new-hope/src/components/TextArea/variations/_disabled/base.ts
@@ -3,12 +3,17 @@ import { css } from 'styled-components';
 import { tokens, classes } from '../../TextArea.tokens';
 import {
     StyledContent,
+    StyledContentWrapper,
+    StyledHeaderSlot,
     StyledHelpers,
+    StyledHintWrapper,
     StyledIndicator,
     StyledLabel,
+    StyledLeftHelper,
     StyledOptionalText,
     StyledOutsideHelpersWrapper,
-    StyledPlaceholder,
+    StyledRightHelper,
+    StyledTextArea,
     StyledTextAreaWrapper,
     TitleCaption,
 } from '../../TextArea.styles';
@@ -17,9 +22,14 @@ const { styledTextArea } = classes;
 
 export const base = css`
     &[disabled] {
-        ${StyledLabel}, ${StyledIndicator}, ${StyledOptionalText}, ${TitleCaption},
-        ${StyledContent}, ${StyledTextAreaWrapper},
-        ${StyledHelpers}, ${StyledPlaceholder}, ${StyledOutsideHelpersWrapper} {
+        cursor: not-allowed;
+                
+        ${StyledHintWrapper}, ${StyledIndicator} {
+            cursor: default;
+        }
+
+        ${StyledLabel}, ${StyledOptionalText}, ${TitleCaption},
+        ${StyledOutsideHelpersWrapper} {
             opacity: var(${tokens.disabledOpacity});
             cursor: not-allowed;
             pointer-events: none;
@@ -28,6 +38,21 @@ export const base = css`
             &:active {
                 transform: none;
             }
+        }
+
+        ${StyledTextAreaWrapper},
+        ${StyledHelpers} {
+            opacity: var(${tokens.disabledBackgroundOpacity}, var(${tokens.disabledOpacity}));
+        }
+
+        ${StyledHeaderSlot},
+        ${StyledContent},
+        ${StyledContentWrapper},
+        ${StyledTextArea},
+        ${StyledLeftHelper},
+        ${StyledRightHelper} {
+            pointer-events: none;
+            opacity: var(${tokens.disabledInnerContentOpacity}, 1);
         }
     }
 

--- a/packages/plasma-new-hope/src/components/TextField/TextField.tokens.ts
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.tokens.ts
@@ -168,6 +168,8 @@ export const tokens = {
 
     /** Прозрачность для всего компонента в состоянии disabled */
     disabledOpacity: '--plasma-textfield-disabled-opacity',
+    disabledBackgroundOpacity: '--plasma-textfield-disabled-background-opacity',
+    disabledInnerContentOpacity: '--plasma-textfield-disabled-inner-content-opacity',
     readOnlyOpacity: '--plasma-textfield-readonly-opacity',
 
     /** Токены для tooltip */

--- a/packages/plasma-new-hope/src/components/TextField/variations/_disabled/base.ts
+++ b/packages/plasma-new-hope/src/components/TextField/variations/_disabled/base.ts
@@ -1,15 +1,40 @@
 import { css } from 'styled-components';
 
 import { tokens } from '../../TextField.tokens';
-import { Input } from '../../TextField.styles';
+import {
+    Input,
+    InputWrapper,
+    StyledContentRight,
+    StyledContentLeft,
+    StyledChips,
+    Label,
+    StyledOptionalText,
+    TitleCaption,
+    StyledHelpers,
+    StyledHintWrapper,
+    StyledIndicator,
+} from '../../TextField.styles';
 
 export const base = css`
     &[disabled] {
-        opacity: var(${tokens.disabledOpacity});
         cursor: not-allowed;
+        
+        ${StyledHintWrapper}, ${StyledIndicator} {
+            cursor: default;
+        }
 
-        * {
+        ${Label}, ${StyledOptionalText}, ${TitleCaption}, ${StyledHelpers} {
+            cursor: not-allowed;
+            opacity: var(${tokens.disabledOpacity}, 1);
+        }
+
+        ${InputWrapper} {
             pointer-events: none;
+            opacity: var(${tokens.disabledBackgroundOpacity}, var(${tokens.disabledOpacity}));
+        }
+
+        ${StyledContentLeft}, ${StyledContentRight}, ${Input}, ${StyledChips} {
+            opacity: var(${tokens.disabledInnerContentOpacity}, 1);
         }
 
         ${Input} {

--- a/packages/plasma-new-hope/src/components/TextFieldSlider/TextFieldSlider.tokens.ts
+++ b/packages/plasma-new-hope/src/components/TextFieldSlider/TextFieldSlider.tokens.ts
@@ -176,4 +176,6 @@ export const tokens = {
 
     /** Прозрачность для всего компонента в состоянии disabled */
     disabledOpacity: '--plasma-textfield-slider-disabled-opacity',
+    disabledBackgroundOpacity: '--plasma-textfield-slider-disabled-background-opacity',
+    disabledInnerContentOpacity: '--plasma-textfield-slider-disabled-inner-content-opacity',
 };

--- a/packages/plasma-new-hope/src/components/TextFieldSlider/ui/Input/Input.styles.ts
+++ b/packages/plasma-new-hope/src/components/TextFieldSlider/ui/Input/Input.styles.ts
@@ -84,6 +84,8 @@ export const StyledInput = styled(TextField)`
     ${textFieldTokens.lineHeight}: var(${tokens.textFieldLineHeight});
 
     ${textFieldTokens.disabledOpacity}: var(${tokens.disabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${tokens.disabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${tokens.disabledInnerContentOpacity});
     
     ${textFieldTokens.textBeforeColor}: var(${tokens.textFieldTextBeforeColor});
     ${textFieldTokens.textAfterColor}: var(${tokens.textFieldTextAfterColor});

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.styles.ts
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.styles.ts
@@ -165,6 +165,8 @@ export const StyledInput = styled(TextField)`
     ${textFieldTokens.lineHeight}: var(${tokens.textFieldLineHeight});
 
     ${textFieldTokens.disabledOpacity}: var(${tokens.disabledOpacity});
+    ${textFieldTokens.disabledBackgroundOpacity}: var(${tokens.disabledBackgroundOpacity});
+    ${textFieldTokens.disabledInnerContentOpacity}: var(${tokens.disabledInnerContentOpacity});
     
     ${textFieldTokens.textBeforeColor}: var(${tokens.textFieldTextBeforeColor});
     ${textFieldTokens.textAfterColor}: var(${tokens.textFieldTextAfterColor});

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.tokens.ts
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.tokens.ts
@@ -189,6 +189,8 @@ export const tokens = {
 
     /** Прозрачность для всего компонента в состоянии disabled */
     disabledOpacity: '--sdds-core-time-picker-disabled-opacity',
+    disabledBackgroundOpacity: '--sdds-core-time-picker-disabled-background-opacity',
+    disabledInnerContentOpacity: '--sdds-core-time-picker-disabled-inner-content-opacity',
 
     dropdownMarginTop: '--sdds-core-time-picker-dropdown-margin-top',
 


### PR DESCRIPTION
## Core

###  TextField-like

- исправлен `disabled`-режим

### What/why changed

- исправлен `disabled`-режим

**Before:**
<img width="636" height="167" alt="image" src="https://github.com/user-attachments/assets/1f1321a2-3428-4c32-a086-730b21345365" />

**After:**
<img width="628" height="177" alt="image" src="https://github.com/user-attachments/assets/7c4447bb-4885-41c5-be18-b7494caa97a6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added more precise disabled-state styling across autocomplete, combobox, date/time pickers, ranges, selects, sliders, text areas, text fields, and related controls.
  * Backgrounds and inner content can now use separate opacity settings for improved visual clarity.
  * Disabled controls now provide more consistent cursor behavior and prevent unintended interactions while preserving appropriate hint and indicator visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.385.0-canary.2975.29910081351.0
  npm install @salutejs/plasma-b2c@1.627.0-canary.2975.29910081351.0
  npm install @salutejs/plasma-giga@0.354.0-canary.2975.29910081351.0
  npm install @salutejs/plasma-homeds@0.354.0-canary.2975.29910081351.0
  npm install @salutejs/plasma-new-hope@0.371.0-canary.2975.29910081351.0
  npm install @salutejs/plasma-web@1.629.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-bizcom@0.359.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-cs@0.363.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-dfa@0.357.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-finai@0.350.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-insol@0.354.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-netology@0.358.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-os@0.29.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-platform-ai@0.358.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-sbcom@0.359.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-scan@0.357.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-serv@0.358.0-canary.2975.29910081351.0
  npm install @salutejs/sdds-api-tests@0.16.0-canary.2975.29910081351.0
  # or 
  yarn add @salutejs/plasma-asdk@0.385.0-canary.2975.29910081351.0
  yarn add @salutejs/plasma-b2c@1.627.0-canary.2975.29910081351.0
  yarn add @salutejs/plasma-giga@0.354.0-canary.2975.29910081351.0
  yarn add @salutejs/plasma-homeds@0.354.0-canary.2975.29910081351.0
  yarn add @salutejs/plasma-new-hope@0.371.0-canary.2975.29910081351.0
  yarn add @salutejs/plasma-web@1.629.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-bizcom@0.359.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-cs@0.363.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-dfa@0.357.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-finai@0.350.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-insol@0.354.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-netology@0.358.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-os@0.29.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-platform-ai@0.358.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-sbcom@0.359.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-scan@0.357.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-serv@0.358.0-canary.2975.29910081351.0
  yarn add @salutejs/sdds-api-tests@0.16.0-canary.2975.29910081351.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
