### PR TITLE
PLASMA: add beta Tooltip to exports

### DIFF
--- a/packages/sdds-insol/package.json
+++ b/packages/sdds-insol/package.json
@@ -7,16 +7,8 @@
     "access": "public"
   },
   "license": "MIT",
-  "files": [
-    "dist",
-    "types"
-  ],
-  "keywords": [
-    "design-system",
-    "react-components",
-    "ui-kit",
-    "react"
-  ],
+  "files": ["dist", "types"],
+  "keywords": ["design-system", "react-components", "ui-kit", "react"],
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com:salute-developers/plasma.git",
@@ -32,6 +24,11 @@
       "import": "./dist/styled-components/es/index.js",
       "require": "./dist/styled-components/cjs/index.js",
       "types": "./types/index.d.ts"
+    },
+    "./beta": {
+      "import": "./dist/beta/es/index.js",
+      "require": "./dist/beta/cjs/index.js",
+      "types": "./dist/beta/types/index.d.ts"
     }
   },
   "peerDependencies": {
@@ -79,7 +76,7 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:css && npm run build:styled-components",
+    "build": "npm run build:css && npm run build:styled-components && npm run build:beta",
     "postbuild": "npm run generate:typings",
     "prebuild:css": "rm -rf src-css && ./scripts/copy-linaria-components.sh",
     "build:css": "rm -rf dist/css && rollup -c",
@@ -87,7 +84,10 @@
     "build:styled-components": "rm -rf dist/styled-components && npm run build:styled-components:esm && npm run build:styled-components:cjs",
     "build:styled-components:cjs": "swc ./src -d ./dist/styled-components/cjs --strip-leading-paths --config-file ../../swc.config.json -C module.type=commonjs",
     "build:styled-components:esm": "swc ./src -d ./dist/styled-components/es --strip-leading-paths --config-file ../../swc.config.json -C module.type=es6",
-    "generate:typings": "rm -rf types && tsc",
+    "prebuild:beta": "rm -rf src-css && ./scripts/copy-linaria-components.sh",
+    "build:beta": "rm -rf dist/beta/es dist/beta/cjs && BETA=true rollup -c",
+    "postbuild:beta": "rm -rf src-css",
+    "generate:typings": "rm -rf types && tsc && rm -rf dist/beta/types && tsc -p src/components/_beta/tsconfig.json",
     "storybook": "npm run storybook:sc",
     "storybook:sc": "USE_STYLED_COMPONENTS=true storybook dev -p ${PORT:-7002} -c .storybook",
     "storybook:build": "storybook build -c .storybook -o build-sb",
@@ -95,16 +95,9 @@
     "lint": "../../node_modules/.bin/eslint ./src --ext .js,.ts,.tsx --quiet"
   },
   "typeCoverage": {
-    "ignoreFiles": [
-      "src/**/*.component-test.tsx",
-      "src/**/*.stories.tsx"
-    ],
+    "ignoreFiles": ["src/**/*.component-test.tsx", "src/**/*.stories.tsx"],
     "atLeast": 99.89
   },
-  "contributors": [
-    "salute.developers@gmail.com"
-  ],
-  "sideEffects": [
-    "*.css"
-  ]
+  "contributors": ["salute.developers@gmail.com"],
+  "sideEffects": ["*.css"]
 }

--- a/packages/sdds-insol/rollup.config.mjs
+++ b/packages/sdds-insol/rollup.config.mjs
@@ -1,43 +1,48 @@
 import path from 'path';
-import { createRequire } from 'module'
-import { createFilter } from '@rollup/pluginutils'
+import { createRequire } from 'module';
+import { createFilter } from '@rollup/pluginutils';
 
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 import linaria from '@linaria/rollup';
 import { babel } from '@rollup/plugin-babel';
 
-import styles from "@ironkinoko/rollup-plugin-styles";
-
+import styles from '@ironkinoko/rollup-plugin-styles';
 
 const inputDir = 'src-css';
-const require = createRequire(import.meta.url)
+const require = createRequire(import.meta.url);
+const isBeta = process.env.BETA === 'true';
+const input = isBeta ? path.join(inputDir, 'components/_beta/index.ts') : path.join(inputDir, 'index.ts');
+const outputDir = isBeta ? 'dist/beta' : 'dist/css';
 
 export default {
-    input: path.join(inputDir, 'index.ts'),
+    input,
     treeshake: {
         propertyReadSideEffects: false,
     },
-    output: [{
-        preserveModules: true,
-        dir: 'dist/css/es',
-        format: 'es',
-        freeze: false,
-        esModule: true,
-        sourcemap: true,
-        exports: 'named',
-        assetFileNames: "[name][extname]",
-    }, {
-        preserveModules: true,
-        dir: 'dist/css/cjs',
-        format: 'cjs',
-        freeze: false,
-        esModule: true,
-        sourcemap: true,
-        exports: 'named',
-        assetFileNames: "[name][extname]",
-        interop: 'auto',
-    }],
+    output: [
+        {
+            preserveModules: true,
+            dir: `${outputDir}/es`,
+            format: 'es',
+            freeze: false,
+            esModule: true,
+            sourcemap: true,
+            exports: 'named',
+            assetFileNames: '[name][extname]',
+        },
+        {
+            preserveModules: true,
+            dir: `${outputDir}/cjs`,
+            format: 'cjs',
+            freeze: false,
+            esModule: true,
+            sourcemap: true,
+            exports: 'named',
+            assetFileNames: '[name][extname]',
+            interop: 'auto',
+        },
+    ],
     external: (id) => {
         if (id.startsWith('regenerator-runtime') || id === 'tslib') {
             return false;
@@ -70,10 +75,10 @@ export default {
         importCssPlugin(),
         // TODO: #717 remove this plugin: it generates index.css but we don't need it
         styles({
-            mode: "extract",
+            mode: 'extract',
             modules: true,
         }),
-        babel({ babelHelpers: 'bundled', extensions: ['.ts', '.tsx'], }),
+        babel({ babelHelpers: 'bundled', extensions: ['.ts', '.tsx'] }),
     ],
 };
 

--- a/packages/sdds-insol/scripts/copy-linaria-components.sh
+++ b/packages/sdds-insol/scripts/copy-linaria-components.sh
@@ -7,9 +7,9 @@ mkdir -p src-css/components/
 touch src-css/index.ts
 touch src-css/index.d.ts
 for component in $components; do
-        cp -R src/components/$component src-css/components/;
-        grep -E "\<$component\>" src/index.ts >> src-css/index.ts
-        echo "export * from '../components/$component';" >> css/index.d.ts;
+    cp -R src/components/$component src-css/components/;
+    grep -E "\<$component\>" src/index.ts >> src-css/index.ts
+    echo "export * from '../components/$component';" >> css/index.d.ts;
 
 done;
 

--- a/packages/sdds-insol/src/components/_beta/Tooltip/Tooltip.config.ts
+++ b/packages/sdds-insol/src/components/_beta/Tooltip/Tooltip.config.ts
@@ -1,0 +1,36 @@
+import { css, _beta_tooltipTokens as tokens } from '@salutejs/plasma-new-hope/styled-components';
+import {
+    bodyS,
+    shadowDownHardM,
+    surfaceSolidCardBrightness,
+    textPrimary,
+} from '@salutejs/sdds-themes/tokens/sdds_insol_next';
+
+export const config = {
+    defaults: {
+        view: 'default',
+        size: 'm',
+    },
+    variations: {
+        view: {
+            default: css`
+                ${tokens.backgroundColor}: ${surfaceSolidCardBrightness};
+                ${tokens.boxShadow}: ${shadowDownHardM};
+                ${tokens.color}: ${textPrimary};
+            `,
+        },
+        size: {
+            m: css`
+                ${tokens.borderRadius}: 0.625rem;
+                ${tokens.padding}: 0.6875rem 0.875rem;
+                ${tokens.gap}: 0.375rem;
+                ${tokens.fontFamily}: ${bodyS.fontFamily};
+                ${tokens.fontSize}: ${bodyS.fontSize};
+                ${tokens.fontStyle}: ${bodyS.fontStyle};
+                ${tokens.fontWeight}: ${bodyS.fontWeight};
+                ${tokens.letterSpacing}: ${bodyS.letterSpacing};
+                ${tokens.lineHeight}: ${bodyS.lineHeight};
+            `,
+        },
+    },
+};

--- a/packages/sdds-insol/src/components/_beta/Tooltip/Tooltip.stories.tsx
+++ b/packages/sdds-insol/src/components/_beta/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import type { ComponentProps } from 'react';
+import type { StoryObj, Meta } from '@storybook/react-vite';
+import { IconPlasma } from '@salutejs/plasma-icons';
+
+import { Button } from '../../Button';
+
+import { Tooltip } from './Tooltip';
+
+type StoryProps = ComponentProps<typeof Tooltip>;
+
+const placements = [
+    'top',
+    'top-start',
+    'top-end',
+    'right',
+    'right-start',
+    'right-end',
+    'bottom',
+    'bottom-start',
+    'bottom-end',
+    'left',
+    'left-start',
+    'left-end',
+];
+const trigger = ['click', 'hover', 'focus'];
+const view = ['default'];
+const size = ['m'];
+
+const meta: Meta<StoryProps> = {
+    title: '_Beta/Overlay/Tooltip',
+    component: Tooltip,
+    argTypes: {
+        placement: {
+            options: placements,
+            control: {
+                type: 'select',
+            },
+        },
+        trigger: {
+            options: trigger,
+            control: {
+                type: 'select',
+            },
+        },
+        hasTail: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        flip: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        shift: {
+            control: {
+                type: 'boolean',
+            },
+        },
+        offset: {
+            control: {
+                type: 'number',
+            },
+        },
+        delayOpen: {
+            control: {
+                type: 'number',
+            },
+        },
+        delayClose: {
+            control: {
+                type: 'number',
+            },
+        },
+        view: {
+            options: view,
+            control: {
+                type: 'select',
+            },
+        },
+        size: {
+            options: size,
+            control: {
+                type: 'select',
+            },
+        },
+        hasIcon: {
+            control: {
+                type: 'boolean',
+            },
+        },
+    },
+    args: {
+        placement: 'bottom',
+        trigger: 'click',
+        hasTail: true,
+        flip: false,
+        shift: false,
+        offset: 0,
+        delayOpen: 0,
+        delayClose: 0,
+        view: 'default',
+        size: 'm',
+        hasIcon: false,
+    },
+};
+
+export default meta;
+
+const StoryDefault = (args: StoryProps) => {
+    React.useEffect(() => {
+        window.scrollTo(
+            (document.documentElement.scrollWidth - window.innerWidth) / 2,
+            (document.documentElement.scrollHeight - window.innerHeight) / 2,
+        );
+    }, []);
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '400vw',
+                height: '400vh',
+            }}
+        >
+            <Tooltip
+                iconSlot={args.hasIcon ? <IconPlasma size="xs" color="inherit" /> : undefined}
+                target={<Button>Target</Button>}
+                {...args}
+            >
+                Контент выпадающего окна
+            </Tooltip>
+        </div>
+    );
+};
+
+export const Default: StoryObj<StoryProps> = {
+    render: (args) => <StoryDefault {...args} />,
+};

--- a/packages/sdds-insol/src/components/_beta/Tooltip/Tooltip.tsx
+++ b/packages/sdds-insol/src/components/_beta/Tooltip/Tooltip.tsx
@@ -1,0 +1,6 @@
+import { _beta_tooltipConfig, component, mergeConfig } from '@salutejs/plasma-new-hope/styled-components';
+
+import { config } from './Tooltip.config';
+
+const mergedConfig = mergeConfig(_beta_tooltipConfig, config);
+export const Tooltip = component(mergedConfig);

--- a/packages/sdds-insol/src/components/_beta/Tooltip/index.ts
+++ b/packages/sdds-insol/src/components/_beta/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip } from './Tooltip';

--- a/packages/sdds-insol/src/components/_beta/index.ts
+++ b/packages/sdds-insol/src/components/_beta/index.ts
@@ -1,0 +1,1 @@
+export * from './Tooltip';

--- a/packages/sdds-insol/src/components/_beta/tsconfig.json
+++ b/packages/sdds-insol/src/components/_beta/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/beta/types",
+        "rootDir": "."
+    },
+    "include": ["."],
+    "exclude": ["./**/*.stories.tsx"]
+}

--- a/packages/sdds-insol/tsconfig.json
+++ b/packages/sdds-insol/tsconfig.json
@@ -41,6 +41,6 @@
         }
     },
     "include": ["./src"],
-    "exclude": ["./src/helpers", "./src/**/*.stories.tsx", "./src/**/*.component-test.tsx"],
+    "exclude": ["./src/helpers", "./src/**/*.stories.tsx", "./src/**/*.component-test.tsx", "src/components/_beta"],
     "references": [{ "path": "./tsconfig.tests.json" }]
 }


### PR DESCRIPTION
### What/why changed

- добавлен Tooltip из beta

<img width="164" height="470" alt="image" src="https://github.com/user-attachments/assets/a955a7bc-2fb9-44c4-b00f-7620a155e40f" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/sdds-insol@0.355.0-canary.2979.29990542740.0
  npm install @salutejs/sdds-api-tests@0.17.0-canary.2979.29990542740.0
  # or 
  yarn add @salutejs/sdds-insol@0.355.0-canary.2979.29990542740.0
  yarn add @salutejs/sdds-api-tests@0.17.0-canary.2979.29990542740.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
