### PR TITLE
PLASMA-7458: fix ref forwarding for {Date/Time}-Picker

### DIFF
--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
@@ -3,6 +3,7 @@ import cls from 'classnames';
 import type { KeyboardEvent, FocusEvent, MouseEvent, MutableRefObject, RefObject } from 'react';
 import type { DateInfo, DateType } from 'src/components/Calendar/Calendar.types';
 import type { RootProps } from 'src/engines';
+import { useForkRef } from 'src/hooks';
 import { getSizeValueFromProp, noop } from 'src/utils';
 
 import { getDateFormatDelimiter } from '../utils/dateHelper';
@@ -128,6 +129,7 @@ export const datePickerRoot = (Root: RootProps<HTMLDivElement, RootDatePickerPro
             ref,
         ) => {
             const inputRef = useRef<HTMLInputElement | null>(null);
+            const inputForkRef = useForkRef(inputRef, ref);
             const innerRef = useRef<HTMLInputElement | null>(null);
             const calendarRootRef = useRef<HTMLDivElement | null>(null);
             const floatingPopoverRef = useRef<HTMLDivElement | null>(null);
@@ -312,7 +314,6 @@ export const datePickerRoot = (Root: RootProps<HTMLDivElement, RootDatePickerPro
                     className={cls(classes.datePickerRoot, className, { [classes.datePickerstretched]: stretched })}
                     disabled={disabled}
                     readOnly={!disabled && readOnly}
-                    ref={ref}
                     eventTooltipSize={eventTooltipOptions?.size}
                     {...(hintText && {
                         hintView,
@@ -333,7 +334,7 @@ export const datePickerRoot = (Root: RootProps<HTMLDivElement, RootDatePickerPro
                         portal={usePortal ? (frame as string | RefObject<HTMLElement>) : undefined}
                         target={(referenceRef) => (
                             <StyledInput
-                                ref={inputRef}
+                                ref={inputForkRef}
                                 inputWrapperRef={referenceRef as MutableRefObject<HTMLDivElement>}
                                 className={cls(datePickerErrorClass, datePickerSuccessClass, datePickerEditedClass)}
                                 value={inputValue}

--- a/packages/plasma-new-hope/src/components/TimePicker/TimePicker.tsx
+++ b/packages/plasma-new-hope/src/components/TimePicker/TimePicker.tsx
@@ -31,7 +31,7 @@ interface ActiveTime {
 export const timePickerRoot = (
     Root: RootProps<HTMLDivElement, Omit<TimePickerProps, 'opened' | 'defaultValue' | 'onChange'>>,
 ) =>
-    forwardRef<HTMLDivElement, TimePickerProps>(
+    forwardRef<HTMLInputElement, TimePickerProps>(
         (
             {
                 className,
@@ -110,11 +110,11 @@ export const timePickerRoot = (
             ref,
         ) => {
             const inputRef = useRef<HTMLInputElement | null>(null);
+            const inputForkRef = useForkRef(inputRef, ref);
             const timeGridRootRef = useRef<HTMLDivElement | null>(null);
             const floatingPopoverRef = useRef<HTMLDivElement | null>(null);
 
             const rootRef = useRef<HTMLDivElement | null>(null);
-            const rootForkRef = useForkRef(rootRef, ref);
 
             const hoursHideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
             const minutesHideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -343,7 +343,7 @@ export const timePickerRoot = (
                     })}
                     disabled={disabled}
                     readonly={readonly}
-                    ref={rootForkRef}
+                    ref={rootRef}
                     {...(hintText && {
                         hintView,
                         hintSize,
@@ -361,7 +361,7 @@ export const timePickerRoot = (
                         zIndex={zIndex}
                         target={(referenceRef) => (
                             <StyledInput
-                                ref={inputRef}
+                                ref={inputForkRef}
                                 inputWrapperRef={referenceRef as MutableRefObject<HTMLDivElement>}
                                 className={cls({
                                     [classes.timePickerError]: valueError,

--- a/website/plasma-b2c-docs/docs/form/ReactHookForm.mdx
+++ b/website/plasma-b2c-docs/docs/form/ReactHookForm.mdx
@@ -334,7 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
 
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/plasma-b2c";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 

--- a/website/plasma-giga-docs/docs/form/ReactHookForm.mdx
+++ b/website/plasma-giga-docs/docs/form/ReactHookForm.mdx
@@ -333,6 +333,84 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
+
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/plasma-giga";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
+
 ### Пример с валидацией
 
 [Пример CodeSandbox](https://codesandbox.io/p/sandbox/form-validation-qj7kp6)

--- a/website/plasma-homeds-docs/docs/form/ReactHookForm.mdx
+++ b/website/plasma-homeds-docs/docs/form/ReactHookForm.mdx
@@ -272,6 +272,90 @@ export function App() {
 
 ```
 
+### Особенности работы
+
+#### DatePicker и DatePickerRange
+
+Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
+
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
+
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/plasma-homeds";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
+
 ### Пример с валидацией
 
 [Пример CodeSandbox](https://codesandbox.io/p/sandbox/form-validation-qj7kp6)

--- a/website/plasma-web-docs/docs/form/ReactHookForm.mdx
+++ b/website/plasma-web-docs/docs/form/ReactHookForm.mdx
@@ -334,6 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
+
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/plasma-web";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 

--- a/website/sdds-bizcom-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-bizcom-docs/docs/form/ReactHookForm.mdx
@@ -334,7 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
 
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-bizcom";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 

--- a/website/sdds-cs-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-cs-docs/docs/form/ReactHookForm.mdx
@@ -334,7 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
 
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-cs";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 

--- a/website/sdds-dfa-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-dfa-docs/docs/form/ReactHookForm.mdx
@@ -332,6 +332,84 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
+
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-dfa";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
+
 ### Пример с валидацией
 
 [Пример CodeSendBox](https://codesandbox.io/p/sandbox/sdds-form-validation-9ls9rd)

--- a/website/sdds-finai-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-finai-docs/docs/form/ReactHookForm.mdx
@@ -334,7 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
 
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-finai";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 

--- a/website/sdds-insol-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-insol-docs/docs/form/ReactHookForm.mdx
@@ -332,6 +332,84 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
+
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-insol";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
+
 ### Пример с валидацией
 
 [Пример CodeSendBox](https://codesandbox.io/p/sandbox/sdds-form-validation-9ls9rd)

--- a/website/sdds-netology-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-netology-docs/docs/form/ReactHookForm.mdx
@@ -334,7 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
 
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-netology";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 

--- a/website/sdds-platform-ai-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-platform-ai-docs/docs/form/ReactHookForm.mdx
@@ -275,6 +275,90 @@ export function App() {
 
 ```
 
+### Особенности работы
+
+#### DatePicker и DatePickerRange
+
+Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
+
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
+
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-platform-ai";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
+
 ### Пример с валидацией
 
 [Пример CodeSandbox](https://codesandbox.io/p/sandbox/form-validation-qj7kp6)

--- a/website/sdds-sbcom-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-sbcom-docs/docs/form/ReactHookForm.mdx
@@ -334,7 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
 
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-sbcom";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 

--- a/website/sdds-scan-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-scan-docs/docs/form/ReactHookForm.mdx
@@ -334,7 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
 
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-scan";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 

--- a/website/sdds-serv-docs/docs/form/ReactHookForm.mdx
+++ b/website/sdds-serv-docs/docs/form/ReactHookForm.mdx
@@ -334,7 +334,83 @@ export function App() {
 
 Свойство `name` и `onChange` лучше передавать напрямую, так как типы передаваемые из `register` в параметрах `min` и `max` несовместимы.
 
+Так как `DatePicker` имеет нестандартную форму `onChange`, для интеграции с обязательными полями удобнее использовать `Controller`.
+При этом `field.ref` из `Controller` попадает на реальный `<input>` внутри `DatePicker`, поэтому `setFocus()` и авто-скролл к полю при ошибке валидации работают корректно.
 
+```tsx live
+import { useForm, Controller } from "react-hook-form";
+import React from "react";
+import { Button, DatePicker } from "@salutejs/sdds-serv";
+
+export function App() {
+  const {
+    control,
+    handleSubmit,
+    setFocus,
+    formState: { errors },
+  } = useForm();
+
+  const onSubmit = (data) => {
+    console.log(data);
+  };
+
+  return (
+    <div>
+      <div
+        style={{
+          height: "120vh",
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "center",
+          paddingBottom: "24px",
+        }}
+      >
+        Прокрутите вниз к форме, нажмите «Отправить» с пустыми полями или кнопку setFocus —
+        страница должна проскроллиться к полю, а поле — получить фокус.
+      </div>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        style={{ display: "flex", flexDirection: "column", gap: "20px", maxWidth: "400px" }}
+      >
+        <Controller
+          name="birthDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата рождения"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.birthDate)}
+              leftHelper={errors.birthDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <Controller
+          name="issueDate"
+          control={control}
+          rules={{ required: true }}
+          render={({ field }) => (
+            <DatePicker
+              {...field}
+              label="Дата выдачи"
+              placeholder="ДД.ММ.ГГГГ"
+              valueError={Boolean(errors.issueDate)}
+              leftHelper={errors.issueDate ? "Заполните поле" : undefined}
+            />
+          )}
+        />
+        <div style={{ display: "flex", gap: "12px" }}>
+          <Button type="submit">Отправить</Button>
+          <Button type="button" view="secondary" onClick={() => setFocus("issueDate")}>
+            setFocus("issueDate")
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
 
 ### Пример с валидацией
 


### PR DESCRIPTION
## Core

### DatePicker, TimePicker

- исправлен проброс `ref` с `Root` на `input`

### What/why changed

- исправлен проброс `ref` с `Root` на `input`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.385.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-b2c@1.627.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-core@1.234.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-giga@0.354.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-homeds@0.354.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-hope@1.381.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-icons@1.244.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-new-hope@0.371.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-tokens@1.146.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-tokens-b2b@1.60.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-tokens-b2c@0.71.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-tokens-web@1.75.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-typo@0.48.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-web@1.629.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-bizcom@0.359.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-cs@0.363.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-dfa@0.357.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-finai@0.350.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-insol@0.354.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-netology@0.358.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-os@0.29.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-platform-ai@0.358.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-sbcom@0.359.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-scan@0.357.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-serv@0.358.0-canary.2986.30090294685.0
  npm install @salutejs/core-themes@0.36.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-themes@0.58.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-themes@0.72.0-canary.2986.30090294685.0
  npm install @salutejs/sdds-api-tests@0.16.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-cy-utils@0.164.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-sb-utils@0.235.0-canary.2986.30090294685.0
  npm install @salutejs/plasma-tokens-utils@0.56.0-canary.2986.30090294685.0
  # or 
  yarn add @salutejs/plasma-asdk@0.385.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-b2c@1.627.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-core@1.234.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-giga@0.354.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-homeds@0.354.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-hope@1.381.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-icons@1.244.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-new-hope@0.371.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-tokens@1.146.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-tokens-b2b@1.60.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-tokens-b2c@0.71.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-tokens-web@1.75.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-typo@0.48.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-web@1.629.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-bizcom@0.359.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-cs@0.363.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-dfa@0.357.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-finai@0.350.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-insol@0.354.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-netology@0.358.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-os@0.29.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-platform-ai@0.358.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-sbcom@0.359.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-scan@0.357.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-serv@0.358.0-canary.2986.30090294685.0
  yarn add @salutejs/core-themes@0.36.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-themes@0.58.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-themes@0.72.0-canary.2986.30090294685.0
  yarn add @salutejs/sdds-api-tests@0.16.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-cy-utils@0.164.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-sb-utils@0.235.0-canary.2986.30090294685.0
  yarn add @salutejs/plasma-tokens-utils@0.56.0-canary.2986.30090294685.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DatePicker and TimePicker refs now target the underlying input, improving programmatic focus and validation auto-scroll behavior.

* **Documentation**
  * Added React Hook Form integration guidance and interactive examples for DatePicker fields.
  * Documented recommended `Controller` usage, validation feedback, and focus handling with `setFocus()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->