### PR TITLE
PLASMA-5469: extend TextField docs with hintTargetPlacement example

### DIFF
--- a/packages/plasma-new-hope/src/components/TextField/TextField.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/TextField/TextField.template-doc.mdx
@@ -227,6 +227,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/{{ package }}';
+
+export function App() {
+    return (
+        <div style=\{{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/plasma-b2c-docs/docs/components/TextField.mdx
+++ b/website/plasma-b2c-docs/docs/components/TextField.mdx
@@ -229,6 +229,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/plasma-b2c';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/plasma-giga-docs/docs/components/TextField.mdx
+++ b/website/plasma-giga-docs/docs/components/TextField.mdx
@@ -229,6 +229,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/plasma-giga';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/plasma-homeds-docs/docs/components/TextField.mdx
+++ b/website/plasma-homeds-docs/docs/components/TextField.mdx
@@ -147,6 +147,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/plasma-homeds';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/plasma-web-docs/docs/components/TextField.mdx
+++ b/website/plasma-web-docs/docs/components/TextField.mdx
@@ -229,6 +229,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/plasma-web';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-bizcom-docs/docs/components/TextField.mdx
+++ b/website/sdds-bizcom-docs/docs/components/TextField.mdx
@@ -73,6 +73,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-bizcom';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-cs-docs/docs/components/TextField.mdx
+++ b/website/sdds-cs-docs/docs/components/TextField.mdx
@@ -170,8 +170,8 @@ import CleaningLogicExample from '../_examples/_textfield/_cleaning-logic.mdx'
 </Tabs>
 
 ### Подсказки
-Для вывода подсказки снизу от поля используйте свойство `leftHelper` - для подсказки слева, и `rightHelper` - для подсказки справа,
-для подсказки в виде Tooltip - `hintText`, для подсказки сверху справа - `titleCaption`:
+Для вывода подсказки снизу от поля используйте свойство `leftHelper` - для подсказки слева, и `rightHelper` - для подсказки справа, 
+для подсказки сверху справа - `titleCaption`:
 
 ```tsx live
 import React from 'react';
@@ -185,9 +185,6 @@ export function App() {
                 leftHelper="Подсказка слева"
                 rightHelper="Подсказка справа"
                 titleCaption="Подсказка сверху"
-                hintText="Подсказка в виде Tooltip"
-                hintView="default"
-                hintSize="m"
             />
         </div>
     );

--- a/website/sdds-dfa-docs/docs/components/TextField.mdx
+++ b/website/sdds-dfa-docs/docs/components/TextField.mdx
@@ -229,6 +229,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-dfa';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-finai-docs/docs/components/TextField.mdx
+++ b/website/sdds-finai-docs/docs/components/TextField.mdx
@@ -226,6 +226,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-finai';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-insol-docs/docs/components/TextField.mdx
+++ b/website/sdds-insol-docs/docs/components/TextField.mdx
@@ -229,6 +229,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-insol';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-netology-docs/docs/components/TextField.mdx
+++ b/website/sdds-netology-docs/docs/components/TextField.mdx
@@ -229,6 +229,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-netology';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-platform-ai-docs/docs/components/TextField.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/TextField.mdx
@@ -201,6 +201,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-sbcom-docs/docs/components/TextField.mdx
+++ b/website/sdds-sbcom-docs/docs/components/TextField.mdx
@@ -72,6 +72,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-sbcom';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-scan-docs/docs/components/TextField.mdx
+++ b/website/sdds-scan-docs/docs/components/TextField.mdx
@@ -208,6 +208,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-scan';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip

--- a/website/sdds-serv-docs/docs/components/TextField.mdx
+++ b/website/sdds-serv-docs/docs/components/TextField.mdx
@@ -73,6 +73,32 @@ export function App() {
 }
 ```
 
+Когда `label` отсутствует или задан `labelPlacement="inner"`, иконка подсказки по умолчанию (`hintTargetPlacement="outer"`) отображается снаружи поля.
+Чтобы расположить иконку внутри поля, используйте `hintTargetPlacement="inner"`:
+
+```tsx live
+import React from 'react';
+import { TextField } from '@salutejs/sdds-serv';
+
+export function App() {
+    return (
+        <div style={{ display: 'flex', gap: '3rem', flexWrap: 'wrap'}}>
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement по умолчанию (outer)"
+            />
+            <TextField
+                labelPlacement="inner"
+                placeholder="Введите значение"
+                hintText="hintTargetPlacement=inner"
+                hintTargetPlacement="inner"
+            />
+        </div>
+    );
+}
+```
+
 ### Обязательность поля
 
 :::tip


### PR DESCRIPTION
## Docs

### TextField

- добавлен раздел с `hintTargetPlacement` в раздел документации по подсказкам

### What/why changed

<img width="876" height="763" alt="image" src="https://github.com/user-attachments/assets/4f7d724c-2881-44a3-a950-c47dd6947962" />

- добавлен раздел с `hintTargetPlacement` в раздел документации по подсказкам


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded `TextField` hint guidance across documentation portals.
  * Clarified that hint icons appear outside the field by default when no label is provided or when the label is positioned inside.
  * Added examples showing how to place the hint icon inside the field.
  * Updated one example to focus on standard helper content and remove unsupported tooltip properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.384.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-b2c@1.626.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-core@1.233.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-giga@0.353.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-homeds@0.353.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-hope@1.380.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-icons@1.243.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-new-hope@0.370.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-tokens@1.145.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-tokens-b2b@1.59.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-tokens-b2c@0.70.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-tokens-web@1.74.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-typo@0.47.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-web@1.628.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-bizcom@0.358.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-cs@0.362.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-dfa@0.356.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-finai@0.349.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-insol@0.353.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-netology@0.357.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-os@0.28.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-platform-ai@0.357.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-sbcom@0.358.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-scan@0.356.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-serv@0.357.1-canary.2994.30345400927.0
  npm install @salutejs/core-themes@0.35.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-themes@0.57.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-themes@0.71.1-canary.2994.30345400927.0
  npm install @salutejs/sdds-api-tests@0.15.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-cy-utils@0.163.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-sb-utils@0.234.1-canary.2994.30345400927.0
  npm install @salutejs/plasma-tokens-utils@0.55.1-canary.2994.30345400927.0
  # or 
  yarn add @salutejs/plasma-asdk@0.384.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-b2c@1.626.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-core@1.233.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-giga@0.353.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-homeds@0.353.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-hope@1.380.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-icons@1.243.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-new-hope@0.370.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-tokens@1.145.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-tokens-b2b@1.59.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-tokens-b2c@0.70.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-tokens-web@1.74.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-typo@0.47.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-web@1.628.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-bizcom@0.358.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-cs@0.362.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-dfa@0.356.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-finai@0.349.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-insol@0.353.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-netology@0.357.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-os@0.28.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-platform-ai@0.357.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-sbcom@0.358.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-scan@0.356.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-serv@0.357.1-canary.2994.30345400927.0
  yarn add @salutejs/core-themes@0.35.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-themes@0.57.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-themes@0.71.1-canary.2994.30345400927.0
  yarn add @salutejs/sdds-api-tests@0.15.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-cy-utils@0.163.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-sb-utils@0.234.1-canary.2994.30345400927.0
  yarn add @salutejs/plasma-tokens-utils@0.55.1-canary.2994.30345400927.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
