### PR TITLE
PLASMA-7852: add staticOffset for arrow with alignment

### DIFF
--- a/packages/plasma-new-hope/src/components/_beta/Popover/Popover.tsx
+++ b/packages/plasma-new-hope/src/components/_beta/Popover/Popover.tsx
@@ -78,6 +78,8 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, Omit<PopoverProps, '
 
             const arrowRef = useRef(null);
 
+            const [, alignment] = placement.split('-');
+
             const handleToggle = (opened: boolean) => {
                 setInnerOpened(opened);
 
@@ -162,6 +164,7 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, Omit<PopoverProps, '
                                                     height={ARROW_HEIGHT}
                                                     fill={`var(${tokens.backgroundColor})`}
                                                     d={ARROW_POLYGON}
+                                                    staticOffset={alignment ? ARROW_PADDING : undefined}
                                                 />
                                             )}
 

--- a/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.tsx
+++ b/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.tsx
@@ -58,6 +58,8 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
 
             const arrowRef = useRef(null);
 
+            const [, alignment] = placement.split('-');
+
             const handleToggle = (opened: boolean) => {
                 setOpened(opened);
             };
@@ -135,6 +137,7 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                                             height={ARROW_HEIGHT}
                                             fill={`var(${tokens.backgroundColor})`}
                                             d={ARROW_POLYGON}
+                                            staticOffset={alignment ? ARROW_PADDING : undefined}
                                         />
                                     )}
                                 </Wrapper>


### PR DESCRIPTION
## Core

### Popover, Tooltip (beta)

- добавлен отступ от края всплывающего окна при позиционировании с alignment

### What/why changed

В FloatingArrow (`node_modules/@floating-ui/react/dist/floating-ui.react.mjs:486`) есть строка
```ts
let xOffsetProp = computedStaticOffset && alignment === 'end' ? 'right' : 'left';
```
`computedStaticOffset` берётся из пропа `staticOffset`, который ни Tooltip.tsx, ни Popover.tsx не передавали - поэтому условия для right/bottom не выполнялись, и хвостик всегда позиционировался от left/top, независимо от alignment

**Before:**
<img width="891" height="157" alt="image" src="https://github.com/user-attachments/assets/45e79e4a-f1af-4489-9686-3ef3053cfc8c" />

**After:**
<img width="971" height="202" alt="image" src="https://github.com/user-attachments/assets/00f71b2b-3d2d-4572-b5eb-22d3e7d4421d" />


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.385.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-b2c@1.627.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-core@1.234.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-giga@0.354.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-homeds@0.354.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-hope@1.381.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-icons@1.244.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-new-hope@0.371.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-tokens@1.146.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-tokens-b2b@1.60.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-tokens-b2c@0.71.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-tokens-web@1.75.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-typo@0.48.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-web@1.629.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-bizcom@0.359.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-cs@0.363.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-dfa@0.357.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-finai@0.350.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-insol@0.354.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-netology@0.358.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-os@0.29.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-platform-ai@0.358.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-sbcom@0.359.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-scan@0.357.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-serv@0.358.0-canary.2996.30350408067.0
  npm install @salutejs/core-themes@0.36.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-themes@0.58.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-themes@0.72.0-canary.2996.30350408067.0
  npm install @salutejs/sdds-api-tests@0.16.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-cy-utils@0.164.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-sb-utils@0.235.0-canary.2996.30350408067.0
  npm install @salutejs/plasma-tokens-utils@0.56.0-canary.2996.30350408067.0
  # or 
  yarn add @salutejs/plasma-asdk@0.385.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-b2c@1.627.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-core@1.234.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-giga@0.354.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-homeds@0.354.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-hope@1.381.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-icons@1.244.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-new-hope@0.371.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-tokens@1.146.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-tokens-b2b@1.60.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-tokens-b2c@0.71.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-tokens-web@1.75.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-typo@0.48.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-web@1.629.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-bizcom@0.359.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-cs@0.363.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-dfa@0.357.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-finai@0.350.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-insol@0.354.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-netology@0.358.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-os@0.29.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-platform-ai@0.358.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-sbcom@0.359.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-scan@0.357.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-serv@0.358.0-canary.2996.30350408067.0
  yarn add @salutejs/core-themes@0.36.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-themes@0.58.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-themes@0.72.0-canary.2996.30350408067.0
  yarn add @salutejs/sdds-api-tests@0.16.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-cy-utils@0.164.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-sb-utils@0.235.0-canary.2996.30350408067.0
  yarn add @salutejs/plasma-tokens-utils@0.56.0-canary.2996.30350408067.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popover and tooltip arrow positioning across different placement options.
  * Ensured arrow spacing is applied only when an alignment is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->