### PR TITLE
PLASMA-7718: add showAll extended example for Tabs

### DIFF
--- a/packages/plasma-new-hope/src/components/Tabs/Tabs.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Tabs/Tabs.template-doc.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/{{ package }}';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style=\{{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style=\{{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/plasma-b2c-docs/docs/components/Tabs.mdx
+++ b/website/plasma-b2c-docs/docs/components/Tabs.mdx
@@ -258,6 +258,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/plasma-b2c';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/plasma-giga-docs/docs/components/Tabs.mdx
+++ b/website/plasma-giga-docs/docs/components/Tabs.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/plasma-giga';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/plasma-homeds-docs/docs/components/Tabs.mdx
+++ b/website/plasma-homeds-docs/docs/components/Tabs.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/plasma-homeds';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="m">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="m"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="m" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="m">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/plasma-web-docs/docs/components/Tabs.mdx
+++ b/website/plasma-web-docs/docs/components/Tabs.mdx
@@ -296,6 +296,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/plasma-web';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/sdds-bizcom-docs/docs/components/Tabs.mdx
+++ b/website/sdds-bizcom-docs/docs/components/Tabs.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-bizcom';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/sdds-cs-docs/docs/components/Tabs.mdx
+++ b/website/sdds-cs-docs/docs/components/Tabs.mdx
@@ -191,6 +191,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-cs';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="s">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="s"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="s" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="s">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Подключение клавиатурной навигации
 Для этого необходимо дополнительно прокинуть свойства `index, itemIndex, onIndexChange`.<br/>
 Для горизонтальных табов: клавиши ArrowLeft, ArrowRight, Home, End для навигации по вкладкам.<br/>

--- a/website/sdds-dfa-docs/docs/components/Tabs.mdx
+++ b/website/sdds-dfa-docs/docs/components/Tabs.mdx
@@ -220,7 +220,7 @@ export function App() {
                     ))}
                     {dropdownItems.length > 0 && (
                         <div style={{ marginLeft: '1.75rem' }}>
-                            <Dropdown size="xs" items={dropdownItems} onItemSelect={(item) => setIndex(item.value)}>
+                            <Dropdown size="s" items={dropdownItems} onItemSelect={(item) => setIndex(item.value)}>
                                 <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
                                     ShowAll
                                 </TabItem>
@@ -246,7 +246,7 @@ export function App() {
                     ))}
                     {dropdownItems.length > 0 && (
                         <div style={{ marginLeft: '1.75rem' }}>
-                            <Dropdown size="xs" items={dropdownItems} onItemSelect={(item) => setIndex(item.value)}>
+                            <Dropdown size="s" items={dropdownItems} onItemSelect={(item) => setIndex(item.value)}>
                                 <IconTabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
                                     <IconClock color="inherit" size="xs" />
                                 </IconTabItem>
@@ -255,6 +255,70 @@ export function App() {
                     )}
                 </Tabs>
             </div>
+        </div>
+    );
+}
+```
+
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-dfa';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="s" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
         </div>
     );
 }

--- a/website/sdds-finai-docs/docs/components/Tabs.mdx
+++ b/website/sdds-finai-docs/docs/components/Tabs.mdx
@@ -191,6 +191,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-finai';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Подключение клавиатурной навигации
 Для этого необходимо дополнительно прокинуть свойства `index, itemIndex, onIndexChange`.<br/>
 Для горизонтальных Tabs: клавиши ArrowLeft, ArrowRight, Home, End для навигации по вкладкам.<br/>

--- a/website/sdds-insol-docs/docs/components/Tabs.mdx
+++ b/website/sdds-insol-docs/docs/components/Tabs.mdx
@@ -73,7 +73,7 @@ export function App() {
 ### Расположение табов
 Табы могут быть горизонтальными (по умолчанию) и вертикальными. За это отвечает свойство `orientation`.
 
-````tsx live
+```tsx live
 import React, { useState } from 'react';
 import { Tabs, TabItem, IconTabItem } from '@salutejs/sdds-insol';
 import { IconClock } from '@salutejs/plasma-icons';
@@ -251,6 +251,70 @@ export function App() {
                     )}
                 </Tabs>
             </div>
+        </div>
+    );
+}
+```
+
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-insol';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
         </div>
     );
 }

--- a/website/sdds-netology-docs/docs/components/Tabs.mdx
+++ b/website/sdds-netology-docs/docs/components/Tabs.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-netology';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/sdds-platform-ai-docs/docs/components/Tabs.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/Tabs.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="m">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="m"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="m" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="m">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/sdds-sbcom-docs/docs/components/Tabs.mdx
+++ b/website/sdds-sbcom-docs/docs/components/Tabs.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-sbcom';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/sdds-scan-docs/docs/components/Tabs.mdx
+++ b/website/sdds-scan-docs/docs/components/Tabs.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-scan';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 

--- a/website/sdds-serv-docs/docs/components/Tabs.mdx
+++ b/website/sdds-serv-docs/docs/components/Tabs.mdx
@@ -256,6 +256,70 @@ export function App() {
 }
 ```
 
+### Пример с Dropdown и перемещением выбранного элемента в видимую область
+При выборе элемента в Dropdown он перемещается в видимую область (на последнее видимое место),
+а крайний видимый TabItem, который он вытеснил, уходит в Dropdown.
+
+```tsx live
+import React, { useState } from 'react';
+import { Tabs, TabItem, Dropdown } from '@salutejs/sdds-serv';
+
+export function App() {
+    const items = Array(8).fill(0);
+
+    const maxItemQuantity = 3;
+
+    const [order, setOrder] = useState(items.map((_, i) => i));
+    const [selected, setSelected] = useState(order[0]);
+
+    const visibleItems = order.slice(0, maxItemQuantity);
+    const otherItems = order.slice(maxItemQuantity);
+
+    const dropdownItems = otherItems.map((itemIndex) => ({
+        label: `Label${itemIndex + 1}`,
+        value: itemIndex,
+    }));
+
+    const onSelectDropdownItem = (item) => {
+        setOrder((prevOrder) => {
+            const newOrder = prevOrder.filter((itemIndex) => itemIndex !== item.value);
+            newOrder.splice(maxItemQuantity - 1, 0, item.value);
+
+            return newOrder;
+        });
+        setSelected(item.value);
+    };
+
+    return (
+        <div style={{ height: '15rem', alignItems: 'flex-start' }}>
+            <Tabs clip="showAll" view="divider" size="xs">
+                {visibleItems.map((itemIndex) => (
+                    <TabItem
+                        key={`item:${itemIndex}`}
+                        view="divider"
+                        selected={itemIndex === selected}
+                        onClick={() => setSelected(itemIndex)}
+                        tabIndex={0}
+                        size="xs"
+                    >
+                        {`Label${itemIndex + 1}`}
+                    </TabItem>
+                ))}
+                {dropdownItems.length > 0 && (
+                    <div style={{ marginLeft: '1.75rem' }}>
+                        <Dropdown size="xs" items={dropdownItems} onItemSelect={onSelectDropdownItem}>
+                            <TabItem key="item:ShowAll" view="divider" tabIndex={0} size="xs">
+                                ShowAll
+                            </TabItem>
+                        </Dropdown>
+                    </div>
+                )}
+            </Tabs>
+        </div>
+    );
+}
+```
+
 ### Слот дополнительного действия в `TabItem`
 Для задания дополнительного действия используется свойство `actionContent`
 


### PR DESCRIPTION
## Docs

### Tabs

- добавлен пример с Dropdown и перемещением выбранного элемента в видимую область

### What/why changed
<img width="772" height="440" alt="Запись-экрана-2026-07-29-в-12 43 46" src="https://github.com/user-attachments/assets/babe5492-377e-4b84-979b-48dc4f7c86d9" />

- добавлен пример с Dropdown и перемещением выбранного элемента в видимую область

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.384.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-b2c@1.626.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-colors@0.16.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-core@1.233.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-giga@0.353.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-homeds@0.353.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-hope@1.380.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-icons@1.243.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-new-hope@0.370.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-tokens@1.145.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-tokens-b2b@1.59.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-tokens-b2c@0.70.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-tokens-core@0.7.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-tokens-web@1.74.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-typo@0.47.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-web@1.628.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-bizcom@0.358.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-cs@0.362.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-dfa@0.356.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-finai@0.349.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-insol@0.353.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-insol-next@0.353.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-netology@0.357.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-os@0.28.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-platform-ai@0.357.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-sbcom@0.358.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-scan@0.356.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-serv@0.357.1-canary.2999.30613602132.0
  npm install @salutejs/core-themes@0.35.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-themes@0.57.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-themes@0.71.1-canary.2999.30613602132.0
  npm install @salutejs/sdds-api-tests@0.15.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-cy-utils@0.163.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-sb-utils@0.234.1-canary.2999.30613602132.0
  npm install @salutejs/plasma-tokens-utils@0.55.1-canary.2999.30613602132.0
  # or 
  yarn add @salutejs/plasma-asdk@0.384.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-b2c@1.626.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-colors@0.16.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-core@1.233.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-giga@0.353.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-homeds@0.353.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-hope@1.380.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-icons@1.243.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-new-hope@0.370.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-tokens@1.145.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-tokens-b2b@1.59.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-tokens-b2c@0.70.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-tokens-core@0.7.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-tokens-web@1.74.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-typo@0.47.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-web@1.628.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-bizcom@0.358.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-cs@0.362.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-dfa@0.356.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-finai@0.349.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-insol@0.353.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-insol-next@0.353.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-netology@0.357.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-os@0.28.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-platform-ai@0.357.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-sbcom@0.358.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-scan@0.356.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-serv@0.357.1-canary.2999.30613602132.0
  yarn add @salutejs/core-themes@0.35.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-themes@0.57.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-themes@0.71.1-canary.2999.30613602132.0
  yarn add @salutejs/sdds-api-tests@0.15.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-cy-utils@0.163.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-sb-utils@0.234.1-canary.2999.30613602132.0
  yarn add @salutejs/plasma-tokens-utils@0.55.1-canary.2999.30613602132.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Tabs example demonstrating Dropdown-based tab reordering.
  * Selecting a hidden tab moves it into the visible tab area, while the displaced tab moves into the Dropdown.
  * Updated Tabs documentation across supported product documentation sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->