### PR TITLE
PLASMA-7867: add curvature in tail in beta Popover, Tooltip

### DIFF
--- a/packages/plasma-new-hope/src/components/_beta/Popover/Popover.styles.ts
+++ b/packages/plasma-new-hope/src/components/_beta/Popover/Popover.styles.ts
@@ -12,6 +12,7 @@ export const Wrapper = styled.div`
     padding: var(${tokens.padding});
     border-radius: var(${tokens.borderRadius});
     box-shadow: var(${tokens.boxShadow});
+    filter: var(${tokens.dropShadow}, none);
     width: 100%;
     height: 100%;
     box-sizing: border-box;
@@ -35,5 +36,45 @@ export const CloseButton = styled.button`
 
     &:active {
         color: var(${tokens.iconColorActive});
+    }
+`;
+
+export const Tail = styled.div<{ side: 'top' | 'right' | 'bottom' | 'left' }>`
+    position: absolute;
+    pointer-events: none;
+    width: ${({ side }) =>
+        side === 'left' || side === 'right' ? `var(${tokens.tailHeight})` : `var(${tokens.tailWidth})`};
+    height: ${({ side }) =>
+        side === 'left' || side === 'right' ? `var(${tokens.tailWidth})` : `var(${tokens.tailHeight})`};
+
+    ${({ side }) => ({
+        [side]: '100%',
+    })}
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: var(${tokens.tailWidth});
+        height: var(${tokens.tailHeight});
+        background: var(${tokens.backgroundColor});
+        transform: translate(-50%, -50%)
+            ${({ side }) =>
+                ({
+                    top: 'rotate(180deg)',
+                    right: 'rotate(-90deg)',
+                    bottom: 'rotate(0deg)',
+                    left: 'rotate(90deg)',
+                }[side])};
+        clip-path: shape(
+            from 100% 100%,
+            line to 0% 100%,
+            curve to 50% 0% with calc(25% - var(${tokens.tailSideCurvature}) * 1.24939)
+                calc(50% - var(${tokens.tailSideCurvature}) * 3.90435),
+            curve to 100% 100% with calc(75% + var(${tokens.tailSideCurvature}) * 1.24939)
+                calc(50% - var(${tokens.tailSideCurvature}) * 3.90435),
+            close
+        );
     }
 `;

--- a/packages/plasma-new-hope/src/components/_beta/Popover/Popover.tokens.ts
+++ b/packages/plasma-new-hope/src/components/_beta/Popover/Popover.tokens.ts
@@ -8,8 +8,12 @@ export const tokens = {
     borderRadius: '--plasma-popover-border-radius',
     padding: '--plasma-popover-padding',
     boxShadow: '--plasma-popover-box-shadow',
+    dropShadow: '--plasma-popover-drop-shadow',
     iconColor: '--plasma-popover-icon-color',
     iconColorHover: '--plasma-popover-icon-color-hover',
     iconColorActive: '--plasma-popover-icon-color-active',
     iconOffset: '--plasma-popover-icon-offset',
+    tailWidth: '--plasma-popover-tail-width',
+    tailHeight: '--plasma-popover-tail-height',
+    tailSideCurvature: '--plasma-popover-tail-side-curvature',
 };

--- a/packages/plasma-new-hope/src/components/_beta/Popover/Popover.tsx
+++ b/packages/plasma-new-hope/src/components/_beta/Popover/Popover.tsx
@@ -9,7 +9,6 @@ import {
     useDismiss,
     useRole,
     FloatingFocusManager,
-    FloatingArrow,
     arrow,
     offset,
     useHover,
@@ -26,9 +25,9 @@ import { IconClose } from '../../_Icon';
 import { Resizable } from '../../_Resizable';
 import { Slot } from '../../_Slot/Slot';
 
-import { sizeToIconSize, matchPlacements, getFloatingPortalProps } from './utils';
-import { tokens, classes } from './Popover.tokens';
-import { base, CloseButton, Wrapper } from './Popover.styles';
+import { sizeToIconSize, matchPlacements, getFloatingPortalProps, useTailStyle } from './utils';
+import { classes } from './Popover.tokens';
+import { base, CloseButton, Wrapper, Tail } from './Popover.styles';
 import type { PopoverProps } from './Popover.types';
 
 /* Ширина хвостика */
@@ -76,9 +75,7 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, Omit<PopoverProps, '
 
             const opened = outerOpened ?? innerOpened;
 
-            const arrowRef = useRef(null);
-
-            const [, alignment] = placement.split('-');
+            const arrowRef = useRef<HTMLDivElement | null>(null);
 
             const handleToggle = (opened: boolean) => {
                 setInnerOpened(opened);
@@ -88,7 +85,14 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, Omit<PopoverProps, '
                 }
             };
 
-            const { refs, floatingStyles, context } = useFloating({
+            const {
+                refs,
+                floatingStyles,
+                context,
+                middlewareData,
+                placement: calculatedPlacement,
+                isPositioned,
+            } = useFloating({
                 whileElementsMounted: autoUpdate,
                 placement,
                 open: opened,
@@ -100,7 +104,20 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, Omit<PopoverProps, '
                         }),
                     outsideFlip && flip(),
                     hasTail && arrow({ element: arrowRef, padding: ARROW_PADDING }),
-                    offset((hasTail ? ARROW_HEIGHT : 0) + outerOffset),
+                    offset(
+                        ({ placement: currentPlacement }) => {
+                            if (!hasTail) {
+                                return outerOffset;
+                            }
+
+                            const side = currentPlacement.split('-')[0];
+                            const { width = 0, height = 0 } = arrowRef.current?.getBoundingClientRect() ?? {};
+                            const tailOffset = side === 'top' || side === 'bottom' ? height : width;
+
+                            return tailOffset + outerOffset;
+                        },
+                        [outerOffset, hasTail],
+                    ),
                 ],
             });
 
@@ -127,6 +144,8 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, Omit<PopoverProps, '
 
             const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, role, click, hover, focus]);
 
+            const { side, tailStyle } = useTailStyle(calculatedPlacement, middlewareData, ARROW_PADDING);
+
             return (
                 <>
                     <Slot ref={refs.setReference} {...getReferenceProps()}>
@@ -140,7 +159,11 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, Omit<PopoverProps, '
                                     ref={refs.setFloating}
                                     size={size}
                                     view={view}
-                                    style={{ ...floatingStyles, zIndex }}
+                                    style={{
+                                        ...floatingStyles,
+                                        zIndex,
+                                        visibility: isPositioned ? 'visible' : 'hidden',
+                                    }}
                                     {...getFloatingProps()}
                                 >
                                     <Resizable
@@ -157,15 +180,7 @@ export const popoverRoot = (Root: RootProps<HTMLDivElement, Omit<PopoverProps, '
                                             {...rest}
                                         >
                                             {hasTail && (
-                                                <FloatingArrow
-                                                    ref={arrowRef}
-                                                    context={context}
-                                                    width={ARROW_WIDTH}
-                                                    height={ARROW_HEIGHT}
-                                                    fill={`var(${tokens.backgroundColor})`}
-                                                    d={ARROW_POLYGON}
-                                                    staticOffset={alignment ? ARROW_PADDING : undefined}
-                                                />
+                                                <Tail ref={arrowRef} side={side} style={tailStyle} aria-hidden="true" />
                                             )}
 
                                             {children}

--- a/packages/plasma-new-hope/src/components/_beta/Popover/utils/index.ts
+++ b/packages/plasma-new-hope/src/components/_beta/Popover/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './sizeToIconSize';
 export * from './matchPlacements';
 export * from './getFloatingPortalProps';
+export * from './useTailStyle';

--- a/packages/plasma-new-hope/src/components/_beta/Popover/utils/useTailStyle.ts
+++ b/packages/plasma-new-hope/src/components/_beta/Popover/utils/useTailStyle.ts
@@ -1,0 +1,30 @@
+import type { CSSProperties } from 'react';
+import type { MiddlewareData } from '@floating-ui/react';
+
+type Side = 'top' | 'right' | 'bottom' | 'left';
+
+/**
+ * Вычисляет сторону хвостика и его позицию.
+ * При выравнивании (start/end) хвостик фиксируется на отступе ARROW_PADDING от края,
+ * чтобы не залезать на скругление угла; без выравнивания — позиционируется динамически
+ * по данным arrow-middleware.
+ */
+export const useTailStyle = (calculatedPlacement: string, middlewareData: MiddlewareData, arrowPadding: number) => {
+    const [side, alignment] = calculatedPlacement.split('-') as [Side, 'start' | 'end' | undefined];
+    const isVerticalSide = side === 'top' || side === 'bottom';
+
+    let tailStyle: CSSProperties;
+
+    if (alignment && isVerticalSide) {
+        tailStyle = alignment === 'end' ? { right: `${arrowPadding}px` } : { left: `${arrowPadding}px` };
+    } else if (alignment && !isVerticalSide) {
+        tailStyle = alignment === 'end' ? { bottom: `${arrowPadding}px` } : { top: `${arrowPadding}px` };
+    } else {
+        tailStyle = {
+            left: middlewareData.arrow?.x == null ? undefined : `${middlewareData.arrow.x}px`,
+            top: middlewareData.arrow?.y == null ? undefined : `${middlewareData.arrow.y}px`,
+        };
+    }
+
+    return { side, tailStyle };
+};

--- a/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.styles.ts
+++ b/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.styles.ts
@@ -15,6 +15,7 @@ export const Wrapper = styled.div`
     padding: var(${tokens.padding});
     border-radius: var(${tokens.borderRadius});
     box-shadow: var(${tokens.boxShadow});
+    filter: var(${tokens.dropShadow}, none);
     width: 100%;
     height: 100%;
     box-sizing: border-box;
@@ -30,4 +31,44 @@ export const Wrapper = styled.div`
 export const IconWrapper = styled.div`
     flex: none;
     line-height: 0;
+`;
+
+export const Tail = styled.div<{ side: 'top' | 'right' | 'bottom' | 'left' }>`
+    position: absolute;
+    pointer-events: none;
+    width: ${({ side }) =>
+        side === 'left' || side === 'right' ? `var(${tokens.tailHeight})` : `var(${tokens.tailWidth})`};
+    height: ${({ side }) =>
+        side === 'left' || side === 'right' ? `var(${tokens.tailWidth})` : `var(${tokens.tailHeight})`};
+
+    ${({ side }) => ({
+        [side]: '100%',
+    })}
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: var(${tokens.tailWidth});
+        height: var(${tokens.tailHeight});
+        background: var(${tokens.backgroundColor});
+        transform: translate(-50%, -50%)
+            ${({ side }) =>
+                ({
+                    top: 'rotate(180deg)',
+                    right: 'rotate(-90deg)',
+                    bottom: 'rotate(0deg)',
+                    left: 'rotate(90deg)',
+                }[side])};
+        clip-path: shape(
+            from 100% 100%,
+            line to 0% 100%,
+            curve to 50% 0% with calc(25% - var(${tokens.tailSideCurvature}) * 1.24939)
+                calc(50% - var(${tokens.tailSideCurvature}) * 3.90435),
+            curve to 100% 100% with calc(75% + var(${tokens.tailSideCurvature}) * 1.24939)
+                calc(50% - var(${tokens.tailSideCurvature}) * 3.90435),
+            close
+        );
+    }
 `;

--- a/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.tokens.ts
+++ b/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.tokens.ts
@@ -7,6 +7,7 @@ export const tokens = {
     borderRadius: '--plasma-tooltip-border-radius',
     padding: '--plasma-tooltip-padding',
     boxShadow: '--plasma-tooltip-box-shadow',
+    dropShadow: '--plasma-tooltip-drop-shadow',
     gap: '--plasma-tooltip-gap',
     color: '--plasma-tooltip-color',
     fontFamily: '--plasma-tooltip-font-family',
@@ -15,4 +16,7 @@ export const tokens = {
     fontWeight: '--plasma-tooltip-font-weight',
     letterSpacing: '--plasma-tooltip-letter-spacing',
     lineHeight: '--plasma-tooltip-lineheight',
+    tailWidth: '--plasma-tooltip-tail-width',
+    tailHeight: '--plasma-tooltip-tail-height',
+    tailSideCurvature: '--plasma-tooltip-tail-side-curvature',
 };

--- a/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.tsx
+++ b/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.tsx
@@ -8,7 +8,6 @@ import {
     useFocus,
     useDismiss,
     useRole,
-    FloatingArrow,
     arrow,
     offset,
     shift,
@@ -22,11 +21,11 @@ import {
 import { css } from 'styled-components';
 
 import { Slot } from '../../_Slot/Slot';
-import { ARROW_HEIGHT, ARROW_PADDING, ARROW_POLYGON, ARROW_WIDTH } from '../Popover/Popover';
-import { getFloatingPortalProps } from '../Popover/utils';
+import { ARROW_PADDING } from '../Popover/Popover';
+import { getFloatingPortalProps, useTailStyle } from '../Popover/utils';
 
-import { tokens, classes } from './Tooltip.tokens';
-import { base, Wrapper, IconWrapper } from './Tooltip.styles';
+import { classes } from './Tooltip.tokens';
+import { base, Wrapper, IconWrapper, Tail } from './Tooltip.styles';
 import type { TooltipProps } from './Tooltip.types';
 
 export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, 'target' | 'children' | 'iconSlot'>>) =>
@@ -56,15 +55,20 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
         ) => {
             const [opened, setOpened] = useState(false);
 
-            const arrowRef = useRef(null);
-
-            const [, alignment] = placement.split('-');
+            const arrowRef = useRef<HTMLDivElement | null>(null);
 
             const handleToggle = (opened: boolean) => {
                 setOpened(opened);
             };
 
-            const { refs, floatingStyles, context } = useFloating({
+            const {
+                refs,
+                floatingStyles,
+                context,
+                middlewareData,
+                placement: calculatedPlacement,
+                isPositioned,
+            } = useFloating({
                 whileElementsMounted: autoUpdate,
                 placement,
                 open: opened,
@@ -76,7 +80,20 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                         }),
                     outsideFlip && flip(),
                     hasTail && arrow({ element: arrowRef, padding: ARROW_PADDING }),
-                    offset((hasTail ? ARROW_HEIGHT : 0) + outerOffset),
+                    offset(
+                        ({ placement: currentPlacement }) => {
+                            if (!hasTail) {
+                                return outerOffset;
+                            }
+
+                            const side = currentPlacement.split('-')[0];
+                            const { width = 0, height = 0 } = arrowRef.current?.getBoundingClientRect() ?? {};
+                            const tailOffset = side === 'top' || side === 'bottom' ? height : width;
+
+                            return tailOffset + outerOffset;
+                        },
+                        [outerOffset, hasTail],
+                    ),
                 ],
             });
 
@@ -103,6 +120,8 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
 
             const { getReferenceProps, getFloatingProps } = useInteractions([dismiss, role, click, hover, focus]);
 
+            const { side, tailStyle } = useTailStyle(calculatedPlacement, middlewareData, ARROW_PADDING);
+
             return (
                 <>
                     <Slot ref={refs.setReference} {...getReferenceProps()}>
@@ -115,7 +134,7 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                                 ref={refs.setFloating}
                                 size={size}
                                 view={view}
-                                style={{ ...floatingStyles, zIndex }}
+                                style={{ ...floatingStyles, zIndex, visibility: isPositioned ? 'visible' : 'hidden' }}
                                 {...getFloatingProps()}
                             >
                                 <Wrapper
@@ -130,15 +149,7 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                                     {children}
 
                                     {hasTail && (
-                                        <FloatingArrow
-                                            ref={arrowRef}
-                                            context={context}
-                                            width={ARROW_WIDTH}
-                                            height={ARROW_HEIGHT}
-                                            fill={`var(${tokens.backgroundColor})`}
-                                            d={ARROW_POLYGON}
-                                            staticOffset={alignment ? ARROW_PADDING : undefined}
-                                        />
+                                        <Tail ref={arrowRef} side={side} style={tailStyle} aria-hidden="true" />
                                     )}
                                 </Wrapper>
                             </Root>

--- a/packages/plasma-new-hope/src/examples/components/_beta/Popover/Popover.closeInner.config.ts
+++ b/packages/plasma-new-hope/src/examples/components/_beta/Popover/Popover.closeInner.config.ts
@@ -28,16 +28,25 @@ export const config = {
                 ${tokens.borderRadius}: 1rem;
                 ${tokens.padding}: 0.75rem;
                 ${tokens.iconOffset}: 0.75rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             m: css`
                 ${tokens.borderRadius}: 0.875rem;
                 ${tokens.padding}: 0.625rem;
                 ${tokens.iconOffset}: 0.625rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             s: css`
                 ${tokens.borderRadius}: 0.75rem;
                 ${tokens.padding}: 0.5rem;
                 ${tokens.iconOffset}: 0.5rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/plasma-new-hope/src/examples/components/_beta/Popover/Popover.closeNone.config.ts
+++ b/packages/plasma-new-hope/src/examples/components/_beta/Popover/Popover.closeNone.config.ts
@@ -21,14 +21,23 @@ export const config = {
             l: css`
                 ${tokens.borderRadius}: 1rem;
                 ${tokens.padding}: 0.75rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             m: css`
                 ${tokens.borderRadius}: 0.875rem;
                 ${tokens.padding}: 0.625rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             s: css`
                 ${tokens.borderRadius}: 0.75rem;
                 ${tokens.padding}: 0.5rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/plasma-new-hope/src/examples/components/_beta/Tooltip/Tooltip.config.ts
+++ b/packages/plasma-new-hope/src/examples/components/_beta/Tooltip/Tooltip.config.ts
@@ -30,6 +30,9 @@ export const config = {
                 ${tokens.fontWeight}: var(--plasma-typo-body-s-font-weight);
                 ${tokens.letterSpacing}: var(--plasma-typo-body-s-letter-spacing);
                 ${tokens.lineHeight}: var(--plasma-typo-body-s-line-height);
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             s: css`
                 ${tokens.borderRadius}: 0.5rem;
@@ -41,6 +44,9 @@ export const config = {
                 ${tokens.fontWeight}: var(--plasma-typo-body-xs-font-weight);
                 ${tokens.letterSpacing}: var(--plasma-typo-body-xs-letter-spacing);
                 ${tokens.lineHeight}: var(--plasma-typo-body-xs-line-height);
+                ${tokens.tailWidth}: 14px;
+                ${tokens.tailHeight}: 6px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/sdds-cs/src/components/_beta/Popover/Popover.closeInner.config.ts
+++ b/packages/sdds-cs/src/components/_beta/Popover/Popover.closeInner.config.ts
@@ -38,11 +38,17 @@ export const config = {
                 ${tokens.borderRadius}: 1rem;
                 ${tokens.padding}: 0.75rem 0.5rem 0.5rem 0.5rem;
                 ${tokens.iconOffset}: 0.625rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             s: css`
                 ${tokens.borderRadius}: 0.75rem;
                 ${tokens.padding}: 0.5rem 0.375rem 0.375rem 0.375rem;
                 ${tokens.iconOffset}: 0.5rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/sdds-cs/src/components/_beta/Popover/Popover.closeNone.config.ts
+++ b/packages/sdds-cs/src/components/_beta/Popover/Popover.closeNone.config.ts
@@ -21,10 +21,16 @@ export const config = {
             m: css`
                 ${tokens.borderRadius}: 1rem;
                 ${tokens.padding}: 0.75rem 0.5rem 0.5rem 0.5rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             s: css`
                 ${tokens.borderRadius}: 0.75rem;
                 ${tokens.padding}: 0.5rem 0.375rem 0.375rem 0.375rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/sdds-cs/src/components/_beta/Tooltip/Tooltip.config.ts
+++ b/packages/sdds-cs/src/components/_beta/Tooltip/Tooltip.config.ts
@@ -1,5 +1,6 @@
 import {
     bodyS,
+    bodyXS,
     inverseSurfaceSolidCard,
     inverseTextPrimary,
     onDarkSurfaceSolidSecondary,
@@ -26,7 +27,7 @@ export const config = {
             `,
         },
         size: {
-            s: css`
+            m: css`
                 ${tokens.borderRadius}: 0.5rem;
                 ${tokens.padding}: 0.5rem 0.75rem;
                 ${tokens.gap}: 0.25rem;
@@ -36,6 +37,23 @@ export const config = {
                 ${tokens.fontWeight}: ${bodyS.fontWeight};
                 ${tokens.letterSpacing}: ${bodyS.letterSpacing};
                 ${tokens.lineHeight}: ${bodyS.lineHeight};
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
+            `,
+            s: css`
+                ${tokens.borderRadius}: 0.5rem;
+                ${tokens.padding}: 0.5rem 0.75rem;
+                ${tokens.gap}: 0.25rem;
+                ${tokens.fontFamily}: ${bodyXS.fontFamily};
+                ${tokens.fontSize}: ${bodyXS.fontSize};
+                ${tokens.fontStyle}: ${bodyXS.fontStyle};
+                ${tokens.fontWeight}: ${bodyXS.fontWeight};
+                ${tokens.letterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.lineHeight}: ${bodyXS.lineHeight};
+                ${tokens.tailWidth}: 14px;
+                ${tokens.tailHeight}: 6px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/sdds-finai/src/components/_beta/Popover/Popover.closeInner.config.ts
+++ b/packages/sdds-finai/src/components/_beta/Popover/Popover.closeInner.config.ts
@@ -38,11 +38,17 @@ export const config = {
                 ${tokens.borderRadius}: 1rem;
                 ${tokens.padding}: 0.75rem 0.5rem 0.5rem 0.5rem;
                 ${tokens.iconOffset}: 0.625rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             s: css`
                 ${tokens.borderRadius}: 0.75rem;
                 ${tokens.padding}: 0.5rem 0.375rem 0.375rem 0.375rem;
                 ${tokens.iconOffset}: 0.5rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/sdds-finai/src/components/_beta/Popover/Popover.closeNone.config.ts
+++ b/packages/sdds-finai/src/components/_beta/Popover/Popover.closeNone.config.ts
@@ -21,10 +21,16 @@ export const config = {
             m: css`
                 ${tokens.borderRadius}: 1rem;
                 ${tokens.padding}: 0.75rem 0.5rem 0.5rem 0.5rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             s: css`
                 ${tokens.borderRadius}: 0.75rem;
                 ${tokens.padding}: 0.5rem 0.375rem 0.375rem 0.375rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/sdds-finai/src/components/_beta/Tooltip/Tooltip.config.ts
+++ b/packages/sdds-finai/src/components/_beta/Tooltip/Tooltip.config.ts
@@ -31,6 +31,9 @@ export const config = {
                 ${tokens.fontWeight}: ${bodyS.fontWeight};
                 ${tokens.letterSpacing}: ${bodyS.letterSpacing};
                 ${tokens.lineHeight}: ${bodyS.lineHeight};
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
             s: css`
                 ${tokens.borderRadius}: 0.5rem;
@@ -42,6 +45,9 @@ export const config = {
                 ${tokens.fontWeight}: ${bodyXS.fontWeight};
                 ${tokens.letterSpacing}: ${bodyXS.letterSpacing};
                 ${tokens.lineHeight}: ${bodyXS.lineHeight};
+                ${tokens.tailWidth}: 14px;
+                ${tokens.tailHeight}: 6px;
+                ${tokens.tailSideCurvature}: -10%;
             `,
         },
     },

--- a/packages/sdds-sbcom/src/components/_beta/Popover/Popover.config.ts
+++ b/packages/sdds-sbcom/src/components/_beta/Popover/Popover.config.ts
@@ -1,5 +1,5 @@
 import { css, _beta_popoverTokens as tokens } from '@salutejs/plasma-new-hope/styled-components';
-import { shadowDownHardM, surfaceSolidTertiary } from '@salutejs-ds/sdds_sbcom/theme/tokens';
+import { surfaceSolidTertiary } from '@salutejs-ds/sdds_sbcom/theme/tokens';
 
 export const config = {
     defaults: {
@@ -10,13 +10,18 @@ export const config = {
         view: {
             default: css`
                 ${tokens.backgroundColor}: ${surfaceSolidTertiary};
-                ${tokens.boxShadow}: ${shadowDownHardM};
+                ${tokens.boxShadow}: none;
+                ${tokens.dropShadow}: drop-shadow(0px 4px 12px rgba(0, 0, 0, 0.16))
+                    drop-shadow(0px 1px 4px rgba(0, 0, 0, 0.08));
             `,
         },
         size: {
             m: css`
                 ${tokens.borderRadius}: 1rem;
                 ${tokens.padding}: 0.75rem 0.5rem 0.5rem 0.5rem;
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: 0%;
             `,
         },
     },

--- a/packages/sdds-sbcom/src/components/_beta/Tooltip/Tooltip.config.ts
+++ b/packages/sdds-sbcom/src/components/_beta/Tooltip/Tooltip.config.ts
@@ -1,5 +1,5 @@
 import { css, _beta_tooltipTokens as tokens } from '@salutejs/plasma-new-hope/styled-components';
-import { bodyS, shadowDownHardM, surfaceSolidCardBrightness, textPrimary } from '@salutejs-ds/sdds_sbcom/theme/tokens';
+import { bodyS, surfaceSolidCardBrightness, textPrimary } from '@salutejs-ds/sdds_sbcom/theme/tokens';
 
 export const config = {
     defaults: {
@@ -10,7 +10,9 @@ export const config = {
         view: {
             default: css`
                 ${tokens.backgroundColor}: ${surfaceSolidCardBrightness};
-                ${tokens.boxShadow}: ${shadowDownHardM};
+                ${tokens.boxShadow}: none;
+                ${tokens.dropShadow}: drop-shadow(0px 4px 12px rgba(0, 0, 0, 0.16))
+                    drop-shadow(0px 1px 4px rgba(0, 0, 0, 0.08));
                 ${tokens.color}: ${textPrimary};
             `,
         },
@@ -25,6 +27,9 @@ export const config = {
                 ${tokens.fontWeight}: ${bodyS.fontWeight};
                 ${tokens.letterSpacing}: ${bodyS.letterSpacing};
                 ${tokens.lineHeight}: ${bodyS.lineHeight};
+                ${tokens.tailWidth}: 20px;
+                ${tokens.tailHeight}: 8px;
+                ${tokens.tailSideCurvature}: 0%;
             `,
         },
     },


### PR DESCRIPTION
## Core

### Tooltip, Popover (Beta)

- добавлена возможность конфигурации tail компонентов

### What/why changed       

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.385.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-b2c@1.627.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-colors@0.17.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-core@1.234.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-giga@0.354.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-homeds@0.354.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-hope@1.381.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-icons@1.244.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-new-hope@0.371.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-tokens@1.146.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-tokens-b2b@1.60.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-tokens-b2c@0.71.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-tokens-core@0.8.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-tokens-web@1.75.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-typo@0.48.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-web@1.629.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-bizcom@0.359.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-cs@0.363.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-dfa@0.357.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-finai@0.350.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-insol@0.354.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-insol-next@0.354.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-netology@0.358.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-os@0.29.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-platform-ai@0.358.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-sbcom@0.359.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-scan@0.357.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-serv@0.358.0-canary.3000.30610297220.0
  npm install @salutejs/core-themes@0.36.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-themes@0.58.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-themes@0.72.0-canary.3000.30610297220.0
  npm install @salutejs/sdds-api-tests@0.16.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-cy-utils@0.164.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-sb-utils@0.235.0-canary.3000.30610297220.0
  npm install @salutejs/plasma-tokens-utils@0.56.0-canary.3000.30610297220.0
  # or 
  yarn add @salutejs/plasma-asdk@0.385.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-b2c@1.627.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-colors@0.17.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-core@1.234.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-giga@0.354.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-homeds@0.354.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-hope@1.381.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-icons@1.244.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-new-hope@0.371.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-tokens@1.146.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-tokens-b2b@1.60.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-tokens-b2c@0.71.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-tokens-core@0.8.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-tokens-web@1.75.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-typo@0.48.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-web@1.629.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-bizcom@0.359.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-cs@0.363.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-dfa@0.357.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-finai@0.350.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-insol@0.354.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-insol-next@0.354.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-netology@0.358.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-os@0.29.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-platform-ai@0.358.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-sbcom@0.359.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-scan@0.357.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-serv@0.358.0-canary.3000.30610297220.0
  yarn add @salutejs/core-themes@0.36.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-themes@0.58.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-themes@0.72.0-canary.3000.30610297220.0
  yarn add @salutejs/sdds-api-tests@0.16.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-cy-utils@0.164.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-sb-utils@0.235.0-canary.3000.30610297220.0
  yarn add @salutejs/plasma-tokens-utils@0.56.0-canary.3000.30610297220.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved Popover and Tooltip tails with more accurate placement-aware positioning and rotation.
  * Introduced configurable tail geometry (width, height, and curvature) across supported sizes.
* **Bug Fixes**
  * Prevented brief visual display by hiding the overlay content until positioning is fully calculated.
* **Theme/Examples**
  * Updated Popover and Tooltip size variants in example and theme configurations to use the new tail token values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->