### PR TITLE
sdds-infra: Use correct permissions

### DIFF
--- a/.github/workflows/authorize-external-pr.yml
+++ b/.github/workflows/authorize-external-pr.yml
@@ -7,8 +7,9 @@ jobs:
   authorize:
     name: Approved
     runs-on: ubuntu-latest
+    permissions: {}
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
-    
+
     steps:
       - name: Echo
         run: |

--- a/.github/workflows/change-detection.yml
+++ b/.github/workflows/change-detection.yml
@@ -18,6 +18,10 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    # Токен нужен только для checkout. Права, переданные вызывающим workflow,
+    # здесь принудительно понижаются до чтения - даже если вызывающий имеет write.
+    permissions:
+      contents: read
     outputs:
       STATE: ${{ steps.set-output.outputs.STATE }}
 
@@ -30,7 +34,7 @@ jobs:
 
       - name: Prepare environment
         # Remote ref (а не локальный ./...) — обязательно, т.к. workflow вызывается
-        # из pull_request_target цепочек (documentation-deploy-pr, publish-canary).
+        # из pull_request_target цепочек (documentation-deploy-pr).
         # Иначе action.yml возьмется из PR-checkout и весь защитный механизм обходится.
         uses: salute-developers/plasma/.github/actions/prepare-environment@dev
 

--- a/.github/workflows/documentation-deploy-pr.yml
+++ b/.github/workflows/documentation-deploy-pr.yml
@@ -4,8 +4,6 @@ on:
     pull_request_target:
         branches:
             - dev
-            - next-insol
-            - next-platform-ai
             - next-sbcom
         paths-ignore:
             - 'docs/**'
@@ -14,6 +12,9 @@ on:
             - master
         paths-ignore:
             - 'docs/**'
+
+permissions:
+    contents: read
 
 concurrency:
     # New commit on branch cancels running workflows of the same branch
@@ -216,6 +217,9 @@ jobs:
         needs: [ state, deploy-website, deploy-artifacts ]
         if: ${{ always() && (contains(needs.deploy-website.result, 'success') || contains(needs.deploy-artifacts.result, 'success')) }}
         runs-on: ubuntu-22.04
+        permissions:
+            contents: read
+            pull-requests: write
         steps:
             -   uses: actions/checkout@v4
                 with:


### PR DESCRIPTION
### What/why changed

Под `pull_request_target` дефолтный `GITHUB_TOKEN` имеет `write-доступ` к репозиторию, при этом jobs исполняют код из PR. 

Ограничиваем токен чтением для ряда workflows.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow security by explicitly limiting automation permissions.
  * Restricted repository access to read-only where appropriate.
  * Limited pull request comment updates to the required permissions.
  * Refined documentation deployment triggers for selected branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->