### PR TITLE
PLASMA-5253: add animation duration for Skeleton

### DIFF
--- a/packages/plasma-new-hope/src/components/Skeleton/LineSkeleton/LineSkeleton.styles.ts
+++ b/packages/plasma-new-hope/src/components/Skeleton/LineSkeleton/LineSkeleton.styles.ts
@@ -25,6 +25,9 @@ export const StyledVisibleLine = styled.div<StyledVisibleLineProps>`
         ${privateTokens.lineSkeletonGradient}: ${({ gradientColor }) =>
             gradientColor || `var(${tokens.gradientColor})`};
 
+        ${tokens.shimmerDuration}: ${({ animationDuration }) =>
+            animationDuration !== undefined ? `${animationDuration}ms` : `var(${tokens.shimmerDuration})`};
+
         ${applySkeletonShimmerGradient(`var(${privateTokens.lineSkeletonGradient})`, tokens.shimmerDuration)};
     }
 
@@ -33,6 +36,9 @@ export const StyledVisibleLine = styled.div<StyledVisibleLineProps>`
             customFadeInColor || `var(${tokens.fadeInColor})`};
         ${privateTokens.skeletonFadeOutColor}: ${({ customFadeOutColor }) =>
             customFadeOutColor || `var(${tokens.fadeOutColor})`};
+
+        ${tokens.pulseDuration}: ${({ animationDuration }) =>
+            animationDuration !== undefined ? `${animationDuration}ms` : `var(${tokens.pulseDuration})`};
 
         ${applySkeletonPulseGradient(
             privateTokens.skeletonFadeInColor,

--- a/packages/plasma-new-hope/src/components/Skeleton/LineSkeleton/LineSkeleton.tsx
+++ b/packages/plasma-new-hope/src/components/Skeleton/LineSkeleton/LineSkeleton.tsx
@@ -22,6 +22,7 @@ export const lineSkeletonRoot = (Root: RootProps<HTMLDivElement, LineSkeletonPro
                 customGradientColor,
                 roundness = '16',
                 animationType = 'shimmer',
+                animationDuration,
                 customFadeInColor,
                 customFadeOutColor,
                 view,
@@ -43,6 +44,7 @@ export const lineSkeletonRoot = (Root: RootProps<HTMLDivElement, LineSkeletonPro
                         gradientColor={skeletonGradientColor}
                         customFadeInColor={customFadeInColor}
                         customFadeOutColor={customFadeOutColor}
+                        animationDuration={animationDuration}
                     />
                 </Root>
             );

--- a/packages/plasma-new-hope/src/components/Skeleton/LineSkeleton/LineSkeleton.types.ts
+++ b/packages/plasma-new-hope/src/components/Skeleton/LineSkeleton/LineSkeleton.types.ts
@@ -10,6 +10,7 @@ export type StyledVisibleLineProps = {
     gradientColor?: string;
     customFadeInColor?: string;
     customFadeOutColor?: string;
+    animationDuration?: number;
 };
 
 export type LineSkeletonProps = HTMLAttributes<HTMLDivElement> &

--- a/packages/plasma-new-hope/src/components/Skeleton/RectSkeleton/RectSkeleton.styles.ts
+++ b/packages/plasma-new-hope/src/components/Skeleton/RectSkeleton/RectSkeleton.styles.ts
@@ -18,6 +18,9 @@ export const StyledRectSkeleton = styled.div<StyledRectProps>`
         ${privateTokens.lineSkeletonGradient}: ${({ gradientColor }) =>
             gradientColor || `var(${tokens.gradientColor})`};
 
+        ${tokens.shimmerDuration}: ${({ animationDuration }) =>
+            animationDuration !== undefined ? `${animationDuration}ms` : `var(${tokens.shimmerDuration})`};
+
         ${applySkeletonShimmerGradient(`var(${privateTokens.lineSkeletonGradient})`, tokens.shimmerDuration)};
     }
 
@@ -26,6 +29,9 @@ export const StyledRectSkeleton = styled.div<StyledRectProps>`
             customFadeInColor || `var(${tokens.fadeInColor})`};
         ${privateTokens.skeletonFadeOutColor}: ${({ customFadeOutColor }) =>
             customFadeOutColor || `var(${tokens.fadeOutColor})`};
+
+        ${tokens.pulseDuration}: ${({ animationDuration }) =>
+            animationDuration !== undefined ? `${animationDuration}ms` : `var(${tokens.pulseDuration})`};
 
         ${applySkeletonPulseGradient(
             privateTokens.skeletonFadeInColor,

--- a/packages/plasma-new-hope/src/components/Skeleton/RectSkeleton/RectSkeleton.tsx
+++ b/packages/plasma-new-hope/src/components/Skeleton/RectSkeleton/RectSkeleton.tsx
@@ -19,6 +19,7 @@ export const RectSkeleton = forwardRef<HTMLDivElement, RectSkeletonProps>(
             customGradientColor,
             roundness = '16',
             animationType = 'shimmer',
+            animationDuration,
             customFadeInColor,
             customFadeOutColor,
             className,
@@ -39,6 +40,7 @@ export const RectSkeleton = forwardRef<HTMLDivElement, RectSkeletonProps>(
                 gradientColor={skeletonGradientColor}
                 customFadeInColor={customFadeInColor}
                 customFadeOutColor={customFadeOutColor}
+                animationDuration={animationDuration}
                 width={Number.isNaN(Number(width)) ? String(width) : `${width}px`}
                 height={Number.isNaN(Number(height)) ? String(height) : `${height}px`}
                 {...rest}

--- a/packages/plasma-new-hope/src/components/Skeleton/RectSkeleton/RectSkeleton.types.ts
+++ b/packages/plasma-new-hope/src/components/Skeleton/RectSkeleton/RectSkeleton.types.ts
@@ -21,6 +21,7 @@ export type StyledRectProps = {
     height: string;
     customFadeInColor?: string;
     customFadeOutColor?: string;
+    animationDuration?: number;
 };
 
 export type RectSkeletonProps = HTMLAttributes<HTMLDivElement> & CustomSkeletonRectProps & SkeletonGradientProps;

--- a/packages/plasma-new-hope/src/components/Skeleton/Skeleton.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Skeleton/Skeleton.template-doc.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/{{ package }}';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/{{ package }}';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/packages/plasma-new-hope/src/components/Skeleton/Skeleton.types.ts
+++ b/packages/plasma-new-hope/src/components/Skeleton/Skeleton.types.ts
@@ -10,7 +10,7 @@ export type SkeletonBaseProps = {
      */
     customFadeInColor?: string;
     /**
-     * Значение цвета фона в кл=онце анимации `pulse`
+     * Значение цвета фона в конце анимации `pulse`
      */
     customFadeOutColor?: string;
     /**
@@ -18,9 +18,14 @@ export type SkeletonBaseProps = {
      */
     roundness?: Roundness;
     /**
-     * Скругленность
+     * Тип анимации
+     * @default 'shimmer'
      */
     animationType?: 'shimmer' | 'pulse';
+    /**
+     * Длительность одного цикла анимации в миллисекундах
+     */
+    animationDuration?: number;
 };
 
 export type SkeletonSizeProps = {

--- a/packages/plasma-new-hope/src/components/Skeleton/TextSkeleton/TextSkeleton.tsx
+++ b/packages/plasma-new-hope/src/components/Skeleton/TextSkeleton/TextSkeleton.tsx
@@ -21,6 +21,7 @@ export const textSkeleton = <T extends LineSkeletonProps>(
     customGradientColor,
     lighter,
     animationType = 'shimmer',
+    animationDuration,
     customFadeInColor,
     customFadeOutColor,
     size = 'bodyM',
@@ -74,6 +75,7 @@ export const textSkeleton = <T extends LineSkeletonProps>(
                         view={view}
                         roundness={roundness}
                         animationType={animationType}
+                        animationDuration={animationDuration}
                         lighter={lighter}
                         customGradientColor={customGradientColor}
                         customFadeInColor={customFadeInColor}

--- a/packages/plasma-new-hope/src/components/Skeleton/hoc/withSkeleton.styles.ts
+++ b/packages/plasma-new-hope/src/components/Skeleton/hoc/withSkeleton.styles.ts
@@ -1,18 +1,28 @@
 import styled from 'styled-components';
 import { applySkeletonPulseGradient, applySkeletonShimmerGradient } from 'src/mixins';
 
-import { classes, privateTokens } from '../tokens';
+import { classes, privateTokens, tokens } from '../tokens';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ animationDuration?: number }>`
     display: contents;
 
     .apply-skeleton-gradient {
         &.${classes.shimmerAnimation} {
-            ${applySkeletonShimmerGradient(`var(${privateTokens.lineSkeletonGradient})`)};
+            ${tokens.shimmerDuration}: ${({ animationDuration }) =>
+                animationDuration !== undefined ? `${animationDuration}ms` : `var(${tokens.shimmerDuration})`};
+
+            ${applySkeletonShimmerGradient(`var(${privateTokens.lineSkeletonGradient})`, tokens.shimmerDuration)};
         }
 
         &.${classes.pulseAnimation} {
-            ${applySkeletonPulseGradient(privateTokens.skeletonFadeInColor, privateTokens.skeletonFadeOutColor)};
+            ${tokens.pulseDuration}: ${({ animationDuration }) =>
+                animationDuration !== undefined ? `${animationDuration}ms` : `var(${tokens.pulseDuration})`};
+
+            ${applySkeletonPulseGradient(
+                privateTokens.skeletonFadeInColor,
+                privateTokens.skeletonFadeOutColor,
+                tokens.pulseDuration,
+            )};
         }
     }
 `;

--- a/packages/plasma-new-hope/src/components/Skeleton/hoc/withSkeleton.tsx
+++ b/packages/plasma-new-hope/src/components/Skeleton/hoc/withSkeleton.tsx
@@ -48,7 +48,7 @@ export const withSkeleton = <P extends WithSkeletonProps, E extends Element = El
             } as P & RefAttributes<E>;
 
             return (
-                <Wrapper style={wrapperStyle}>
+                <Wrapper style={wrapperStyle} animationDuration={animationConfig?.duration}>
                     <Component {...componentProps} />
                 </Wrapper>
             );

--- a/packages/plasma-new-hope/src/components/Skeleton/hoc/withSkeleton.types.ts
+++ b/packages/plasma-new-hope/src/components/Skeleton/hoc/withSkeleton.types.ts
@@ -13,7 +13,12 @@ type PulseConfig = {
     customFadeOutColor?: string;
 };
 
-export type AnimationConfig = ShimmerConfig | PulseConfig;
+export type AnimationConfig = (ShimmerConfig | PulseConfig) & {
+    /**
+     * Длительность одного цикла анимации в миллисекундах.
+     */
+    duration?: number;
+};
 
 export type WithSkeletonProps = {
     /**

--- a/utils/plasma-sb-utils/src/components/Skeleton/stories.tsx
+++ b/utils/plasma-sb-utils/src/components/Skeleton/stories.tsx
@@ -7,6 +7,9 @@ const baseSkeletonArgTypes = {
         options: animationTypeOptions,
         control: { type: 'select' },
     },
+    animationDuration: {
+        control: { type: 'number', min: 0 },
+    },
     customGradientColor: {
         if: { arg: 'animationType', eq: 'shimmer' },
     },
@@ -89,31 +92,21 @@ export const createButtonStory = (withSkeleton: any, Button: any) => {
             customFadeOutColor: '',
         },
         argTypes: {
-            animationType: {
-                options: animationTypeOptions,
-                control: { type: 'select' },
-            },
-            customGradientColor: {
-                if: { arg: 'animationType', eq: 'shimmer' },
-            },
-            customFadeInColor: {
-                if: { arg: 'animationType', eq: 'pulse' },
-            },
-            customFadeOutColor: {
-                if: { arg: 'animationType', eq: 'pulse' },
-            },
+            ...baseSkeletonArgTypes,
         },
         render: ({
             animationType,
             customGradientColor,
             customFadeInColor,
             customFadeOutColor,
+            animationDuration,
             ...args
         }: {
             animationType: 'shimmer' | 'pulse';
             customGradientColor: string;
             customFadeInColor: string;
             customFadeOutColor: string;
+            animationDuration: number;
             [key: string]: unknown;
         }) => {
             const animationConfig =
@@ -122,8 +115,13 @@ export const createButtonStory = (withSkeleton: any, Button: any) => {
                           type: 'pulse' as const,
                           customFadeInColor: customFadeInColor || undefined,
                           customFadeOutColor: customFadeOutColor || undefined,
+                          duration: animationDuration ?? undefined,
                       }
-                    : { type: 'shimmer' as const, customGradientColor: customGradientColor || undefined };
+                    : {
+                          type: 'shimmer' as const,
+                          customGradientColor: customGradientColor || undefined,
+                          duration: animationDuration ?? undefined,
+                      };
 
             return <ButtonSkeleton view="default" text="test" animationConfig={animationConfig} {...args} />;
         },

--- a/website/plasma-b2c-docs/docs/components/Skeleton.mdx
+++ b/website/plasma-b2c-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/plasma-b2c';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/plasma-b2c';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/plasma-giga-docs/docs/components/Skeleton.mdx
+++ b/website/plasma-giga-docs/docs/components/Skeleton.mdx
@@ -23,7 +23,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="shimmer" label="shimmer" default>
         ```tsx live
         import React from 'react';
-        import { LineSkeleton } from '@salutejs/plasma-gga';
+        import { LineSkeleton } from '@salutejs/plasma-giga';
 
         export function App() {
             return (
@@ -35,7 +35,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="pulse" label="pulse">
         ```tsx live
         import React from 'react';
-        import { LineSkeleton } from '@salutejs/plasma-gga';
+        import { LineSkeleton } from '@salutejs/plasma-giga';
 
         export function App() {
             return (
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/plasma-giga';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -53,7 +74,7 @@ import TabItem from '@theme/TabItem';
 
 ```tsx live
 import React from 'react';
-import { LineSkeleton } from '@salutejs/plasma-gga';
+import { LineSkeleton } from '@salutejs/plasma-giga';
 
 export function App() {
     return (
@@ -73,7 +94,7 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { RectSkeleton } from '@salutejs/plasma-gga';
+import { RectSkeleton } from '@salutejs/plasma-giga';
 
 export function App() {
     return (
@@ -93,7 +114,7 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { TextSkeleton } from '@salutejs/plasma-gga';
+import { TextSkeleton } from '@salutejs/plasma-giga';
 
 export function App() {
     return (
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/plasma-giga';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/plasma-web-docs/docs/components/Skeleton.mdx
+++ b/website/plasma-web-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/plasma-web';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/plasma-web';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/sdds-bizcom-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-bizcom-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-bizcom';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-bizcom';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/sdds-cs-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-cs-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-cs';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-cs';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/sdds-dfa-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-dfa-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-dfa';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-dfa';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/sdds-finai-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-finai-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-finai';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-finai';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/sdds-insol-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-insol-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-insol';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-insol';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/sdds-netology-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-netology-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-netology';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-netology';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/sdds-platform-ai-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 

--- a/website/sdds-sbcom-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-sbcom-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-sbcom';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -97,7 +118,7 @@ import { TextSkeleton } from '@salutejs/sdds-sbcom';
 
 export function App() {
     return (
-        <TextSkeleton size="bodyM" lines={4} />
+        <TextSkeleton size="textM" lines={4} />
     );
 }
 ```
@@ -124,7 +145,7 @@ export function App() {
         <ButtonSkeleton
             fullWidth
             text="Загрузка..."
-            view="accentFiled"
+            view="primary"
             size="s"
             scaleOnInteraction={false}
             outlined={false}
@@ -151,7 +172,7 @@ export function App() {
             return (
                 <ButtonSkeleton
                     text="Загрузка..."
-                    view="accentFiled"
+                    view="default"
                     size="s"
                     skeleton={true}
                     animationConfig={{ type: 'shimmer' }}
@@ -171,7 +192,7 @@ export function App() {
             return (
                 <ButtonSkeleton
                     text="Загрузка..."
-                    view="accentFiled"
+                    view="default"
                     size="s"
                     skeleton={true}
                     animationConfig={{ type: 'pulse' }}
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-sbcom';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 
@@ -198,7 +244,7 @@ export function App() {
             return (
                 <ButtonSkeleton
                     text="Загрузка..."
-                    view="accentFiled"
+                    view="default"
                     size="s"
                     skeleton={true}
                     animationConfig={{
@@ -221,7 +267,7 @@ export function App() {
             return (
                 <ButtonSkeleton
                     text="Загрузка..."
-                    view="accentFiled"
+                    view="default"
                     size="s"
                     skeleton={true}
                     animationConfig={{

--- a/website/sdds-serv-docs/docs/components/Skeleton.mdx
+++ b/website/sdds-serv-docs/docs/components/Skeleton.mdx
@@ -46,6 +46,27 @@ import TabItem from '@theme/TabItem';
     </TabItem>
 </Tabs>
 
+### Длительность анимации
+
+Свойство `animationDuration` позволяет регулировать скорость анимации, переопределяя длительность цикла, заданную по умолчанию.
+Значение указывается в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { LineSkeleton, RectSkeleton, TextSkeleton } from '@salutejs/sdds-serv';
+
+export function App() {
+    return (
+        <>
+            <LineSkeleton size="h3" animationDuration={1200} />
+            <RectSkeleton width="12rem" height="8rem" animationDuration={600} />
+            <TextSkeleton size="textM" lines={4} animationDuration={0} />
+        </>
+    );
+}
+```
+
 ## LineSkeleton
 <Description name="LineSkeleton" />
 
@@ -181,6 +202,31 @@ export function App() {
         ```
     </TabItem>
 </Tabs>
+
+### Длительность анимации
+
+Поле `duration` в `animationConfig` задаёт длительность одного цикла анимации в миллисекундах.
+Значение `0` отключает анимацию.
+
+```tsx live
+import React from 'react';
+import { Button, withSkeleton } from '@salutejs/sdds-serv';
+
+export function App() {
+    const ButtonSkeleton = withSkeleton(Button);
+
+    return (
+        <ButtonSkeleton
+            text="Загрузка..."
+            skeleton={true}
+            animationConfig={{
+                type: 'shimmer',
+                duration: 1000,
+            }}
+        />
+    );
+}
+```
 
 ### Кастомные цвета
 


### PR DESCRIPTION
## Core

### Skeleton

- добавлено свойство `animationDuration` для управления скоростью анимации

### What/why changed

- добавлено свойство `animationDuration` для управления скоростью анимации `Skeleton`

<img width="1694" height="644" alt="Запись экрана — 2026-08-11 в 15 48 50" src="https://github.com/user-attachments/assets/9b8632fa-f2a5-4d84-91d9-29abfba24431" />



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.387.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-b2c@1.629.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-colors@0.18.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-core@1.236.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-giga@0.356.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-homeds@0.356.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-hope@1.383.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-icons@1.245.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-new-hope@0.373.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-tokens@1.147.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-tokens-b2b@1.61.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-tokens-b2c@0.72.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-tokens-core@0.9.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-tokens-web@1.76.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-typo@0.49.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-web@1.631.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-bizcom@0.361.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-cs@0.365.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-dfa@0.359.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-finai@0.352.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-insol@0.356.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-insol-next@0.355.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-netology@0.360.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-os@0.31.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-platform-ai@0.360.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-sbcom@0.361.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-scan@0.359.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-serv@0.360.0-canary.3024.31379935868.0
  npm install @salutejs/core-themes@0.37.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-themes@0.59.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-themes@0.74.0-canary.3024.31379935868.0
  npm install @salutejs/sdds-api-tests@0.18.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-cy-utils@0.166.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-sb-utils@0.237.0-canary.3024.31379935868.0
  npm install @salutejs/plasma-tokens-utils@0.57.0-canary.3024.31379935868.0
  # or 
  yarn add @salutejs/plasma-asdk@0.387.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-b2c@1.629.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-colors@0.18.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-core@1.236.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-giga@0.356.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-homeds@0.356.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-hope@1.383.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-icons@1.245.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-new-hope@0.373.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-tokens@1.147.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-tokens-b2b@1.61.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-tokens-b2c@0.72.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-tokens-core@0.9.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-tokens-web@1.76.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-typo@0.49.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-web@1.631.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-bizcom@0.361.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-cs@0.365.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-dfa@0.359.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-finai@0.352.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-insol@0.356.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-insol-next@0.355.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-netology@0.360.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-os@0.31.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-platform-ai@0.360.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-sbcom@0.361.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-scan@0.359.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-serv@0.360.0-canary.3024.31379935868.0
  yarn add @salutejs/core-themes@0.37.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-themes@0.59.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-themes@0.74.0-canary.3024.31379935868.0
  yarn add @salutejs/sdds-api-tests@0.18.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-cy-utils@0.166.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-sb-utils@0.237.0-canary.3024.31379935868.0
  yarn add @salutejs/plasma-tokens-utils@0.57.0-canary.3024.31379935868.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable animation duration for `LineSkeleton`, `RectSkeleton`, and `TextSkeleton`.
  - Added duration configuration for `withSkeleton` through `animationConfig.duration`.
  - Supports custom durations in milliseconds, including disabling animations with `0`, while preserving defaults.

- **Documentation**
  - Added usage examples and guidance across Skeleton documentation.
  - Corrected Skeleton examples, supported values, and package references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->