### PR TITLE
fix: Move applyPaper out of mixins barrel to make it tree-shakable

### DIFF
--- a/packages/plasma-b2c/src/mixins/applyPaper.ts
+++ b/packages/plasma-b2c/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_b2c';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/plasma-b2c/src/mixins/index.ts
+++ b/packages/plasma-b2c/src/mixins/index.ts
@@ -1,6 +1,3 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_b2c';
-
 export {
     addFocus,
     syntheticFocus,
@@ -40,4 +37,4 @@ export type {
 
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/plasma-giga/src/mixins/applyPaper.ts
+++ b/packages/plasma-giga/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_giga';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/plasma-giga/src/mixins/index.ts
+++ b/packages/plasma-giga/src/mixins/index.ts
@@ -1,8 +1,5 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_giga';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/plasma-homeds/src/mixins/applyPaper.ts
+++ b/packages/plasma-homeds/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_homeds';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/plasma-homeds/src/mixins/index.ts
+++ b/packages/plasma-homeds/src/mixins/index.ts
@@ -1,7 +1,4 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_homeds';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/plasma-web/src/mixins/applyPaper.ts
+++ b/packages/plasma-web/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_web';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/plasma-web/src/mixins/index.ts
+++ b/packages/plasma-web/src/mixins/index.ts
@@ -1,6 +1,3 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_web';
-
 export {
     addFocus,
     syntheticFocus,
@@ -40,4 +37,4 @@ export type {
 
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-bizcom/src/mixins/applyPaper.ts
+++ b/packages/sdds-bizcom/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_bizcom';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-bizcom/src/mixins/index.ts
+++ b/packages/sdds-bizcom/src/mixins/index.ts
@@ -1,6 +1,3 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_bizcom';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-cs/src/mixins/applyPaper.ts
+++ b/packages/sdds-cs/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/emotion';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_cs';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-cs/src/mixins/index.ts
+++ b/packages/sdds-cs/src/mixins/index.ts
@@ -1,6 +1,3 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/emotion';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_cs';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/emotion';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-dfa/src/mixins/applyPaper.ts
+++ b/packages/sdds-dfa/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_dfa';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-dfa/src/mixins/index.ts
+++ b/packages/sdds-dfa/src/mixins/index.ts
@@ -1,7 +1,4 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_dfa';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-finai/src/mixins/applyPaper.ts
+++ b/packages/sdds-finai/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_finai';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-finai/src/mixins/index.ts
+++ b/packages/sdds-finai/src/mixins/index.ts
@@ -1,6 +1,3 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_finai';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-insol-next/src/mixins/applyPaper.ts
+++ b/packages/sdds-insol-next/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_insol';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-insol-next/src/mixins/index.ts
+++ b/packages/sdds-insol-next/src/mixins/index.ts
@@ -1,6 +1,3 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_insol';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-insol/src/mixins/applyPaper.ts
+++ b/packages/sdds-insol/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_insol';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-insol/src/mixins/index.ts
+++ b/packages/sdds-insol/src/mixins/index.ts
@@ -1,6 +1,3 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_insol';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-netology/src/mixins/applyPaper.ts
+++ b/packages/sdds-netology/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_b2c';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-netology/src/mixins/index.ts
+++ b/packages/sdds-netology/src/mixins/index.ts
@@ -1,8 +1,5 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/plasma-themes/tokens/plasma_b2c';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-os/src/mixins/applyPaper.ts
+++ b/packages/sdds-os/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs-ds/sdds_os';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-os/src/mixins/index.ts
+++ b/packages/sdds-os/src/mixins/index.ts
@@ -1,7 +1,4 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs-ds/sdds_os';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-platform-ai/src/mixins/applyPaper.ts
+++ b/packages/sdds-platform-ai/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_platform_ai';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-platform-ai/src/mixins/index.ts
+++ b/packages/sdds-platform-ai/src/mixins/index.ts
@@ -1,7 +1,4 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_platform_ai';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-sbcom/src/mixins/applyPaper.ts
+++ b/packages/sdds-sbcom/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs-ds/sdds_sbcom';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-sbcom/src/mixins/index.ts
+++ b/packages/sdds-sbcom/src/mixins/index.ts
@@ -1,7 +1,4 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs-ds/sdds_sbcom';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-scan/src/mixins/applyPaper.ts
+++ b/packages/sdds-scan/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_scan';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-scan/src/mixins/index.ts
+++ b/packages/sdds-scan/src/mixins/index.ts
@@ -1,8 +1,5 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_scan';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';

--- a/packages/sdds-serv/src/mixins/applyPaper.ts
+++ b/packages/sdds-serv/src/mixins/applyPaper.ts
@@ -1,0 +1,4 @@
+import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
+import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_serv';
+
+export const applyPaper = /*#__PURE__*/ createApplyPaperMixin(allTokens);

--- a/packages/sdds-serv/src/mixins/index.ts
+++ b/packages/sdds-serv/src/mixins/index.ts
@@ -1,7 +1,4 @@
-import { createApplyPaperMixin } from '@salutejs/plasma-new-hope/styled-components';
-import * as allTokens from '@salutejs/sdds-themes/tokens/sdds_serv';
-
 export { addFocus, mediaQuery } from '@salutejs/plasma-new-hope/styled-components';
 export { addScrollbar } from '../components/Scrollbar/Scrollbar';
 
-export const applyPaper = createApplyPaperMixin(allTokens);
+export { applyPaper } from './applyPaper';


### PR DESCRIPTION
The mixins barrel evaluated createApplyPaperMixin(allTokens) at module scope over a namespace import of the whole theme tokens index (~950 exports, ~136 KB min). Bundlers cannot drop a namespace-consumed index per-export, so any app importing only addFocus/mediaQuery/addScrollbar from mixins still shipped the entire tokens index.

applyPaper now lives in its own module (src/mixins/applyPaper.ts) and is re-exported from the barrel, so the package-level sideEffects flag lets bundlers skip it entirely when unused. The call is also annotated with /*#__PURE__*/ as defense in depth. Public API is unchanged.

Measured with a minified esbuild repro against the real plasma_giga tokens index: importing addFocus/mediaQuery/addScrollbar from mixins goes from 169 KB to 0.1 KB; applyPaper keeps its current contract, including token fallback values.

## [Heading 2]

Может быть:

-   `Core` - используем если изменения в библиотеки new-hope и затрагивают все библиотеки
-   `SDDS-CS, PLASMA-WEB, PLASMA-ICONS` - если изменения только для конкретной библиотеки используем ее название

Например,

```md
## Core
```

```md
## PLASMA-WEB
```

### [Heading 3] Названия компонента, функции, темы, etc

Например,

```md
### Dropdown
```

```md
### PopoverProvider
```

Резюме вносимых изменений.

```md
-   исправлено поведение, когда нажатие на `Tab` очищало набранный текст в `single` mode;
```

Полный пример:

```md
## Core

### Combobox

-   исправлено поведение, когда нажатие на `Tab` очищало набранный текст в `single` mode;
```

```md
## SDDS-CS

### Notification

-   добавлен layout `horizontal`
-   добавлены токены для позиционирования `actions`, `iconLeft` и `iconClose`
```

Когда pull request содержит изменения и в core и в конечной библиотеки

```md
## Core

### Drawer, Panel

-   добавлена возможность изменить цвет закрывающей иконки

## SDDS-CS

### Datepicker

-   актуализированы примеры в storybook
```

**Примечания:**

-   По возможности приложите скриншоты решенной проблемы в формате "до/после" или скриншоты нового компонента.

### What/why changed

Это **обязательный** блок и заголовок!

Более подробное описание решаемой проблемы.

### Прежде чем перевести в статус "requested a review" убедитесь

-   Добавлен номер issue (если есть);
-   Добавлены/обновлены **cypress тесты** если PR касается визуальной составляющей;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tree-shakeable `applyPaper` styling mixin across all supported design-system packages.
  * The mixin is now available through each package’s public mixin exports and uses the corresponding theme tokens.

* **Refactor**
  * Moved mixin definitions into dedicated modules while preserving existing styling behavior and related mixin exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->