### PR TITLE
PLASMA-7898: add tracking of the current month and year for Calendar

### DIFF
--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.component-test.tsx
@@ -169,6 +169,7 @@ describeFn('Calendar', () => {
             stretched = false,
             uncontrolled = false,
             renderFromDate,
+            onChangeVisibleDate,
         } = args;
         const [value, setValue] = useState(baseValue);
 
@@ -194,6 +195,7 @@ describeFn('Calendar', () => {
                     locale={locale}
                     stretched={stretched}
                     onChangeValue={handleOnChange}
+                    onChangeVisibleDate={onChangeVisibleDate}
                 />
             ) : (
                 <CalendarBase
@@ -207,6 +209,7 @@ describeFn('Calendar', () => {
                     locale={locale}
                     stretched={stretched}
                     onChangeValue={handleOnChange}
+                    onChangeVisibleDate={onChangeVisibleDate}
                 />
             );
         };
@@ -372,6 +375,108 @@ describeFn('Calendar', () => {
         cy.matchImageSnapshot({
             failureThreshold: 0.01,
             failureThresholdType: 'percent',
+        });
+    });
+
+    describe('onChangeVisibleDate', () => {
+        const ExternalValueDemo = ({ type, nextValue, onChangeVisibleDate }) => {
+            const [value, setValue] = useState(baseDate);
+
+            const calendarProps: any = {
+                size: 's',
+                locale: 'ru',
+                type,
+                value,
+                onChangeValue: setValue,
+                onChangeVisibleDate,
+            };
+
+            return (
+                <>
+                    <button type="button" id="set-external-value" onClick={() => setValue(nextValue)}>
+                        set value
+                    </button>
+                    <CalendarBase {...calendarProps} />
+                </>
+            );
+        };
+
+        const mountWithStub = (props) => {
+            const onChangeVisibleDate = cy.stub().as('onChangeVisibleDate');
+
+            mount(<Demo baseValue={baseDate} onChangeVisibleDate={onChangeVisibleDate} {...props} />);
+        };
+
+        const assertCalledWith = (date: Date) =>
+            cy.get('@onChangeVisibleDate').should('have.been.calledOnceWith', date);
+
+        const clickNext = (unit: string) => cy.get(`button[aria-label="Следующий ${unit}"]`).first().click();
+
+        it('days: next month', () => {
+            mountWithStub({ type: 'Days', baseValue: new Date(1999, 11, 7) });
+
+            clickNext('месяц');
+
+            assertCalledWith(new Date(2000, 0));
+        });
+
+        it('months: next year', () => {
+            mountWithStub({ type: 'Months' });
+
+            clickNext('год');
+
+            assertCalledWith(new Date(2000, 0));
+        });
+
+        it('days: month selected through the header', () => {
+            mountWithStub({ type: 'Days' });
+
+            cy.get('#id-grid-label').click();
+            cy.get('[data-month-index="8"][data-year="1999"]').click();
+
+            assertCalledWith(new Date(1999, 8));
+        });
+
+        it('days: year selected through the header', () => {
+            mountWithStub({ type: 'Days' });
+
+            cy.get('#id-grid-label').click();
+            cy.get('#id-grid-label').click();
+            cy.get('[data-year="2001"]').click();
+
+            assertCalledWith(new Date(2001, 0));
+        });
+
+        it('days: value changed from outside to another month', () => {
+            const onChangeVisibleDate = cy.stub().as('onChangeVisibleDate');
+
+            mount(
+                <ExternalValueDemo
+                    type="Days"
+                    nextValue={new Date(1999, 9, 3)}
+                    onChangeVisibleDate={onChangeVisibleDate}
+                />,
+            );
+
+            cy.get('#set-external-value').click();
+
+            assertCalledWith(new Date(1999, 9));
+        });
+
+        it('months: not called when value stays within the visible year', () => {
+            const onChangeVisibleDate = cy.stub().as('onChangeVisibleDate');
+
+            mount(
+                <ExternalValueDemo
+                    type="Months"
+                    nextValue={new Date(1999, 2, 3)}
+                    onChangeVisibleDate={onChangeVisibleDate}
+                />,
+            );
+
+            cy.get('#set-external-value').click();
+
+            cy.get('@onChangeVisibleDate').should('not.have.been.called');
         });
     });
 

--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.template-doc.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/{{ package }}';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style=\{{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`
@@ -429,7 +471,7 @@ import { CalendarBase } from '@salutejs/{{ package }}';
             <CalendarBase
                 type="Days"
                 eventList={events}
-                eventTooltipOptions={{ 
+                eventTooltipOptions=\{{
                     bodyWrapper: EventTooltipBody,
                     size: 'm'
                 }}

--- a/packages/plasma-new-hope/src/components/Calendar/Calendar.types.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/Calendar.types.ts
@@ -153,6 +153,10 @@ export interface Calendar extends HTMLAttributes<HTMLDivElement> {
      */
     onChangeValue: (value: Date, dateInfo?: DateInfo) => void;
     /**
+     * Обработчик изменения отображаемых месяца или года при навигации по календарю.
+     */
+    onChangeVisibleDate?: (date: Date) => void;
+    /**
      * Дата, определяющая отображаемый период календаря.
      */
     focusedDate?: DateType;

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarBase/CalendarBase.tsx
@@ -18,7 +18,7 @@ import { RootProps } from 'src/engines';
 import type { Calendar, CalendarConfigProps, CalendarValueType, DateInfo, DateObject } from '../Calendar.types';
 import { getInitialState, reducer, sizeMap } from '../store/reducer';
 import { ActionType, CalendarState } from '../store/types';
-import { I18N, isValueUpdate } from '../utils';
+import { I18N, getVisibleDate, getVisibleDateFromValue, isValueUpdate } from '../utils';
 import { useKeyNavigation, useCalendarNavigation, useCalendarDateChange } from '../hooks';
 import { CalendarDays, CalendarHeader, CalendarMonths, CalendarQuarters, CalendarYears, EventTooltip } from '../ui';
 import { classes } from '../Calendar.tokens';
@@ -59,6 +59,7 @@ export const calendarBaseRoot = (
                 locale = 'ru',
                 stretched,
                 onChangeValue,
+                onChangeVisibleDate,
                 ...rest
             },
             outerRootRef,
@@ -108,6 +109,8 @@ export const calendarBaseRoot = (
                 calendarState,
                 date,
                 dispatch,
+                startYear,
+                onChangeVisibleDate,
             });
 
             const [selectIndexes, onKeyDown, onSelectIndexes, outerRefs, isOutOfRange] = useKeyNavigation({
@@ -133,7 +136,13 @@ export const calendarBaseRoot = (
                 handleOnChangeQuarter,
                 handleOnChangeYear,
                 handleUpdateCalendarState,
-            } = useCalendarDateChange({ type, onChangeValue: handleOnChangeValue, onSelectIndexes, dispatch });
+            } = useCalendarDateChange({
+                type,
+                onChangeValue: handleOnChangeValue,
+                onChangeVisibleDate,
+                onSelectIndexes,
+                dispatch,
+            });
 
             // Изменяем ключ каждый раз как пытаемся перейти на даты которые находятся за пределами min/max ограничений.
             // Это необходимо для того чтобы screen-reader корректно озвучивал уведомление aria-live="assertive"
@@ -199,6 +208,15 @@ export const calendarBaseRoot = (
                         type: ActionType.UPDATE_DATE,
                         payload: { value },
                     });
+
+                    const currentVisibleDate = getVisibleDate(calendarState, date, startYear);
+                    const nextVisibleDate = getVisibleDateFromValue(calendarState, value);
+
+                    if (nextVisibleDate.getTime() !== currentVisibleDate.getTime()) {
+                        if (onChangeVisibleDate) {
+                            onChangeVisibleDate(nextVisibleDate);
+                        }
+                    }
                 }
 
                 if (!value && !prevValue) {

--- a/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
+++ b/packages/plasma-new-hope/src/components/Calendar/CalendarDouble/CalendarDouble.tsx
@@ -16,7 +16,7 @@ import type { RootProps } from 'src/engines';
 
 import { useForkRef } from '../../../hooks';
 import type { Calendar, CalendarConfigProps, CalendarValueType, DateInfo, DateObject } from '../Calendar.types';
-import { YEAR_RENDER_COUNT, getNextDate, isValueUpdate, I18N } from '../utils';
+import { YEAR_RENDER_COUNT, getNextDate, getVisibleDate, getVisibleDateFromValue, isValueUpdate, I18N } from '../utils';
 import { useKeyNavigation, useCalendarNavigation, useCalendarDateChange } from '../hooks';
 import { CalendarDays, CalendarHeader, CalendarMonths, CalendarQuarters, CalendarYears, EventTooltip } from '../ui';
 import { getInitialState, reducer, sizeMap } from '../store/reducer';
@@ -60,6 +60,7 @@ export const calendarDoubleRoot = (
                 locale = 'ru',
                 stretched,
                 onChangeValue,
+                onChangeVisibleDate,
                 ...rest
             },
             outerRootRef,
@@ -109,6 +110,8 @@ export const calendarDoubleRoot = (
                 calendarState,
                 date,
                 dispatch,
+                startYear,
+                onChangeVisibleDate,
             });
 
             const [selectIndexes, onKeyDown, onSelectIndexes, outerRefs, isOutOfRange] = useKeyNavigation({
@@ -135,7 +138,13 @@ export const calendarDoubleRoot = (
                 handleOnChangeQuarter,
                 handleOnChangeYear,
                 handleUpdateCalendarState,
-            } = useCalendarDateChange({ type, onChangeValue: handleOnChangeValue, onSelectIndexes, dispatch });
+            } = useCalendarDateChange({
+                type,
+                onChangeValue: handleOnChangeValue,
+                onChangeVisibleDate,
+                onSelectIndexes,
+                dispatch,
+            });
 
             const updateSecondDate = () => {
                 if (calendarState === CalendarState.Days) {
@@ -236,6 +245,15 @@ export const calendarDoubleRoot = (
                             type: ActionType.UPDATE_DATE,
                             payload: { value },
                         });
+
+                        const currentVisibleDate = getVisibleDate(calendarState, date, startYear);
+                        const nextVisibleDate = getVisibleDateFromValue(calendarState, value);
+
+                        if (nextVisibleDate.getTime() !== currentVisibleDate.getTime()) {
+                            if (onChangeVisibleDate) {
+                                onChangeVisibleDate(nextVisibleDate);
+                            }
+                        }
                     }
                 }
 

--- a/packages/plasma-new-hope/src/components/Calendar/hooks/types.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/hooks/types.ts
@@ -15,6 +15,8 @@ export type UseCalendarNavigationArgs = {
     calendarState: CalendarStateType;
     dispatch: Dispatch<Action>;
     date: DateObject;
+    startYear: number;
+    onChangeVisibleDate?: (date: Date) => void;
 };
 
 export type UseCalendarDateChangeArgs = {
@@ -22,6 +24,7 @@ export type UseCalendarDateChangeArgs = {
     onChangeValue: (value: Date, dateInfo?: DateInfo) => void;
     onSelectIndexes: Dispatch<SetStateAction<number[]>>;
     dispatch: Dispatch<Action>;
+    onChangeVisibleDate?: (date: Date) => void;
 };
 
 export type UseDateStructureArgs = {

--- a/packages/plasma-new-hope/src/components/Calendar/hooks/useCalendarDateChange.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/hooks/useCalendarDateChange.ts
@@ -3,12 +3,14 @@ import { useCallback } from 'react';
 import type { DateObject } from '../Calendar.types';
 import { ActionType, CalendarState, CalendarStateType } from '../store/types';
 import { sizeMap } from '../store/reducer';
+import { getStartYear, getVisibleDate } from '../utils';
 
 import type { UseCalendarDateChangeArgs } from './types';
 
 export const useCalendarDateChange = ({
     type,
     onChangeValue,
+    onChangeVisibleDate,
     onSelectIndexes,
     dispatch,
 }: UseCalendarDateChangeArgs) => {
@@ -59,8 +61,11 @@ export const useCalendarDateChange = ({
                     size: sizeMap.Days.double,
                 },
             });
+            if (onChangeVisibleDate) {
+                onChangeVisibleDate(getVisibleDate(CalendarState.Days, newDate, getStartYear(newDate.year)));
+            }
         },
-        [onChangeValue, onSelectIndexes, type],
+        [dispatch, onChangeVisibleDate, onChangeValue, onSelectIndexes, type],
     );
 
     const handleOnChangeYear = useCallback(
@@ -82,6 +87,9 @@ export const useCalendarDateChange = ({
                         size: sizeMap.Quarters.double,
                     },
                 });
+                if (onChangeVisibleDate) {
+                    onChangeVisibleDate(getVisibleDate(CalendarState.Quarters, newDate, getStartYear(newDate.year)));
+                }
 
                 return;
             }
@@ -94,8 +102,11 @@ export const useCalendarDateChange = ({
                     size: sizeMap.Months.double,
                 },
             });
+            if (onChangeVisibleDate) {
+                onChangeVisibleDate(getVisibleDate(CalendarState.Months, newDate, getStartYear(newDate.year)));
+            }
         },
-        [onChangeValue, onSelectIndexes, type],
+        [dispatch, onChangeVisibleDate, onChangeValue, onSelectIndexes, type],
     );
 
     const handleUpdateCalendarState = useCallback((newCalendarState: CalendarStateType, newSize: [number, number]) => {

--- a/packages/plasma-new-hope/src/components/Calendar/hooks/useCalendarNavigation.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/hooks/useCalendarNavigation.ts
@@ -1,42 +1,72 @@
 import { useCallback } from 'react';
 
 import { ActionType, CalendarState } from '../store/types';
-import { YEAR_RENDER_COUNT } from '../utils';
+import { getNextDate, getPrevDate, getPrevYear, getVisibleDate, YEAR_RENDER_COUNT } from '../utils';
 
 import type { UseCalendarNavigationArgs, UseKeyNavigationArgs } from './types';
 
-export const useCalendarNavigation = ({ calendarState, dispatch, date }: UseCalendarNavigationArgs) => {
+export const useCalendarNavigation = ({
+    calendarState,
+    dispatch,
+    date,
+    startYear,
+    onChangeVisibleDate,
+}: UseCalendarNavigationArgs) => {
     const handlePrev = useCallback<UseKeyNavigationArgs['onPrev']>(
         (withShift = false) => {
             if (calendarState === CalendarState.Days) {
                 if (withShift) {
+                    const year = getPrevYear(date.year);
+
                     dispatch({
                         type: ActionType.PREVIOUS_YEAR,
                         payload: { step: 1 },
                     });
 
+                    if (onChangeVisibleDate) {
+                        onChangeVisibleDate(getVisibleDate(calendarState, { ...date, year }, startYear));
+                    }
+
                     return;
                 }
+
+                const [year, monthIndex] = getPrevDate(date.year, date.monthIndex);
 
                 dispatch({
                     type: ActionType.PREVIOUS_MONTH,
                     payload: { monthIndex: date.monthIndex, year: date.year },
                 });
 
+                if (onChangeVisibleDate) {
+                    onChangeVisibleDate(getVisibleDate(calendarState, { ...date, monthIndex, year }, startYear));
+                }
+
                 return;
             }
 
             if (calendarState === CalendarState.Months || calendarState === CalendarState.Quarters) {
+                const year = getPrevYear(date.year);
+
                 dispatch({ type: ActionType.PREVIOUS_YEAR, payload: { step: 1 } });
+
+                if (onChangeVisibleDate) {
+                    onChangeVisibleDate(getVisibleDate(calendarState, { ...date, year }, startYear));
+                }
 
                 return;
             }
 
             if (calendarState === CalendarState.Years) {
+                const prevStartYear = getPrevYear(startYear, YEAR_RENDER_COUNT);
+
                 dispatch({ type: ActionType.PREVIOUS_START_YEAR, payload: { yearsCount: YEAR_RENDER_COUNT } });
+
+                if (onChangeVisibleDate) {
+                    onChangeVisibleDate(getVisibleDate(calendarState, date, prevStartYear));
+                }
             }
         },
-        [date, calendarState],
+        [date, startYear, calendarState, dispatch, onChangeVisibleDate],
     );
 
     const handleNext = useCallback<UseKeyNavigationArgs['onNext']>(
@@ -48,13 +78,23 @@ export const useCalendarNavigation = ({ calendarState, dispatch, date }: UseCale
                         payload: { step: 1 },
                     });
 
+                    if (onChangeVisibleDate) {
+                        onChangeVisibleDate(getVisibleDate(calendarState, { ...date, year: date.year + 1 }, startYear));
+                    }
+
                     return;
                 }
+
+                const [year, monthIndex] = getNextDate(date.year, date.monthIndex);
 
                 dispatch({
                     type: ActionType.NEXT_MONTH,
                     payload: { monthIndex: date.monthIndex, year: date.year },
                 });
+
+                if (onChangeVisibleDate) {
+                    onChangeVisibleDate(getVisibleDate(calendarState, { ...date, monthIndex, year }, startYear));
+                }
 
                 return;
             }
@@ -62,14 +102,24 @@ export const useCalendarNavigation = ({ calendarState, dispatch, date }: UseCale
             if (calendarState === CalendarState.Months || calendarState === CalendarState.Quarters) {
                 dispatch({ type: ActionType.NEXT_YEAR, payload: { step: 1 } });
 
+                if (onChangeVisibleDate) {
+                    onChangeVisibleDate(getVisibleDate(calendarState, { ...date, year: date.year + 1 }, startYear));
+                }
+
                 return;
             }
 
             if (calendarState === CalendarState.Years) {
+                const nextStartYear = startYear + YEAR_RENDER_COUNT;
+
                 dispatch({ type: ActionType.NEXT_START_YEAR, payload: { yearsCount: YEAR_RENDER_COUNT } });
+
+                if (onChangeVisibleDate) {
+                    onChangeVisibleDate(getVisibleDate(calendarState, date, nextStartYear));
+                }
             }
         },
-        [date, calendarState],
+        [date, startYear, calendarState, dispatch, onChangeVisibleDate],
     );
 
     return {

--- a/packages/plasma-new-hope/src/components/Calendar/store/reducer.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/store/reducer.ts
@@ -1,5 +1,5 @@
 import type { DateType } from '../Calendar.types';
-import { getDateFromValue, getNextDate, getPrevDate, getStartYear } from '../utils';
+import { getDateFromValue, getNextDate, getPrevDate, getPrevYear, getStartYear } from '../utils';
 
 import { CalendarStateType, Action, ActionType, InitialState, SizeMap } from './types';
 
@@ -72,7 +72,7 @@ export const reducer = (state: InitialState, action: Action): InitialState => {
         }
         case ActionType.PREVIOUS_YEAR: {
             const { step } = action.payload;
-            const startYear = state.date.year - step <= 0 ? 0 : state.date.year - step;
+            const startYear = getPrevYear(state.date.year, step);
 
             return {
                 ...state,
@@ -99,7 +99,7 @@ export const reducer = (state: InitialState, action: Action): InitialState => {
         }
         case ActionType.PREVIOUS_START_YEAR: {
             const { yearsCount } = action.payload;
-            const startYear = state.startYear - yearsCount < 0 ? 0 : state.startYear - yearsCount;
+            const startYear = getPrevYear(state.startYear, yearsCount);
 
             return {
                 ...state,

--- a/packages/plasma-new-hope/src/components/Calendar/utils/calendarGridHelper.ts
+++ b/packages/plasma-new-hope/src/components/Calendar/utils/calendarGridHelper.ts
@@ -7,7 +7,7 @@ import type {
     ItemProps,
     Locales,
 } from '../Calendar.types';
-import type { CalendarStateType } from '../store/types';
+import { CalendarState, CalendarStateType } from '../store/types';
 
 import { isSelectProcess } from './calendarRangeHelper';
 import { MONTHS, YEAR_RENDER_COUNT, I18N } from './constants';
@@ -17,6 +17,31 @@ export const getDaysInMonth = (monthIndex: number, year: number) => new Date(yea
 export const getOffsetDayInWeek = (monthIndex: number, year: number) => (new Date(year, monthIndex).getDay() || 7) - 1;
 
 export const getStartYear = (year: number) => Math.floor(year / YEAR_RENDER_COUNT) * YEAR_RENDER_COUNT;
+
+export const getPrevYear = (currentYear: number, step = 1) => Math.max(0, currentYear - step);
+
+/**
+ * Первое число видимого периода: месяца в режиме дней, года в режимах месяцев и кварталов,
+ * первого года страницы в режиме годов.
+ */
+export const getVisibleDate = (
+    calendarState: CalendarStateType,
+    { monthIndex, year }: DateObject,
+    startYear: number,
+): Date => {
+    if (calendarState === CalendarState.Years) {
+        return new Date(startYear, 0);
+    }
+
+    if (calendarState === CalendarState.Months || calendarState === CalendarState.Quarters) {
+        return new Date(year, 0);
+    }
+
+    return new Date(year, monthIndex);
+};
+
+export const getVisibleDateFromValue = (calendarState: CalendarStateType, date: Date): Date =>
+    getVisibleDate(calendarState, getDateFromValue(date), getStartYear(date.getFullYear()));
 
 export const getNextDate = (currentYear: number, currentMonth: number) =>
     currentMonth + 1 === MONTHS.length ? [currentYear + 1, 0] : [currentYear, currentMonth + 1];

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePicker.component-test.tsx
@@ -408,6 +408,18 @@ describeFn('DatePicker', () => {
         cy.matchImageSnapshot();
     });
 
+    it('prop: onChangeVisibleDate', () => {
+        const onChangeVisibleDate = cy.stub().as('onChangeVisibleDate');
+
+        mount(<Demo defaultDate={new Date(2023, 5, 14)} onChangeVisibleDate={onChangeVisibleDate} />);
+
+        cy.get('input').first().click();
+        assertDatePickerPopoverOpen();
+
+        cy.get('button[aria-label="Следующий месяц"]').click();
+        cy.get('@onChangeVisibleDate').should('have.been.calledWith', new Date(2023, 6));
+    });
+
     it('case: very future date', () => {
         mount(<Demo defaultDate={new Date(9999, 5, 14)} />);
 
@@ -904,6 +916,18 @@ describeFnRange('DatePickerRange', () => {
         cy.get('input').last().should('have.value', '17.06.2023');
         cy.get('input').first().should('have.value', '');
         cy.get('input').first().should('be.focused');
+    });
+
+    it('prop: onChangeVisibleDate', () => {
+        const onChangeVisibleDate = cy.stub().as('onChangeVisibleDate');
+
+        mount(<Demo renderFromDate={new Date(2023, 5, 1)} onChangeVisibleDate={onChangeVisibleDate} />);
+
+        cy.get('.input-wrapper input').first().click();
+
+        cy.get('button[aria-label="Следующий месяц"]').first().click();
+
+        cy.get('@onChangeVisibleDate').should('have.been.calledWith', new Date(2023, 6));
     });
 
     it('DatePickerRange: complete range by selecting first date after second', () => {

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePicker.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePicker.template-doc.mdx
@@ -16,7 +16,7 @@ import TabItem from '@theme/TabItem';
     <TabItem value="uncontrolled" label="Uncontrolled" default>
         ```tsx live
         import React, {useState} from 'react';
-        import { DatePicker } from {{ package }};
+        import { DatePicker } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         export function App() {
@@ -102,7 +102,7 @@ import TabItem from '@theme/TabItem';
         :::
         ```tsx live
         import React, {useState} from 'react';
-        import { DatePicker } from {{ package }};
+        import { DatePicker } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         export function App() {
@@ -158,7 +158,7 @@ import TabItem from '@theme/TabItem';
 
         ```tsx live
         import React from 'react';
-        import { DatePicker } from {{ package }};
+        import { DatePicker } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         export function App() {
@@ -191,7 +191,7 @@ import TabItem from '@theme/TabItem';
 
         ```tsx live
         import React from 'react';
-        import { DatePicker } from {{ package }};
+        import { DatePicker } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         export function App() {
@@ -237,7 +237,7 @@ import TabItem from '@theme/TabItem';
 
 ```tsx live
 import React from 'react';
-import { DatePicker } from {{ package }};
+import { DatePicker } from '@salutejs/{{ package }}';
 import { IconDone } from '@salutejs/plasma-icons';
 
 export function App() {
@@ -269,7 +269,7 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { DatePicker } from {{ package }};
+import { DatePicker } from '@salutejs/{{ package }}';
 import { IconDone } from '@salutejs/plasma-icons';
 
 export function App() {
@@ -297,7 +297,7 @@ export function App() {
 
 ```tsx live
 import React, {useState} from 'react';
-import { DatePicker } from {{ package }};
+import { DatePicker } from '@salutejs/{{ package }}';
 import { IconDone } from '@salutejs/plasma-icons';
 
 export function App() {
@@ -356,7 +356,7 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { DatePicker, IconButton } from {{ package }};
+import { DatePicker, IconButton } from '@salutejs/{{ package }}';
 import { IconDone } from '@salutejs/plasma-icons';
 
 export function App() {
@@ -380,6 +380,46 @@ export function App() {
                 required
                 requiredPlacement="right"
             />
+        </div>
+    );
+}
+```
+
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/{{ package }}';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style=\{{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
         </div>
     );
 }
@@ -441,7 +481,7 @@ type EventTooltipOptions = {
 
 ```tsx live
 import React from 'react';
-import { DatePicker } from {{ package }};
+import { DatePicker } from '@salutejs/{{ package }}';
 
     export function App() {
 
@@ -499,7 +539,7 @@ import { DatePicker } from {{ package }};
                 placeholder="Введите дату"
                 format="DD MMMM YYYY"
                 eventList={events}
-                eventTooltipOptions={{
+                eventTooltipOptions=\{{
                     bodyWrapper: EventTooltipBody,
                     size: 'm'
                 }}
@@ -522,7 +562,7 @@ import { DatePicker } from {{ package }};
     <TabItem value="uncontrolled" label="Uncontrolled" default>
         ```tsx live
         import React, {useState} from 'react';
-        import { DatePickerRange, IconButton } from {{ package }};
+        import { DatePickerRange, IconButton } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         type DateType = Date | string | undefined | null
@@ -599,7 +639,7 @@ import { DatePicker } from {{ package }};
     <TabItem value="controlled" label="Controlled">
         ```tsx live
         import React, {useState} from 'react';
-        import { DatePickerRange } from {{ package }};
+        import { DatePickerRange } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         type DateType = Date | string | undefined | null
@@ -673,7 +713,7 @@ import { DatePicker } from {{ package }};
 
         ```tsx live
         import React from 'react';
-        import { DatePickerRange, IconButton } from {{ package }};
+        import { DatePickerRange, IconButton } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         export function App() {
@@ -732,7 +772,7 @@ import { DatePicker } from {{ package }};
 
         ```tsx live
         import React from 'react';
-        import { DatePickerRange, IconButton } from {{ package }};
+        import { DatePickerRange, IconButton } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         export function App() {
@@ -771,7 +811,7 @@ import { DatePicker } from {{ package }};
 
         ```tsx live
         import React from 'react';
-        import { DatePickerRange, IconButton } from {{ package }};
+        import { DatePickerRange, IconButton } from '@salutejs/{{ package }}';
         import { IconDone } from '@salutejs/plasma-icons';
 
         export function App() {
@@ -821,7 +861,7 @@ import { DatePicker } from {{ package }};
 
 ```tsx live
 import React from 'react';
-import { DatePickerRange } from {{ package }};
+import { DatePickerRange } from '@salutejs/{{ package }}';
 
 export function App() {
     return (
@@ -843,7 +883,7 @@ export function App() {
 
 ```tsx live
 import React from 'react';
-import { DatePickerRange } from {{ package }};
+import { DatePickerRange } from '@salutejs/{{ package }}';
 
 export function App() {
     const today = new Date();

--- a/packages/plasma-new-hope/src/components/DatePicker/DatePickerBase.types.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePickerBase.types.ts
@@ -160,6 +160,10 @@ export type DatePickerCalendarProps = {
      * @default 'left'
      */
     dateShortcutsPlacement?: 'right' | 'left';
+    /**
+     * Обработчик изменения отображаемых месяца или года при навигации по календарю.
+     */
+    onChangeVisibleDate?: (date: Date) => void;
 };
 
 export type DatePickerVariationProps = {

--- a/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDate.tsx
@@ -145,6 +145,7 @@ export const datePickerRangeRoot = (Root: RootProps<HTMLDivElement, RootDatePick
                 onChange,
                 onChangeFirstValue,
                 onChangeSecondValue,
+                onChangeVisibleDate,
 
                 onCommitFirstDate,
                 onCommitSecondDate,
@@ -701,6 +702,7 @@ export const datePickerRangeRoot = (Root: RootProps<HTMLDivElement, RootDatePick
                         calendarContainerWidth={calendarContainerWidth}
                         calendarContainerHeight={calendarContainerHeight}
                         type={type}
+                        onChangeVisibleDate={onChangeVisibleDate}
                         onToggle={handleToggle}
                         lang={lang}
                         isDoubleCalendar={isDoubleCalendar}

--- a/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDatePopover/RangeDatePopover.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/RangeDate/RangeDatePopover/RangeDatePopover.tsx
@@ -47,7 +47,7 @@ export const RangeDatePopover = ({
     calendarContainerHeight,
     stretched,
 
-    type,
+    type = 'Days',
     size,
     lang = 'ru',
 
@@ -63,6 +63,7 @@ export const RangeDatePopover = ({
     onChangeValue,
     onChangeStartOfRange,
     onChangeSingleValue,
+    onChangeVisibleDate,
 
     onToggle,
 }: RangeDatePopoverProps) => {
@@ -159,6 +160,7 @@ export const RangeDatePopover = ({
                             onChangeValue={onChangeValue}
                             onChangeStartOfRange={onChangeStartOfRange}
                             onChangeSingleValue={onChangeSingleValue}
+                            onChangeVisibleDate={onChangeVisibleDate}
                         />
                     </StyledCalendarContent>
                 </Root>
@@ -230,6 +232,7 @@ export const RangeDatePopover = ({
                         onChangeValue={onChangeValue}
                         onChangeStartOfRange={onChangeStartOfRange}
                         onChangeSingleValue={onChangeSingleValue}
+                        onChangeVisibleDate={onChangeVisibleDate}
                     />
                 </StyledCalendarContent>
             </Root>

--- a/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/SingleDate/SingleDate.tsx
@@ -123,6 +123,8 @@ export const datePickerRoot = (Root: RootProps<HTMLDivElement, RootDatePickerPro
                 dateShortcutsPlacement = 'left',
                 dateShortcutsWidth,
 
+                // callbacks
+                onChangeVisibleDate,
                 onChangeValue,
                 onCommitDate,
                 onToggle,
@@ -436,6 +438,7 @@ export const datePickerRoot = (Root: RootProps<HTMLDivElement, RootDatePickerPro
                                     isRange={false}
                                     locale={lang}
                                     onChangeValue={handleCalendarPick}
+                                    onChangeVisibleDate={onChangeVisibleDate}
                                 />
                             </StyledCalendarContent>
                         </Root>

--- a/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.component-test.tsx
@@ -704,6 +704,23 @@ describeFn('DateTimePicker', () => {
         cy.get('body').click(0, 0);
     });
 
+    it('prop: onChangeVisibleDate', () => {
+        cy.viewport(750, 700);
+
+        const onChangeVisibleDate = cy.stub().as('onChangeVisibleDate');
+
+        mount(<Demo defaultDate={new Date(2023, 5, 14, 0, 0, 0)} onChangeVisibleDate={onChangeVisibleDate} />);
+
+        cy.get('input').first().click();
+
+        // NOTE: cy.click внутри поповера DateTimePicker до кнопки не доходит, поэтому кликаем узел напрямую.
+        cy.get('button[aria-label="Следующий месяц"]')
+            .first()
+            .then(($next) => $next[0].click());
+
+        cy.get('@onChangeVisibleDate').should('have.been.calledWith', new Date(2023, 6));
+    });
+
     it('prop: onChange', () => {
         cy.viewport(750, 700);
 

--- a/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.template-doc.mdx
+++ b/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.template-doc.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/{{ package }}';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style=\{{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`
@@ -492,7 +532,7 @@ import { DateTimePicker } from '@salutejs/{{ package }}';
                 placeholder="Введите дату"
                 format="DD MMMM YYYY"
                 eventList={events}
-                eventTooltipOptions={{ 
+                eventTooltipOptions=\{{
                     bodyWrapper: EventTooltipBody,
                     size: 'm'
                 }}

--- a/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/packages/plasma-new-hope/src/components/DateTimePicker/DateTimePicker.tsx
@@ -114,6 +114,7 @@ export const dateTimePickerRoot = (Root: RootProps<HTMLDivElement, DateTimePicke
                 hintContentLeft,
 
                 // callbacks
+                onChangeVisibleDate,
                 onChangeValue,
                 onCommitDate,
                 onToggle,
@@ -350,6 +351,7 @@ export const dateTimePickerRoot = (Root: RootProps<HTMLDivElement, DateTimePicke
                                 includeEdgeDates={includeEdgeDates}
                                 lang={lang}
                                 handleCalendarPick={handleCalendarPick}
+                                onChangeVisibleDate={onChangeVisibleDate}
                             />
 
                             <StyledSeparator />

--- a/website/plasma-b2c-docs/docs/components/Calendar.mdx
+++ b/website/plasma-b2c-docs/docs/components/Calendar.mdx
@@ -319,6 +319,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/plasma-b2c';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-b2c-docs/docs/components/DatePicker.mdx
+++ b/website/plasma-b2c-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/plasma-b2c';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-b2c-docs/docs/components/DateTimePicker.mdx
+++ b/website/plasma-b2c-docs/docs/components/DateTimePicker.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/plasma-b2c';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-giga-docs/docs/components/Calendar.mdx
+++ b/website/plasma-giga-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/plasma-giga';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-giga-docs/docs/components/DatePicker.mdx
+++ b/website/plasma-giga-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/plasma-giga';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-giga-docs/docs/components/DateTimePicker.mdx
+++ b/website/plasma-giga-docs/docs/components/DateTimePicker.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/plasma-giga';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-homeds-docs/docs/components/DatePicker.mdx
+++ b/website/plasma-homeds-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/plasma-homeds';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-homeds-docs/docs/components/DateTimePicker.mdx
+++ b/website/plasma-homeds-docs/docs/components/DateTimePicker.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/plasma-homeds';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-web-docs/docs/components/Calendar.mdx
+++ b/website/plasma-web-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/plasma-web';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-web-docs/docs/components/DatePicker.mdx
+++ b/website/plasma-web-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/plasma-web';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/plasma-web-docs/docs/components/DateTimePicker.mdx
+++ b/website/plasma-web-docs/docs/components/DateTimePicker.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/plasma-web';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-bizcom-docs/docs/components/Calendar.mdx
+++ b/website/sdds-bizcom-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-bizcom';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-bizcom-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-bizcom-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-bizcom';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-bizcom-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-bizcom-docs/docs/components/DateTimePicker.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-bizcom';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-cs-docs/docs/components/Calendar.mdx
+++ b/website/sdds-cs-docs/docs/components/Calendar.mdx
@@ -318,3 +318,45 @@ export function App() {
     );
 }
 ```
+
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-cs';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```

--- a/website/sdds-cs-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-cs-docs/docs/components/DatePicker.mdx
@@ -342,6 +342,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-cs';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## DatePickerRange
 <Description name="DatePickerRange" />
 

--- a/website/sdds-dfa-docs/docs/components/Calendar.mdx
+++ b/website/sdds-dfa-docs/docs/components/Calendar.mdx
@@ -319,6 +319,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-dfa';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-dfa-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-dfa-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-dfa';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-dfa-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-dfa-docs/docs/components/DateTimePicker.mdx
@@ -338,6 +338,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-dfa';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-finai-docs/docs/components/Calendar.mdx
+++ b/website/sdds-finai-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-finai';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-finai-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-finai-docs/docs/components/DatePicker.mdx
@@ -376,6 +376,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-finai';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-finai-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-finai-docs/docs/components/DateTimePicker.mdx
@@ -388,6 +388,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-finai';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-insol-docs/docs/components/Calendar.mdx
+++ b/website/sdds-insol-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-insol';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-insol-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-insol-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-insol';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-insol-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-insol-docs/docs/components/DateTimePicker.mdx
@@ -338,6 +338,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-insol';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-netology-docs/docs/components/Calendar.mdx
+++ b/website/sdds-netology-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-netology';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-netology-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-netology-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-netology';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-netology-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-netology-docs/docs/components/DateTimePicker.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-netology';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-platform-ai-docs/docs/components/Calendar.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-platform-ai-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-platform-ai-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/DateTimePicker.mdx
@@ -338,6 +338,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-platform-ai';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-sbcom-docs/docs/components/Calendar.mdx
+++ b/website/sdds-sbcom-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-sbcom';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-sbcom-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-sbcom-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-sbcom';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-sbcom-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-sbcom-docs/docs/components/DateTimePicker.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-sbcom';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-scan-docs/docs/components/Calendar.mdx
+++ b/website/sdds-scan-docs/docs/components/Calendar.mdx
@@ -308,6 +308,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-scan';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-scan-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-scan-docs/docs/components/DatePicker.mdx
@@ -348,6 +348,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-scan';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-scan-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-scan-docs/docs/components/DateTimePicker.mdx
@@ -338,6 +338,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-scan';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-serv-docs/docs/components/Calendar.mdx
+++ b/website/sdds-serv-docs/docs/components/Calendar.mdx
@@ -318,6 +318,48 @@ export function App() {
 }
 ```
 
+## Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { CalendarBase } from '@salutejs/sdds-serv';
+
+export function App() {
+    const [value, setValue] = useState(new Date());
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <CalendarBase
+                value={value}
+                onChangeValue={setValue}
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'изначальный месяц'}
+            </div>
+        </div>
+    );
+}
+```
+
 ## Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-serv-docs/docs/components/DatePicker.mdx
+++ b/website/sdds-serv-docs/docs/components/DatePicker.mdx
@@ -385,6 +385,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме двойного календаря возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DatePicker } from '@salutejs/sdds-serv';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DatePicker
+                label="Дата"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`

--- a/website/sdds-serv-docs/docs/components/DateTimePicker.mdx
+++ b/website/sdds-serv-docs/docs/components/DateTimePicker.mdx
@@ -378,6 +378,46 @@ export function App() {
 }
 ```
 
+### Отслеживание отображаемого месяца и года
+
+Свойство `onChangeVisibleDate` сообщает, какой период сейчас показан в календаре.
+Обработчик получает `Date` — первое число видимого периода: месяца в режиме `Days`,
+года в режимах `Months` и `Quarters`, первого года страницы в режиме `Years`.
+
+Вызывается, когда период меняется:
+
+- при листании стрелками вперёд и назад;
+- при выборе месяца или года через заголовок календаря;
+- когда новое значение выводит календарь на другой период.
+
+В режиме `isDouble` возвращается левый, первый из отображаемых месяцев.
+
+Обработчик не вызывается при переключении уровня через заголовок (дни → месяцы → годы):
+меняется масштаб, а не период.
+
+```tsx live
+import React, { useState } from 'react';
+import { DateTimePicker } from '@salutejs/sdds-serv';
+
+export function App() {
+    const [currentDate, setCurrentDate] = useState<Date>();
+
+    return (
+        <div style={{display: 'flex', flexDirection: 'column'}}>
+            <DateTimePicker
+                label="Дата и время"
+                onChangeVisibleDate={setCurrentDate}
+            />
+            <div>
+                Отображаемый период: {currentDate
+                    ? currentDate.toLocaleDateString('ru', { month: 'long', year: 'numeric' })
+                    : 'календарь ещё не листали'}
+            </div>
+        </div>
+    );
+}
+```
+
 ### Всплывающая подсказка для событий календаря
 
 С помощью `eventList`, `eventMonthList`, `eventQuarterList` и `eventYearList`


### PR DESCRIPTION
## Core

### Calendar, DatePicker, DateTimePicker

- добавлено свойство `onChangeVisibleDate` для отслеживания текущего месяца и года
 
### What/why changed

- добавлено свойство `onChangeVisibleDate` для отслеживания текущего месяца и года

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.387.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-b2c@1.629.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-colors@0.18.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-core@1.236.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-giga@0.356.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-homeds@0.356.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-hope@1.383.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-icons@1.245.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-new-hope@0.373.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-tokens@1.147.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-tokens-b2b@1.61.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-tokens-b2c@0.72.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-tokens-core@0.9.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-tokens-web@1.76.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-typo@0.49.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-web@1.631.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-bizcom@0.361.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-cs@0.365.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-dfa@0.359.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-finai@0.352.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-icons@0.2.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-insol@0.356.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-insol-next@0.355.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-netology@0.360.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-os@0.31.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-platform-ai@0.360.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-sbcom@0.361.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-scan@0.359.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-serv@0.360.0-canary.3049.32128672031.0
  npm install @salutejs/core-themes@0.37.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-themes@0.59.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-themes@0.74.0-canary.3049.32128672031.0
  npm install @salutejs/sdds-api-tests@0.18.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-cy-utils@0.166.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-sb-utils@0.237.0-canary.3049.32128672031.0
  npm install @salutejs/plasma-tokens-utils@0.57.0-canary.3049.32128672031.0
  # or 
  yarn add @salutejs/plasma-asdk@0.387.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-b2c@1.629.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-colors@0.18.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-core@1.236.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-giga@0.356.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-homeds@0.356.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-hope@1.383.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-icons@1.245.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-new-hope@0.373.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-tokens@1.147.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-tokens-b2b@1.61.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-tokens-b2c@0.72.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-tokens-core@0.9.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-tokens-web@1.76.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-typo@0.49.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-web@1.631.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-bizcom@0.361.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-cs@0.365.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-dfa@0.359.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-finai@0.352.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-icons@0.2.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-insol@0.356.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-insol-next@0.355.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-netology@0.360.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-os@0.31.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-platform-ai@0.360.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-sbcom@0.361.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-scan@0.359.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-serv@0.360.0-canary.3049.32128672031.0
  yarn add @salutejs/core-themes@0.37.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-themes@0.59.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-themes@0.74.0-canary.3049.32128672031.0
  yarn add @salutejs/sdds-api-tests@0.18.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-cy-utils@0.166.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-sb-utils@0.237.0-canary.3049.32128672031.0
  yarn add @salutejs/plasma-tokens-utils@0.57.0-canary.3049.32128672031.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `onChangeVisibleDate` support to Calendar, DatePicker, DatePickerRange, and DateTimePicker.
  * The callback reports the first date of the currently visible period during navigation and relevant value changes.
  * Double-calendar views report the left calendar’s visible period.

* **Documentation**
  * Added usage examples and guidance covering supported views, callback behavior, and double-calendar scenarios.

* **Tests**
  * Added coverage for navigation, header selection, controlled value changes, and callback suppression when the visible period is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->