### PR TITLE
PLASMA-7721: changelog `19.02.2026` for sdds-finai

### DIFF
--- a/packages/sdds-finai/src/components/Autocomplete/Autocomplete.config.ts
+++ b/packages/sdds-finai/src/components/Autocomplete/Autocomplete.config.ts
@@ -286,7 +286,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.1875rem 0.25rem -0.1875rem -0.25rem;
                 ${tokens.textFieldRightContentMargin}: -0.1875rem -0.25rem -0.1875rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -362,7 +362,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.25rem -0.0625rem -0.1875rem;
                 ${tokens.textFieldRightContentMargin}: -0.0625rem -0.1875rem -0.0625rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;

--- a/packages/sdds-finai/src/components/Combobox/Combobox.config.ts
+++ b/packages/sdds-finai/src/components/Combobox/Combobox.config.ts
@@ -365,7 +365,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.1875rem 0.25rem -0.1875rem -0.25rem;
                 ${tokens.textFieldRightContentMargin}: -0.1875rem -0.375rem -0.1875rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -489,7 +489,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.25rem -0.0625rem -0.1875rem;
                 ${tokens.textFieldRightContentMargin}: -0.0625rem -0.25rem -0.0625rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;

--- a/packages/sdds-finai/src/components/DateTimePicker/DateTimePicker.clear.config.ts
+++ b/packages/sdds-finai/src/components/DateTimePicker/DateTimePicker.clear.config.ts
@@ -162,7 +162,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.1875rem 0.25rem -0.1875rem -0.125rem;
                 ${tokens.textFieldRightContentMargin}: -0.1875rem -0.125rem -0.1875rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.375rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -330,7 +330,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.25rem -0.0625rem -0.125rem;
                 ${tokens.textFieldRightContentMargin}: -0.0625rem 0 -0.0625rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;

--- a/packages/sdds-finai/src/components/DateTimePicker/DateTimePicker.config.ts
+++ b/packages/sdds-finai/src/components/DateTimePicker/DateTimePicker.config.ts
@@ -169,7 +169,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.1875rem 0.25rem -0.1875rem -0.125rem;
                 ${tokens.textFieldRightContentMargin}: -0.1875rem -0.25rem -0.1875rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.375rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -337,7 +337,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.25rem -0.0625rem -0.125rem;
                 ${tokens.textFieldRightContentMargin}: -0.0625rem -0.25rem -0.0625rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;

--- a/packages/sdds-finai/src/components/Select/Select.config.ts
+++ b/packages/sdds-finai/src/components/Select/Select.config.ts
@@ -511,7 +511,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.1875rem 0.25rem -0.1875rem -0.25rem;
                 ${tokens.textFieldRightContentMargin}: -0.1875rem -0.375rem -0.1875rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -639,7 +639,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.25rem -0.0625rem -0.1875rem;
                 ${tokens.textFieldRightContentMargin}: -0.0625rem -0.25rem -0.0625rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;

--- a/packages/sdds-finai/src/components/TextField/TextField.clear.config.ts
+++ b/packages/sdds-finai/src/components/TextField/TextField.clear.config.ts
@@ -243,7 +243,7 @@ export const config = {
 
                 ${tokens.leftContentMargin}: -0.1875rem 0.25rem -0.1875rem 0;
                 ${tokens.rightContentMargin}: -0.1875rem 0 -0.1875rem 0.75rem;
-                ${tokens.rightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.rightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.contentRightWrapperGap}: 0.25rem;
                 ${tokens.contentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -329,7 +329,7 @@ export const config = {
 
                 ${tokens.leftContentMargin}: -0.0625rem 0.25rem -0.0625rem 0;
                 ${tokens.rightContentMargin}: -0.0625rem 0 -0.0625rem 0.75rem;
-                ${tokens.rightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.rightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.contentRightWrapperGap}: 0.25rem;
                 ${tokens.contentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;

--- a/packages/sdds-finai/src/components/TextField/TextField.config.ts
+++ b/packages/sdds-finai/src/components/TextField/TextField.config.ts
@@ -254,7 +254,7 @@ export const config = {
 
                 ${tokens.leftContentMargin}: -0.1875rem 0.25rem -0.1875rem -0.375rem;
                 ${tokens.rightContentMargin}: -0.1875rem -0.375rem -0.1875rem 0.75rem;
-                ${tokens.rightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.rightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.contentRightWrapperGap}: 0.25rem;
                 ${tokens.contentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -340,7 +340,7 @@ export const config = {
 
                 ${tokens.leftContentMargin}: -0.0625rem 0.25rem -0.0625rem -0.25rem;
                 ${tokens.rightContentMargin}: -0.0625rem -0.25rem -0.0625rem 0.75rem;
-                ${tokens.rightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.rightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.contentRightWrapperGap}: 0.25rem;
                 ${tokens.contentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;

--- a/packages/sdds-finai/src/components/TimePicker/TimePicker.clear.config.ts
+++ b/packages/sdds-finai/src/components/TimePicker/TimePicker.clear.config.ts
@@ -144,7 +144,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.1875rem 0.25rem -0.1875rem 0;
                 ${tokens.textFieldRightContentMargin}: -0.1875rem 0 -0.1875rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.375rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -229,7 +229,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.25rem -0.0625rem 0;
                 ${tokens.textFieldRightContentMargin}: -0.0625rem 0 -0.0625rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;

--- a/packages/sdds-finai/src/components/TimePicker/TimePicker.config.ts
+++ b/packages/sdds-finai/src/components/TimePicker/TimePicker.config.ts
@@ -152,7 +152,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.1875rem 0.25rem -0.1875rem -0.125rem;
                 ${tokens.textFieldRightContentMargin}: -0.1875rem -0.125rem -0.1875rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.1875rem -0.1875rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.375rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
@@ -237,7 +237,7 @@ export const config = {
 
                 ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.25rem -0.0625rem -0.125rem;
                 ${tokens.textFieldRightContentMargin}: -0.0625rem -0.125rem -0.0625rem 0.75rem;
-                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
 
                 ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
                 ${tokens.textFieldContentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;


### PR DESCRIPTION
## SDDS-FINAI

### TextField-like

- изменен отступ между `right content` и `hint` согласно changelog от `19.02.2026`

### What/why changed

- изменен отступ между `right content` и `hint` согласно changelog от `19.02.2026`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved right-side spacing for hints and content in small and extra-small Autocomplete, Combobox, DateTimePicker, Select, TextField, and TimePicker fields.
  * Reduced visual crowding and improved alignment across these compact input variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.386.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-b2c@1.628.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-colors@0.17.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-core@1.235.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-giga@0.355.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-homeds@0.355.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-hope@1.382.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-icons@1.244.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-new-hope@0.372.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-tokens@1.146.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-tokens-b2b@1.60.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-tokens-b2c@0.71.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-tokens-core@0.8.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-tokens-web@1.75.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-typo@0.48.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-web@1.630.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-bizcom@0.360.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-cs@0.364.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-dfa@0.358.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-finai@0.351.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-icons@0.1.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-insol@0.355.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-insol-next@0.354.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-netology@0.359.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-os@0.30.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-platform-ai@0.359.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-sbcom@0.360.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-scan@0.358.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-serv@0.359.1-canary.3056.32117778340.0
  npm install @salutejs/core-themes@0.36.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-themes@0.58.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-themes@0.73.1-canary.3056.32117778340.0
  npm install @salutejs/sdds-api-tests@0.17.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-cy-utils@0.165.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-sb-utils@0.236.1-canary.3056.32117778340.0
  npm install @salutejs/plasma-tokens-utils@0.56.1-canary.3056.32117778340.0
  # or 
  yarn add @salutejs/plasma-asdk@0.386.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-b2c@1.628.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-colors@0.17.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-core@1.235.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-giga@0.355.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-homeds@0.355.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-hope@1.382.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-icons@1.244.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-new-hope@0.372.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-tokens@1.146.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-tokens-b2b@1.60.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-tokens-b2c@0.71.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-tokens-core@0.8.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-tokens-web@1.75.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-typo@0.48.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-web@1.630.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-bizcom@0.360.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-cs@0.364.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-dfa@0.358.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-finai@0.351.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-icons@0.1.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-insol@0.355.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-insol-next@0.354.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-netology@0.359.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-os@0.30.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-platform-ai@0.359.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-sbcom@0.360.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-scan@0.358.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-serv@0.359.1-canary.3056.32117778340.0
  yarn add @salutejs/core-themes@0.36.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-themes@0.58.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-themes@0.73.1-canary.3056.32117778340.0
  yarn add @salutejs/sdds-api-tests@0.17.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-cy-utils@0.165.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-sb-utils@0.236.1-canary.3056.32117778340.0
  yarn add @salutejs/plasma-tokens-utils@0.56.1-canary.3056.32117778340.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
