### PR TITLE
PLASMA: change styled-components interpolation to common syntax

### DIFF
--- a/packages/plasma-new-hope/src/components/_beta/Popover/Popover.styles.ts
+++ b/packages/plasma-new-hope/src/components/_beta/Popover/Popover.styles.ts
@@ -47,9 +47,10 @@ export const Tail = styled.div<{ side: 'top' | 'right' | 'bottom' | 'left' }>`
     height: ${({ side }) =>
         side === 'left' || side === 'right' ? `var(${tokens.tailWidth})` : `var(${tokens.tailHeight})`};
 
-    ${({ side }) => ({
-        [side]: '100%',
-    })}
+    top: ${({ side }) => (side === 'top' ? '100%' : 'auto')};
+    right: ${({ side }) => (side === 'right' ? '100%' : 'auto')};
+    bottom: ${({ side }) => (side === 'bottom' ? '100%' : 'auto')};
+    left: ${({ side }) => (side === 'left' ? '100%' : 'auto')};
 
     &::before {
         content: '';

--- a/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.styles.ts
+++ b/packages/plasma-new-hope/src/components/_beta/Tooltip/Tooltip.styles.ts
@@ -41,9 +41,10 @@ export const Tail = styled.div<{ side: 'top' | 'right' | 'bottom' | 'left' }>`
     height: ${({ side }) =>
         side === 'left' || side === 'right' ? `var(${tokens.tailWidth})` : `var(${tokens.tailHeight})`};
 
-    ${({ side }) => ({
-        [side]: '100%',
-    })}
+    top: ${({ side }) => (side === 'top' ? '100%' : 'auto')};
+    right: ${({ side }) => (side === 'right' ? '100%' : 'auto')};
+    bottom: ${({ side }) => (side === 'bottom' ? '100%' : 'auto')};
+    left: ${({ side }) => (side === 'left' ? '100%' : 'auto')};
 
     &::before {
         content: '';


### PR DESCRIPTION
### What/why changed

Убрали интерполяцию styled-components на общий синтаксис

**Before:**
<img width="1388" height="230" alt="image" src="https://github.com/user-attachments/assets/d262510c-73b5-49e2-be14-fe774e1402d8" />


**After:**
<img width="1452" height="209" alt="image" src="https://github.com/user-attachments/assets/3e2838d5-9e9e-43e4-9411-c15524194b84" />


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.387.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-b2c@1.629.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-colors@0.18.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-core@1.236.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-giga@0.356.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-homeds@0.356.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-hope@1.383.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-icons@1.245.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-new-hope@0.373.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-tokens@1.147.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-tokens-b2b@1.61.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-tokens-b2c@0.72.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-tokens-core@0.9.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-tokens-web@1.76.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-typo@0.49.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-web@1.631.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-bizcom@0.361.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-cs@0.365.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-dfa@0.359.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-finai@0.352.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-icons@0.2.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-insol@0.356.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-insol-next@0.355.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-netology@0.360.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-os@0.31.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-platform-ai@0.360.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-sbcom@0.361.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-scan@0.359.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-serv@0.360.0-canary.3058.32125551975.0
  npm install @salutejs/core-themes@0.37.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-themes@0.59.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-themes@0.74.0-canary.3058.32125551975.0
  npm install @salutejs/sdds-api-tests@0.18.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-cy-utils@0.166.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-sb-utils@0.237.0-canary.3058.32125551975.0
  npm install @salutejs/plasma-tokens-utils@0.57.0-canary.3058.32125551975.0
  # or 
  yarn add @salutejs/plasma-asdk@0.387.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-b2c@1.629.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-colors@0.18.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-core@1.236.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-giga@0.356.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-homeds@0.356.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-hope@1.383.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-icons@1.245.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-new-hope@0.373.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-tokens@1.147.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-tokens-b2b@1.61.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-tokens-b2c@0.72.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-tokens-core@0.9.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-tokens-web@1.76.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-typo@0.49.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-web@1.631.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-bizcom@0.361.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-cs@0.365.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-dfa@0.359.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-finai@0.352.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-icons@0.2.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-insol@0.356.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-insol-next@0.355.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-netology@0.360.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-os@0.31.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-platform-ai@0.360.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-sbcom@0.361.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-scan@0.359.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-serv@0.360.0-canary.3058.32125551975.0
  yarn add @salutejs/core-themes@0.37.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-themes@0.59.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-themes@0.74.0-canary.3058.32125551975.0
  yarn add @salutejs/sdds-api-tests@0.18.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-cy-utils@0.166.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-sb-utils@0.237.0-canary.3058.32125551975.0
  yarn add @salutejs/plasma-tokens-utils@0.57.0-canary.3058.32125551975.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
