### PR TITLE
PLASMA-7989: hide Tooltip on page visibility change

### DIFF
--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.component-test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { getComponent, getDescribeFN, hasComponent, mount } from '@salutejs/plasma-cy-utils';
+
+import type { IconButtonProps } from '../IconButton';
+
+import type { TooltipProps } from './Tooltip.types';
+
+const componentExists = hasComponent('Tooltip');
+const iconButtonExists = hasComponent('IconButton');
+const describeFn = getDescribeFN('Tooltip');
+
+describeFn('Tooltip', () => {
+    const Tooltip = componentExists ? getComponent<TooltipProps>('Tooltip') : () => null;
+    const IconButton = iconButtonExists ? getComponent<IconButtonProps>('IconButton') : () => null;
+
+    it('does not open on focus restored after page visibility changes', () => {
+        cy.window().then((window) => {
+            cy.stub(window, 'matchMedia').returns({ matches: false } as MediaQueryList);
+        });
+
+        mount(
+            <Tooltip
+                target={<IconButton aria-label="Target">Icon</IconButton>}
+                text="Tooltip text"
+                trigger="hover"
+                mouseLeaveDelay={0}
+            />,
+        );
+
+        cy.get('button').focus().should('be.focused');
+        cy.contains('Tooltip text').should('be.visible');
+
+        cy.get('button').trigger('mouseout', { force: true });
+        cy.contains('Tooltip text').should('not.be.visible');
+
+        cy.document().then((document) => {
+            Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+            document.dispatchEvent(new Event('visibilitychange'));
+
+            Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+            document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        cy.get('button').trigger('focusin').should('be.focused');
+        cy.contains('Tooltip text').should('not.be.visible');
+    });
+});

--- a/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
+++ b/packages/plasma-new-hope/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, forwardRef, useState } from 'react';
+import React, { useEffect, forwardRef, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { RootProps, component } from 'src/engines';
-import { cx } from 'src/utils';
+import { canUseDOM, cx } from 'src/utils';
 
 import { popoverConfig, popoverTokens } from '../Popover';
 
@@ -71,10 +71,11 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
 
             mouseLeaveDelay = mouseLeaveDelay ?? hoverTimeout ?? 300;
 
-            const { opened: openedState, showTooltip, hideTooltip, setOpened } = useDelayedTooltip(
+            const { opened: openedState, showTooltip, hideTooltip, resetTooltip, setOpened } = useDelayedTooltip(
                 mouseEnterDelay,
                 mouseLeaveDelay,
             );
+            const ignoreNextFocusRef = useRef(false);
 
             const isTooltipOpened = Boolean(text) && (isVisible || isOpen || opened || openedState);
 
@@ -92,7 +93,48 @@ export const tooltipRoot = (Root: RootProps<HTMLDivElement, Omit<TooltipProps, '
                 };
             }, []);
 
-            const onToggle = (isOpen: boolean) => {
+            useEffect(() => {
+                if (trigger !== 'hover') {
+                    ignoreNextFocusRef.current = false;
+                    return undefined;
+                }
+
+                const onVisibilityChange = () => {
+                    if (canUseDOM && document.visibilityState === 'hidden') {
+                        ignoreNextFocusRef.current = true;
+                        resetTooltip();
+                    }
+                };
+
+                const onUserInteraction = () => {
+                    ignoreNextFocusRef.current = false;
+                };
+
+                document.addEventListener('visibilitychange', onVisibilityChange);
+                document.addEventListener('pointerdown', onUserInteraction, true);
+                document.addEventListener('keydown', onUserInteraction, true);
+
+                return () => {
+                    document.removeEventListener('visibilitychange', onVisibilityChange);
+                    document.removeEventListener('pointerdown', onUserInteraction, true);
+                    document.removeEventListener('keydown', onUserInteraction, true);
+                };
+            }, [resetTooltip, trigger]);
+
+            const onToggle = (isOpen: boolean, event: React.SyntheticEvent | Event) => {
+                if (canUseDOM && isOpen && document.visibilityState === 'hidden') {
+                    return;
+                }
+
+                if (isOpen && event.type === 'focus' && ignoreNextFocusRef.current) {
+                    // Возврат на вкладку восстанавливает фокус последнего активного target,
+                    // но не является новым пользовательским действием для открытия Tooltip.
+                    ignoreNextFocusRef.current = false;
+                    return;
+                }
+
+                ignoreNextFocusRef.current = false;
+
                 if (trigger === 'hover') {
                     if (isOpen) {
                         showTooltip();

--- a/packages/plasma-new-hope/src/components/Tooltip/hooks/useDelayedTooltip.ts
+++ b/packages/plasma-new-hope/src/components/Tooltip/hooks/useDelayedTooltip.ts
@@ -1,12 +1,12 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 
 export const useDelayedTooltip = (openDelay: number, closeDelay: number) => {
     const [opened, setOpened] = useState(false);
 
-    const openTimeoutRef = useRef<number | null>(null);
-    const closeTimeoutRef = useRef<number | null>(null);
+    const openTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const clearTimeouts = () => {
+    const clearTimeouts = useCallback(() => {
         if (openTimeoutRef.current) {
             clearTimeout(openTimeoutRef.current);
             openTimeoutRef.current = null;
@@ -16,32 +16,38 @@ export const useDelayedTooltip = (openDelay: number, closeDelay: number) => {
             clearTimeout(closeTimeoutRef.current);
             closeTimeoutRef.current = null;
         }
-    };
+    }, []);
 
-    const showTooltip = () => {
+    const showTooltip = useCallback(() => {
         clearTimeouts();
 
         openTimeoutRef.current = setTimeout(() => {
             setOpened(true);
         }, openDelay);
-    };
+    }, [clearTimeouts, openDelay]);
 
-    const hideTooltip = () => {
+    const hideTooltip = useCallback(() => {
         clearTimeouts();
 
         closeTimeoutRef.current = setTimeout(() => {
             setOpened(false);
         }, closeDelay);
-    };
+    }, [clearTimeouts, closeDelay]);
+
+    const resetTooltip = useCallback(() => {
+        clearTimeouts();
+        setOpened(false);
+    }, [clearTimeouts]);
 
     useEffect(() => {
         return clearTimeouts;
-    }, []);
+    }, [clearTimeouts]);
 
     return {
         opened,
         setOpened,
         showTooltip,
         hideTooltip,
+        resetTooltip,
     };
 };


### PR DESCRIPTION
## Core

### Tooltip

- скрываем `Tooltip` при событии `visibilitychange` (смене активной страницы в браузере)

### What/why changed

**Before:**
<img width="832" height="698" alt="not hiding" src="https://github.com/user-attachments/assets/c5a8961a-e3b3-42d6-a708-2c6a768fa7ab" />

**After:**
<img width="866" height="768" alt="hide tooltip" src="https://github.com/user-attachments/assets/2f986dda-5e66-4f3c-a2d1-b06c6c9d4a63" />

- скрываем `Tooltip` при событии `visibilitychange` (смене активной страницы в браузере)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.391.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-b2c@1.633.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-colors@0.21.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-core@1.240.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-giga@0.360.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-homeds@0.360.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-hope@1.387.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-icons@1.248.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-new-hope@0.377.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-tokens@1.151.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-tokens-b2b@1.64.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-tokens-b2c@0.75.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-tokens-core@0.12.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-tokens-web@1.79.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-typo@0.52.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-web@1.635.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-bizcom@0.365.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-cs@0.369.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-dfa@0.363.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-finai@0.356.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-icons@0.5.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-insol@0.360.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-insol-next@0.359.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-netology@0.364.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-os@0.35.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-platform-ai@0.364.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-sbcom@0.365.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-scan@0.363.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-serv@0.364.0-canary.3065.32715101466.0
  npm install @salutejs/core-themes@0.40.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-themes@0.62.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-themes@0.78.0-canary.3065.32715101466.0
  npm install @salutejs/sdds-api-tests@0.22.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-cy-utils@0.170.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-sb-utils@0.241.0-canary.3065.32715101466.0
  npm install @salutejs/plasma-tokens-utils@0.60.0-canary.3065.32715101466.0
  # or 
  yarn add @salutejs/plasma-asdk@0.391.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-b2c@1.633.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-colors@0.21.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-core@1.240.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-giga@0.360.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-homeds@0.360.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-hope@1.387.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-icons@1.248.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-new-hope@0.377.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-tokens@1.151.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-tokens-b2b@1.64.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-tokens-b2c@0.75.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-tokens-core@0.12.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-tokens-web@1.79.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-typo@0.52.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-web@1.635.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-bizcom@0.365.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-cs@0.369.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-dfa@0.363.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-finai@0.356.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-icons@0.5.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-insol@0.360.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-insol-next@0.359.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-netology@0.364.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-os@0.35.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-platform-ai@0.364.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-sbcom@0.365.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-scan@0.363.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-serv@0.364.0-canary.3065.32715101466.0
  yarn add @salutejs/core-themes@0.40.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-themes@0.62.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-themes@0.78.0-canary.3065.32715101466.0
  yarn add @salutejs/sdds-api-tests@0.22.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-cy-utils@0.170.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-sb-utils@0.241.0-canary.3065.32715101466.0
  yarn add @salutejs/plasma-tokens-utils@0.60.0-canary.3065.32715101466.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip behavior when switching tabs or when the page becomes hidden.
  * Hover-triggered tooltips now close reliably when visibility changes and do not reopen unexpectedly when returning to the page.
  * Tooltip timers are canceled during resets, preventing delayed or stale tooltip appearances.
* **Tests**
  * Added coverage for focus restoration and tooltip behavior after page visibility changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->