### PR TITLE
PLASMA-7956: plasma-giga typograph

### DIFF
--- a/packages/plasma-giga/src/components/Typography/Typography.component-test.tsx
+++ b/packages/plasma-giga/src/components/Typography/Typography.component-test.tsx
@@ -1,5 +1,17 @@
+/* eslint-disable react/jsx-curly-brace-presence */
 import React from 'react';
 import { mount, CypressTestDecorator, getComponent } from '@salutejs/plasma-cy-utils';
+
+import {
+    addTypographRule,
+    createTypograph,
+    dash,
+    defaultTypographRules,
+    quotes,
+    setTypographRules,
+    typograph,
+} from './typograph';
+import { withTypograph } from './typograph/withTypograph';
 
 describe('plasma-giga: ResponsiveTypography', () => {
     const BodyL = getComponent('BodyL');
@@ -156,5 +168,202 @@ describe('plasma-giga: ResponsiveTypography', () => {
 
         cy.viewport(1366, 768);
         cy.matchImageSnapshot();
+    });
+});
+
+const NBSP = '\u00A0';
+
+describe('plasma-giga: typograph', () => {
+    afterEach(() => {
+        setTypographRules(defaultTypographRules);
+    });
+
+    describe('кавычки', () => {
+        it('заменяет прямые кавычки на ёлочки', () => {
+            expect(typograph('он сказал "привет" вчера')).to.equal(`он${NBSP}сказал «привет» вчера`);
+        });
+
+        it('вкладывает лапки во второй уровень', () => {
+            expect(typograph('журнал "Вестник "Науки" сегодня"')).to.equal('журнал «Вестник „Науки“ сегодня»');
+        });
+
+        it('открывает кавычку в начале куска — парность не нужна', () => {
+            expect(typograph('"начало')).to.equal('«начало');
+        });
+
+        it('закрывает кавычку после слова, даже если открывающая осталась в другом куске', () => {
+            expect(typograph('важно" и дальше')).to.equal(`важно» и${NBSP}дальше`);
+        });
+
+        it('открывает кавычку после открывающей скобки', () => {
+            expect(typograph('текст ("цитата")')).to.equal('текст («цитата»)');
+        });
+
+        it('открывает кавычку после двоеточия и тире без пробела', () => {
+            expect(typograph('Он сказал:"привет"')).to.equal(`Он${NBSP}сказал:«привет»`);
+            expect(typograph('сказал—"привет"')).to.equal('сказал—«привет»');
+        });
+
+        it('не трогает текст без кавычек', () => {
+            expect(typograph('обычный текст')).to.equal('обычный текст');
+        });
+    });
+
+    describe('неразрывные пробелы', () => {
+        it('привязывает предлог к следующему слову', () => {
+            expect(typograph('в лесу')).to.equal(`в${NBSP}лесу`);
+        });
+
+        it('обрабатывает цепочку коротких слов подряд', () => {
+            expect(typograph('и в не лесу')).to.equal(`и${NBSP}в${NBSP}не${NBSP}лесу`);
+        });
+
+        it('не трогает слова длиннее двух букв', () => {
+            expect(typograph('под деревом')).to.equal('под деревом');
+        });
+
+        it('не привязывает окончание слова, похожее на предлог', () => {
+            expect(typograph('поле в поле')).to.equal(`поле в${NBSP}поле`);
+        });
+
+        it('работает с латиницей', () => {
+            expect(typograph('at home')).to.equal(`at${NBSP}home`);
+        });
+    });
+
+    describe('тире', () => {
+        it('прижимает длинное тире к предыдущему слову', () => {
+            expect(typograph('ГигаЧат — помощник')).to.equal(`ГигаЧат${NBSP}— помощник`);
+        });
+
+        it('прижимает среднее тире', () => {
+            expect(typograph('строки 10 – 20')).to.equal(`строки 10${NBSP}– 20`);
+        });
+
+        it('не трогает дефис внутри слова', () => {
+            expect(typograph('из-за угла')).to.equal('из-за угла');
+        });
+
+        it('заменяет все обычные пробелы перед тире', () => {
+            expect(typograph('слово  — далее')).to.equal(`слово${NBSP}— далее`);
+        });
+    });
+
+    describe('безопасность на стриминге', () => {
+        it('результат для префикса — префикс результата для целого', () => {
+            const full = 'он сказал "это очень важно" и ушёл';
+
+            for (let i = 1; i <= full.length; i += 1) {
+                const prefixResult = typograph(full.slice(0, i));
+                const fullResult = typograph(full);
+
+                expect(fullResult.startsWith(prefixResult.slice(0, -1))).to.equal(true);
+            }
+        });
+
+        it('не ломается на пустой строке', () => {
+            expect(typograph('')).to.equal('');
+        });
+    });
+
+    describe('URL', () => {
+        it('не трогает кавычки внутри URL', () => {
+            const text = 'зайди на https://example.com/a?b="c и посмотри';
+            const result = typograph(text);
+
+            expect(result).to.include('https://example.com/a?b="c');
+            expect(result).to.not.include('»c');
+            expect(result).to.not.include('«c');
+        });
+
+        it('не забирает закрывающую кавычку из обёртки URL', () => {
+            expect(typograph('"https://example.test"')).to.equal('«https://example.test»');
+        });
+    });
+
+    describe('рантайм', () => {
+        it('addTypographRule добавляет правило в дефолтный пайплайн', () => {
+            addTypographRule((text) => text.replace(/\(c\)/gi, '©'));
+
+            expect(typograph('(c) 2026')).to.equal('© 2026');
+        });
+
+        it('createTypograph собирает кастомный пайплайн', () => {
+            const compact = createTypograph([quotes, dash]);
+
+            expect(compact('и в лесу — "цитата"')).to.equal(`и в лесу${NBSP}— «цитата»`);
+        });
+
+        it('кастомное правило с заменой цифр не ломает URL', () => {
+            const withDigits = createTypograph([(text) => text.replace(/\d/g, '#')]);
+
+            expect(withDigits('см https://example.com/a1 и 2')).to.equal('см https://example.com/a1 и #');
+        });
+    });
+});
+
+describe('plasma-giga: withTypograph', () => {
+    const TextM = withTypograph(getComponent('TextM'));
+
+    afterEach(() => {
+        setTypographRules(defaultTypographRules);
+    });
+
+    it('обрабатывает строковых children', () => {
+        mount(
+            <CypressTestDecorator>
+                <TextM data-testid="typo">{'в лесу — "привет"'}</TextM>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('[data-testid="typo"]').should('have.text', `в${NBSP}лесу${NBSP}— «привет»`);
+    });
+
+    it('не обрабатывает текст без HOC', () => {
+        const PlainTextM = getComponent('TextM');
+
+        mount(
+            <CypressTestDecorator>
+                <PlainTextM data-testid="typo">{'в лесу — "привет"'}</PlainTextM>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('[data-testid="typo"]').should('have.text', 'в лесу — "привет"');
+    });
+
+    it('не трогает смешанных children', () => {
+        mount(
+            <CypressTestDecorator>
+                <TextM data-testid="typo">
+                    в лесу <span>и ещё</span>
+                </TextM>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('[data-testid="typo"]').should('have.text', 'в лесу и ещё');
+    });
+
+    it('принимает кастомный пайплайн', () => {
+        mount(
+            <CypressTestDecorator>
+                <TextM data-testid="typo" typograph={[quotes]}>
+                    {'в лесу "привет"'}
+                </TextM>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('[data-testid="typo"]').should('have.text', 'в лесу «привет»');
+    });
+
+    it('typograph={false} отключает обработку', () => {
+        mount(
+            <CypressTestDecorator>
+                <TextM data-testid="typo" typograph={false}>
+                    {'в лесу — "привет"'}
+                </TextM>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('[data-testid="typo"]').should('have.text', 'в лесу — "привет"');
     });
 });

--- a/packages/plasma-giga/src/components/Typography/Typography.stories.tsx
+++ b/packages/plasma-giga/src/components/Typography/Typography.stories.tsx
@@ -21,6 +21,7 @@ import {
     TextM,
     TextS,
     TextXS,
+    withTypograph,
 } from '.';
 
 const meta: Meta = {
@@ -44,6 +45,13 @@ const meta: Meta = {
 export default meta;
 
 type Story = StoryObj;
+
+type TypographStoryProps = {
+    children?: string;
+    noWrap?: boolean;
+    breakWord?: boolean;
+    color?: string;
+};
 
 export const Dspl: Story = {
     render: (props) => (
@@ -250,5 +258,90 @@ export const Text: Story = {
                 1234567890
             </TextXS>
         </>
+    ),
+};
+
+const typographCardStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    padding: 16,
+    borderRadius: 16,
+    background: 'var(--surface-solid-secondary)',
+};
+
+const typographCaptionStyle: React.CSSProperties = {
+    color: 'var(--text-secondary)',
+};
+
+const TextMTypo = withTypograph(TextM);
+const TextSTypo = withTypograph(TextS);
+
+const TypographRuleCard = ({ title, hint, example }: { title: string; hint: string; example: string }) => (
+    <div style={typographCardStyle}>
+        <H6 bold={false}>{title}</H6>
+        <BodyXS style={typographCaptionStyle}>{hint}</BodyXS>
+        <TextSTypo style={{ maxWidth: 160 }}>{example}</TextSTypo>
+    </div>
+);
+
+export const Typograph: StoryObj<TypographStoryProps> = {
+    args: {
+        children: 'он сказал "привет" в лесу — и ушёл',
+    },
+    argTypes: {
+        children: {
+            control: { type: 'text' },
+        },
+        ...disableProps(['typograph']),
+    },
+    render: ({ children, ...props }) => (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 720 }}>
+            <div>
+                <H4>Дефолтные правила</H4>
+                <BodyS style={typographCaptionStyle}>
+                    withTypograph прогоняет строку через три правила. Узкая колонка показывает, как ведут себя переносы.
+                </BodyS>
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 12 }}>
+                <TypographRuleCard
+                    title="Кавычки"
+                    hint={'"цитата" → «ёлочки» и „лапки“'}
+                    example={'журнал "Вестник "Науки""'}
+                />
+                <TypographRuleCard
+                    title="Предлоги"
+                    hint="Слова из 1–2 букв не висят в конце строки"
+                    example="в лесу стоял я у избушки"
+                />
+                <TypographRuleCard
+                    title="Тире"
+                    hint="Тире не уезжает на новую строку"
+                    example="Наш ГигаЧат — помощник"
+                />
+            </div>
+
+            <div>
+                <H4>Песочница</H4>
+                <BodyS style={{ ...typographCaptionStyle, marginBottom: 12 }}>
+                    Слева исходный TextM, справа — обёрнутый в withTypograph. Текст можно менять в Controls.
+                </BodyS>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+                    <div style={typographCardStyle}>
+                        <BodyXS style={typographCaptionStyle}>TextM</BodyXS>
+                        <TextM {...props} style={{ maxWidth: 200 }}>
+                            {children}
+                        </TextM>
+                    </div>
+                    <div style={typographCardStyle}>
+                        <BodyXS style={typographCaptionStyle}>withTypograph(TextM)</BodyXS>
+                        <TextMTypo {...props} style={{ maxWidth: 200 }}>
+                            {children}
+                        </TextMTypo>
+                    </div>
+                </div>
+            </div>
+        </div>
     ),
 };

--- a/packages/plasma-giga/src/components/Typography/index.ts
+++ b/packages/plasma-giga/src/components/Typography/index.ts
@@ -18,3 +18,15 @@ export {
     TextS,
     TextXS,
 } from './Typography';
+export {
+    addTypographRule,
+    afterShortWord,
+    createTypograph,
+    dash,
+    defaultTypographRules,
+    quotes,
+    setTypographRules,
+    typograph,
+} from './typograph';
+export { withTypograph } from './typograph/withTypograph';
+export type { TypographProps, TypographRule } from './typograph';

--- a/packages/plasma-giga/src/components/Typography/typograph/index.ts
+++ b/packages/plasma-giga/src/components/Typography/typograph/index.ts
@@ -1,0 +1,50 @@
+import { afterShortWord, dash, quotes, withProtectedUrls } from './rules';
+
+export { afterShortWord, dash, quotes };
+
+export type TypographRule = (text: string) => string;
+
+export interface TypographProps {
+    /**
+     * `true` или не передан — дефолтные правила и правила из `addTypographRule`.
+     * `false` — без обработки. Массив — полный пайплайн только для этого компонента.
+     */
+    typograph?: boolean | TypographRule[];
+}
+
+export const defaultTypographRules: TypographRule[] = [quotes, afterShortWord, dash];
+
+let activeRules: TypographRule[] = [...defaultTypographRules];
+let extraRules: TypographRule[] = [];
+
+const getTypographRules = (): TypographRule[] => [...activeRules, ...extraRules];
+
+/**
+ * Собирает пайплайн правил. URL на время обработки прячутся за плейсхолдеры.
+ */
+export const createTypograph = (rules: TypographRule[]): TypographRule =>
+    withProtectedUrls((text) => rules.reduce((acc, rule) => rule(acc), text));
+
+/**
+ * Применяет типографику к строке.
+ * Без второго аргумента используются текущие правила реестра.
+ */
+export const typograph = (text: string, rules: TypographRule[] = getTypographRules()): string =>
+    createTypograph(rules)(text);
+
+/**
+ * Добавляет правило в конец пайплайна для компонентов, обёрнутых в `withTypograph`.
+ * Вызывать на бутстрапе приложения.
+ */
+export const addTypographRule = (rule: TypographRule): void => {
+    extraRules = [...extraRules, rule];
+};
+
+/**
+ * Полностью заменяет дефолтный набор правил и сбрасывает правила из `addTypographRule`.
+ * Вызывать на бутстрапе приложения.
+ */
+export const setTypographRules = (rules: TypographRule[]): void => {
+    activeRules = [...rules];
+    extraRules = [];
+};

--- a/packages/plasma-giga/src/components/Typography/typograph/rules.ts
+++ b/packages/plasma-giga/src/components/Typography/typograph/rules.ts
@@ -1,0 +1,156 @@
+// Escape, а не литерал: неразрывный пробел визуально неотличим от
+// обычного, и опечатка в исходнике не ловится ни глазом, ни ревью.
+const NBSP = '\u00A0';
+
+const PLACEHOLDER_START = '\uE000';
+const PLACEHOLDER_MARK = 0xe010;
+const PLACEHOLDER_END = '\uE001';
+
+const URL_RE = /https?:\/\/[^\s]+/gi;
+const TRAILING_WRAP = /["<>]+$/;
+
+const LEFT_BOUNDARY = /[\s([«„]/;
+const OPENING_QUOTE = /[\s([{«„:;—–]/;
+const LETTER = /[А-Яа-яЁёA-Za-z]/;
+
+const urlToken = (index: number) =>
+    `${PLACEHOLDER_START}${String.fromCharCode(PLACEHOLDER_MARK + index)}${PLACEHOLDER_END}`;
+
+const isLeftBoundary = (char: string | undefined): boolean => char === undefined || LEFT_BOUNDARY.test(char);
+
+const isLetter = (char: string | undefined): char is string => typeof char === 'string' && LETTER.test(char);
+
+/**
+ * Заменяет прямые кавычки на «ёлочки» первого уровня и „лапки“ второго.
+ *
+ * Пары не ищутся: сторона определяется по соседу слева. Так правило переживает
+ * два случая, где парность недоступна — кусок текста может быть оборван
+ * разметкой и может быть недописан, пока ответ стримится.
+ */
+export const quotes = (text: string): string => {
+    if (!text.includes('"')) {
+        return text;
+    }
+
+    let depth = 0;
+    let out = '';
+
+    for (let i = 0; i < text.length; i += 1) {
+        const char = text[i];
+
+        if (char !== '"') {
+            out += char;
+        } else {
+            const prev = text[i - 1];
+            const isOpening = prev === undefined || OPENING_QUOTE.test(prev);
+
+            if (isOpening) {
+                out += depth === 0 ? '«' : '„';
+                depth += 1;
+            } else {
+                depth = Math.max(0, depth - 1);
+                out += depth === 0 ? '»' : '“';
+            }
+        }
+    }
+
+    return out;
+};
+
+/**
+ * Ставит неразрывный пробел после слов из одной-двух букв.
+ * Один проход слева направо: уже поставленный NBSP становится границей для следующего слова.
+ */
+export const afterShortWord = (text: string): string => {
+    let out = '';
+    let i = 0;
+
+    while (i < text.length) {
+        const prev = out.length === 0 ? undefined : out[out.length - 1];
+        let step = 1;
+        let chunk = text[i];
+
+        if (isLeftBoundary(prev)) {
+            const first = text[i];
+            const second = text[i + 1];
+            const third = text[i + 2];
+
+            if (isLetter(first) && isLetter(second) && third === ' ') {
+                chunk = `${first}${second}${NBSP}`;
+                step = 3;
+            } else if (isLetter(first) && second === ' ') {
+                chunk = `${first}${NBSP}`;
+                step = 2;
+            }
+        }
+
+        out += chunk;
+        i += step;
+    }
+
+    return out;
+};
+
+/**
+ * Прижимает длинное и среднее тире к предыдущему слову: оторвавшись на новую
+ * строку, оно мимикрирует под начало прямой речи.
+ */
+export const dash = (text: string): string => {
+    let out = '';
+    let i = 0;
+
+    while (i < text.length) {
+        const char = text[i];
+
+        if (char === ' ' || char === '\t') {
+            let j = i;
+
+            while (j < text.length && (text[j] === ' ' || text[j] === '\t')) {
+                j += 1;
+            }
+
+            const next = text[j];
+
+            if (next === '—' || next === '–') {
+                out += `${NBSP}${next}`;
+                i = j + 1;
+            } else {
+                out += text.slice(i, j);
+                i = j;
+            }
+        } else {
+            out += char;
+            i += 1;
+        }
+    }
+
+    return out;
+};
+
+/**
+ * Прячет URL за плейсхолдеры на время применения правил (аналог typograf safeTags).
+ * Замыкающие обёрточные кавычки/скобки в URL не входят, чтобы `"https://example.test"`
+ * отдало обе кавычки правилу quotes.
+ */
+export const withProtectedUrls = (apply: (text: string) => string) => (text: string): string => {
+    const urls: string[] = [];
+    const urlRe = new RegExp(URL_RE.source, URL_RE.flags);
+
+    const masked = text.replace(urlRe, (raw) => {
+        const url = raw.replace(TRAILING_WRAP, '');
+        const trailing = raw.slice(url.length);
+        const token = urlToken(urls.length);
+
+        urls.push(url);
+
+        return `${token}${trailing}`;
+    });
+
+    let processed = apply(masked);
+
+    urls.forEach((url, index) => {
+        processed = processed.split(urlToken(index)).join(url);
+    });
+
+    return processed;
+};

--- a/packages/plasma-giga/src/components/Typography/typograph/withTypograph.tsx
+++ b/packages/plasma-giga/src/components/Typography/typograph/withTypograph.tsx
@@ -1,0 +1,33 @@
+import React, { forwardRef } from 'react';
+import type { FunctionComponent, RefAttributes } from 'react';
+
+import { typograph } from '.';
+import type { TypographProps } from '.';
+
+/**
+ * HOC: прогоняет строковые children через пайплайн типографики.
+ * По умолчанию включён. Массив задаёт пайплайн инстанса.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const withTypograph = <P extends Record<string, any>>(Component: FunctionComponent<P>) => {
+    const Wrapped = forwardRef<HTMLElement, P & TypographProps>((props, ref) => {
+        const { typograph: typographProp = true, children, ...rest } = props;
+
+        const nextChildren =
+            typographProp && typeof children === 'string'
+                ? typograph(children, typographProp === true ? undefined : typographProp)
+                : children;
+
+        const componentProps = ({
+            ...rest,
+            ref,
+            children: nextChildren,
+        } as unknown) as P & RefAttributes<HTMLElement>;
+
+        return <Component {...componentProps} />;
+    });
+
+    Wrapped.displayName = `withTypograph(${Component.displayName || Component.name || 'Component'})`;
+
+    return Wrapped;
+};

--- a/website/plasma-giga-docs/docs/components/Typography.mdx
+++ b/website/plasma-giga-docs/docs/components/Typography.mdx
@@ -37,6 +37,76 @@ title: Typography
 По умолчанию в типографике если текст превышает ширину элемента, то слова будут переноситься по пробелам.
 Чтобы запретить перенос по пробелам, необходимо установить свойство `noWrap` в значении `true`.
 
+## Типографская обработка текста
+Компоненты типографики сами текст не обрабатывают. Чтобы включить правила, оберните нужный компонент в `withTypograph`:
+
+- прямые кавычки заменяются на «ёлочки» и вложенные „лапки“;
+- после коротких слов (1–2 буквы) ставится неразрывный пробел, чтобы предлоги не висели в конце строки;
+- длинное и среднее тире прижимается к предыдущему слову и не переносится на новую строку.
+
+Обрабатывается только строка. Смешанные дети (`текст <Link /> ещё`) не меняются. URL на время обработки прячутся, чтобы не портить кавычки в query-параметрах.
+
+```tsx live
+import React from 'react';
+import { TextM, withTypograph } from '@salutejs/plasma-giga';
+
+export function App() {
+    const TextWithTypograph = withTypograph(TextM);
+
+    return (
+        <TextWithTypograph style={{ maxWidth: 240 }}>
+            {'он сказал "привет" в лесу — и ушёл'}
+        </TextWithTypograph>
+    );
+}
+```
+
+По умолчанию обёрнутый компонент берёт правила из модульного реестра: базовый набор плюс то, что добавили через `addTypographRule`. `typograph={false}` отключает обработку у конкретного инстанса. Массив на пропе — полный пайплайн только этого инстанса, реестр не читается.
+
+Менять реестр нужно один раз на старте приложения — уже смонтированные инстансы сами не пересчитаются.
+
+`addTypographRule` дописывает правило в конец текущего набора:
+
+```tsx
+import { addTypographRule } from '@salutejs/plasma-giga';
+
+// bootstrap приложения, не внутри компонента
+addTypographRule((text) => text.replace(/\(c\)/gi, '©'));
+```
+
+После этого любой компонент с `withTypograph` подхватит новое правило:
+
+```tsx
+const Text = withTypograph(TextM);
+
+<Text>в лесу — "цитата" (c)</Text>
+```
+
+`setTypographRules` полностью заменяет базовый набор и сбрасывает правила из `addTypographRule`. Например, оставить только кавычки и тире:
+
+```tsx
+import { setTypographRules, quotes, dash, defaultTypographRules } from '@salutejs/plasma-giga';
+
+// bootstrap приложения, не внутри компонента
+setTypographRules([quotes, dash]);
+
+// вернуть дефолт
+setTypographRules(defaultTypographRules);
+```
+
+Локальные правила для отдельного инстанса:
+
+```tsx
+import { TextM, withTypograph, createTypograph, quotes, dash } from '@salutejs/plasma-giga';
+
+const Text = withTypograph(TextM);
+const compact = createTypograph([quotes, dash]);
+
+<Text typograph={[compact]}>без предлогов</Text>
+```
+
+Та же функция `typograph()` доступна отдельно — например, для markdown-рендерера.
+
 ## Смена тега
 Если при использовании компонентов необходимо сменить тег, то можно использовать свойство `as`:
 


### PR DESCRIPTION
## PLASMA-GIGA

### Typography

- Добавил HOC для обработки правил  типографики у текстовых компонентов

### What/why changed

<img width="933" height="556" alt="изображение" src="https://github.com/user-attachments/assets/be070b38-b51e-4fca-8cb6-babfc643a717" />

Пример использования в песочнице дефолтных правил
https://stackblitz.com/edit/stackblitz-starters-yncypog1?file=app%2Fpage.tsx

Пример использования кастомных правил глобально
https://stackblitz.com/edit/stackblitz-starters-5rpyjm5e?file=app%2FsetupTypograph.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic typographic formatting for quotes, short-word spacing, and dash spacing.
  * Added `withTypograph` support for applying formatting to typography components, with options to customize or disable rules.
  * Preserved URLs during text formatting and supported mixed content.
  * Added a Storybook example demonstrating configurable typographic formatting.

* **Documentation**
  * Added usage guidance for default, custom, and standalone typographic processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-giga@0.358.0-canary.3066.32359014274.0
  npm install @salutejs/sdds-api-tests@0.20.0-canary.3066.32359014274.0
  # or 
  yarn add @salutejs/plasma-giga@0.358.0-canary.3066.32359014274.0
  yarn add @salutejs/sdds-api-tests@0.20.0-canary.3066.32359014274.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
