### PR TITLE
PLASMA-4263: add Overlay api in Drawer

### DIFF
--- a/packages/plasma-b2c/src/components/Drawer/Drawer.component-test.tsx
+++ b/packages/plasma-b2c/src/components/Drawer/Drawer.component-test.tsx
@@ -6,6 +6,11 @@ import { IconDone } from '@salutejs/plasma-icons';
 type DrawerDemoProps = {
     width?: string;
     height?: string;
+    overlayProps?: {
+        width?: string;
+        height?: string;
+        position?: 'absolute' | 'fixed';
+    };
     placement?: string;
     closeOnEsc?: boolean;
     closeOnOverlayClick?: boolean;
@@ -17,6 +22,7 @@ type DrawerDemoProps = {
     asModal?: boolean;
     customBackgroundColor?: string;
     customContentBackgroundColor?: string;
+    frame?: 'element' | 'document';
     'data-testid'?: string;
 };
 
@@ -41,9 +47,11 @@ describe('plasma-b2c: Drawer', () => {
 
     function Demo(props: DrawerDemoProps) {
         const [isOpen, setIsOpen] = React.useState(false);
+        const frameRef = React.useRef<HTMLDivElement>(null);
         const {
             width = '50vw',
             height,
+            overlayProps,
             placement = 'right',
             closePlacement = 'right',
             hasClose = true,
@@ -55,11 +63,12 @@ describe('plasma-b2c: Drawer', () => {
             closeOnOverlayClick = false,
             customBackgroundColor,
             customContentBackgroundColor,
+            frame,
             'data-testid': testId,
         } = props;
 
         return (
-            <div style={{ height: '480px', width: '500px' }}>
+            <div ref={frameRef} style={{ height: '480px', width: '500px', position: 'relative' }}>
                 <Button text="Open drawer" onClick={() => setIsOpen(true)} />
                 <Drawer
                     className="plasma-drawer"
@@ -71,6 +80,8 @@ describe('plasma-b2c: Drawer', () => {
                     closeOnOverlayClick={closeOnOverlayClick}
                     width={width}
                     height={height}
+                    overlayProps={overlayProps}
+                    frame={frame === 'element' ? frameRef : frame}
                     data-testid={testId}
                     customBackgroundColor={customBackgroundColor}
                     customContentBackgroundColor={customContentBackgroundColor}
@@ -214,6 +225,59 @@ describe('plasma-b2c: Drawer', () => {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(300);
         cy.get('.popup-base-root').should('not.exist');
+    });
+
+    it('props: overlayProps and default position in frame', () => {
+        mount(
+            <CypressTestDecorator>
+                <NoAnimationStyle />
+
+                <PopupBaseProvider>
+                    <Demo frame="element" overlayProps={{ width: '280px', height: '320px' }} />
+                </PopupBaseProvider>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('button').click();
+
+        cy.get('.drawer-overlay')
+            .should('have.css', 'width', '280px')
+            .and('have.css', 'height', '320px')
+            .and('have.css', 'position', 'absolute');
+    });
+
+    ([undefined, 'document'] as const).forEach((frame) => {
+        it(`default overlay position: fixed for ${frame ?? 'undefined'} frame`, () => {
+            mount(
+                <CypressTestDecorator>
+                    <NoAnimationStyle />
+
+                    <PopupBaseProvider>
+                        <Demo frame={frame} />
+                    </PopupBaseProvider>
+                </CypressTestDecorator>,
+            );
+
+            cy.get('button').click();
+
+            cy.get('.drawer-overlay').should('have.css', 'position', 'fixed');
+        });
+    });
+
+    it('props: overlayProps.position overrides default position', () => {
+        mount(
+            <CypressTestDecorator>
+                <NoAnimationStyle />
+
+                <PopupBaseProvider>
+                    <Demo frame="element" overlayProps={{ position: 'fixed' }} />
+                </PopupBaseProvider>
+            </CypressTestDecorator>,
+        );
+
+        cy.get('button').click();
+
+        cy.get('.drawer-overlay').should('have.css', 'position', 'fixed');
     });
 
     it('close X', () => {

--- a/packages/plasma-b2c/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-b2c/src/components/Drawer/Drawer.stories.tsx
@@ -1,217 +1,39 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupBaseProvider as PopupProvider } from '../PopupBase';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
+    },
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
     title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-    },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
 };
 
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
+export default meta;
 
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    closePlacement,
-    hasClose,
-    offsetX,
-    offsetY,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} offset={[offsetX, offsetY]} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
-        width: '50vw',
-        height: '100dvh',
-        borderRadius: 'none',
-    },
-    render: (args) => <StoryDrawerDemo {...args} />,
-};
+export { Default };

--- a/packages/plasma-giga/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-giga/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/plasma-homeds/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-homeds/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/plasma-new-hope/src/components/Drawer/Drawer.tsx
+++ b/packages/plasma-new-hope/src/components/Drawer/Drawer.tsx
@@ -27,6 +27,7 @@ export const drawerRoot = (Root: RootProps<HTMLDivElement, DrawerProps>) =>
                 zIndex,
                 popupInfo,
                 withBlur,
+                overlayProps,
                 children,
                 view,
                 size,
@@ -70,6 +71,8 @@ export const drawerRoot = (Root: RootProps<HTMLDivElement, DrawerProps>) =>
                 : `var(${tokens.drawerOverlayColor})`;
             const innerWidth = width ? getSizeValueFromProp(width) : '100%';
             const innerHeight = height ? getSizeValueFromProp(height) : '100%';
+            const overlayPosition =
+                overlayProps?.position ?? (frame === undefined || frame === 'document' ? 'fixed' : 'absolute');
 
             const placementClass = placement ? classes[`${placement}Placement` as keyof typeof classes] : undefined;
 
@@ -128,6 +131,7 @@ export const drawerRoot = (Root: RootProps<HTMLDivElement, DrawerProps>) =>
                                     transparent={transparent}
                                     isClickable={closeOnOverlayClick}
                                     onOverlayClick={onDrawerOverlayKeyDown}
+                                    style={{ ...overlayProps, position: overlayPosition }}
                                 />
                             </Root>
                         )

--- a/packages/plasma-new-hope/src/components/Drawer/Drawer.types.ts
+++ b/packages/plasma-new-hope/src/components/Drawer/Drawer.types.ts
@@ -1,3 +1,5 @@
+import type { CSSProperties } from 'react';
+
 import type { PopupProps } from '../Popup';
 import type { PanelProps } from '../Panel';
 import type { PopupHookArgs } from '../Popup/Popup.types';
@@ -15,6 +17,21 @@ export type DrawerAnimationInfo = {
     enter?: string;
     exit?: string;
 };
+
+export type DrawerOverlayProps = Pick<
+    CSSProperties,
+    | 'width'
+    | 'height'
+    | 'position'
+    | 'inset'
+    | 'top'
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'background'
+    | 'backdropFilter'
+    | 'cursor'
+>;
 
 export type DrawerProps = Omit<PopupProps, 'draggable' | 'resizable'> &
     PanelProps & {
@@ -57,6 +74,11 @@ export type DrawerProps = Omit<PopupProps, 'draggable' | 'resizable'> &
          * Нужно ли применять blur для подложки.
          */
         withBlur?: boolean;
+        /**
+         * Настройки подложки.
+         * По умолчанию `position` равен `fixed` для document и `absolute` для остальных frame.
+         */
+        overlayProps?: DrawerOverlayProps;
         /**
          * Закрывать модальное окно при нажатии на ESC(по умолчанию true).
          */

--- a/packages/plasma-new-hope/src/components/Drawer/index.ts
+++ b/packages/plasma-new-hope/src/components/Drawer/index.ts
@@ -2,5 +2,5 @@ export { drawerConfig, drawerRoot } from './Drawer';
 export * from './ui';
 
 export { classes as drawerClasses, tokens as drawerTokens } from './Drawer.tokens';
-export type { DrawerProps } from './Drawer.types';
+export type { DrawerOverlayProps, DrawerProps } from './Drawer.types';
 export type { ClosePlacementType } from '../Panel';

--- a/packages/plasma-new-hope/src/examples/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/components/Drawer/Drawer.stories.tsx
@@ -1,228 +1,43 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
+import React from 'react';
 import type { ComponentProps } from 'react';
-import type { StoryObj, Meta } from '@storybook/react-vite';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button/Button';
-import { WithTheme } from '../../_helpers';
 import { Heading } from '../typography/components/Heading/Heading';
-import { IconDone } from '../../../components/_Icon';
 import { SSRProvider } from '../../../components/SSRProvider';
 import { PopupProvider } from '../Popup/Popup';
-import type { ClosePlacementType } from '../../../components/Drawer';
 
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from './Drawer';
+import { config } from './Drawer.config';
 
-const meta: Meta<typeof Drawer> = {
-    title: 'Overlay/Drawer',
-    decorators: [WithTheme],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+type HeadingProps = ComponentProps<typeof Heading>;
+
+const H2 = (props: HeadingProps) => <Heading {...props} size="h2" />;
+const H3 = (props: HeadingProps) => <Heading {...props} size="h3" />;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
+    frame: 'theme-root',
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
 
 export default meta;
 
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    offsetX,
-    offsetY,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer
-                            frame="theme-root"
-                            opened={isOpen}
-                            offset={[offsetX, offsetY]}
-                            onClose={() => setIsOpen(false)}
-                            {...rest}
-                            overlayProps={{ background: 'red', left: '20%', right: '20%' }}
-                        >
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <Heading size="h3">Header</Heading>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <Heading size="h3">Footer</Heading>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <Heading style={{ margin: '2rem' }} size="h2">
-                                Some basic content
-                            </Heading>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
-        width: '50vw',
-        height: '100dvh',
-        borderRadius: 'none',
-    },
-    render: (args) => <StoryDrawerDemo {...args} />,
-};
+export { Default };

--- a/packages/plasma-new-hope/src/examples/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/components/Drawer/Drawer.stories.tsx
@@ -170,6 +170,7 @@ const StoryDrawerDemo = ({
                             offset={[offsetX, offsetY]}
                             onClose={() => setIsOpen(false)}
                             {...rest}
+                            overlayProps={{ background: 'red', left: '20%', right: '20%' }}
                         >
                             <DrawerHeader
                                 hasClose={hasClose}

--- a/packages/plasma-web/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/plasma-web/src/components/Drawer/Drawer.stories.tsx
@@ -1,216 +1,39 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupBaseProvider as PopupProvider } from '../PopupBase';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
+    },
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
     title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-    },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
 };
 
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
+export default meta;
 
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    closePlacement,
-    hasClose,
-    offsetX,
-    offsetY,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} offset={[offsetX, offsetY]} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
-        width: '50vw',
-        height: '100dvh',
-    },
-    render: (args) => <StoryDrawerDemo {...args} />,
-};
+export { Default };

--- a/packages/sdds-bizcom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-bizcom/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-cs/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-cs/src/components/Drawer/Drawer.stories.tsx
@@ -1,217 +1,43 @@
-import React, { useState } from 'react';
-import styled from '@emotion/styled';
 import type { ComponentProps } from 'react';
-import { disableProps, InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        ...disableProps(['view', 'size']),
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-    color: var(--text-secondary);
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+    iconButtonColor: 'var(--text-secondary)',
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-dfa/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-dfa/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-finai/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-finai/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-insol-next/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-insol-next/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-insol/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-insol/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-netology/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-netology/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-os/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-os/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-platform-ai/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-platform-ai/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-sbcom/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-sbcom/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,43 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/⚠️ Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+    title: 'Overlay/⚠️ Drawer',
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/⚠️ Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-scan/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-scan/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/packages/sdds-serv/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/sdds-serv/src/components/Drawer/Drawer.stories.tsx
@@ -1,215 +1,42 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
 import type { ComponentProps } from 'react';
-import { InSpacingDecorator } from '@salutejs/plasma-sb-utils';
-import type { StoryObj, Meta } from '@storybook/react-vite';
-import { IconDone } from '@salutejs/plasma-icons';
+import type { Meta } from '@storybook/react-vite';
+import { getDrawerStories } from '@salutejs/plasma-sb-utils';
 
 import { Button } from '../Button';
 import { SSRProvider } from '../SSRProvider';
 import { H2, H3 } from '../Typography';
 import { PopupProvider } from '../Popup';
 
-import type { ClosePlacementType } from '.';
+import { config } from './Drawer.config';
+
 import { Drawer, DrawerContent, DrawerFooter, DrawerHeader } from '.';
 
-export default {
-    title: 'Overlay/Drawer',
-    decorators: [InSpacingDecorator],
-    argTypes: {
-        placement: {
-            options: ['top', 'bottom', 'right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'center' } },
-        },
-        offsetX: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        offsetY: {
-            control: {
-                type: 'number',
-            },
-            table: { defaultValue: { summary: 0 } },
-        },
-        closeOnEsc: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closeOnOverlayClick: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        withBlur: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: false } },
-        },
-        showHeader: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showFooter: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        showActions: {
-            control: {
-                type: 'boolean',
-            },
-            table: { defaultValue: { summary: true } },
-        },
-        closePlacement: {
-            options: ['right', 'left'],
-            control: {
-                type: 'select',
-            },
-            table: { defaultValue: { summary: 'right' } },
-        },
-        borderRadius: {
-            options: ['none', 'default'],
-            control: {
-                type: 'select',
-            },
-        },
-        customBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
-        customContentBackgroundColor: {
-            control: {
-                type: 'color',
-            },
-        },
+type DrawerProps = ComponentProps<typeof Drawer>;
+
+const { meta: META, Default } = getDrawerStories({
+    component: Drawer,
+    componentConfig: config,
+    additionalComponents: {
+        Button,
+        DrawerContent,
+        DrawerFooter,
+        DrawerHeader,
+        H2,
+        H3,
+        PopupProvider,
+        SSRProvider,
     },
-} as Meta;
-
-type StoryDrawerProps = ComponentProps<typeof Drawer> & {
-    placement: string;
-    offsetX: number;
-    offsetY: number;
-    closeOnEsc: boolean;
-    closeOnOverlayClick: boolean;
-    showHeader: boolean;
-    showFooter: boolean;
-    showActions: boolean;
-    closePlacement: string;
-    hasClose: boolean;
-    asModal: boolean;
-};
-
-const StyledWrapper = styled.div`
-    height: 100vh;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-`;
-
-const StyledContentWrapper = styled.div`
-    height: 80%;
-    display: flex;
-    flex-grow: 1;
-`;
-
-const StyledContent = styled.div`
-    background: #a8a875;
-    flex-grow: 1;
-    height: 100%;
-`;
-
-const StyledSection = styled.div`
-    background: #808080;
-    min-height: 20%;
-`;
-
-const StyledIconButton = styled(Button)`
-    position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
-`;
-
-const StoryDrawerDemo = ({
-    showHeader,
-    showFooter,
-    showActions,
-    hasClose,
-    closePlacement,
-    ...rest
-}: StoryDrawerProps) => {
-    const [isOpen, setIsOpen] = useState(false);
-
-    return (
-        <SSRProvider>
-            <PopupProvider>
-                <StyledWrapper>
-                    <StyledSection>
-                        <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
-                    </StyledSection>
-                    <StyledContentWrapper>
-                        <Drawer opened={isOpen} onClose={() => setIsOpen(false)} {...rest}>
-                            <DrawerHeader
-                                hasClose={hasClose}
-                                closePlacement={closePlacement as ClosePlacementType}
-                                actions={
-                                    showActions && (
-                                        <StyledIconButton size="s" view="clear">
-                                            <IconDone size="s" color="inherit" />
-                                        </StyledIconButton>
-                                    )
-                                }
-                                onClose={() => setIsOpen(false)}
-                            >
-                                {showHeader && <H3>Header</H3>}
-                            </DrawerHeader>
-                            <DrawerContent>Content</DrawerContent>
-                            {showFooter && (
-                                <DrawerFooter>
-                                    <H3>Footer</H3>
-                                </DrawerFooter>
-                            )}
-                        </Drawer>
-                        <StyledContent>
-                            <H2 style={{ margin: '2rem' }}>Some basic content</H2>
-                        </StyledContent>
-                    </StyledContentWrapper>
-                    <StyledSection />
-                </StyledWrapper>
-            </PopupProvider>
-        </SSRProvider>
-    );
-};
-
-export const DrawerDemo: StoryObj<StoryDrawerProps> = {
-    args: {
-        placement: 'right',
-        withBlur: false,
-        closeOnEsc: true,
-        closeOnOverlayClick: true,
-        offsetX: 0,
-        offsetY: 0,
-        showHeader: true,
-        showFooter: true,
-        showActions: true,
-        hasClose: true,
-        asModal: true,
-        closePlacement: 'right',
+    defaultArgs: {
         width: '25vw',
-        height: '100dvh',
-        borderRadius: 'none',
     },
-    render: (args) => <StoryDrawerDemo {...args} />,
+    disablePropsList: ['view', 'size'],
+});
+
+const meta: Meta<DrawerProps> = {
+    ...META,
+    title: 'Overlay/Drawer',
 };
+
+export default meta;
+
+export { Default };

--- a/utils/plasma-sb-utils/src/components/Drawer/Drawer.tsx
+++ b/utils/plasma-sb-utils/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { getConfigVariations } from '../../helpers';
+
+import { createMeta } from './meta';
+import { createDefaultStory } from './stories';
+
+type CreateDrawerStoriesProps = {
+    component: any;
+    componentConfig: any;
+    additionalComponents: {
+        Button: React.ComponentType<any>;
+        DrawerContent: React.ComponentType<any>;
+        DrawerFooter: React.ComponentType<any>;
+        DrawerHeader: React.ComponentType<any>;
+        H2: React.ComponentType<any>;
+        H3: React.ComponentType<any>;
+        PopupProvider: React.ComponentType<any>;
+        SSRProvider: React.ComponentType<any>;
+    };
+    title?: string;
+    disablePropsList?: string[];
+    defaultArgs?: {};
+    additionalArgTypes?: {};
+    frame?: string;
+    iconButtonColor?: string;
+};
+
+export const getDrawerStories = (config: CreateDrawerStoriesProps) => {
+    const { component, componentConfig, additionalComponents, frame, iconButtonColor, ...rest } = config;
+
+    const meta = createMeta({
+        component,
+        componentConfig: getConfigVariations(componentConfig),
+        ...rest,
+    });
+
+    const DefaultStoryComponent = createDefaultStory(component, additionalComponents, { frame, iconButtonColor });
+
+    const Default = {
+        render: (args: any) => <DefaultStoryComponent {...args} />,
+    };
+
+    return { meta, Default };
+};

--- a/utils/plasma-sb-utils/src/components/Drawer/fixtures.ts
+++ b/utils/plasma-sb-utils/src/components/Drawer/fixtures.ts
@@ -1,0 +1,3 @@
+export const placements = ['top', 'bottom', 'right', 'left'];
+export const closePlacements = ['right', 'left'];
+export const borderRadiuses = ['none', 'default'];

--- a/utils/plasma-sb-utils/src/components/Drawer/index.ts
+++ b/utils/plasma-sb-utils/src/components/Drawer/index.ts
@@ -1,0 +1,1 @@
+export * from './Drawer';

--- a/utils/plasma-sb-utils/src/components/Drawer/meta.ts
+++ b/utils/plasma-sb-utils/src/components/Drawer/meta.ts
@@ -1,0 +1,153 @@
+import { disableProps, InSpacingDecorator } from '../../index';
+
+import { borderRadiuses, closePlacements, placements } from './fixtures';
+
+type CreateMetaProps = {
+    component: any;
+    componentConfig: any;
+    title?: string;
+    defaultArgs?: {};
+    additionalArgTypes?: {};
+    disablePropsList?: string[];
+};
+
+const commonDisabledArgs = [
+    'children',
+    'frame',
+    'isOpen',
+    'offset',
+    'onClose',
+    'onEscKeyDown',
+    'onOverlayClick',
+    'opened',
+    'overlay',
+];
+
+export const createMeta = ({
+    component,
+    componentConfig,
+    title = 'Overlay/Drawer',
+    defaultArgs = {},
+    additionalArgTypes = {},
+    disablePropsList = [],
+}: CreateMetaProps) => ({
+    title,
+    decorators: [InSpacingDecorator],
+    component,
+    args: {
+        view: 'default',
+        size: 'm',
+        placement: 'right',
+        withBlur: false,
+        closeOnEsc: true,
+        closeOnOverlayClick: true,
+        offsetX: 0,
+        offsetY: 0,
+        showHeader: true,
+        showFooter: true,
+        showActions: true,
+        hasClose: true,
+        asModal: true,
+        overlayProps: {
+            background: '',
+            top: '0',
+            left: '0',
+            width: '100%',
+            height: '100%',
+        },
+        closePlacement: 'right',
+        width: '50vw',
+        height: '100dvh',
+        borderRadius: 'none',
+        ...defaultArgs,
+    },
+    argTypes: {
+        view: {
+            options: componentConfig.views,
+            control: { type: 'select' },
+            table: { category: 'variation' },
+        },
+        size: {
+            options: componentConfig.sizes,
+            control: { type: 'select' },
+            table: { category: 'variation' },
+        },
+        borderRadius: {
+            options: borderRadiuses,
+            control: { type: 'select' },
+            table: { category: 'variation' },
+        },
+        customBackgroundColor: {
+            control: { type: 'color' },
+            table: { category: 'variation' },
+        },
+        customContentBackgroundColor: {
+            control: { type: 'color' },
+            table: { category: 'variation' },
+        },
+        placement: {
+            options: placements,
+            control: { type: 'select' },
+            table: { category: 'layout', defaultValue: { summary: 'right' } },
+        },
+        width: {
+            control: { type: 'text' },
+            table: { category: 'layout' },
+        },
+        height: {
+            control: { type: 'text' },
+            table: { category: 'layout' },
+        },
+        offsetX: {
+            control: { type: 'number' },
+            table: { category: 'layout', defaultValue: { summary: 0 } },
+        },
+        offsetY: {
+            control: { type: 'number' },
+            table: { category: 'layout', defaultValue: { summary: 0 } },
+        },
+        closeOnEsc: {
+            control: { type: 'boolean' },
+            table: { category: 'overlay', defaultValue: { summary: true } },
+        },
+        closeOnOverlayClick: {
+            control: { type: 'boolean' },
+            table: { category: 'overlay', defaultValue: { summary: true } },
+        },
+        withBlur: {
+            control: { type: 'boolean' },
+            table: { category: 'overlay', defaultValue: { summary: false } },
+        },
+        asModal: {
+            control: { type: 'boolean' },
+            table: { category: 'overlay' },
+        },
+        overlayProps: {
+            control: { type: 'object' },
+            table: { category: 'overlay' },
+        },
+        showHeader: {
+            control: { type: 'boolean' },
+            table: { category: 'story' },
+        },
+        showFooter: {
+            control: { type: 'boolean' },
+            table: { category: 'story' },
+        },
+        showActions: {
+            control: { type: 'boolean' },
+            table: { category: 'story' },
+        },
+        hasClose: {
+            control: { type: 'boolean' },
+            table: { category: 'story' },
+        },
+        closePlacement: {
+            options: closePlacements,
+            control: { type: 'select' },
+            table: { category: 'story', defaultValue: { summary: 'right' } },
+        },
+        ...additionalArgTypes,
+        ...disableProps([...commonDisabledArgs, ...disablePropsList]),
+    },
+});

--- a/utils/plasma-sb-utils/src/components/Drawer/stories.tsx
+++ b/utils/plasma-sb-utils/src/components/Drawer/stories.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { IconDone } from '@salutejs/plasma-icons';
+import { action } from 'storybook/actions';
+
+type Components = {
+    Button: React.ComponentType<any>;
+    DrawerContent: React.ComponentType<any>;
+    DrawerFooter: React.ComponentType<any>;
+    DrawerHeader: React.ComponentType<any>;
+    H2: React.ComponentType<any>;
+    H3: React.ComponentType<any>;
+    PopupProvider: React.ComponentType<any>;
+    SSRProvider: React.ComponentType<any>;
+};
+
+type StoryConfig = {
+    frame?: string;
+    iconButtonColor?: string;
+};
+
+const onCloseAction = action('onClose');
+
+const wrapperStyle: React.CSSProperties = {
+    height: '100vh',
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+};
+
+const contentWrapperStyle: React.CSSProperties = {
+    height: '80%',
+    display: 'flex',
+    flexGrow: 1,
+};
+
+const contentStyle: React.CSSProperties = {
+    background: '#a8a875',
+    flexGrow: 1,
+    height: '100%',
+};
+
+const sectionStyle: React.CSSProperties = {
+    background: '#808080',
+    minHeight: '20%',
+};
+
+export const createDefaultStory = (
+    Drawer: React.ComponentType<any>,
+    { Button, DrawerContent, DrawerFooter, DrawerHeader, H2, H3, PopupProvider, SSRProvider }: Components,
+    { frame, iconButtonColor }: StoryConfig = {},
+) => {
+    return ({ showHeader, showFooter, showActions, hasClose, closePlacement, offsetX, offsetY, ...rest }: any) => {
+        const [isOpen, setIsOpen] = useState(false);
+
+        const onClose = () => {
+            setIsOpen(false);
+            onCloseAction();
+        };
+
+        return (
+            <SSRProvider>
+                <PopupProvider>
+                    <div style={wrapperStyle}>
+                        <div style={sectionStyle}>
+                            <Button text="Открыть панель" onClick={() => setIsOpen(true)} />
+                        </div>
+                        <div style={contentWrapperStyle}>
+                            <Drawer
+                                {...rest}
+                                frame={frame}
+                                opened={isOpen}
+                                offset={[offsetX, offsetY]}
+                                onClose={onClose}
+                            >
+                                <DrawerHeader
+                                    hasClose={hasClose}
+                                    closePlacement={closePlacement}
+                                    actions={
+                                        showActions && (
+                                            <Button
+                                                size="s"
+                                                view="clear"
+                                                style={{
+                                                    position: 'relative',
+                                                    width: '1.5rem',
+                                                    height: '1.5rem',
+                                                    color: iconButtonColor,
+                                                }}
+                                            >
+                                                <IconDone size="s" color="inherit" />
+                                            </Button>
+                                        )
+                                    }
+                                    onClose={onClose}
+                                >
+                                    {showHeader && <H3>Header</H3>}
+                                </DrawerHeader>
+                                <DrawerContent>Content</DrawerContent>
+                                {showFooter && (
+                                    <DrawerFooter>
+                                        <H3>Footer</H3>
+                                    </DrawerFooter>
+                                )}
+                            </Drawer>
+                            <div style={contentStyle}>
+                                <H2 style={{ margin: '2rem' }}>Some basic content</H2>
+                            </div>
+                        </div>
+                        <div style={sectionStyle} />
+                    </div>
+                </PopupProvider>
+            </SSRProvider>
+        );
+    };
+};

--- a/utils/plasma-sb-utils/src/components/index.ts
+++ b/utils/plasma-sb-utils/src/components/index.ts
@@ -34,6 +34,7 @@ export * from './Select';
 export * from './Combobox';
 export * from './Dropdown';
 export * from './BottomSheet';
+export * from './Drawer';
 export * from './Popover';
 export * from './Dropzone';
 export * from './Progress';

--- a/website/plasma-b2c-docs/docs/components/Drawer.mdx
+++ b/website/plasma-b2c-docs/docs/components/Drawer.mdx
@@ -136,10 +136,15 @@ export function App() {
                     isOpen={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/plasma-giga-docs/docs/components/Drawer.mdx
+++ b/website/plasma-giga-docs/docs/components/Drawer.mdx
@@ -135,10 +135,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/plasma-web-docs/docs/components/Drawer.mdx
+++ b/website/plasma-web-docs/docs/components/Drawer.mdx
@@ -137,10 +137,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-bizcom-docs/docs/components/Drawer.mdx
+++ b/website/sdds-bizcom-docs/docs/components/Drawer.mdx
@@ -135,10 +135,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-cs-docs/docs/components/Drawer.mdx
+++ b/website/sdds-cs-docs/docs/components/Drawer.mdx
@@ -145,10 +145,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-dfa-docs/docs/components/Drawer.mdx
+++ b/website/sdds-dfa-docs/docs/components/Drawer.mdx
@@ -135,10 +135,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-finai-docs/docs/components/Drawer.mdx
+++ b/website/sdds-finai-docs/docs/components/Drawer.mdx
@@ -135,10 +135,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-insol-docs/docs/components/Drawer.mdx
+++ b/website/sdds-insol-docs/docs/components/Drawer.mdx
@@ -145,10 +145,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-insol-next-docs/docs/components/Drawer.mdx
+++ b/website/sdds-insol-next-docs/docs/components/Drawer.mdx
@@ -145,10 +145,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-netology-docs/docs/components/Drawer.mdx
+++ b/website/sdds-netology-docs/docs/components/Drawer.mdx
@@ -135,10 +135,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-platform-ai-docs/docs/components/Drawer.mdx
+++ b/website/sdds-platform-ai-docs/docs/components/Drawer.mdx
@@ -147,10 +147,15 @@ export function App() {
                         opened={isOpenB}
                         onClose={() => setIsOpenB(false)}
                         placement="right"
-                        asModal={false}
+                        asModal={true}
                         frame={ref}
                         width="250px"
                         height="100%"
+                        overlayProps={{
+                            width: "100%",
+                            height: "100%",
+                            position: "absolute"
+                        }}
                     >
                             <DrawerHeader
                                 hasClose={true}

--- a/website/sdds-sbcom-docs/docs/components/Drawer.mdx
+++ b/website/sdds-sbcom-docs/docs/components/Drawer.mdx
@@ -144,10 +144,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-scan-docs/docs/components/Drawer.mdx
+++ b/website/sdds-scan-docs/docs/components/Drawer.mdx
@@ -135,10 +135,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}

--- a/website/sdds-serv-docs/docs/components/Drawer.mdx
+++ b/website/sdds-serv-docs/docs/components/Drawer.mdx
@@ -145,10 +145,15 @@ export function App() {
                     opened={isOpenB}
                     onClose={() => setIsOpenB(false)}
                     placement="right"
-                    asModal={false}
+                    asModal={true}
                     frame={ref}
                     width="250px"
                     height="100%"
+                    overlayProps={{
+                        width: "100%",
+                        height: "100%",
+                        position: "absolute"
+                    }}
                 >
                         <DrawerHeader
                             hasClose={true}


### PR DESCRIPTION
## Core

### Drawer

- добавлены `overlayProps` для настройки `overlay`

### What/why changed
<img width="2097" height="1257" alt="Снимок экрана 2026-08-24 123701" src="https://github.com/user-attachments/assets/6366cb95-4854-4129-9b01-ace0c3f80b2e" />

- добавлены `overlayProps` для настройки `overlay`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.391.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-b2c@1.633.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-colors@0.21.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-core@1.240.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-giga@0.360.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-homeds@0.360.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-hope@1.387.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-icons@1.248.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-new-hope@0.377.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-tokens@1.151.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-tokens-b2b@1.64.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-tokens-b2c@0.75.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-tokens-core@0.12.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-tokens-web@1.79.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-typo@0.52.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-web@1.635.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-bizcom@0.365.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-cs@0.369.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-dfa@0.363.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-finai@0.356.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-icons@0.5.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-insol@0.360.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-insol-next@0.359.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-netology@0.364.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-os@0.35.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-platform-ai@0.364.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-sbcom@0.365.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-scan@0.363.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-serv@0.364.0-canary.3089.33159208733.0
  npm install @salutejs/core-themes@0.40.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-themes@0.62.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-themes@0.78.0-canary.3089.33159208733.0
  npm install @salutejs/sdds-api-tests@0.22.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-cy-utils@0.170.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-sb-utils@0.241.0-canary.3089.33159208733.0
  npm install @salutejs/plasma-tokens-utils@0.60.0-canary.3089.33159208733.0
  # or 
  yarn add @salutejs/plasma-asdk@0.391.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-b2c@1.633.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-colors@0.21.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-core@1.240.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-giga@0.360.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-homeds@0.360.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-hope@1.387.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-icons@1.248.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-new-hope@0.377.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-tokens@1.151.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-tokens-b2b@1.64.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-tokens-b2c@0.75.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-tokens-core@0.12.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-tokens-web@1.79.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-typo@0.52.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-web@1.635.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-bizcom@0.365.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-cs@0.369.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-dfa@0.363.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-finai@0.356.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-icons@0.5.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-insol@0.360.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-insol-next@0.359.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-netology@0.364.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-os@0.35.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-platform-ai@0.364.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-sbcom@0.365.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-scan@0.363.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-serv@0.364.0-canary.3089.33159208733.0
  yarn add @salutejs/core-themes@0.40.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-themes@0.62.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-themes@0.78.0-canary.3089.33159208733.0
  yarn add @salutejs/sdds-api-tests@0.22.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-cy-utils@0.170.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-sb-utils@0.241.0-canary.3089.33159208733.0
  yarn add @salutejs/plasma-tokens-utils@0.60.0-canary.3089.33159208733.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drawer overlays support customizable dimensions, positioning, and styling.
  * Overlay positioning adapts to document- or element-based frames.
  * Standardized Drawer stories and controls are available across Storybook.
* **Bug Fixes**
  * Framed modal Drawers now correctly fill and position overlays within their frame.
* **Documentation**
  * Updated Drawer examples to demonstrate full-size modal overlays inside frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->