### PR TITLE
PLASMA-7996: update Steps with Accordion example

### DIFF
--- a/website/sdds-finai-docs/docs/components/Steps.mdx
+++ b/website/sdds-finai-docs/docs/components/Steps.mdx
@@ -565,7 +565,7 @@ import React, { useState } from 'react';
 import { Steps, Accordion, AccordionItem } from '@salutejs/sdds-finai';
 
 export function App() {
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false);
 
     const [innerSteps, setInnerSteps] = useState([{
         indicator: 1,
@@ -584,8 +584,8 @@ export function App() {
     }]);
 
     const [outerStatuses, setOuterStatuses] = useState([
-        { status: 'completed' },
         { status: 'active' },
+        { status: 'inactive' },
         { status: 'inactive' },
     ]);
 
@@ -609,6 +609,10 @@ export function App() {
             next[idx] = { ...next[idx], status: 'active' };
             return next;
         });
+
+        if (idx === 1) {
+            setOpen(v => !v);
+        }
     };
 
     const outerItems = [{
@@ -618,15 +622,15 @@ export function App() {
         ...outerStatuses[0],
     }, {
         indicator: 2,
-        title: 'Установка',
         height: open ? '16rem' : '7rem',
         content: (
-            <Accordion stretching="filled">
+            <Accordion size="h4" view="clear" stretching="filled">
                 <AccordionItem
                     title="Шаги установки"
                     type="arrow"
                     opened={open}
                     onClick={() => setOpen(v => !v)}
+                    style={{ marginTop: '-10px' }}
                 >
                     <Steps
                         orientation="vertical"


### PR DESCRIPTION
## SDDS-FINAI

### Steps

- расширен пример документации с вложенным `Accordion`

### What/why changed

- расширен пример документации с вложенным `Accordion`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the nested steps with accordion example.
  - The accordion is now collapsed by default and opens when the second step is selected.
  - Revised initial step statuses to better reflect the active workflow.
  - Improved accordion sizing, appearance, stretching, and spacing in the example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.390.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-b2c@1.632.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-colors@0.20.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-core@1.239.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-giga@0.359.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-homeds@0.359.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-hope@1.386.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-icons@1.247.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-new-hope@0.376.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-tokens@1.150.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-tokens-b2b@1.63.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-tokens-b2c@0.74.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-tokens-core@0.11.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-tokens-web@1.78.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-typo@0.51.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-web@1.634.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-bizcom@0.364.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-cs@0.368.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-dfa@0.362.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-finai@0.355.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-icons@0.4.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-insol@0.359.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-insol-next@0.358.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-netology@0.363.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-os@0.34.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-platform-ai@0.363.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-sbcom@0.364.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-scan@0.362.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-serv@0.363.1-canary.3099.33060714615.0
  npm install @salutejs/core-themes@0.39.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-themes@0.61.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-themes@0.77.1-canary.3099.33060714615.0
  npm install @salutejs/sdds-api-tests@0.21.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-cy-utils@0.169.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-sb-utils@0.240.1-canary.3099.33060714615.0
  npm install @salutejs/plasma-tokens-utils@0.59.1-canary.3099.33060714615.0
  # or 
  yarn add @salutejs/plasma-asdk@0.390.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-b2c@1.632.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-colors@0.20.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-core@1.239.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-giga@0.359.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-homeds@0.359.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-hope@1.386.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-icons@1.247.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-new-hope@0.376.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-tokens@1.150.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-tokens-b2b@1.63.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-tokens-b2c@0.74.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-tokens-core@0.11.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-tokens-web@1.78.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-typo@0.51.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-web@1.634.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-bizcom@0.364.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-cs@0.368.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-dfa@0.362.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-finai@0.355.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-icons@0.4.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-insol@0.359.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-insol-next@0.358.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-netology@0.363.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-os@0.34.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-platform-ai@0.363.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-sbcom@0.364.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-scan@0.362.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-serv@0.363.1-canary.3099.33060714615.0
  yarn add @salutejs/core-themes@0.39.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-themes@0.61.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-themes@0.77.1-canary.3099.33060714615.0
  yarn add @salutejs/sdds-api-tests@0.21.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-cy-utils@0.169.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-sb-utils@0.240.1-canary.3099.33060714615.0
  yarn add @salutejs/plasma-tokens-utils@0.59.1-canary.3099.33060714615.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
