### PR TITLE
PLASMA-4901: fix typography short name

### DIFF
--- a/packages/plasma-b2c/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/plasma-b2c/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/plasma-giga/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/plasma-giga/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/plasma-homeds/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/plasma-homeds/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/plasma-new-hope/src/examples/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/plasma-new-hope/src/examples/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/plasma-web/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/plasma-web/src/components/Tokens/Typography/Typography.stories.tsx
@@ -157,9 +157,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-bizcom/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-bizcom/src/components/Tokens/Typography/Typography.stories.tsx
@@ -168,9 +168,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-cs/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-cs/src/components/Tokens/Typography/Typography.stories.tsx
@@ -155,9 +155,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-dfa/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-dfa/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-finai/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-finai/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-insol-next/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-insol-next/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-insol/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-insol/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-netology/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-netology/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-os/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-os/src/components/Tokens/Typography/Typography.stories.tsx
@@ -157,9 +157,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-platform-ai/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-platform-ai/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-sbcom/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-sbcom/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-scan/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-scan/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>

--- a/packages/sdds-serv/src/components/Tokens/Typography/Typography.stories.tsx
+++ b/packages/sdds-serv/src/components/Tokens/Typography/Typography.stories.tsx
@@ -156,9 +156,7 @@ const TokenData: FC<TokenDataProps> = ({ title, token, size, fontFamily, fontWei
 
     return (
         <AccordionInfo>
-            <TokenShortName onClick={copyFontTokens}>
-                {actualTitle} {fontWeight.charAt(0).toLocaleUpperCase()}
-            </TokenShortName>
+            <TokenShortName onClick={copyFontTokens}>{actualTitle}</TokenShortName>
 
             <TokenInfo>
                 <TokenText {...data} isDisplay={token === 'dspl'}>


### PR DESCRIPTION
### What/why changed

- Исправлено отображение названия токенов типографики, к токенам приписывалась первая буква формата (`Normal` или `Bold`)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.392.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-b2c@1.634.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-colors@0.22.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-core@1.241.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-giga@0.361.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-homeds@0.361.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-hope@1.388.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-icons@1.249.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-new-hope@0.378.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-tokens@1.152.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-tokens-b2b@1.65.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-tokens-b2c@0.76.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-tokens-core@0.13.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-tokens-web@1.80.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-typo@0.53.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-web@1.636.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-bizcom@0.366.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-cs@0.370.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-dfa@0.364.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-finai@0.357.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-icons@0.6.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-insol@0.361.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-insol-next@0.360.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-netology@0.365.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-os@0.36.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-platform-ai@0.365.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-sbcom@0.366.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-scan@0.364.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-serv@0.365.1-canary.3128.33701026869.0
  npm install @salutejs/core-themes@0.41.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-themes@0.63.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-themes@0.79.1-canary.3128.33701026869.0
  npm install @salutejs/sdds-api-tests@0.23.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-cy-utils@0.171.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-sb-utils@0.242.1-canary.3128.33701026869.0
  npm install @salutejs/plasma-tokens-utils@0.61.1-canary.3128.33701026869.0
  # or 
  yarn add @salutejs/plasma-asdk@0.392.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-b2c@1.634.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-colors@0.22.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-core@1.241.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-giga@0.361.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-homeds@0.361.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-hope@1.388.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-icons@1.249.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-new-hope@0.378.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-tokens@1.152.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-tokens-b2b@1.65.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-tokens-b2c@0.76.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-tokens-core@0.13.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-tokens-web@1.80.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-typo@0.53.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-web@1.636.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-bizcom@0.366.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-cs@0.370.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-dfa@0.364.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-finai@0.357.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-icons@0.6.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-insol@0.361.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-insol-next@0.360.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-netology@0.365.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-os@0.36.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-platform-ai@0.365.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-sbcom@0.366.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-scan@0.364.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-serv@0.365.1-canary.3128.33701026869.0
  yarn add @salutejs/core-themes@0.41.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-themes@0.63.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-themes@0.79.1-canary.3128.33701026869.0
  yarn add @salutejs/sdds-api-tests@0.23.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-cy-utils@0.171.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-sb-utils@0.242.1-canary.3128.33701026869.0
  yarn add @salutejs/plasma-tokens-utils@0.61.1-canary.3128.33701026869.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Typography token labels now display only the typography title across component stories.
  * Removed the appended font-weight initial from displayed labels.
  * Copy-on-click behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->