### PR TITLE
feat(Combobox): add sortItems API

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.component-test.tsx
@@ -2642,6 +2642,122 @@ describeFn('Combobox', () => {
         cy.get('ul').find('li').should('have.length', 4);
     });
 
+    it('flow: custom sortItems', () => {
+        cy.viewport(500, 500);
+
+        const sortExampleItems = [
+            { value: 'c', label: 'Charlie' },
+            { value: 'a', label: 'Alpha' },
+            { value: 'b', label: 'Bravo' },
+        ];
+
+        const Component = () => {
+            return (
+                <div style={{ width: '300px' }}>
+                    <Combobox
+                        id="combobox"
+                        label="Label"
+                        placeholder="Placeholder"
+                        items={sortExampleItems}
+                        sortItems={(list) => [...list].sort((a, b) => a.label.localeCompare(b.label))}
+                        listMaxHeight="300px"
+                        alwaysOpened
+                    />
+                </div>
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('ul').should('be.visible');
+        cy.get('ul')
+            .find('li')
+            .then(($lis) => {
+                expect($lis.eq(0)).to.contain('Alpha');
+                expect($lis.eq(1)).to.contain('Bravo');
+                expect($lis.eq(2)).to.contain('Charlie');
+            });
+    });
+
+    it('flow: sortItems freezes order while list is open', () => {
+        cy.viewport(800, 500);
+
+        type NestedItem = {
+            value: string;
+            label: string;
+            items?: NestedItem[];
+        };
+
+        const nestedItems: NestedItem[] = [
+            {
+                value: 'europe',
+                label: 'Europe',
+                items: [
+                    { value: 'berlin', label: 'Berlin' },
+                    { value: 'paris', label: 'Paris' },
+                ],
+            },
+            {
+                value: 'asia',
+                label: 'Asia',
+                items: [
+                    { value: 'tokyo', label: 'Tokyo' },
+                    { value: 'osaka', label: 'Osaka' },
+                ],
+            },
+        ];
+
+        const Component = () => {
+            const [value, setValue] = useState<string[]>(['berlin']);
+
+            const sortSelectedFirst = (list: NestedItem[]) =>
+                [...list].sort((a, b) => {
+                    const hasSelected = (item: NestedItem): boolean =>
+                        value.includes(item.value) || Boolean(item.items?.some((child) => value.includes(child.value)));
+
+                    return Number(hasSelected(b)) - Number(hasSelected(a));
+                });
+
+            return (
+                <div style={{ width: '300px' }}>
+                    <Combobox
+                        id="combobox"
+                        multiple
+                        label="Label"
+                        placeholder="Placeholder"
+                        items={nestedItems}
+                        value={value}
+                        onChange={setValue}
+                        listMaxHeight="300px"
+                        sortItems={sortSelectedFirst}
+                    />
+                </div>
+            );
+        };
+
+        mount(<Component />);
+
+        cy.get('#combobox').click();
+
+        // При открытии Europe выше (есть berlin).
+        cy.get('[id$="tree_level_1"]').find('li').eq(0).should('contain', 'Europe');
+        cy.get('[id$="tree_level_1"]').find('li').eq(1).should('contain', 'Asia');
+
+        // Выбираем Tokyo — порядок верхнего уровня не должен меняться, пока список открыт.
+        cy.get('[id$="tree_level_1"]').contains('li', 'Asia').trigger('mouseover');
+        cy.get('[id$="tree_level_2"]').contains('li', 'Tokyo').click({ force: true });
+
+        cy.get('[id$="tree_level_1"]').find('li').eq(0).should('contain', 'Europe');
+        cy.get('[id$="tree_level_1"]').find('li').eq(1).should('contain', 'Asia');
+
+        // После закрытия и повторного открытия Asia поднимается вверх.
+        cy.get('body').click(0, 0);
+        cy.get('#combobox').click();
+
+        cy.get('[id$="tree_level_1"]').find('li').eq(0).should('contain', 'Asia');
+        cy.get('[id$="tree_level_1"]').find('li').eq(1).should('contain', 'Europe');
+    });
+
     it('flow: single mode, async items loading', () => {
         const Component = () => {
             const [value, setValue] = useState('');

--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.tsx
@@ -81,6 +81,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             renderItem,
             renderSelectionIcon,
             filter,
+            sortItems,
             closeAfterSelect: outerCloseAfterSelect,
             onChangeValue,
             filterValue,
@@ -139,20 +140,6 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
         const currentLabel = getTextValue(multiple, value, valueToItemMap, renderValue);
 
         const {
-            filteredItems,
-            filteredMaps: {
-                pathMap: filteredPathMap,
-                focusedToValueMap: filteredFocusedToValueMap,
-                valueToPathMap: filteredValueToPathMap,
-            },
-        } = useComboboxItems({
-            items: transformedItems,
-            textValue,
-            currentLabel,
-            filter,
-        });
-
-        const {
             path,
             treePath,
             focusedPath,
@@ -173,6 +160,22 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
             value,
             valueToItemMap,
             setTextValue,
+        });
+
+        const {
+            filteredItems,
+            filteredMaps: {
+                pathMap: filteredPathMap,
+                focusedToValueMap: filteredFocusedToValueMap,
+                valueToPathMap: filteredValueToPathMap,
+            },
+        } = useComboboxItems({
+            items: transformedItems,
+            textValue,
+            currentLabel,
+            filter,
+            sortItems,
+            isListOpened,
         });
 
         const { checked, handleCheckboxChange, handleItemClick, handlePressDown } = useCheckedState({
@@ -533,7 +536,7 @@ export const comboboxRoot = (Root: RootProps<HTMLInputElement, Omit<ComboboxProp
                                                     ) : (
                                                         filteredItems.map((item, index) => (
                                                             <Inner
-                                                                key={`${index}/0`}
+                                                                key={String(item.value)}
                                                                 item={item}
                                                                 currentLevel={0}
                                                                 path={path}

--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.types.ts
@@ -209,6 +209,11 @@ type BasicProps<T extends ItemOption = ItemOption> = {
      */
     filter?: (item: T, textValue: string) => boolean;
     /**
+     * Функция сортировки элементов после фильтрации.
+     * Вызывается при открытии выпадающего списка; порядок фиксируется, пока список открыт.
+     */
+    sortItems?: (items: T[], textValue: string) => T[];
+    /**
      * Закрывать ли выпадающий список после выбора элемента.
      * @default если single, то true; если multiple, то false; если передан alwaysOpened, то false
      */

--- a/packages/plasma-new-hope/src/components/Combobox/hooks/useComboboxItems.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/hooks/useComboboxItems.ts
@@ -1,23 +1,70 @@
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import type { ComboboxProps, ItemOptionTransformed } from '../Combobox.types';
 import { filterItems } from '../utils';
 
 import { useNavigationMaps } from './usePathMaps';
 
-type Props = Pick<ComboboxProps, 'filter'> & {
+type Props = Pick<ComboboxProps, 'filter' | 'sortItems'> & {
     items: ItemOptionTransformed[];
     textValue: string;
     currentLabel: string;
+    isListOpened: boolean;
 };
 
-export const useComboboxItems = ({ items, textValue, currentLabel, filter }: Props) => {
-    const filteredItems = useMemo(() => filterItems(items, textValue, currentLabel, filter), [
-        currentLabel,
-        filter,
-        items,
-        textValue,
-    ]);
+/**
+ * Сортировка через `sortItems` применяется только при открытии списка.
+ * Снимок хранится в state и не обновляется при выборе, пока дропдаун открыт —
+ * иначе вложенные меню «прыгают». Фильтрация по тексту работает по снимку.
+ */
+export const useComboboxItems = ({ items, textValue, currentLabel, filter, sortItems, isListOpened }: Props) => {
+    const [openedSortBase, setOpenedSortBase] = useState<ItemOptionTransformed[] | null>(null);
+    const wasOpenedRef = useRef(false);
+    const sortItemsRef = useRef(sortItems);
+    const itemsRef = useRef(items);
+    const textValueRef = useRef(textValue);
+    const currentLabelRef = useRef(currentLabel);
+    const filterRef = useRef(filter);
+
+    sortItemsRef.current = sortItems;
+    itemsRef.current = items;
+    textValueRef.current = textValue;
+    currentLabelRef.current = currentLabel;
+    filterRef.current = filter;
+
+    useLayoutEffect(() => {
+        const wasOpened = wasOpenedRef.current;
+
+        if (isListOpened && !wasOpened) {
+            const currentSortItems = sortItemsRef.current;
+
+            if (currentSortItems) {
+                const filtered = filterItems(
+                    itemsRef.current,
+                    textValueRef.current,
+                    currentLabelRef.current,
+                    filterRef.current,
+                );
+                setOpenedSortBase(currentSortItems(filtered, textValueRef.current));
+            } else {
+                setOpenedSortBase(null);
+            }
+        }
+
+        if (!isListOpened && wasOpened) {
+            setOpenedSortBase(null);
+        }
+
+        wasOpenedRef.current = isListOpened;
+    }, [isListOpened]);
+
+    const filteredItems = useMemo(() => {
+        if (isListOpened && openedSortBase) {
+            return filterItems(openedSortBase, textValue, currentLabel, filter);
+        }
+
+        return filterItems(items, textValue, currentLabel, filter);
+    }, [currentLabel, filter, isListOpened, items, openedSortBase, textValue]);
 
     const [filteredPathMap, filteredFocusedToValueMap, filteredValueToPathMap] = useNavigationMaps(filteredItems);
 

--- a/packages/plasma-new-hope/src/components/Combobox/ui/Inner/Inner.tsx
+++ b/packages/plasma-new-hope/src/components/Combobox/ui/Inner/Inner.tsx
@@ -63,7 +63,7 @@ export const Inner: FC<InnerProps> = ({
                     <Ul role="group" id={listId} virtual={false} listMaxHeight={item?.listMaxHeight}>
                         {item.items?.map((innerItem: ItemOptionTransformed, innerIndex: number) => (
                             <Inner
-                                key={`${innerIndex}/${currentLevel}`}
+                                key={String(innerItem.value)}
                                 item={innerItem}
                                 currentLevel={nextLevel}
                                 path={path}

--- a/packages/sdds-finai/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-finai/src/components/Combobox/Combobox.stories.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { ComponentProps } from 'react';
-import type { Meta } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { getComboboxStories } from '@salutejs/plasma-sb-utils';
 import { IconLockOutline } from '@salutejs/plasma-icons';
 
@@ -39,3 +39,185 @@ const meta: Meta<ComboboxProps> = {
 export default meta;
 
 export { Single, Multiple, SelectAll, AddItem };
+
+const sortItemsExample = [
+    { value: 'paris', label: 'Париж' },
+    { value: 'berlin', label: 'Берлин' },
+    { value: 'rome', label: 'Рим' },
+    { value: 'madrid', label: 'Мадрид' },
+    { value: 'lisbon', label: 'Лиссабон' },
+    { value: 'vienna', label: 'Вена' },
+    { value: 'prague', label: 'Прага' },
+    { value: 'amsterdam', label: 'Амстердам' },
+];
+
+type SortItem = {
+    value: string;
+    label: string;
+    items?: SortItem[];
+};
+
+const sortNestedItemsExample: SortItem[] = [
+    {
+        value: 'europe',
+        label: 'Европа',
+        items: [
+            {
+                value: 'france',
+                label: 'Франция',
+                items: [
+                    { value: 'paris', label: 'Париж' },
+                    { value: 'lyon', label: 'Лион' },
+                ],
+            },
+            {
+                value: 'germany',
+                label: 'Германия',
+                items: [
+                    { value: 'berlin', label: 'Берлин' },
+                    { value: 'munich', label: 'Мюнхен' },
+                ],
+            },
+            {
+                value: 'italy',
+                label: 'Италия',
+                items: [
+                    { value: 'rome', label: 'Рим' },
+                    { value: 'milan', label: 'Милан' },
+                ],
+            },
+        ],
+    },
+    {
+        value: 'south_america',
+        label: 'Южная Америка',
+        items: [
+            {
+                value: 'brazil',
+                label: 'Бразилия',
+                items: [
+                    { value: 'rio_de_janeiro', label: 'Рио-де-Жанейро' },
+                    { value: 'sao_paulo', label: 'Сан-Паулу' },
+                ],
+            },
+            {
+                value: 'argentina',
+                label: 'Аргентина',
+                items: [
+                    { value: 'buenos_aires', label: 'Буэнос-Айрес' },
+                    { value: 'cordoba', label: 'Кордова' },
+                ],
+            },
+        ],
+    },
+    {
+        value: 'asia',
+        label: 'Азия',
+        items: [
+            {
+                value: 'japan',
+                label: 'Япония',
+                items: [
+                    { value: 'tokyo', label: 'Токио' },
+                    { value: 'osaka', label: 'Осака' },
+                ],
+            },
+            {
+                value: 'china',
+                label: 'Китай',
+                items: [
+                    { value: 'beijing', label: 'Пекин' },
+                    { value: 'shanghai', label: 'Шанхай' },
+                ],
+            },
+        ],
+    },
+];
+
+const hasSelectedInTree = (item: SortItem, selected: string[]): boolean => {
+    if (selected.includes(item.value)) {
+        return true;
+    }
+
+    return Boolean(item.items?.some((child) => hasSelectedInTree(child, selected)));
+};
+
+const sortSelectedFirst = <T extends SortItem>(items: T[], selected: string[]): T[] =>
+    [...items]
+        .map((item) =>
+            item.items
+                ? {
+                      ...item,
+                      items: sortSelectedFirst(item.items, selected),
+                  }
+                : item,
+        )
+        .sort((a, b) => {
+            const aSelected = hasSelectedInTree(a, selected) ? 0 : 1;
+            const bSelected = hasSelectedInTree(b, selected) ? 0 : 1;
+
+            return aSelected - bSelected || a.label.localeCompare(b.label, 'ru');
+        });
+
+/**
+ * Multiple + chips: выбранные элементы поднимаются вверх списка через `sortItems`.
+ */
+const CustomSortExample = (args: ComboboxProps) => {
+    const [value, setValue] = useState<string[]>(['berlin', 'vienna']);
+
+    return (
+        <div style={{ width: '400px' }}>
+            <Combobox
+                {...args}
+                multiple
+                items={sortItemsExample}
+                value={value}
+                onChange={setValue}
+                sortItems={(list) => sortSelectedFirst(list, value)}
+            />
+        </div>
+    );
+};
+
+export const CustomSort: StoryObj<ComboboxProps> = {
+    render: (args) => <CustomSortExample {...args} />,
+    args: {
+        label: 'Label',
+        placeholder: 'Placeholder',
+        helperText: 'Сортировка при открытии списка: выбранные элементы сверху',
+        listMaxHeight: '300px',
+        chipView: 'default',
+    },
+};
+
+/**
+ * Multiple + chips + nested items: ветки с выбранными элементами поднимаются вверх на каждом уровне.
+ * Порядок фиксируется при открытии списка и не меняется, пока дропдаун открыт.
+ */
+const CustomSortNestedExample = (args: ComboboxProps) => {
+    const [value, setValue] = useState<string[]>(['berlin', 'rio_de_janeiro']);
+
+    return (
+        <div style={{ width: '400px' }}>
+            <Combobox
+                {...args}
+                multiple
+                items={sortNestedItemsExample}
+                value={value}
+                onChange={setValue}
+                sortItems={(list) => sortSelectedFirst(list, value)}
+            />
+        </div>
+    );
+};
+
+export const CustomSortNested: StoryObj<ComboboxProps> = {
+    render: (args) => <CustomSortNestedExample {...args} />,
+    args: {
+        label: 'Label',
+        placeholder: 'Placeholder',
+        helperText: 'Сортировка при открытии: ветки с выбранными элементами сверху',
+        listMaxHeight: '300px',
+        chipView: 'default',
+    },
+};

--- a/utils/api-tests/src/components/Combobox/Combobox.api.test.tsx
+++ b/utils/api-tests/src/components/Combobox/Combobox.api.test.tsx
@@ -88,6 +88,9 @@ describe('Basics', () => {
             .toHaveProperty('filter')
             .toEqualTypeOf<((item: ItemOption, textValue: string) => boolean) | undefined>();
         expectTypeOf<ComboboxProps>()
+            .toHaveProperty('sortItems')
+            .toEqualTypeOf<((items: ItemOption[], textValue: string) => ItemOption[]) | undefined>();
+        expectTypeOf<ComboboxProps>()
             .toHaveProperty('onChangeValue')
             .toEqualTypeOf<((value: string) => void) | undefined>();
         expectTypeOf<ComboboxProps>()
@@ -339,6 +342,9 @@ describe('Generics', () => {
                 onChange={(_, item) => item?.customLabel}
                 renderItem={(item) => item?.customLabel}
                 filter={(item) => item.isAvailable}
+                sortItems={(sortedItems) => {
+                    return [...sortedItems].sort((a, b) => Number(b.isAvailable) - Number(a.isAvailable));
+                }}
             />
         );
 
@@ -350,6 +356,9 @@ describe('Generics', () => {
                 renderItem={(item) => item?.customLabel}
                 renderValue={(item) => item?.customLabel}
                 filter={(item) => item.isAvailable}
+                sortItems={(sortedItems) => {
+                    return [...sortedItems].sort((a, b) => Number(b.isAvailable) - Number(a.isAvailable));
+                }}
             />
         );
 
@@ -360,6 +369,8 @@ describe('Generics', () => {
                 renderItem={(item) => item?.nonExistedProp}
                 // @ts-expect-error
                 filter={(item) => item.nonExistedProp}
+                // @ts-expect-error
+                sortItems={(sortedItems) => [...sortedItems].sort((a, b) => a.nonExistedProp - b.nonExistedProp)}
                 // @ts-expect-error
                 onChange={(_, item) => item?.nonExistedProp}
             />
@@ -375,6 +386,8 @@ describe('Generics', () => {
                 renderValue={(item) => item?.nonExistedProp}
                 // @ts-expect-error
                 filter={(item) => item.nonExistedProp}
+                // @ts-expect-error
+                sortItems={(sortedItems) => [...sortedItems].sort((a, b) => a.nonExistedProp - b.nonExistedProp)}
                 // @ts-expect-error
                 onChange={(_, item) => item?.nonExistedProp}
             />

--- a/website/sdds-finai-docs/docs/components/Combobox.mdx
+++ b/website/sdds-finai-docs/docs/components/Combobox.mdx
@@ -651,6 +651,188 @@ export function App() {
         }
         ```
     </TabItem>
+    <TabItem value="sortItems" label="Custom Sort">
+        `sortItems` — функция сортировки после фильтрации. Вызывается **при открытии** списка; порядок фиксируется, пока дропдаун открыт (удобно для nested). В примере выбранные chips-элементы поднимаются вверх.
+
+        ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/sdds-finai';
+
+        export function App() {
+            const [value, setValue] = useState(['berlin', 'vienna']);
+
+            const items = [
+                { value: 'paris', label: 'Париж' },
+                { value: 'berlin', label: 'Берлин' },
+                { value: 'rome', label: 'Рим' },
+                { value: 'madrid', label: 'Мадрид' },
+                { value: 'lisbon', label: 'Лиссабон' },
+                { value: 'vienna', label: 'Вена' },
+                { value: 'prague', label: 'Прага' },
+                { value: 'amsterdam', label: 'Амстердам' },
+            ];
+
+            return (
+                <div style={{ display: "block", width: "350px", height: "400px" }}>
+                    <Combobox
+                        multiple
+                        label="Label"
+                        placeholder="Placeholder"
+                        helperText="Сортировка при открытии списка: выбранные элементы сверху"
+                        items={items}
+                        value={value}
+                        onChange={setValue}
+                        listMaxHeight="250px"
+                        sortItems={(items) =>
+                            [...items].sort((a, b) => {
+                                const aSelected = value.includes(a.value) ? 0 : 1;
+                                const bSelected = value.includes(b.value) ? 0 : 1;
+
+                                return aSelected - bSelected || a.label.localeCompare(b.label, 'ru');
+                            })
+                        }
+                    />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
+    <TabItem value="sortItemsNested" label="Custom Sort Nested">
+        Тот же подход для вложенных `items`. Порядок на каждом уровне фиксируется при открытии, поэтому каскадные меню не прыгают при выборе.
+
+        ```tsx live
+        import React, { useState } from 'react';
+        import { Combobox } from '@salutejs/sdds-finai';
+
+        type Item = {
+            value: string;
+            label: string;
+            items?: Item[];
+        };
+
+        const hasSelectedInTree = (item: Item, selected: string[]): boolean => {
+            if (selected.includes(item.value)) {
+                return true;
+            }
+
+            return Boolean(item.items?.some((child) => hasSelectedInTree(child, selected)));
+        };
+
+        const sortSelectedFirst = (items: Item[], selected: string[]): Item[] =>
+            [...items]
+                .map((item) =>
+                    item.items
+                        ? {
+                              ...item,
+                              items: sortSelectedFirst(item.items, selected),
+                          }
+                        : item,
+                )
+                .sort((a, b) => {
+                    const aSelected = hasSelectedInTree(a, selected) ? 0 : 1;
+                    const bSelected = hasSelectedInTree(b, selected) ? 0 : 1;
+
+                    return aSelected - bSelected || a.label.localeCompare(b.label, 'ru');
+                });
+
+        export function App() {
+            const [value, setValue] = useState(['berlin', 'rio_de_janeiro']);
+
+            const items = [
+                {
+                    value: 'europe',
+                    label: 'Европа',
+                    items: [
+                        {
+                            value: 'france',
+                            label: 'Франция',
+                            items: [
+                                { value: 'paris', label: 'Париж' },
+                                { value: 'lyon', label: 'Лион' },
+                            ],
+                        },
+                        {
+                            value: 'germany',
+                            label: 'Германия',
+                            items: [
+                                { value: 'berlin', label: 'Берлин' },
+                                { value: 'munich', label: 'Мюнхен' },
+                            ],
+                        },
+                        {
+                            value: 'italy',
+                            label: 'Италия',
+                            items: [
+                                { value: 'rome', label: 'Рим' },
+                                { value: 'milan', label: 'Милан' },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    value: 'south_america',
+                    label: 'Южная Америка',
+                    items: [
+                        {
+                            value: 'brazil',
+                            label: 'Бразилия',
+                            items: [
+                                { value: 'rio_de_janeiro', label: 'Рио-де-Жанейро' },
+                                { value: 'sao_paulo', label: 'Сан-Паулу' },
+                            ],
+                        },
+                        {
+                            value: 'argentina',
+                            label: 'Аргентина',
+                            items: [
+                                { value: 'buenos_aires', label: 'Буэнос-Айрес' },
+                                { value: 'cordoba', label: 'Кордова' },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    value: 'asia',
+                    label: 'Азия',
+                    items: [
+                        {
+                            value: 'japan',
+                            label: 'Япония',
+                            items: [
+                                { value: 'tokyo', label: 'Токио' },
+                                { value: 'osaka', label: 'Осака' },
+                            ],
+                        },
+                        {
+                            value: 'china',
+                            label: 'Китай',
+                            items: [
+                                { value: 'beijing', label: 'Пекин' },
+                                { value: 'shanghai', label: 'Шанхай' },
+                            ],
+                        },
+                    ],
+                },
+            ];
+
+            return (
+                <div style={{ display: "block", width: "350px", height: "400px" }}>
+                    <Combobox
+                        multiple
+                        label="Label"
+                        placeholder="Placeholder"
+                        helperText="Сортировка при открытии: ветки с выбранными элементами сверху"
+                        items={items}
+                        value={value}
+                        onChange={setValue}
+                        listMaxHeight="250px"
+                        sortItems={(items) => sortSelectedFirst(items, value)}
+                    />
+                </div>
+            );
+        }
+        ```
+    </TabItem>
     <TabItem value="renderSelectionIcon" label="Render icon">
         `renderSelectionIcon` - свойство для кастомной настройки иконки выбора элемента. Принимает коллбэк с одним параметром: `selected`.
 


### PR DESCRIPTION
## Core

### Combobox

- добавлен prop `sortItems` для кастомной сортировки элементов после фильтрации
- сортировка применяется при открытии списка и фиксируется, пока дропдаун открыт (чтобы nested-меню не прыгали при выборе)
- ключи элементов списка переведены на `value` для стабильности при сортировке
- добавлены Cypress и API-тесты

## SDDS-FINAI

### Combobox

- добавлены Storybook-примеры `Custom Sort` и `Custom Sort Nested` (multiple + chips, выбранные сверху)
- обновлена документация с примерами Custom Sort / Custom Sort Nested

### What/why changed

Веб-инженеры уже могли кастомизировать фильтрацию через `filter`. Нужен аналогичный API для сортировки — например, поднимать выбранные chips вверх списка. Для nested-элементов сортировка «на лету» ломает UX каскадных меню, поэтому `sortItems` вызывается только при открытии списка.


Made with [Cursor](https://cursor.com)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.393.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-b2c@1.635.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-colors@0.23.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-core@1.242.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-giga@0.362.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-homeds@0.362.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-hope@1.389.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-icons@1.250.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-new-hope@0.379.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-tokens@1.153.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-tokens-b2b@1.66.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-tokens-b2c@0.77.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-tokens-core@0.14.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-tokens-web@1.81.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-typo@0.54.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-web@1.637.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-bizcom@0.367.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-cs@0.371.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-dfa@0.365.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-finai@0.358.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-icons@0.7.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-insol@0.362.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-insol-next@0.361.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-netology@0.366.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-os@0.37.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-platform-ai@0.366.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-sbcom@0.367.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-scan@0.365.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-serv@0.366.0-canary.3140.33875275234.0
  npm install @salutejs/core-themes@0.42.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-themes@0.64.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-themes@0.80.0-canary.3140.33875275234.0
  npm install @salutejs/sdds-api-tests@0.24.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-cy-utils@0.172.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-sb-utils@0.243.0-canary.3140.33875275234.0
  npm install @salutejs/plasma-tokens-utils@0.62.0-canary.3140.33875275234.0
  # or 
  yarn add @salutejs/plasma-asdk@0.393.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-b2c@1.635.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-colors@0.23.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-core@1.242.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-giga@0.362.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-homeds@0.362.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-hope@1.389.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-icons@1.250.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-new-hope@0.379.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-tokens@1.153.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-tokens-b2b@1.66.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-tokens-b2c@0.77.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-tokens-core@0.14.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-tokens-web@1.81.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-typo@0.54.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-web@1.637.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-bizcom@0.367.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-cs@0.371.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-dfa@0.365.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-finai@0.358.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-icons@0.7.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-insol@0.362.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-insol-next@0.361.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-netology@0.366.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-os@0.37.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-platform-ai@0.366.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-sbcom@0.367.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-scan@0.365.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-serv@0.366.0-canary.3140.33875275234.0
  yarn add @salutejs/core-themes@0.42.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-themes@0.64.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-themes@0.80.0-canary.3140.33875275234.0
  yarn add @salutejs/sdds-api-tests@0.24.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-cy-utils@0.172.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-sb-utils@0.243.0-canary.3140.33875275234.0
  yarn add @salutejs/plasma-tokens-utils@0.62.0-canary.3140.33875275234.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
