### PR TITLE
PLASMA-7860: add clear Combobox (bizcom)

### DIFF
--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.tokens.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.tokens.ts
@@ -80,10 +80,15 @@ export const tokens = {
     textFieldBorderColorHover: '--plasma-combobox-new-textfield-border-color-hover',
     textFieldBorderColorFocus: '--plasma-combobox-new-textfield-border-color-focus',
 
+    textFieldDividerColor: '--plasma-combobox-new-textfield-divider-color',
+    textFieldDividerColorHover: '--plasma-combobox-new-textfield-divider-color-hover',
+    textFieldDividerColorFocus: '--plasma-combobox-new-textfield-divider-color-focus',
+
     textFieldColorReadOnly: '--plasma-combobox-new-textfield-color-readonly',
     textFieldBackgroundColorReadOnly: '--plasma-combobox-new-textfield-bg-color-readonly',
     textFieldBorderColorReadOnly: '--plasma-combobox-new-textfield-border-color-readonly',
     textFieldPlaceholderColorReadOnly: '--plasma-combobox-new-textfield-placeholder-color-readonly',
+    textFieldDividerColorReadOnly: '--plasma-combobox-new-textfield-divider-color-readonly',
 
     textFieldCaretColor: '--plasma-combobox-new-textfield-caret-color',
     textFieldPlaceholderColor: '--plasma-combobox-new-textfield-placeholder-color',

--- a/packages/plasma-new-hope/src/components/Combobox/Combobox.types.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/Combobox.types.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties, InputHTMLAttributes, ChangeEventHandler, Dispatch, ReactNode } from 'react';
 import { SafeExtract } from 'src/types';
-import type { RequiredProps, HintProps, LabelProps } from 'src/components/TextField/TextField.types';
+import type { RequiredProps, HintProps, LabelProps, TextFieldProps } from 'src/components/TextField/TextField.types';
 
 import { FocusedPathState, TreePathState, TreePathAction } from './reducers';
 import type { ValueToCheckedMapType, CheckedType } from './hooks';
@@ -316,6 +316,7 @@ type PrivateProps = {
 
 export type ComboboxProps<T extends ItemOption = ItemOption> = BasicProps<T> &
     LabelProps &
+    Pick<TextFieldProps, 'appearance' | 'hasDivider'> &
     IsMultiple<T> &
     RequiredProps &
     HintProps &

--- a/packages/plasma-new-hope/src/components/Combobox/ui/Target/Target.styles.ts
+++ b/packages/plasma-new-hope/src/components/Combobox/ui/Target/Target.styles.ts
@@ -27,6 +27,11 @@ export const StyledTextField = styled(TextField)<{ opened: boolean }>`
     opened ? `var(${comboboxTokens.textFieldBorderColorFocus})` : `var(${comboboxTokens.textFieldBorderColorHover})`};
     ${textFieldTokens.borderColorFocus}: var(${comboboxTokens.textFieldBorderColorFocus});
 
+    ${textFieldTokens.dividerColor}: var(${comboboxTokens.textFieldDividerColor});
+    ${textFieldTokens.dividerColorHover}: var(${comboboxTokens.textFieldDividerColorHover});
+    ${textFieldTokens.dividerColorFocus}: var(${comboboxTokens.textFieldDividerColorFocus});
+    ${textFieldTokens.dividerColorReadOnly}: var(${comboboxTokens.textFieldDividerColorReadOnly});
+
     ${textFieldTokens.colorReadOnly}: var(${comboboxTokens.textFieldColorReadOnly});
     ${textFieldTokens.backgroundColorReadOnly}: var(${comboboxTokens.textFieldBackgroundColorReadOnly});
     ${textFieldTokens.borderColorReadOnly}: var(${comboboxTokens.textFieldBorderColorReadOnly});

--- a/packages/sdds-bizcom/src/components/Combobox/Combobox.clear.config.ts
+++ b/packages/sdds-bizcom/src/components/Combobox/Combobox.clear.config.ts
@@ -1,0 +1,908 @@
+import { css, comboboxTokens as tokens } from '@salutejs/plasma-new-hope/styled-components';
+import {
+    bodyL,
+    bodyM,
+    bodyS,
+    bodyXS,
+    inverseTextPrimary,
+    inverseTextSecondary,
+    onDarkTextPrimary,
+    onDarkTextSecondary,
+    surfaceAccent,
+    surfaceAccentHover,
+    surfacePositive,
+    surfaceNegative,
+    surfaceSolidCard,
+    surfaceSolidCardBrightness,
+    surfaceSolidDefault,
+    surfaceSolidDefaultHover,
+    surfaceTransparentPrimary,
+    surfaceTransparentSecondary,
+    surfaceTransparentSecondaryActive,
+    surfaceTransparentSecondaryHover,
+    surfaceTransparentTertiary,
+    surfaceWarning,
+    textAccent,
+    textNegative,
+    textNegativeActive,
+    textNegativeHover,
+    textPositive,
+    textPositiveActive,
+    textPositiveHover,
+    textPrimary,
+    textSecondary,
+    textSecondaryActive,
+    textSecondaryHover,
+    textTertiary,
+    textWarning,
+    textWarningActive,
+    textWarningHover,
+} from '@salutejs/sdds-themes/tokens/sdds_bizcom';
+
+export const config = {
+    defaults: {
+        view: 'default',
+        size: 'm',
+        labelPlacement: 'outer',
+        chipView: 'secondary',
+        hintView: 'default',
+        hintSize: 'm',
+    },
+    variations: {
+        view: {
+            default: css`
+                ${tokens.textFieldColor}: ${textPrimary};
+                ${tokens.textFieldClearColor}: ${textPrimary};
+
+                ${tokens.textFieldPlaceholderColor}: ${textSecondary};
+                ${tokens.textFieldPlaceholderColorFocus}: ${textTertiary};
+                ${tokens.textFieldClearPlaceholderColor}: ${textSecondary};
+                ${tokens.textFieldClearPlaceholderColorFocus}: ${textTertiary};
+
+                ${tokens.textFieldBackgroundColor}: transparent;
+                ${tokens.textFieldBackgroundColorFocus}: transparent;
+                ${tokens.textFieldCaretColor}: ${textAccent};
+                ${tokens.textFieldTextBeforeColor}: ${textTertiary};
+                ${tokens.textFieldTextAfterColor}: ${textTertiary};
+                ${tokens.textFieldLabelColor}: ${textPrimary};
+                ${tokens.textFieldLeftHelperColor}: ${textSecondary};
+                ${tokens.textFieldFocusColor}: ${textAccent};
+
+                ${tokens.textFieldContentSlotColor}: ${textSecondary};
+                ${tokens.textFieldContentSlotColorHover}: ${textSecondaryHover};
+                ${tokens.textFieldContentSlotColorActive}: ${textSecondaryActive};
+
+                ${tokens.textFieldIndicatorColor}: ${surfaceNegative};
+                ${tokens.textFieldOptionalColor}: ${textTertiary};
+
+                ${tokens.textFieldChipCloseIconColor}: ${textSecondary};
+                ${tokens.textFieldChipCloseIconColorHover}: ${textSecondaryHover};
+                ${tokens.textFieldChipCloseIconColorReadonly}: ${textSecondary};
+                ${tokens.textFieldChipColor}: ${textPrimary};
+                ${tokens.textFieldChipBackground}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorHover}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundHover}: ${surfaceTransparentSecondaryHover};
+                ${tokens.textFieldChipColorActive}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundActive}: ${surfaceTransparentSecondaryActive};
+                ${tokens.textFieldChipBackgroundReadOnly}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnly}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnlyHover}: ${textPrimary};
+                ${tokens.textFieldChipOpacityReadonly}: 0.72;
+
+                ${tokens.disclosureIconColor}: ${textSecondary};
+                ${tokens.disclosureIconColorHover}: ${textSecondaryHover};
+                ${tokens.itemBackgroundHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldHintIconColor}: ${textSecondary};
+
+                ${tokens.dividerColor}: ${surfaceTransparentTertiary};
+
+                ${tokens.itemIconColor}: ${textAccent};
+
+                ${tokens.checkboxFillColor}: ${textAccent};
+                ${tokens.checkboxIconColor}: ${onDarkTextPrimary};
+                ${tokens.checkboxTriggerBorderCheckedColor}: transparent;
+                ${tokens.checkboxTriggerBorderColor}: ${textSecondary};
+                ${tokens.textFieldBackgroundColorHover}: transparent;
+                ${tokens.textFieldDividerColor}: ${surfaceTransparentTertiary};
+                ${tokens.textFieldDividerColorHover}: ${textSecondary};
+                ${tokens.textFieldDividerColorFocus}: ${surfaceAccent};
+            `,
+            positive: css`
+                ${tokens.textFieldColor}: ${textPositive};
+                ${tokens.textFieldClearColor}: ${textPositive};
+
+                ${tokens.textFieldPlaceholderColor}: ${textPositive};
+                ${tokens.textFieldPlaceholderColorFocus}: ${textPositive};
+                ${tokens.textFieldClearPlaceholderColor}: ${textPositive};
+                ${tokens.textFieldClearPlaceholderColorFocus}: ${textPositive};
+
+                ${tokens.textFieldBackgroundColor}: transparent;
+                ${tokens.textFieldBackgroundColorFocus}: transparent;
+                ${tokens.textFieldCaretColor}: ${textAccent};
+                ${tokens.textFieldTextBeforeColor}: ${textTertiary};
+                ${tokens.textFieldTextAfterColor}: ${textTertiary};
+                ${tokens.textFieldLabelColor}: ${textPrimary};
+                ${tokens.textFieldLeftHelperColor}: ${textPositive};
+                ${tokens.textFieldFocusColor}: ${textAccent};
+
+                ${tokens.textFieldContentSlotColor}: ${textPositive};
+                ${tokens.textFieldContentSlotColorHover}: ${textPositiveHover};
+                ${tokens.textFieldContentSlotColorActive}: ${textPositiveActive};
+
+                ${tokens.textFieldIndicatorColor}: ${surfaceNegative};
+                ${tokens.textFieldOptionalColor}: ${textTertiary};
+
+                ${tokens.textFieldChipCloseIconColor}: ${textSecondary};
+                ${tokens.textFieldChipCloseIconColorHover}: ${textSecondaryHover};
+                ${tokens.textFieldChipCloseIconColorReadonly}: ${textSecondary};
+                ${tokens.textFieldChipColor}: ${textPrimary};
+                ${tokens.textFieldChipBackground}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorHover}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundHover}: ${surfaceTransparentSecondaryHover};
+                ${tokens.textFieldChipColorActive}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundActive}: ${surfaceTransparentSecondaryActive};
+                ${tokens.textFieldChipBackgroundReadOnly}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnly}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnlyHover}: ${textPrimary};
+                ${tokens.textFieldChipOpacityReadonly}: 0.72;
+
+                ${tokens.disclosureIconColor}: ${textSecondary};
+                ${tokens.disclosureIconColorHover}: ${textSecondaryHover};
+                ${tokens.itemBackgroundHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldHintIconColor}: ${textSecondary};
+
+                ${tokens.dividerColor}: ${surfaceTransparentTertiary};
+
+                ${tokens.itemIconColor}: ${textAccent};
+
+                ${tokens.checkboxFillColor}: ${textAccent};
+                ${tokens.checkboxIconColor}: ${onDarkTextPrimary};
+                ${tokens.checkboxTriggerBorderCheckedColor}: transparent;
+                ${tokens.checkboxTriggerBorderColor}: ${textSecondary};
+                ${tokens.textFieldBackgroundColorHover}: transparent;
+                ${tokens.textFieldDividerColor}: ${surfacePositive};
+                ${tokens.textFieldDividerColorHover}: ${surfacePositive};
+                ${tokens.textFieldDividerColorFocus}: ${surfaceAccent};
+            `,
+            warning: css`
+                ${tokens.textFieldColor}: ${textWarning};
+                ${tokens.textFieldClearColor}: ${textWarning};
+
+                ${tokens.textFieldPlaceholderColor}: ${textWarning};
+                ${tokens.textFieldPlaceholderColorFocus}: ${textWarning};
+                ${tokens.textFieldClearPlaceholderColor}: ${textWarning};
+                ${tokens.textFieldClearPlaceholderColorFocus}: ${textWarning};
+
+                ${tokens.textFieldBackgroundColor}: transparent;
+                ${tokens.textFieldBackgroundColorFocus}: transparent;
+                ${tokens.textFieldCaretColor}: ${textAccent};
+                ${tokens.textFieldTextBeforeColor}: ${textTertiary};
+                ${tokens.textFieldTextAfterColor}: ${textTertiary};
+                ${tokens.textFieldLabelColor}: ${textPrimary};
+                ${tokens.textFieldLeftHelperColor}: ${textWarning};
+                ${tokens.textFieldFocusColor}: ${textAccent};
+
+                ${tokens.textFieldContentSlotColor}: ${textWarning};
+                ${tokens.textFieldContentSlotColorHover}: ${textWarningHover};
+                ${tokens.textFieldContentSlotColorActive}: ${textWarningActive};
+
+                ${tokens.textFieldIndicatorColor}: ${surfaceNegative};
+                ${tokens.textFieldOptionalColor}: ${textTertiary};
+
+                ${tokens.textFieldChipCloseIconColor}: ${textSecondary};
+                ${tokens.textFieldChipCloseIconColorHover}: ${textSecondaryHover};
+                ${tokens.textFieldChipCloseIconColorReadonly}: ${textSecondary};
+                ${tokens.textFieldChipColor}: ${textPrimary};
+                ${tokens.textFieldChipBackground}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorHover}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundHover}: ${surfaceTransparentSecondaryHover};
+                ${tokens.textFieldChipColorActive}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundActive}: ${surfaceTransparentSecondaryActive};
+                ${tokens.textFieldChipBackgroundReadOnly}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnly}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnlyHover}: ${textPrimary};
+                ${tokens.textFieldChipOpacityReadonly}: 0.72;
+
+                ${tokens.disclosureIconColor}: ${textSecondary};
+                ${tokens.disclosureIconColorHover}: ${textSecondaryHover};
+                ${tokens.itemBackgroundHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldHintIconColor}: ${textSecondary};
+
+                ${tokens.dividerColor}: ${surfaceTransparentTertiary};
+
+                ${tokens.itemIconColor}: ${textAccent};
+
+                ${tokens.checkboxFillColor}: ${textAccent};
+                ${tokens.checkboxIconColor}: ${onDarkTextPrimary};
+                ${tokens.checkboxTriggerBorderCheckedColor}: transparent;
+                ${tokens.checkboxTriggerBorderColor}: ${textSecondary};
+                ${tokens.textFieldBackgroundColorHover}: transparent;
+                ${tokens.textFieldDividerColor}: ${surfaceWarning};
+                ${tokens.textFieldDividerColorHover}: ${surfaceWarning};
+                ${tokens.textFieldDividerColorFocus}: ${surfaceAccent};
+            `,
+            negative: css`
+                ${tokens.textFieldColor}: ${textNegative};
+                ${tokens.textFieldClearColor}: ${textNegative};
+
+                ${tokens.textFieldPlaceholderColor}: ${textNegative};
+                ${tokens.textFieldPlaceholderColorFocus}: ${textNegative};
+                ${tokens.textFieldClearPlaceholderColor}: ${textNegative};
+                ${tokens.textFieldClearPlaceholderColorFocus}: ${textNegative};
+
+                ${tokens.textFieldBackgroundColor}: transparent;
+                ${tokens.textFieldBackgroundColorFocus}: transparent;
+
+                ${tokens.textFieldCaretColor}: ${textAccent};
+                ${tokens.textFieldTextBeforeColor}: ${textTertiary};
+                ${tokens.textFieldTextAfterColor}: ${textTertiary};
+                ${tokens.textFieldLabelColor}: ${textPrimary};
+                ${tokens.textFieldLeftHelperColor}: ${textNegative};
+                ${tokens.textFieldFocusColor}: ${textAccent};
+
+                ${tokens.textFieldContentSlotColor}: ${textNegative};
+                ${tokens.textFieldContentSlotColorHover}: ${textNegativeHover};
+                ${tokens.textFieldContentSlotColorActive}: ${textNegativeActive};
+
+                ${tokens.textFieldIndicatorColor}: ${surfaceNegative};
+                ${tokens.textFieldOptionalColor}: ${textTertiary};
+
+                ${tokens.textFieldChipCloseIconColor}: ${textSecondary};
+                ${tokens.textFieldChipCloseIconColorHover}: ${textSecondaryHover};
+                ${tokens.textFieldChipCloseIconColorReadonly}: ${textSecondary};
+                ${tokens.textFieldChipColor}: ${textPrimary};
+                ${tokens.textFieldChipBackground}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorHover}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundHover}: ${surfaceTransparentSecondaryHover};
+                ${tokens.textFieldChipColorActive}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundActive}: ${surfaceTransparentSecondaryActive};
+                ${tokens.textFieldChipBackgroundReadOnly}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnly}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnlyHover}: ${textPrimary};
+                ${tokens.textFieldChipOpacityReadonly}: 0.72;
+
+                ${tokens.disclosureIconColor}: ${textSecondary};
+                ${tokens.disclosureIconColorHover}: ${textSecondaryHover};
+                ${tokens.itemBackgroundHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldHintIconColor}: ${textSecondary};
+
+                ${tokens.dividerColor}: ${surfaceTransparentTertiary};
+
+                ${tokens.itemIconColor}: ${textAccent};
+
+                ${tokens.checkboxFillColor}: ${textAccent};
+                ${tokens.checkboxIconColor}: ${onDarkTextPrimary};
+                ${tokens.checkboxTriggerBorderCheckedColor}: transparent;
+                ${tokens.checkboxTriggerBorderColor}: ${textSecondary};
+                ${tokens.textFieldBackgroundColorHover}: transparent;
+                ${tokens.textFieldDividerColor}: ${surfaceNegative};
+                ${tokens.textFieldDividerColorHover}: ${surfaceNegative};
+                ${tokens.textFieldDividerColorFocus}: ${surfaceAccent};
+            `,
+        },
+        size: {
+            l: css`
+                ${tokens.textFieldHeight}: 3.5rem;
+                ${tokens.textFieldPadding}: 1.0625rem 0;
+                ${tokens.textFieldPaddingWithChips}: 0.375rem 0;
+                ${tokens.textFieldBorderRadius}: 0;
+
+                ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.5rem -0.0625rem 0;
+                ${tokens.textFieldRightContentMargin}: -0.0625rem 0 -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.438rem -0.0625rem 0.75rem;
+
+                ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
+                ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
+
+                ${tokens.textFieldTextBeforeMargin}: 0 0.25rem 0 0;
+                ${tokens.textFieldTextAfterMargin}: 0 0 0 0.25rem;
+
+                ${tokens.textFieldFontFamily}: ${bodyL.fontFamily};
+                ${tokens.textFieldFontSize}: ${bodyL.fontSize};
+                ${tokens.textFieldFontStyle}: ${bodyL.fontStyle};
+                ${tokens.textFieldFontWeight}: ${bodyL.fontWeight};
+                ${tokens.textFieldLetterSpacing}: ${bodyL.letterSpacing};
+                ${tokens.textFieldLineHeight}: ${bodyL.lineHeight};
+
+                ${tokens.textFieldLabelOffset}: 0.25rem;
+                ${tokens.textFieldLabelFontFamily}: ${bodyL.fontFamily};
+                ${tokens.textFieldLabelFontSize}: ${bodyL.fontSize};
+                ${tokens.textFieldLabelFontStyle}: ${bodyL.fontStyle};
+                ${tokens.textFieldLabelFontWeight}: ${bodyL.fontWeight};
+                ${tokens.textFieldLabelLetterSpacing}: ${bodyL.letterSpacing};
+                ${tokens.textFieldLabelLineHeight}: ${bodyL.lineHeight};
+
+                ${tokens.textFieldHintMargin}: -0.688rem -0.5rem;
+                ${tokens.textFieldHintTargetSize}: 2.375rem;
+                ${tokens.textFieldHintInnerLabelPlacementOffset}: 0.563rem -2.188rem auto auto;
+                ${tokens.textFieldClearHintInnerLabelPlacementOffset}: 0.563rem -2.188rem auto auto;
+
+                ${tokens.textFieldLeftHelperOffset}: 0.25rem 0 0 0;
+                ${tokens.textFieldLeftHelperFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldLeftHelperFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldLeftHelperFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldLeftHelperFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldLeftHelperLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldLeftHelperLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.textFieldLabelInnerPadding}: 0.5625rem 0 0.125rem 0;
+                ${tokens.textFieldContentLabelInnerPadding}: 1.5625rem 0 0.5625rem 0;
+
+                ${tokens.textFieldIndicatorSizeInner}: 0.5rem;
+                ${tokens.textFieldIndicatorSizeOuter}: 0.375rem;
+                ${tokens.textFieldIndicatorLabelPlacementInner}: 1.5rem auto auto -0.875rem;
+                ${tokens.textFieldIndicatorLabelPlacementOuter}: 0.5rem auto auto -0.75rem;
+                ${tokens.textFieldIndicatorLabelPlacementInnerRight}: 1.5rem -0.875rem auto auto;
+                ${tokens.textFieldIndicatorLabelPlacementOuterRight}: 0.25rem -0.625rem auto auto;
+                ${tokens.textFieldClearIndicatorLabelPlacementInner}: 1.5rem auto auto -0.875rem;
+                ${tokens.textFieldClearIndicatorLabelPlacementInnerRight}: 1.5rem -0.875rem auto auto;
+                ${tokens.textFieldClearIndicatorHintInnerRight}: 1.5rem -2.488rem auto auto;
+
+                ${tokens.textFieldChipGap}: 0.25rem;
+                ${tokens.textFieldChipBorderRadius}: 0.5rem;
+                ${tokens.textFieldChipWidth}: auto;
+                ${tokens.textFieldChipHeight}: 2.75rem;
+                ${tokens.textFieldChipPadding}: 0 0.75rem 0 1rem;
+                ${tokens.textFieldChipClearContentMarginLeft}: 0.625rem;
+                ${tokens.textFieldChipClearContentMarginRight}: 0rem;
+                ${tokens.textFieldChipCloseIconSize}: 1.5rem;
+                ${tokens.textFieldChipFontFamily}: ${bodyL.fontFamily};
+                ${tokens.textFieldChipFontSize}: ${bodyL.fontSize};
+                ${tokens.textFieldChipFontStyle}: ${bodyL.fontStyle};
+                ${tokens.textFieldChipFontWeight}: ${bodyL.fontWeight};
+                ${tokens.textFieldChipLetterSpacing}: ${bodyL.letterSpacing};
+                ${tokens.textFieldChipLineHeight}: ${bodyL.lineHeight};
+
+                ${tokens.emptyStatePadding}: 1rem;
+                ${tokens.padding}: 0.125rem;
+                ${tokens.borderRadius}: 0.875rem;
+
+                ${tokens.itemHeight}: 1.5rem;
+                ${tokens.itemPadding}: 1rem 0.875rem;
+                ${tokens.itemPaddingTight}: 0.75rem 0.875rem;
+                ${tokens.itemBorderRadius}: 0.75rem;
+                ${tokens.itemIconMargin}: 0 0.5rem 0 0;
+                ${tokens.itemIconSize}: 1.5rem;
+                ${tokens.itemIconSizeTight}: 1.5rem;
+                ${tokens.itemGap}: 0.5rem;
+                ${tokens.itemTreeOffsetWidth}: 2rem;
+
+                ${tokens.cellPadding}: 0rem;
+                ${tokens.cellPaddingLeftContent}: 0rem;
+                ${tokens.cellPaddingContent}: 0rem;
+                ${tokens.cellPaddingRightContent}: 0rem;
+                ${tokens.cellTextboxGap}: 0.125rem;
+                ${tokens.cellGap}: 0.375rem;
+                ${tokens.cellTitleFontFamily}: ${bodyL.fontFamily};
+                ${tokens.cellTitleFontSize}: ${bodyL.fontSize};
+                ${tokens.cellTitleFontStyle}: ${bodyL.fontStyle};
+                ${tokens.cellTitleFontWeight}: ${bodyL.fontWeight};
+                ${tokens.cellTitleLetterSpacing}: ${bodyL.letterSpacing};
+                ${tokens.cellTitleLineHeight}: ${bodyL.lineHeight};
+
+                ${tokens.fontFamily}: ${bodyL.fontFamily};
+                ${tokens.fontSize}: ${bodyL.fontSize};
+                ${tokens.fontStyle}: ${bodyL.fontStyle};
+                ${tokens.fontWeight}: ${bodyL.fontWeight};
+                ${tokens.fontLetterSpacing}: ${bodyL.letterSpacing};
+                ${tokens.fontLineHeight}: ${bodyL.lineHeight};
+
+                ${tokens.checkboxTriggerSize}: 1.25rem;
+                ${tokens.checkboxTriggerSizeTight}: 1.25rem;
+                ${tokens.checkboxTriggerBorderRadius}: 0.375rem;
+                ${tokens.checkboxTriggerBorderRadiusTight}: 0.375rem;
+                ${tokens.checkboxTriggerBorderWidth}: 0.125rem;
+
+                ${tokens.indicatorSize}: 0.375rem;
+
+                ${tokens.dividerMarginTop}: 0.5rem;
+                ${tokens.dividerMarginRight}: 1rem;
+                ${tokens.dividerMarginBottom}: 0.5rem;
+                ${tokens.dividerMarginLeft}: 1rem;
+                ${tokens.dividerMarginTopTight}: 0.375rem;
+                ${tokens.dividerMarginBottomTight}: 0.375rem;
+            `,
+            m: css`
+                ${tokens.textFieldHeight}: 3rem;
+                ${tokens.textFieldPadding}: 0.875rem 0;
+                ${tokens.textFieldPaddingWithChips}: 0.375rem 0;
+                ${tokens.textFieldBorderRadius}: 0;
+
+                ${tokens.textFieldLeftContentMargin}: -0.125rem 0.375rem -0.125rem 0;
+                ${tokens.textFieldRightContentMargin}: -0.125rem 0 -0.125rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.125rem -0.438rem -0.125rem 0.75rem;
+
+                ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
+                ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
+
+                ${tokens.textFieldTextBeforeMargin}: 0 0.25rem 0 0;
+                ${tokens.textFieldTextAfterMargin}: 0 0 0 0.25rem;
+
+                ${tokens.textFieldFontFamily}: ${bodyM.fontFamily};
+                ${tokens.textFieldFontSize}: ${bodyM.fontSize};
+                ${tokens.textFieldFontStyle}: ${bodyM.fontStyle};
+                ${tokens.textFieldFontWeight}: ${bodyM.fontWeight};
+                ${tokens.textFieldLetterSpacing}: ${bodyM.letterSpacing};
+                ${tokens.textFieldLineHeight}: ${bodyM.lineHeight};
+
+                ${tokens.textFieldLabelOffset}: 0.25rem;
+                ${tokens.textFieldLabelFontFamily}: ${bodyM.fontFamily};
+                ${tokens.textFieldLabelFontSize}: ${bodyM.fontSize};
+                ${tokens.textFieldLabelFontStyle}: ${bodyM.fontStyle};
+                ${tokens.textFieldLabelFontWeight}: ${bodyM.fontWeight};
+                ${tokens.textFieldLabelLetterSpacing}: ${bodyM.letterSpacing};
+                ${tokens.textFieldLabelLineHeight}: ${bodyM.lineHeight};
+
+                ${tokens.textFieldHintMargin}: -0.688rem -0.5rem;
+                ${tokens.textFieldHintTargetSize}: 2.375rem;
+                ${tokens.textFieldHintInnerLabelPlacementOffset}: 0.312rem -2.188rem auto auto;
+                ${tokens.textFieldClearHintInnerLabelPlacementOffset}: 0.312rem -2.188rem auto auto;
+
+                ${tokens.textFieldLeftHelperOffset}: 0.25rem 0 0 0;
+                ${tokens.textFieldLeftHelperFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldLeftHelperFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldLeftHelperFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldLeftHelperFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldLeftHelperLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldLeftHelperLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.textFieldLabelInnerPadding}: 0.375rem 0 0.125rem 0;
+                ${tokens.textFieldContentLabelInnerPadding}: 1.375rem 0 0.375rem 0;
+
+                ${tokens.textFieldIndicatorSizeInner}: 0.5rem;
+                ${tokens.textFieldIndicatorSizeOuter}: 0.375rem;
+                ${tokens.textFieldIndicatorLabelPlacementInner}: 1.25rem auto auto -0.875rem;
+                ${tokens.textFieldIndicatorLabelPlacementOuter}: 0.375rem auto auto -0.75rem;
+                ${tokens.textFieldIndicatorLabelPlacementInnerRight}: 1.25rem -0.875rem auto auto;
+                ${tokens.textFieldIndicatorLabelPlacementOuterRight}: 0.25rem -0.6875rem auto auto;
+                ${tokens.textFieldClearIndicatorLabelPlacementInner}: 1.25rem auto auto -0.875rem;
+                ${tokens.textFieldClearIndicatorLabelPlacementInnerRight}: 1.25rem -0.875rem auto auto;
+                ${tokens.textFieldClearIndicatorHintInnerRight}: 1.25rem -2.488rem auto auto;
+
+                ${tokens.textFieldChipGap}: 0.25rem;
+                ${tokens.textFieldChipBorderRadius}: 0.375rem;
+                ${tokens.textFieldChipWidth}: auto;
+                ${tokens.textFieldChipHeight}: 2.25rem;
+                ${tokens.textFieldChipPadding}: 0 0.625rem 0 0.875rem;
+                ${tokens.textFieldChipClearContentMarginLeft}: 0.5rem;
+                ${tokens.textFieldChipClearContentMarginRight}: 0rem;
+                ${tokens.textFieldChipCloseIconSize}: 1.25rem;
+                ${tokens.textFieldChipFontFamily}: ${bodyM.fontFamily};
+                ${tokens.textFieldChipFontSize}: ${bodyM.fontSize};
+                ${tokens.textFieldChipFontStyle}: ${bodyM.fontStyle};
+                ${tokens.textFieldChipFontWeight}: ${bodyM.fontWeight};
+                ${tokens.textFieldChipLetterSpacing}: ${bodyM.letterSpacing};
+                ${tokens.textFieldChipLineHeight}: ${bodyM.lineHeight};
+
+                ${tokens.emptyStatePadding}: 0.875rem 1rem 0.875rem 1rem;
+                ${tokens.padding}: 0.125rem;
+                ${tokens.borderRadius}: 0.75rem;
+
+                ${tokens.itemHeight}: 1.5rem;
+                ${tokens.itemPadding}: 0.75rem 0.75rem;
+                ${tokens.itemPaddingTight}: 0.5rem 0.75rem;
+                ${tokens.itemBorderRadius}: 0.625rem;
+                ${tokens.itemIconMargin}: 0 0.375rem 0 0;
+                ${tokens.itemIconSize}: 1.5rem;
+                ${tokens.itemIconSizeTight}: 1.5rem;
+                ${tokens.itemGap}: 0.375rem;
+                ${tokens.itemTreeOffsetWidth}: 2rem;
+
+                ${tokens.cellPadding}: 0rem;
+                ${tokens.cellPaddingLeftContent}: 0rem;
+                ${tokens.cellPaddingContent}: 0rem;
+                ${tokens.cellPaddingRightContent}: 0rem;
+                ${tokens.cellTextboxGap}: 0.125rem;
+                ${tokens.cellGap}: 0.375rem;
+                ${tokens.cellTitleFontFamily}: ${bodyM.fontFamily};
+                ${tokens.cellTitleFontSize}: ${bodyM.fontSize};
+                ${tokens.cellTitleFontStyle}: ${bodyM.fontStyle};
+                ${tokens.cellTitleFontWeight}: ${bodyM.fontWeight};
+                ${tokens.cellTitleLetterSpacing}: ${bodyM.letterSpacing};
+                ${tokens.cellTitleLineHeight}: ${bodyM.lineHeight};
+
+                ${tokens.fontFamily}: ${bodyM.fontFamily};
+                ${tokens.fontSize}: ${bodyM.fontSize};
+                ${tokens.fontStyle}: ${bodyM.fontStyle};
+                ${tokens.fontWeight}: ${bodyM.fontWeight};
+                ${tokens.fontLetterSpacing}: ${bodyM.letterSpacing};
+                ${tokens.fontLineHeight}: ${bodyM.lineHeight};
+
+                ${tokens.checkboxTriggerSize}: 1.25rem;
+                ${tokens.checkboxTriggerSizeTight}: 1.25rem;
+                ${tokens.checkboxTriggerBorderRadius}: 0.375rem;
+                ${tokens.checkboxTriggerBorderRadiusTight}: 0.375rem;
+                ${tokens.checkboxTriggerBorderWidth}: 0.125rem;
+
+                ${tokens.indicatorSize}: 0.375rem;
+
+                ${tokens.dividerMarginTop}: 0.375rem;
+                ${tokens.dividerMarginRight}: 0.875rem;
+                ${tokens.dividerMarginBottom}: 0.375rem;
+                ${tokens.dividerMarginLeft}: 0.875rem;
+                ${tokens.dividerMarginTopTight}: 0.375rem;
+                ${tokens.dividerMarginBottomTight}: 0.375rem;
+            `,
+            s: css`
+                ${tokens.textFieldHeight}: 2.5rem;
+                ${tokens.textFieldPadding}: 0.6875rem 0;
+                ${tokens.textFieldPaddingWithChips}: 0.375rem 0;
+                ${tokens.textFieldBorderRadius}: 0;
+
+                ${tokens.textFieldLeftContentMargin}: -0.1875rem 0.25rem -0.1875rem 0;
+                ${tokens.textFieldRightContentMargin}: -0.1875rem 0 -0.1875rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.1875rem -0.438rem -0.1875rem 0.75rem;
+
+                ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
+                ${tokens.textFieldContentRightWrapperMargin}: -0.438rem -0.438rem -0.438rem 0;
+
+                ${tokens.textFieldTextBeforeMargin}: 0 0.25rem 0 0;
+                ${tokens.textFieldTextAfterMargin}: 0 0 0 0.25rem;
+
+                ${tokens.textFieldFontFamily}: ${bodyS.fontFamily};
+                ${tokens.textFieldFontSize}: ${bodyS.fontSize};
+                ${tokens.textFieldFontStyle}: ${bodyS.fontStyle};
+                ${tokens.textFieldFontWeight}: ${bodyS.fontWeight};
+                ${tokens.textFieldLetterSpacing}: ${bodyS.letterSpacing};
+                ${tokens.textFieldLineHeight}: ${bodyS.lineHeight};
+
+                ${tokens.textFieldLabelOffset}: 0.25rem;
+                ${tokens.textFieldLabelFontFamily}: ${bodyS.fontFamily};
+                ${tokens.textFieldLabelFontSize}: ${bodyS.fontSize};
+                ${tokens.textFieldLabelFontStyle}: ${bodyS.fontStyle};
+                ${tokens.textFieldLabelFontWeight}: ${bodyS.fontWeight};
+                ${tokens.textFieldLabelLetterSpacing}: ${bodyS.letterSpacing};
+                ${tokens.textFieldLabelLineHeight}: ${bodyS.lineHeight};
+
+                ${tokens.textFieldHintMargin}: -0.688rem -0.5rem;
+                ${tokens.textFieldHintTargetSize}: 2.375rem;
+                ${tokens.textFieldHintInnerLabelPlacementOffset}: 0.062rem -2.188rem auto auto;
+                ${tokens.textFieldClearHintInnerLabelPlacementOffset}: 0.062rem -2.188rem auto auto;
+
+                ${tokens.textFieldLeftHelperOffset}: 0.25rem 0 0 0;
+                ${tokens.textFieldLeftHelperFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldLeftHelperFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldLeftHelperFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldLeftHelperFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldLeftHelperLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldLeftHelperLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.textFieldLabelInnerPadding}: 0.3125rem 0 0 0;
+                ${tokens.textFieldContentLabelInnerPadding}: 1.0625rem 0 0.3125rem 0;
+
+                ${tokens.textFieldIndicatorSizeInner}: 0.375rem;
+                ${tokens.textFieldIndicatorSizeOuter}: 0.375rem;
+                ${tokens.textFieldIndicatorLabelPlacementInner}: 1.063rem auto auto -0.75rem;
+                ${tokens.textFieldIndicatorLabelPlacementOuter}: 0.3125rem auto auto -0.6875rem;
+                ${tokens.textFieldIndicatorLabelPlacementInnerRight}: 1.063rem -0.75rem auto auto;
+                ${tokens.textFieldIndicatorLabelPlacementOuterRight}: 0.25rem -0.625rem auto auto;
+                ${tokens.textFieldClearIndicatorLabelPlacementInner}: 1.063rem auto auto -0.75rem;
+                ${tokens.textFieldClearIndicatorLabelPlacementInnerRight}: 1.063rem -0.75rem auto auto;
+                ${tokens.textFieldClearIndicatorHintInnerRight}: 1.063rem -2.238rem auto auto;
+
+                ${tokens.textFieldChipGap}: 0.25rem;
+                ${tokens.textFieldChipBorderRadius}: 0.25rem;
+                ${tokens.textFieldChipWidth}: auto;
+                ${tokens.textFieldChipHeight}: 1.75rem;
+                ${tokens.textFieldChipPadding}: 0 0.5rem 0 0.75rem;
+                ${tokens.textFieldChipClearContentMarginLeft}: 0.375rem;
+                ${tokens.textFieldChipClearContentMarginRight}: 0rem;
+                ${tokens.textFieldChipCloseIconSize}: 1rem;
+                ${tokens.textFieldChipFontFamily}: ${bodyS.fontFamily};
+                ${tokens.textFieldChipFontSize}: ${bodyS.fontSize};
+                ${tokens.textFieldChipFontStyle}: ${bodyS.fontStyle};
+                ${tokens.textFieldChipFontWeight}: ${bodyS.fontWeight};
+                ${tokens.textFieldChipLetterSpacing}: ${bodyS.letterSpacing};
+                ${tokens.textFieldChipLineHeight}: ${bodyS.lineHeight};
+
+                ${tokens.emptyStatePadding}: 0.625rem 0.875rem 0.625rem 0.875rem;
+                ${tokens.padding}: 0.125rem;
+                ${tokens.borderRadius}: 0.625rem;
+
+                ${tokens.itemHeight}: 1.5rem;
+                ${tokens.itemPadding}: 0.5rem 0.625rem;
+                ${tokens.itemPaddingTight}: 0.25rem 0.625rem;
+                ${tokens.itemBorderRadius}: 0.5rem;
+                ${tokens.itemIconSize}: 1.5rem;
+                ${tokens.itemIconSizeTight}: 1rem;
+                ${tokens.itemIconMargin}: 0 0.375rem 0 0;
+                ${tokens.itemGap}: 0.375rem;
+                ${tokens.itemTreeOffsetWidth}: 1.875rem;
+
+                ${tokens.cellPadding}: 0rem;
+                ${tokens.cellPaddingLeftContent}: 0rem;
+                ${tokens.cellPaddingContent}: 0rem;
+                ${tokens.cellPaddingRightContent}: 0rem;
+                ${tokens.cellTextboxGap}: 0.125rem;
+                ${tokens.cellGap}: 0.375rem;
+                ${tokens.cellTitleFontFamily}: ${bodyS.fontFamily};
+                ${tokens.cellTitleFontSize}: ${bodyS.fontSize};
+                ${tokens.cellTitleFontStyle}: ${bodyS.fontStyle};
+                ${tokens.cellTitleFontWeight}: ${bodyS.fontWeight};
+                ${tokens.cellTitleLetterSpacing}: ${bodyS.letterSpacing};
+                ${tokens.cellTitleLineHeight}: ${bodyS.lineHeight};
+
+                ${tokens.fontFamily}: ${bodyS.fontFamily};
+                ${tokens.fontSize}: ${bodyS.fontSize};
+                ${tokens.fontStyle}: ${bodyS.fontStyle};
+                ${tokens.fontWeight}: ${bodyS.fontWeight};
+                ${tokens.fontLetterSpacing}: ${bodyS.letterSpacing};
+                ${tokens.fontLineHeight}: ${bodyS.lineHeight};
+
+                ${tokens.checkboxTriggerSize}: 1.25rem;
+                ${tokens.checkboxTriggerSizeTight}: 0.875rem;
+                ${tokens.checkboxTriggerBorderRadius}: 0.375rem;
+                ${tokens.checkboxTriggerBorderRadiusTight}: 0.25rem;
+                ${tokens.checkboxTriggerBorderWidth}: 0.125rem;
+
+                ${tokens.indicatorSize}: 0.375rem;
+
+                ${tokens.dividerMarginTop}: 0.375rem;
+                ${tokens.dividerMarginRight}: 0.75rem;
+                ${tokens.dividerMarginBottom}: 0.375rem;
+                ${tokens.dividerMarginLeft}: 0.75rem;
+                ${tokens.dividerMarginTopTight}: 0.25rem;
+                ${tokens.dividerMarginBottomTight}: 0.25rem;
+            `,
+            xs: css`
+                ${tokens.textFieldHeight}: 2rem;
+                ${tokens.textFieldPadding}: 0.5625rem 0;
+                ${tokens.textFieldPaddingWithChips}: 0.375rem 0;
+                ${tokens.textFieldBorderRadius}: 0;
+
+                ${tokens.textFieldLeftContentMargin}: -0.0625rem 0.25rem -0.0625rem 0;
+                ${tokens.textFieldRightContentMargin}: -0.0625rem 0 -0.0625rem 0.75rem;
+                ${tokens.textFieldRightContentWithHintMargin}: -0.0625rem -0.688rem -0.0625rem 0.75rem;
+
+                ${tokens.textFieldContentRightWrapperGap}: 0.25rem;
+                ${tokens.textFieldContentRightWrapperMargin}: -0.688rem -0.688rem -0.688rem 0;
+
+                ${tokens.textFieldTextBeforeMargin}: 0 0.25rem 0 0;
+                ${tokens.textFieldTextAfterMargin}: 0 0 0 0.25rem;
+
+                ${tokens.textFieldFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.textFieldLabelOffset}: 0.25rem;
+                ${tokens.textFieldLabelFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldLabelFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldLabelFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldLabelFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldLabelLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldLabelLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.textFieldHintMargin}: -0.75rem -0.625rem -0.75rem -0.5rem;
+                ${tokens.textFieldHintTargetSize}: 2.375rem;
+                ${tokens.textFieldHintInnerLabelPlacementOffset}: -0.188rem -1.938rem auto auto;
+                ${tokens.textFieldClearHintInnerLabelPlacementOffset}: -0.188rem -1.938rem auto auto;
+
+                ${tokens.textFieldLeftHelperOffset}: 0.25rem 0 0 0;
+                ${tokens.textFieldLeftHelperFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldLeftHelperFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldLeftHelperFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldLeftHelperFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldLeftHelperLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldLeftHelperLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.textFieldLabelInnerPadding}: 0.3125rem 0 0 0;
+                ${tokens.textFieldContentLabelInnerPadding}: 1.0625rem 0 0.3125rem 0;
+
+                ${tokens.textFieldIndicatorSizeInner}: 0.375rem;
+                ${tokens.textFieldIndicatorSizeOuter}: 0.375rem;
+                ${tokens.textFieldIndicatorLabelPlacementInner}: 0.813rem auto auto -0.625rem;
+                ${tokens.textFieldIndicatorLabelPlacementOuter}: 0.25rem auto auto -0.625rem;
+                ${tokens.textFieldIndicatorLabelPlacementInnerRight}: 0.813rem -0.625rem auto auto;
+                ${tokens.textFieldIndicatorLabelPlacementOuterRight}: 0.125rem -0.6875rem auto auto;
+                ${tokens.textFieldClearIndicatorLabelPlacementInner}: 0.813rem auto auto -0.625rem;
+                ${tokens.textFieldClearIndicatorLabelPlacementInnerRight}: 0.813rem -0.625rem auto auto;
+                ${tokens.textFieldClearIndicatorHintInnerRight}: 0.813rem -1.988rem auto auto;
+
+                ${tokens.textFieldChipGap}: 0.25rem;
+                ${tokens.textFieldChipBorderRadius}: 0.125rem;
+                ${tokens.textFieldChipWidth}: auto;
+                ${tokens.textFieldChipHeight}: 1.25rem;
+                ${tokens.textFieldChipPadding}: 0 0.375rem 0 0.625rem;
+                ${tokens.textFieldChipClearContentMarginLeft}: 0.25rem;
+                ${tokens.textFieldChipClearContentMarginRight}: 0rem;
+                ${tokens.textFieldChipCloseIconSize}: 0.75rem;
+                ${tokens.textFieldChipFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldChipFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldChipFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldChipFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldChipLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldChipLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.emptyStatePadding}: 0.5rem 0.625rem 0.5rem 0.625rem;
+                ${tokens.padding}: 0.125rem;
+                ${tokens.borderRadius}: 0.5rem;
+
+                ${tokens.itemHeight}: 1rem;
+                ${tokens.itemPadding}: 0.5rem 0.375rem;
+                ${tokens.itemPaddingTight}: 0.25rem 0.375rem;
+                ${tokens.itemBorderRadius}: 0.375rem;
+                ${tokens.itemIconSize}: 1rem;
+                ${tokens.itemIconSizeTight}: 1rem;
+                ${tokens.itemIconMargin}: 0 0.25rem 0 0;
+                ${tokens.itemGap}: 0.25rem;
+                ${tokens.itemTreeOffsetWidth}: 1.25rem;
+
+                ${tokens.cellPadding}: 0rem;
+                ${tokens.cellPaddingLeftContent}: 0rem;
+                ${tokens.cellPaddingContent}: 0rem;
+                ${tokens.cellPaddingRightContent}: 0rem;
+                ${tokens.cellTextboxGap}: 0.125rem;
+                ${tokens.cellGap}: 0.25rem;
+                ${tokens.cellTitleFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.cellTitleFontSize}: ${bodyXS.fontSize};
+                ${tokens.cellTitleFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.cellTitleFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.cellTitleLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.cellTitleLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.fontFamily}: ${bodyM.fontFamily};
+                ${tokens.fontSize}: ${bodyM.fontSize};
+                ${tokens.fontStyle}: ${bodyM.fontStyle};
+                ${tokens.fontWeight}: ${bodyM.fontWeight};
+                ${tokens.fontLetterSpacing}: ${bodyM.letterSpacing};
+                ${tokens.fontLineHeight}: ${bodyM.lineHeight};
+
+                ${tokens.checkboxTriggerSize}: 0.875rem;
+                ${tokens.checkboxTriggerSizeTight}: 0.875rem;
+                ${tokens.checkboxTriggerBorderRadius}: 0.25rem;
+                ${tokens.checkboxTriggerBorderRadiusTight}: 0.25rem;
+                ${tokens.checkboxTriggerBorderWidth}: 0.125rem;
+
+                ${tokens.indicatorSize}: 0.375rem;
+
+                ${tokens.dividerMarginTop}: 0.25rem;
+                ${tokens.dividerMarginRight}: 0.5rem;
+                ${tokens.dividerMarginBottom}: 0.225rem;
+                ${tokens.dividerMarginLeft}: 0.5rem;
+                ${tokens.dividerMarginTopTight}: 0.125rem;
+                ${tokens.dividerMarginBottomTight}: 0.125rem;
+            `,
+        },
+        labelPlacement: {
+            inner: css`
+                ${tokens.textFieldPlaceholderColor}: ${textSecondary};
+                ${tokens.textFieldLabelInnerFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldLabelInnerFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldLabelInnerFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldLabelInnerFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldLabelInnerLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldLabelInnerLineHeight}: ${bodyXS.lineHeight};
+            `,
+            outer: css``,
+        },
+        chipView: {
+            default: css`
+                ${tokens.textFieldChipColor}: ${inverseTextPrimary};
+                ${tokens.textFieldChipColorHover}: ${inverseTextPrimary};
+                ${tokens.textFieldChipBackground}: ${surfaceSolidDefault};
+                ${tokens.textFieldChipBackgroundHover}: ${surfaceSolidDefaultHover};
+                ${tokens.textFieldChipCloseIconColor}: ${inverseTextSecondary};
+                ${tokens.textFieldChipCloseIconColorReadonly}: ${inverseTextSecondary};
+                ${tokens.textFieldChipCloseIconColorHover}: ${inverseTextPrimary};
+
+                ${tokens.textFieldChipBackgroundReadOnly}: ${surfaceSolidDefault};
+                ${tokens.textFieldChipColorReadOnly}: ${inverseTextPrimary};
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: ${surfaceSolidDefault};
+                ${tokens.textFieldChipColorReadOnlyHover}: ${inverseTextPrimary};
+                ${tokens.textFieldChipOpacityReadonly}: 1;
+            `,
+            secondary: css`
+                ${tokens.textFieldChipColor}: ${textPrimary};
+                ${tokens.textFieldChipColorHover}: ${textPrimary};
+                ${tokens.textFieldChipBackground}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipBackgroundHover}: ${surfaceTransparentSecondaryHover};
+                ${tokens.textFieldChipCloseIconColor}: ${textSecondary};
+                ${tokens.textFieldChipCloseIconColorHover}: ${textSecondaryHover};
+                ${tokens.textFieldChipCloseIconColorReadonly}: ${textSecondary};
+
+                ${tokens.textFieldChipBackgroundReadOnly}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnly}: ${textPrimary};
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: ${surfaceTransparentSecondary};
+                ${tokens.textFieldChipColorReadOnlyHover}: ${textPrimary};
+                ${tokens.textFieldChipOpacityReadonly}: 1;
+            `,
+            accent: css`
+                ${tokens.textFieldChipColor}: ${onDarkTextPrimary};
+                ${tokens.textFieldChipColorHover}: ${onDarkTextPrimary};
+                ${tokens.textFieldChipBackground}: ${surfaceAccent};
+                ${tokens.textFieldChipBackgroundHover}: ${surfaceAccentHover};
+                ${tokens.textFieldChipCloseIconColor}: ${onDarkTextSecondary};
+                ${tokens.textFieldChipCloseIconColorReadonly}: ${onDarkTextSecondary};
+                ${tokens.textFieldChipCloseIconColorHover}: ${onDarkTextPrimary};
+
+                ${tokens.textFieldChipBackgroundReadOnly}: ${surfaceAccent};
+                ${tokens.textFieldChipColorReadOnly}: ${onDarkTextPrimary};
+                ${tokens.textFieldChipBackgroundReadOnlyHover}: ${surfaceAccent};
+                ${tokens.textFieldChipColorReadOnlyHover}: ${onDarkTextPrimary};
+                ${tokens.textFieldChipOpacityReadonly}: 1;
+            `,
+        },
+        hintView: {
+            default: css`
+                ${tokens.textFieldTooltipBackgroundColor}: ${surfaceSolidCardBrightness};
+                ${tokens.textFieldTooltipBoxShadow}: var(--shadow-down-hard-m, 0px 4px 12px 0px rgba(0, 0, 0, 0.16),0px 1px 4px 0px rgba(0, 0, 0, 0.08));
+                ${tokens.textFieldTooltipColor}: ${textPrimary};
+                ${tokens.textFieldTooltipArrowBackground}: ${surfaceSolidCard};
+            `,
+        },
+        hintSize: {
+            m: css`
+                ${tokens.textFieldTooltipPaddingTop}: 0.6875rem;
+                ${tokens.textFieldTooltipPaddingRight}: 0.875rem;
+                ${tokens.textFieldTooltipPaddingBottom}: 0.6875rem;
+                ${tokens.textFieldTooltipPaddingLeft}: 0.875rem;
+
+                ${tokens.textFieldTooltipMinHeight}: 2.5rem;
+                ${tokens.textFieldTooltipBorderRadius}: 0.625rem;
+
+                ${tokens.textFieldTooltipTextFontFamily}: ${bodyS.fontFamily};
+                ${tokens.textFieldTooltipTextFontSize}: ${bodyS.fontSize};
+                ${tokens.textFieldTooltipTextFontStyle}: ${bodyS.fontStyle};
+                ${tokens.textFieldTooltipTextFontWeight}: ${bodyS.fontWeight};
+                ${tokens.textFieldTooltipTextFontLetterSpacing}: ${bodyS.letterSpacing};
+                ${tokens.textFieldTooltipTextFontLineHeight}: ${bodyS.lineHeight};
+
+                ${tokens.textFieldTooltipContentLeftMargin}: 0.375rem;
+
+                ${tokens.textFieldTooltipArrowMaskWidth}: 1.25rem;
+                ${tokens.textFieldTooltipArrowMaskHeight}: 1.25rem;
+                ${tokens.textFieldTooltipArrowMaskImage}: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtMC4xNywxMS44M2wyMCwwYy01LjUyLDAgLTEwLDMuNTkgLTEwLDhjMCwtNC40MSAtNC40OCwtOCAtMTAsLTh6IiBmaWxsPSIjMTcxNzE3IiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGlkPSJUYWlsIi8+Cjwvc3ZnPg==");
+                ${tokens.textFieldTooltipArrowHeight}: 0.5rem;
+                ${tokens.textFieldTooltipArrowEdgeMargin}: 0.625rem;
+            `,
+            s: css`
+                ${tokens.textFieldTooltipPaddingTop}: 0.5rem;
+                ${tokens.textFieldTooltipPaddingRight}: 0.75rem;
+                ${tokens.textFieldTooltipPaddingBottom}: 0.5rem;
+                ${tokens.textFieldTooltipPaddingLeft}: 0.75rem;
+
+                ${tokens.textFieldTooltipMinHeight}: 2rem;
+                ${tokens.textFieldTooltipBorderRadius}: 0.5rem;
+
+                ${tokens.textFieldTooltipTextFontFamily}: ${bodyXS.fontFamily};
+                ${tokens.textFieldTooltipTextFontSize}: ${bodyXS.fontSize};
+                ${tokens.textFieldTooltipTextFontStyle}: ${bodyXS.fontStyle};
+                ${tokens.textFieldTooltipTextFontWeight}: ${bodyXS.fontWeight};
+                ${tokens.textFieldTooltipTextFontLetterSpacing}: ${bodyXS.letterSpacing};
+                ${tokens.textFieldTooltipTextFontLineHeight}: ${bodyXS.lineHeight};
+
+                ${tokens.textFieldTooltipContentLeftMargin}: 0.25rem;
+
+                ${tokens.textFieldTooltipArrowMaskWidth}: 1rem;
+                ${tokens.textFieldTooltipArrowMaskHeight}: 1rem;
+                ${tokens.textFieldTooltipArrowMaskImage}: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtMCw5Ljg1bDE2LDBjLTQuNDEsMCAtOCwyLjY5IC04LDZjMCwtMy4zMSAtMy41OSwtNiAtOCwtNnoiIGZpbGw9IiMxNzE3MTciIGZpbGwtcnVsZT0iZXZlbm9kZCIgaWQ9IlRhaWwiLz4KPC9zdmc+");
+                ${tokens.textFieldTooltipArrowHeight}: 0.375rem;
+                ${tokens.textFieldTooltipArrowEdgeMargin}: 0.5625rem;
+            `,
+        },
+        disabled: {
+            true: css`
+                ${tokens.textFieldDisabledOpacity}: 0.4;
+            `,
+        },
+        readOnly: {
+            true: css`
+                ${tokens.textFieldColorReadOnly}: ${textPrimary};
+                ${tokens.textFieldReadOnlyOpacity}: 0.1;
+                ${tokens.textFieldContentSlotRightOpacityReadOnly}: 0.4;
+                ${tokens.textFieldBackgroundColorReadOnly}: transparent;
+                ${tokens.textFieldPlaceholderColorReadOnly}: ${textSecondary};
+                ${tokens.textFieldLeftHelperColorReadOnly}: ${textSecondary};
+                ${tokens.textFieldLabelColorReadOnly}: ${textPrimary};
+                ${tokens.textFieldDividerColorReadOnly}: ${surfaceTransparentPrimary};
+            `,
+        },
+    },
+};

--- a/packages/sdds-bizcom/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/sdds-bizcom/src/components/Combobox/Combobox.stories.tsx
@@ -10,6 +10,24 @@ type ComboboxProps = ComponentProps<typeof Combobox>;
 const { meta: META, Single, Multiple, SelectAll, AddItem } = getComboboxStories({
     component: Combobox,
     componentConfig: config,
+    defaultArgs: {
+        ...config.defaults,
+        appearance: 'default',
+        hasDivider: false,
+    },
+    additionalArgTypes: {
+        appearance: {
+            options: ['default', 'clear'],
+            control: { type: 'select' },
+        },
+        hasDivider: {
+            control: { type: 'boolean' },
+            if: {
+                arg: 'appearance',
+                eq: 'clear',
+            },
+        },
+    },
 });
 
 const meta: Meta<ComboboxProps> = {

--- a/packages/sdds-bizcom/src/components/Combobox/Combobox.tsx
+++ b/packages/sdds-bizcom/src/components/Combobox/Combobox.tsx
@@ -1,16 +1,33 @@
-import { comboboxConfig, component, mergeConfig, fixedForwardRef } from '@salutejs/plasma-new-hope/styled-components';
+import {
+    comboboxConfig,
+    component,
+    mergeConfig,
+    fixedForwardRef,
+    createConditionalComponent,
+} from '@salutejs/plasma-new-hope/styled-components';
 import type { ComboboxItemOption, ComboboxProps, DistributiveOmit, DistributivePick } from '@salutejs/plasma-new-hope';
 import React, { ComponentProps } from 'react';
 
 import { config } from './Combobox.config';
+import { config as clearConfig } from './Combobox.clear.config';
 
 const mergedConfig = mergeConfig(comboboxConfig, config);
-const ComboboxNew = component(mergedConfig);
+const ComboboxDefault = component(mergedConfig);
+
+const mergedClearConfig = mergeConfig(comboboxConfig, clearConfig);
+const ComboboxClear = component(mergedClearConfig);
+
+const ComboboxNew = createConditionalComponent({
+    default: ComboboxDefault,
+    clear: ComboboxClear,
+});
 
 type PropsFromConfig = keyof typeof config['variations'];
 
 export type Props<T extends ComboboxItemOption> = DistributiveOmit<ComboboxProps<T>, PropsFromConfig> &
-    DistributivePick<ComponentProps<typeof ComboboxNew>, PropsFromConfig>;
+    DistributivePick<ComponentProps<typeof ComboboxDefault>, PropsFromConfig> & {
+        appearance?: 'default' | 'clear';
+    };
 
 const ComboboxComponent = <T extends ComboboxItemOption>(
     props: Props<T>,

--- a/website/sdds-bizcom-docs/docs/components/Combobox.mdx
+++ b/website/sdds-bizcom-docs/docs/components/Combobox.mdx
@@ -12,6 +12,30 @@ import TabItem from '@theme/TabItem';
 <Description name="Combobox" />
 <PropsTable name="Combobox" />
 
+## Appearance
+
+Для `appearance="clear"` есть возможность отобразить разделитель с помощью `hasDivider`.
+
+```tsx live
+import React from 'react';
+import { Combobox } from '@salutejs/sdds-bizcom';
+
+export function App() {
+    const items = [
+        { value: 'option_1', label: 'Опция 1' },
+        { value: 'option_2', label: 'Опция 2' },
+    ];
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '20px', maxWidth: '350px', height: '250px' }}>
+            <Combobox items={items} appearance="default" label="Default" placeholder="Placeholder" />
+            <Combobox items={items} appearance="clear" label="Clear" placeholder="Placeholder" />
+            <Combobox items={items} appearance="clear" hasDivider label="Clear with divider" placeholder="Placeholder" />
+        </div>
+    );
+}
+```
+
 ## Использование
 Обязательным параметром является только `items`. Внутри items может быть такой же вложенный массив items. Формат следующий:
 


### PR DESCRIPTION
## SDDS-BIZCOM

### Combobox

- добавлена `clear` вариация


### What/why changed

- добавлена `clear` вариация
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.393.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-b2c@1.635.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-colors@0.23.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-core@1.242.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-giga@0.362.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-homeds@0.362.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-hope@1.389.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-icons@1.250.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-new-hope@0.379.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-tokens@1.153.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-tokens-b2b@1.66.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-tokens-b2c@0.77.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-tokens-core@0.14.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-tokens-web@1.81.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-typo@0.54.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-web@1.637.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-bizcom@0.367.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-cs@0.371.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-dfa@0.365.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-finai@0.358.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-icons@0.7.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-insol@0.362.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-insol-next@0.361.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-netology@0.366.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-os@0.37.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-platform-ai@0.366.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-sbcom@0.367.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-scan@0.365.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-serv@0.366.0-canary.3145.34167073118.0
  npm install @salutejs/core-themes@0.42.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-themes@0.64.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-themes@0.80.0-canary.3145.34167073118.0
  npm install @salutejs/sdds-api-tests@0.24.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-cy-utils@0.172.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-sb-utils@0.243.0-canary.3145.34167073118.0
  npm install @salutejs/plasma-tokens-utils@0.62.0-canary.3145.34167073118.0
  # or 
  yarn add @salutejs/plasma-asdk@0.393.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-b2c@1.635.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-colors@0.23.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-core@1.242.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-giga@0.362.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-homeds@0.362.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-hope@1.389.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-icons@1.250.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-new-hope@0.379.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-tokens@1.153.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-tokens-b2b@1.66.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-tokens-b2c@0.77.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-tokens-core@0.14.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-tokens-web@1.81.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-typo@0.54.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-web@1.637.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-bizcom@0.367.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-cs@0.371.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-dfa@0.365.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-finai@0.358.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-icons@0.7.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-insol@0.362.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-insol-next@0.361.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-netology@0.366.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-os@0.37.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-platform-ai@0.366.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-sbcom@0.367.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-scan@0.365.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-serv@0.366.0-canary.3145.34167073118.0
  yarn add @salutejs/core-themes@0.42.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-themes@0.64.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-themes@0.80.0-canary.3145.34167073118.0
  yarn add @salutejs/sdds-api-tests@0.24.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-cy-utils@0.172.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-sb-utils@0.243.0-canary.3145.34167073118.0
  yarn add @salutejs/plasma-tokens-utils@0.62.0-canary.3145.34167073118.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `default` and `clear` visual appearances for the Combobox.
  * Added optional dividers for clear Comboboxes, including hover, focus, and read-only states.
  * Added styling support for Combobox sizes, labels, chips, hints, and status states in SDDS Bizcom.

* **Documentation**
  * Added Combobox appearance and divider examples to the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->