### PR TITLE
PLASMA-8051: normalize date on Calendar pick

### DIFF
--- a/packages/plasma-new-hope/src/components/DatePicker/DatePicker.component-test.tsx
+++ b/packages/plasma-new-hope/src/components/DatePicker/DatePicker.component-test.tsx
@@ -468,6 +468,29 @@ describeFn('DatePicker', () => {
         cy.matchImageSnapshot();
     });
 
+    it('normalizes a calendar value before calling onChangeValue', () => {
+        const onChangeValue = cy.stub().as('onChangeValue');
+        const max = new Date(2026, 7, 22);
+        const dateShortcuts = [{ value: max, label: 'Верхняя граница' }];
+
+        mount(
+            <Demo
+                defaultDate={new Date(2026, 7, 20)}
+                max={max}
+                includeEdgeDates={false}
+                dateShortcuts={dateShortcuts}
+                onChangeValue={onChangeValue}
+            />,
+        );
+
+        cy.get('input').first().click();
+        cy.contains('Верхняя граница').click();
+
+        cy.get('input').first().should('have.value', '21.08.2026');
+        cy.get('@onChangeValue').its('lastCall.args.1').should('equal', '21.08.2026');
+        cy.get('@onChangeValue').its('lastCall.args.2').should('deep.equal', new Date(2026, 7, 21));
+    });
+
     it.skip('controlled datepicker: set date', () => {
         cy.viewport(500, 544);
 

--- a/packages/plasma-new-hope/src/components/DatePicker/hooks/useDatePicker.ts
+++ b/packages/plasma-new-hope/src/components/DatePicker/hooks/useDatePicker.ts
@@ -212,18 +212,24 @@ export const useDatePicker = ({
             return;
         }
 
-        customDayjs.locale(lang);
-        const formattedDate = customDayjs(date).format(format);
-        const isoDate = date.toISOString();
+        const { formattedDate, isoDate, originalDate } = getFormattedDates({
+            value: date,
+            lang,
+            delimiter: dateFormatDelimiter,
+            format,
+            includeEdgeDates,
+            min,
+            max,
+        });
 
-        setInnerDate(date);
-        setCorrectDates({ calendar: date, input: formattedDate });
+        setInnerDate(originalDate);
+        setCorrectDates({ calendar: originalDate, input: formattedDate });
 
         if (onChangeValue) {
-            onChangeValue(null, formattedDate, date, isoDate);
+            onChangeValue(null, formattedDate, originalDate, isoDate);
         }
         if (onChange) {
-            onChange({ target: { value: formattedDate, originalDate: date, isoDate, name } });
+            onChange({ target: { value: formattedDate, originalDate, isoDate, name } });
         }
         if (onCommitDate) {
             invokeOnCommitDate({
@@ -233,7 +239,7 @@ export const useDatePicker = ({
                     error: false,
                     success: true,
                     dateInfo,
-                    originalDate: date,
+                    originalDate,
                     isoDate,
                 },
             });


### PR DESCRIPTION
## Core

### DatePicker

- добавлена нормализация даты при выборе из календаря

### What/why changed

**Before:**
<img width="1190" height="828" alt="dates sync before" src="https://github.com/user-attachments/assets/752ec9c7-6cc5-4fe4-afbb-55dafcfc15ec" />

**After:**
<img width="1112" height="844" alt="dates sync" src="https://github.com/user-attachments/assets/bdc28086-0fd6-4460-8555-c4734aa33411" />

- добавлена нормализация даты при выборе из календаря


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DatePicker now consistently normalizes dates selected from calendar shortcuts according to the configured minimum and maximum boundaries.
  - When edge dates are excluded, selecting the maximum date now correctly displays and returns the preceding valid date.
  - Date values remain consistently formatted across calendar selections and other date entry methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @salutejs/plasma-asdk@0.393.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-b2c@1.635.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-colors@0.23.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-core@1.242.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-giga@0.362.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-homeds@0.362.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-hope@1.389.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-icons@1.250.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-new-hope@0.379.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-tokens@1.153.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-tokens-b2b@1.66.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-tokens-b2c@0.77.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-tokens-core@0.14.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-tokens-web@1.81.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-typo@0.54.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-web@1.637.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-bizcom@0.367.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-cs@0.371.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-dfa@0.365.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-finai@0.358.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-icons@0.7.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-insol@0.362.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-insol-next@0.361.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-netology@0.366.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-os@0.37.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-platform-ai@0.366.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-sbcom@0.367.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-scan@0.365.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-serv@0.366.0-canary.3148.34202994317.0
  npm install @salutejs/core-themes@0.42.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-themes@0.64.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-themes@0.80.0-canary.3148.34202994317.0
  npm install @salutejs/sdds-api-tests@0.24.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-cy-utils@0.172.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-sb-utils@0.243.0-canary.3148.34202994317.0
  npm install @salutejs/plasma-tokens-utils@0.62.0-canary.3148.34202994317.0
  # or 
  yarn add @salutejs/plasma-asdk@0.393.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-b2c@1.635.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-colors@0.23.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-core@1.242.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-giga@0.362.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-homeds@0.362.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-hope@1.389.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-icons@1.250.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-new-hope@0.379.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-tokens@1.153.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-tokens-b2b@1.66.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-tokens-b2c@0.77.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-tokens-core@0.14.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-tokens-web@1.81.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-typo@0.54.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-web@1.637.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-bizcom@0.367.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-cs@0.371.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-dfa@0.365.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-finai@0.358.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-icons@0.7.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-insol@0.362.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-insol-next@0.361.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-netology@0.366.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-os@0.37.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-platform-ai@0.366.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-sbcom@0.367.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-scan@0.365.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-serv@0.366.0-canary.3148.34202994317.0
  yarn add @salutejs/core-themes@0.42.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-themes@0.64.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-themes@0.80.0-canary.3148.34202994317.0
  yarn add @salutejs/sdds-api-tests@0.24.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-cy-utils@0.172.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-sb-utils@0.243.0-canary.3148.34202994317.0
  yarn add @salutejs/plasma-tokens-utils@0.62.0-canary.3148.34202994317.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
